### PR TITLE
fix(release): remove auto-provisioning flags that hang CI export

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -15,19 +15,10 @@ platform :ios do
       )
     end
 
-    # Build with automatic signing
-    xc_args = "-allowProvisioningUpdates"
-    if ENV["APPSTORE_KEY_ID"] && ENV["APPSTORE_ISSUER_ID"]
-      key_path = File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{ENV['APPSTORE_KEY_ID']}.p8")
-      xc_args += " -authenticationKeyPath '#{key_path}'"
-      xc_args += " -authenticationKeyID '#{ENV['APPSTORE_KEY_ID']}'"
-      xc_args += " -authenticationKeyIssuerID '#{ENV['APPSTORE_ISSUER_ID']}'"
-    end
-
+    # Build with match-installed signing profiles (no auto-provisioning needed)
     build_app(
       scheme: "RandomTimer",
-      export_method: "app-store",
-      xcargs: xc_args
+      export_method: "app-store"
     )
 
     # Upload to TestFlight


### PR DESCRIPTION
## Summary
- Removes `-allowProvisioningUpdates` and `-authenticationKey*` xcargs from `build_app`
- These flags cause `xcodebuild -exportArchive` to hang indefinitely on CI (22+ min before timeout)
- Match already installs distribution profiles, so auto-provisioning is unnecessary

## Root cause
`-allowProvisioningUpdates` with API key auth causes xcodebuild to attempt remote provisioning during IPA export, which hangs on GitHub Actions macOS runners. The archive step succeeds but the export never completes.

## Test plan
- [ ] IPA export completes within ~5 min (not hanging)
- [ ] TestFlight upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)