### PR TITLE
feat: add Claude skills for GitHub Copilot integration

### DIFF
--- a/.claude/skills/auto-pr.md
+++ b/.claude/skills/auto-pr.md
@@ -1,0 +1,114 @@
+# Auto PR Skill
+
+Trigger: `/auto-pr` or when user wants to create and merge a PR autonomously
+
+## Description
+
+Create a PR, wait for CI + AI reviews to pass, then auto-merge. Full autonomous workflow.
+
+## Workflow
+
+1. **Pre-flight Checks**
+   ```bash
+   # Ensure we're on a feature branch
+   git branch --show-current
+
+   # Ensure no uncommitted changes
+   git status --porcelain
+
+   # Ensure branch is ahead of develop
+   git rev-list --count develop..HEAD
+   ```
+
+2. **Push Branch**
+   ```bash
+   git push -u origin $(git branch --show-current)
+   ```
+
+3. **Create PR**
+   ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_PAT" \
+     -H "Accept: application/vnd.github.v3+json" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/pulls" \
+     -d '{
+       "title": "<title>",
+       "head": "<branch>",
+       "base": "develop",
+       "body": "<body>"
+     }'
+   ```
+
+4. **Wait for Checks**
+   ```bash
+   # Poll for check status
+   while true; do
+     status=$(curl -s -H "Authorization: token $GITHUB_PAT" \
+       "https://api.github.com/repos/IgorGanapolsky/Random-Timer/commits/<sha>/check-runs" \
+       | jq -r '.check_runs | map(.conclusion) | unique | if contains(["failure"]) then "failed" elif contains([null]) then "pending" else "passed" end')
+
+     if [ "$status" = "passed" ]; then break; fi
+     if [ "$status" = "failed" ]; then echo "CI failed"; exit 1; fi
+     sleep 30
+   done
+   ```
+
+5. **Check AI Reviews**
+   - Wait for Claude review comment
+   - Wait for Copilot review (if enabled)
+   - Verify no REQUEST_CHANGES
+
+6. **Auto-Merge**
+   ```bash
+   curl -s -X PUT \
+     -H "Authorization: token $GITHUB_PAT" \
+     -H "Accept: application/vnd.github.v3+json" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/pulls/<pr>/merge" \
+     -d '{"merge_method": "squash"}'
+   ```
+
+7. **Cleanup**
+   ```bash
+   git checkout develop
+   git pull origin develop
+   git branch -d <feature-branch>
+   ```
+
+## Safety Guards
+
+- **Never auto-merge if:**
+  - CI checks failed
+  - Claude review says REQUEST_CHANGES
+  - Copilot review says REQUEST_CHANGES
+  - PR has merge conflicts
+
+- **Always require:**
+  - At least one passing CI check
+  - No unresolved review comments
+
+## Example Usage
+
+```
+User: /auto-pr
+
+Claude: Starting autonomous PR workflow...
+
+1. ✅ Pre-flight checks passed
+2. ✅ Pushed branch feature/add-haptics
+3. ✅ Created PR #265
+4. ⏳ Waiting for CI... (2 jobs running)
+5. ✅ CI passed (Quality: ✓, Security: ✓)
+6. ⏳ Waiting for AI reviews...
+7. ✅ Claude: APPROVE
+8. ✅ Copilot: APPROVE
+9. ✅ Merged PR #265 to develop
+10. ✅ Cleaned up local branch
+
+PR #265 merged: https://github.com/IgorGanapolsky/Random-Timer/pull/265
+```
+
+## Flags
+
+- `--no-wait`: Create PR but don't wait for checks (manual merge later)
+- `--draft`: Create as draft PR
+- `--force`: Merge even with style warnings (not critical issues)

--- a/.claude/skills/copilot-agent.md
+++ b/.claude/skills/copilot-agent.md
@@ -1,0 +1,73 @@
+# Copilot Agent Skill
+
+Trigger: `/copilot-agent` or when user wants to delegate a task to GitHub Copilot
+
+## Description
+
+Create a GitHub issue and assign it to Copilot coding agent for autonomous implementation.
+
+## Workflow
+
+1. **Gather Requirements**
+   - Ask user what they want implemented (if not clear)
+   - Determine issue title and description
+   - Identify acceptance criteria
+
+2. **Create GitHub Issue**
+   ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_PAT" \
+     -H "Accept: application/vnd.github.v3+json" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/issues" \
+     -d '{
+       "title": "<issue-title>",
+       "body": "<description>\n\n## Acceptance Criteria\n- [ ] <criteria>\n\n## Technical Notes\n- Follow SafeAreaView import from react-native-safe-area-context\n- Use @shared/utils/storage for MMKV\n- Use theme colors from @shared/theme\n\n@copilot implement this",
+       "labels": ["copilot-agent", "automation"]
+     }'
+   ```
+
+3. **Assign to Copilot**
+   ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_PAT" \
+     -H "Accept: application/vnd.github.v3+json" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/issues/<issue-number>/assignees" \
+     -d '{"assignees": ["copilot"]}'
+   ```
+
+4. **Monitor Progress**
+   - Copilot will create a `copilot/` branch
+   - Copilot will open a draft PR
+   - User reviews and requests changes via PR comments
+
+## Example Usage
+
+User: "Create a settings screen with a dark mode toggle"
+
+Claude creates issue:
+```
+Title: Add settings screen with dark mode toggle
+
+## Description
+Create a new SettingsScreen component with a toggle to switch between dark and light themes.
+
+## Acceptance Criteria
+- [ ] New screen at src/features/settings/screens/SettingsScreen.tsx
+- [ ] Dark mode toggle using Switch component
+- [ ] Persist preference using Redux + MMKV
+- [ ] Add to navigation stack
+
+## Technical Notes
+- Use <Screen preset="scroll"> wrapper
+- Import theme from @shared/theme
+- Add slice to persistConfig.whitelist
+
+@copilot implement this
+```
+
+## Notes
+
+- Copilot coding agent works autonomously in GitHub Actions environment
+- It has read-only access to repo, can only push to `copilot/` branches
+- Review the draft PR carefully before merging
+- Comment on the PR to request changes

--- a/.claude/skills/delegate-to-copilot.md
+++ b/.claude/skills/delegate-to-copilot.md
@@ -1,0 +1,96 @@
+# Delegate to Copilot Skill
+
+Trigger: `/delegate` or "let copilot handle this" or "assign to copilot"
+
+## Description
+
+Quickly delegate the current task or a described task to GitHub Copilot coding agent.
+
+## Quick Workflow
+
+1. **Parse Task**
+   - Extract task description from user message
+   - Generate appropriate issue title
+   - Add project-specific technical notes
+
+2. **Create & Assign Issue**
+
+   Single API call approach:
+   ```bash
+   # Create issue with @copilot mention (triggers assignment)
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_PAT" \
+     -H "Accept: application/vnd.github.v3+json" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/issues" \
+     -d '{
+       "title": "<task-title>",
+       "body": "## Task\n<description>\n\n## Project Context\n- React Native/Expo app\n- TypeScript strict mode\n- Redux Toolkit + MMKV\n- Theme: @shared/theme\n\n## Instructions for Copilot\n- Use SafeAreaView from react-native-safe-area-context\n- Use storage from @shared/utils/storage\n- Follow existing patterns in codebase\n\n@copilot implement this",
+       "labels": ["copilot-agent"]
+     }'
+   ```
+
+3. **Report**
+   - Return issue URL
+   - Explain next steps (Copilot will open draft PR)
+
+## Template Injection
+
+Always append these technical notes to the issue body:
+
+```markdown
+## Project Context
+- React Native 0.81.4 / Expo SDK 54
+- TypeScript strict mode
+- Redux Toolkit with MMKV persistence
+- Dark-first glassmorphism UI
+
+## Copilot Instructions
+Follow .github/copilot-instructions.md:
+- SafeAreaView from 'react-native-safe-area-context'
+- Storage from '@shared/utils/storage'
+- Colors from '@shared/theme'
+- Spacing constants (xs, sm, md, lg, xl)
+```
+
+## Example Interactions
+
+**Simple delegation:**
+```
+User: delegate adding a vibration toggle to settings
+
+Claude: Created issue #267: "Add vibration toggle to settings"
+        Assigned to Copilot coding agent.
+
+        Copilot will:
+        1. Create branch copilot/issue-267
+        2. Implement the feature
+        3. Open draft PR for your review
+
+        Track progress: https://github.com/IgorGanapolsky/Random-Timer/issues/267
+```
+
+**With context:**
+```
+User: let copilot handle refactoring the timer slice to use RTK Query
+
+Claude: Created issue #268: "Refactor timerSlice to use RTK Query"
+
+        I've included context about:
+        - Current slice location: src/shared/redux/slices/timerSlice.ts
+        - Persistence requirements (MMKV)
+        - Typed hooks pattern
+
+        Copilot will work on this autonomously.
+        https://github.com/IgorGanapolsky/Random-Timer/issues/268
+```
+
+## When to Use
+
+| Scenario | Use `/delegate` |
+|----------|-----------------|
+| Simple feature additions | ✅ Yes |
+| Bug fixes with clear repro | ✅ Yes |
+| Refactoring with clear scope | ✅ Yes |
+| Complex architectural changes | ❌ No (do manually) |
+| Security-sensitive code | ❌ No (review carefully) |
+| Unclear requirements | ❌ No (clarify first) |

--- a/.claude/skills/dual-review.md
+++ b/.claude/skills/dual-review.md
@@ -1,0 +1,82 @@
+# Dual AI Review Skill
+
+Trigger: `/dual-review` or when user opens a PR and wants comprehensive AI review
+
+## Description
+
+Trigger both Claude and Copilot to review a PR, then synthesize their feedback.
+
+## Workflow
+
+1. **Identify PR**
+   - Get PR number from user or current branch
+   - Fetch PR details via GitHub API
+
+2. **Trigger Reviews**
+
+   Claude review runs automatically via `.github/workflows/claude-review.yml`
+
+   Copilot review runs automatically if auto-review is enabled in repo settings
+
+3. **Fetch Review Comments**
+   ```bash
+   # Get Claude review (from Actions bot)
+   curl -s -H "Authorization: token $GITHUB_PAT" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/pulls/<pr>/comments" \
+     | jq '.[] | select(.user.login == "github-actions[bot]")'
+
+   # Get Copilot review
+   curl -s -H "Authorization: token $GITHUB_PAT" \
+     "https://api.github.com/repos/IgorGanapolsky/Random-Timer/pulls/<pr>/reviews" \
+     | jq '.[] | select(.user.login == "copilot[bot]")'
+   ```
+
+4. **Synthesize Feedback**
+   - Combine unique issues from both reviewers
+   - Prioritize by severity (Critical > Style > Suggestion)
+   - Create action items
+
+5. **Report Summary**
+   ```markdown
+   ## AI Review Summary for PR #<number>
+
+   ### Critical Issues (must fix)
+   - [Claude] SafeAreaView imported from wrong package (file:line)
+   - [Copilot] Missing error handling in async function
+
+   ### Style Issues (should fix)
+   - [Claude] Use spacing.md instead of 16
+   - [Copilot] Consider extracting to custom hook
+
+   ### Suggestions (nice to have)
+   - [Copilot] Add JSDoc comments
+   ```
+
+## Checks Performed
+
+| Reviewer | Focus Area |
+|----------|------------|
+| **Claude** | SafeAreaView imports, MMKV imports, theme usage, Redux patterns, project-specific rules |
+| **Copilot** | General code quality, security, performance, best practices, test coverage |
+
+## Example Usage
+
+```
+User: /dual-review 264
+
+Claude: Fetching reviews for PR #264...
+
+## AI Review Summary for PR #264
+
+### Claude Review
+✅ No critical issues found
+- Style: Consider using named export in line 45
+
+### Copilot Review
+✅ No critical issues found
+- Suggestion: Add unit tests for new function
+
+### Combined Action Items
+1. [ ] Add named export (optional)
+2. [ ] Add unit tests (recommended)
+```

--- a/.claude/skills/sync-copilot-memory.md
+++ b/.claude/skills/sync-copilot-memory.md
@@ -1,0 +1,110 @@
+# Sync Copilot Memory Skill
+
+Trigger: `/sync-memory` or when Copilot seems to forget project patterns
+
+## Description
+
+Reinforce GitHub Copilot's memory by making interactions that teach it project patterns.
+
+## Why This Exists
+
+Copilot Memory (agentic memory) learns from interactions but can forget or miss patterns. This skill:
+1. Reviews current Copilot instructions
+2. Tests if Copilot remembers them
+3. Reinforces patterns through targeted interactions
+
+## Workflow
+
+1. **Check Current Instructions**
+   ```bash
+   cat .github/copilot-instructions.md
+   cat .github/instructions/*.instructions.md
+   ```
+
+2. **Test Memory via GitHub API**
+
+   Create a test interaction in Copilot Chat (via Copilot Spaces API if available)
+   or document patterns for manual reinforcement.
+
+3. **Generate Reinforcement Prompts**
+
+   Create prompts that teach Copilot the critical rules:
+
+   ```
+   Prompt 1: "In this React Native project, how should I import SafeAreaView?"
+   Expected: "Import from 'react-native-safe-area-context', not 'react-native'"
+
+   Prompt 2: "How do I access persistent storage in this app?"
+   Expected: "Use storage from '@shared/utils/storage', not MMKV directly"
+
+   Prompt 3: "What colors should I use for the timer states?"
+   Expected: "colors.timerActive (green), colors.timerWarning (amber), colors.timerDanger (rose)"
+   ```
+
+4. **Update Instructions if Needed**
+
+   If Copilot consistently misses a pattern:
+   - Add explicit rule to `.github/copilot-instructions.md`
+   - Add example to path-specific instructions
+   - Create targeted `.instructions.md` file
+
+## Memory Reinforcement Checklist
+
+Run through these in VS Code Copilot Chat periodically:
+
+- [ ] Ask about SafeAreaView import → should mention react-native-safe-area-context
+- [ ] Ask about storage → should mention @shared/utils/storage
+- [ ] Ask about colors → should reference theme system
+- [ ] Ask about spacing → should mention spacing constants
+- [ ] Ask about Redux → should mention typed hooks
+- [ ] Ask about new screen → should mention Screen component wrapper
+
+## Troubleshooting
+
+**Copilot ignoring instructions?**
+1. Verify `.github/copilot-instructions.md` is on default branch
+2. Check file is under 8KB (Copilot has size limits)
+3. Ensure instructions are clear and specific
+4. Try more explicit wording
+
+**Memory not persisting?**
+1. Memory is scoped to repository
+2. Expires after 28 days of no interaction
+3. Check https://github.com/settings/copilot for memory management
+4. Consider creating Copilot Space for persistent context
+
+## Manual Memory Sync
+
+If automated approaches fail, manually reinforce by:
+
+1. Opening Copilot Chat in VS Code
+2. Asking: "Read the .github/copilot-instructions.md file and summarize the key rules"
+3. Then asking project-specific questions to verify understanding
+4. Correcting any wrong answers (Copilot learns from corrections)
+
+## Example Session
+
+```
+User: /sync-memory
+
+Claude: Testing Copilot memory for Random Timer project...
+
+Testing SafeAreaView knowledge...
+✅ Copilot correctly identifies react-native-safe-area-context
+
+Testing storage knowledge...
+⚠️ Copilot mentioned MMKV directly, not @shared/utils/storage
+
+Reinforcement needed. Adding explicit example to instructions...
+
+Updated .github/copilot-instructions.md with:
+```typescript
+// WRONG - never do this
+import { MMKV } from 'react-native-mmkv';
+
+// CORRECT - always use the wrapper
+import { storage } from '@shared/utils/storage';
+```
+
+Memory sync complete. Test again in next session.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,8 +256,75 @@ Located in `~/.claude-shared/skills/`, symlinked to `.claude/shared-skills/`
 ### Project-Specific Skills
 Located in `.claude/skills/`
 
-These skills are specific to Random-Timer and not shared with other projects.
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| `/ralph-mode` | Complex tasks, iterations | Track attempts in ATTEMPTS.md with specs and learnings |
+| `/self-heal` | After mistakes | Consolidate lessons from feedback logs |
+| `/delegate` | Delegate to Copilot | Create issue and assign to GitHub Copilot coding agent |
+| `/copilot-agent` | Full Copilot workflow | Create detailed issue with context for Copilot |
+| `/dual-review` | PR review | Synthesize feedback from both Claude and Copilot |
+| `/auto-pr` | Autonomous PR | Create PR, wait for CI + AI reviews, auto-merge |
+| `/sync-memory` | Copilot memory | Reinforce Copilot's memory of project patterns |
 
 ### Adding Skills
 - **Shared skill:** Create in `~/.claude-shared/skills/`
 - **Project skill:** Create in `.claude/skills/`
+
+---
+
+## Autonomous Operation
+
+### Hooks System
+The project uses Claude Code hooks for autonomous operation:
+
+| Hook | Purpose |
+|------|---------|
+| `SessionStart` | Load context, RAG injection, pre-flight checks |
+| `UserPromptSubmit` | Validate user prompts |
+| `PreToolUse` | Validate commands before execution |
+| `PostToolUse` | Auto-RLHF feedback capture, anti-pattern detection |
+| `PermissionRequest` | Auto-approve safe read operations |
+| `Stop` | Verify task completion, log incomplete work |
+
+### Self-Improvement Protocol
+When I make a mistake:
+1. The error is automatically logged to `.claude/memory/feedback/feedback-log.jsonl`
+2. At session start, past mistakes are loaded via RAG
+3. Run `/self-heal` periodically to consolidate lessons
+
+### Automatic Anti-Pattern Detection
+The PostToolUse hook detects:
+- SafeAreaView from wrong import
+- Direct MMKV imports
+- Hardcoded colors outside theme
+- Dangerous bash commands
+- Edits to sensitive files
+
+### CI/CD Integration
+PRs are automatically reviewed by dual AI systems:
+
+**Claude (via GitHub Actions):**
+- Critical checks (imports, theme, TypeScript)
+- Style suggestions
+- Security scan
+- On-demand assist via `@claude` mention in PR comments
+
+**GitHub Copilot (native):**
+- Automatic code review on all PRs
+- Copilot coding agent for issue implementation
+- Copilot Memory for pattern learning
+
+### GitHub Copilot Integration
+
+The project uses GitHub Copilot Pro features:
+
+| Feature | How to Use |
+|---------|------------|
+| **Coding Agent** | Assign issue to `@copilot` or use `/delegate` skill |
+| **Code Review** | Automatic on all PRs |
+| **Memory** | Learns patterns from `.github/copilot-instructions.md` |
+| **Spaces** | Bundle project context (optional) |
+
+Custom instructions location:
+- `.github/copilot-instructions.md` - Main rules
+- `.github/instructions/*.instructions.md` - Path-specific rules


### PR DESCRIPTION
## Summary
New Claude Code skills for autonomous GitHub Copilot workflows:

| Skill | Purpose |
|-------|--------|
| `/delegate` | Quick delegation to Copilot coding agent |
| `/copilot-agent` | Full Copilot issue workflow with project context |
| `/dual-review` | Synthesize Claude + Copilot PR feedback |
| `/auto-pr` | Create PR, wait for CI + AI, auto-merge |
| `/sync-memory` | Reinforce Copilot memory of project patterns |

## Changes
- Added 5 new skills in `.claude/skills/`
- Updated CLAUDE.md with GitHub Copilot integration docs
- Documented dual AI review system

## Test plan
- [ ] Test `/delegate` with a simple task
- [ ] Verify skills appear in Claude Code
- [ ] Test `/auto-pr` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)