### PR TITLE
fix: provide match git auth in CI

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -16,10 +16,18 @@ platform :ios do
     end
 
     # Build with automatic signing
+    xc_args = "-allowProvisioningUpdates"
+    if ENV["APPSTORE_KEY_ID"] && ENV["APPSTORE_ISSUER_ID"]
+      key_path = File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{ENV['APPSTORE_KEY_ID']}.p8")
+      xc_args += " -authenticationKeyPath '#{key_path}'"
+      xc_args += " -authenticationKeyID '#{ENV['APPSTORE_KEY_ID']}'"
+      xc_args += " -authenticationKeyIssuerID '#{ENV['APPSTORE_ISSUER_ID']}'"
+    end
+
     build_app(
       scheme: "RandomTimer",
       export_method: "app-store",
-      xcargs: "-allowProvisioningUpdates"
+      xcargs: xc_args
     )
 
     # Upload to TestFlight


### PR DESCRIPTION
## Summary
- Passes App Store Connect API key authentication to xcodebuild via `-authenticationKeyPath`, `-authenticationKeyID`, and `-authenticationKeyIssuerID` flags
- Fixes CI build failure: `No profiles found` and `No Accounts: Add a new account in Accounts settings`
- The `-allowProvisioningUpdates` flag requires authentication credentials in CI where no Apple ID is logged in

## Test plan
- [ ] iOS build succeeds on CI with automatic signing
- [ ] TestFlight upload completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)