### PR TITLE
fix(release): provide match git auth in CI

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: |
           if [ -z "$MATCH_GIT_URL" ]; then
             echo "❌ MATCH_GIT_URL secret is not set"
@@ -51,6 +52,10 @@ jobs:
           fi
           if [ -z "$MATCH_PASSWORD" ]; then
             echo "❌ MATCH_PASSWORD secret is not set"
+            exit 1
+          fi
+          if [ -z "$MATCH_GIT_BASIC_AUTHORIZATION" ]; then
+            echo "❌ MATCH_GIT_BASIC_AUTHORIZATION secret is not set"
             exit 1
           fi
 
@@ -68,6 +73,7 @@ jobs:
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: fastlane setup
         working-directory: native-ios
 


### PR DESCRIPTION
## Summary
- require `MATCH_GIT_BASIC_AUTHORIZATION` in iOS release workflow validation
- pass `MATCH_GIT_BASIC_AUTHORIZATION` into the `fastlane setup` (match) step

## Why
`match` failed in CI with `could not read Username for 'https://github.com': terminal prompts disabled`, which means the certificates repo URL is private and needed explicit non-interactive Git credentials.
