### PR TITLE
fix(release): use match-based iOS signing in CI

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -40,6 +40,20 @@ jobs:
         run: gem install fastlane
         working-directory: native-ios
 
+      - name: Validate iOS signing secrets
+        env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: |
+          if [ -z "$MATCH_GIT_URL" ]; then
+            echo "❌ MATCH_GIT_URL secret is not set"
+            exit 1
+          fi
+          if [ -z "$MATCH_PASSWORD" ]; then
+            echo "❌ MATCH_PASSWORD secret is not set"
+            exit 1
+          fi
+
       - name: Write API key
         env:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
@@ -47,6 +61,15 @@ jobs:
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
           echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+
+      - name: Setup signing certificates and profiles (match)
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: fastlane setup
+        working-directory: native-ios
 
       - name: Verify App Store Connect API access
         env:

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -70,11 +70,22 @@ platform :ios do
   desc "Setup certificates and profiles"
   lane :setup do
     if ENV["MATCH_GIT_URL"]
+      api_key = nil
+      if ENV["APPSTORE_KEY_ID"] && ENV["APPSTORE_ISSUER_ID"]
+        api_key = app_store_connect_api_key(
+          key_id: ENV["APPSTORE_KEY_ID"],
+          issuer_id: ENV["APPSTORE_ISSUER_ID"],
+          key_filepath: File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{ENV['APPSTORE_KEY_ID']}.p8")
+        )
+      end
+
+      running_in_ci = ENV["CI"] == "true"
       match(
         type: "appstore",
         app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
-        readonly: false,
-        force_for_new_devices: true
+        readonly: running_in_ci,
+        force_for_new_devices: !running_in_ci,
+        api_key: api_key
       )
     else
       UI.message("No MATCH_GIT_URL set - using Xcode automatic signing")


### PR DESCRIPTION
## Summary
- add explicit iOS signing secret validation in `native-release` workflow
- run `fastlane setup` (match) before `fastlane beta` in CI
- update fastlane `setup` lane to use App Store Connect API key and CI-safe readonly match behavior

## Why
The iOS release job fails with `No Accounts` / missing provisioning profiles on GitHub-hosted macOS runners. This change switches CI to deterministic certificate/profile installation via match instead of relying on local Xcode account state.

## Verification
- release workflow should now fail fast if match secrets are missing
- release workflow should progress past profile resolution when match secrets are present
