### PR TITLE
fix: match step continue-on-error for signing fallback

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -74,6 +74,7 @@ jobs:
           git config --global url."https://x-access-token:${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup signing certificates and profiles (match)
+        continue-on-error: true
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}


### PR DESCRIPTION
## Summary
- Makes the fastlane match step `continue-on-error: true` in the release workflow
- The match certificates repo doesn't have provisioning profiles yet (readonly mode fails)
- The `beta` lane uses `-allowProvisioningUpdates` for Xcode automatic signing, so match is not strictly required

## Test plan
- [ ] iOS release workflow proceeds past match failure to build step
- [ ] Xcode automatic signing works with the API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)