### PR TITLE
fix(ci): upgrade upload-artifact action to v4 in security pipeline

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload Security Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-results-${{ matrix.scan-type }}
           path: |


### PR DESCRIPTION
## Summary\n- replace deprecated `actions/upload-artifact@v3` with `@v4` in `.github/workflows/security.yml`\n- unblocks scheduled `Security Pipeline` run that was auto-failing during setup\n\n## Verification\n- confirmed failing run 21969908019 reported artifact v3 deprecation\n- this PR updates the deprecated action usage