### PR TITLE
Remove AD_ID permission, bump to v1.1.1

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = 35
-        versionCode = 4
-        versionName = "1.1.0"
+        versionCode = 5
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-android/app/src/main/AndroidManifest.xml
+++ b/native-android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
     <!-- Allow timer notifications to bypass Do Not Disturb -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
+    <!-- Remove AD_ID permission added by dependencies (Firebase/PostHog) — app does not use advertising ID -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
+
     <application
         android:name=".RandomTimerApp"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- Remove `com.google.android.gms.permission.AD_ID` inherited from Firebase via `tools:node="remove"`
- Bump versionCode 4→5, versionName 1.1.0→1.1.1
- Resolves Google Play Console conflict: AD_ID permission in binary vs "No" declaration

## Test plan
- [ ] CI builds release AAB successfully
- [ ] AAB does not contain AD_ID permission
- [ ] Google Play API commit succeeds for closed testing track

🤖 Generated with [Claude Code](https://claude.com/claude-code)