### PR TITLE
fix: update Claude Review action to native app context

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,7 +34,6 @@ jobs:
             4. No google-services.json, .env, or local.properties committed
 
             STYLE CHECKS (suggest improvements):
-            - Named exports only (no default exports)
             - Android: Coroutines with delay() instead of Handler(Looper)
             - iOS: Swift concurrency (async/await) over completion handlers
             - Both platforms: Match animation timing parity


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` to full commit SHA to fix recurring SDK crash
- Update review prompt from legacy React Native/Expo context to native Kotlin/Swift
- Update assist prompt to match current architecture

## Context
The Claude Review CI check has been failing with an SDK crash (`Claude Code process exited with code 1`) on every PR. This pins to a specific SHA and fixes the outdated prompt that referenced React Native libraries no longer in the codebase.

## Test plan
- [ ] Verify Claude Review check passes on this PR (meta-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)