### PR TITLE
fix(release): use match-based iOS signing in CI

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -74,7 +74,6 @@ jobs:
           git config --global url."https://x-access-token:${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup signing certificates and profiles (match)
-        continue-on-error: true
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -87,12 +87,10 @@ platform :ios do
         )
       end
 
-      running_in_ci = ENV["CI"] == "true"
       match(
         type: "appstore",
         app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
-        readonly: running_in_ci,
-        force_for_new_devices: !running_in_ci,
+        readonly: false,
         api_key: api_key
       )
     else


### PR DESCRIPTION
## Summary
- Sets match `readonly: false` so it can create distribution certificates and provisioning profiles on first CI run
- Removes `continue-on-error` from the match step — match must succeed for proper IPA export signing
- Fixes: `exportArchive` was hanging indefinitely because `-allowProvisioningUpdates` couldn't find/create profiles

## Root cause
The match certificates repo was empty. With `readonly: true`, match couldn't create profiles, so none were installed. The build archive succeeded but IPA export hung trying to auto-provision.

## Test plan
- [ ] Match creates App Store distribution profiles in CI
- [ ] IPA export completes without hanging
- [ ] TestFlight upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)