### PR TITLE
fix(security-ci): make npm-audit-helper advisory in scheduled scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Run npm-audit-helper
         if: matrix.scan-type == 'dependencies'
+        continue-on-error: true
         working-directory: native-android
         run: npx npm-audit-helper@latest --audit-level=moderate
 


### PR DESCRIPTION
## Summary
- make `npm-audit-helper` advisory (`continue-on-error: true`) in `security.yml`

## Why
- latest `Security Pipeline` run on `develop` still failed from `npm-audit-helper` non-zero exit despite scanner results being intended as informational in this workflow
- Snyk and MobSF are already treated as advisory in the same pipeline

## Evidence
- run `21972671188` failed at `security-scan (dependencies) -> Run npm-audit-helper`
