### PR TITLE
fix: POSIX-compatible preflight-release.sh for macOS CI

### DIFF
--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -238,7 +238,10 @@ if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
   # - at least 3 iPad 13" screenshots
   IOS_SCREENSHOTS_DIR="$PROJECT_ROOT/native-ios/fastlane/screenshots/en-US"
   if [[ -d "$IOS_SCREENSHOTS_DIR" ]]; then
-    mapfile -t IOS_SCREENSHOTS < <(find "$IOS_SCREENSHOTS_DIR" -maxdepth 1 -name "*.png" -type f 2>/dev/null | sort)
+    IOS_SCREENSHOTS=()
+    while IFS= read -r -d '' _f; do
+      IOS_SCREENSHOTS+=("$_f")
+    done < <(find "$IOS_SCREENSHOTS_DIR" -maxdepth 1 -name "*.png" -type f -print0 2>/dev/null | sort -z)
     IOS_SHOTS="${#IOS_SCREENSHOTS[@]}"
     if (( IOS_SHOTS < 6 )); then
       err "iOS screenshots: expected at least 6 PNG files in $IOS_SCREENSHOTS_DIR, found $IOS_SHOTS"


### PR DESCRIPTION
## Summary
- Replaces `mapfile` (bash 4+) with a POSIX-compatible `while/read` loop in `preflight-release.sh`
- macOS CI runners ship with bash 3.x which lacks `mapfile`, causing `exit code 127` in the native release workflow
- Uses null-delimited `find -print0` + `sort -z` for safe filename handling

## Test plan
- [ ] iOS preflight job passes on macOS runner (bash 3.x)
- [ ] Screenshot counting logic still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)