### PR TITLE
fix: store publishing readiness — signing, secrets, workflow paths

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -75,9 +75,9 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > app/src/main/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
           else
-            echo '{"project_info":{"project_number":"","project_id":"","storage_bucket":""},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000","android_client_info":{"package_name":"com.iganapolsky.randomtimer"}},"api_key":[{"current_key":""}]}]}' > app/src/main/google-services.json
+            echo '{"project_info":{"project_number":"","project_id":"","storage_bucket":""},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000","android_client_info":{"package_name":"com.iganapolsky.randomtimer"}},"api_key":[{"current_key":""}]}]}' > app/google-services.json
           fi
         working-directory: native-android
 


### PR DESCRIPTION
## Summary
- Fixed `google-services.json` path in release workflow (was `app/src/main/`, corrected to `app/`)
- Added secret validation and error handling to native release workflow
- Configured Android signing (keystore, bundle ID) and Play Store upload via service account
- Updated iOS Fastlane config for TestFlight

All required GitHub secrets are now set:
- `GOOGLE_SERVICES_JSON` (Firebase config)
- `ANDROID_KEYSTORE_BASE64` / `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD`
- `GOOGLE_PLAY_JSON_KEY` (Play Store service account)
- `APPSTORE_PRIVATE_KEY` / `APPSTORE_KEY_ID` / `APPSTORE_ISSUER_ID`

## Test plan
- [ ] Trigger `Native App Release` workflow with platform=android
- [ ] Trigger `Native App Release` workflow with platform=ios
- [ ] Verify AAB artifact is uploaded
- [ ] Verify Play Store internal track receives the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)