### PR TITLE
chore: ignore local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ expo-env.d.ts
 # Metro
 .metro-health-check*
 
+# Gradle/Android build artifacts
+**/.gradle/
+**/build/
+native-android/fastlane/README.md
+native-android/fastlane/report.xml
+
 # debug
 npm-debug.*
 yarn-debug.*


### PR DESCRIPTION
Ignores Gradle/build outputs that were showing up as untracked files after local Android builds.