### PR TITLE
fix(release): drop manual-signing branch for iOS archive

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -15,25 +15,12 @@ platform :ios do
       )
     end
 
-    # In CI with match profiles, disable automatic signing and build with
-    # match-installed certificates. Without match, fall back to auto-signing.
-    if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"]
-      update_code_signing_settings(
-        use_automatic_signing: false,
-        path: "RandomTimer.xcodeproj"
-      )
-
-      build_app(
-        scheme: "RandomTimer",
-        export_method: "app-store"
-      )
-    else
-      build_app(
-        scheme: "RandomTimer",
-        export_method: "app-store",
-        xcargs: "-allowProvisioningUpdates"
-      )
-    end
+    # Keep provisioning updates enabled, but do not pass auth-key xcargs.
+    build_app(
+      scheme: "RandomTimer",
+      export_method: "app-store",
+      xcargs: "-allowProvisioningUpdates"
+    )
 
     # Upload to TestFlight
     upload_to_testflight(


### PR DESCRIPTION
## Summary
- removes manual-signing branch in `fastlane beta`
- uses `build_app(..., xcargs: "-allowProvisioningUpdates")` directly
- keeps auth-key xcargs removed (no `-authenticationKey*` flags)

## Why
Latest iOS release run (`22082368491`) fails with:
- `"RandomTimer" requires a provisioning profile`
- `"RandomTimerWidgetExtension" requires a provisioning profile`

Manual signing without explicit profile specifiers fails archive on CI.

## Validation
- `ruby -c native-ios/fastlane/Fastfile` => Syntax OK
- CI + fresh iOS release run after merge