### PR TITLE
feat: closed testing track for production access

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -102,7 +102,7 @@ jobs:
         run: ./gradlew bundleRelease
         working-directory: native-android
 
-      - name: Upload to Google Play (internal track)
+      - name: Upload to Google Play (closed testing track)
         env:
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
         run: |
@@ -140,12 +140,12 @@ jobs:
               service.edits().tracks().update(
                   packageName=PACKAGE,
                   editId=edit_id,
-                  track='internal',
+                  track='alpha',
                   body={'releases': [{'versionCodes': [bundle['versionCode']], 'status': 'completed'}]}
               ).execute()
 
               service.edits().commit(packageName=PACKAGE, editId=edit_id).execute()
-              print(f"✅ Uploaded version code {bundle['versionCode']} to internal track")
+              print(f"✅ Uploaded version code {bundle['versionCode']} to closed testing (alpha) track")
           except Exception as e:
               print(f"❌ Google Play upload failed: {e}", file=sys.stderr)
               sys.exit(1)

--- a/native-android/fastlane/Fastfile
+++ b/native-android/fastlane/Fastfile
@@ -26,6 +26,18 @@ platform :android do
     )
   end
 
+  desc "Upload AAB to closed testing (alpha) track"
+  lane :closed do
+    upload_to_play_store(
+      package_name: "com.iganapolsky.randomtimer",
+      track: "alpha",
+      aab: "app/build/outputs/bundle/release/app-release.aab",
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+
   desc "Promote internal to production"
   lane :promote do
     upload_to_play_store(


### PR DESCRIPTION
## Summary
- Switch Play Store upload from internal to closed testing (alpha) track
- Add `closed` Fastlane lane targeting alpha track
- Required for 12-tester/14-day closed testing gate before production access

## Test plan
- [ ] Trigger Native App Release workflow for Android
- [ ] Verify AAB uploads to alpha track in Play Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)