### PR TITLE
fix(release): deterministic iOS CI signing with match profiles

### DIFF
--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CURRENT_PROJECT_VERSION = 11;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -15,12 +15,47 @@ platform :ios do
       )
     end
 
-    # Keep provisioning updates enabled, but do not pass auth-key xcargs.
-    build_app(
-      scheme: "RandomTimer",
-      export_method: "app-store",
-      xcargs: "-allowProvisioningUpdates"
-    )
+    if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"]
+      # CI runners do not have Apple ID accounts configured; force manual signing
+      # with match-managed App Store profiles for deterministic archives.
+      app_profile = "match AppStore com.igorganapolsky.randomtimer"
+      widget_profile = "match AppStore com.igorganapolsky.randomtimer.widget"
+
+      update_code_signing_settings(
+        path: "RandomTimer.xcodeproj",
+        use_automatic_signing: false,
+        targets: ["RandomTimer"],
+        code_sign_identity: "Apple Distribution",
+        profile_name: app_profile
+      )
+
+      update_code_signing_settings(
+        path: "RandomTimer.xcodeproj",
+        use_automatic_signing: false,
+        targets: ["RandomTimerWidgetExtension"],
+        code_sign_identity: "Apple Distribution",
+        profile_name: widget_profile
+      )
+
+      build_app(
+        scheme: "RandomTimer",
+        export_method: "app-store",
+        export_options: {
+          signingStyle: "manual",
+          provisioningProfiles: {
+            "com.igorganapolsky.randomtimer" => app_profile,
+            "com.igorganapolsky.randomtimer.widget" => widget_profile
+          }
+        }
+      )
+    else
+      # Local/dev fallback when match is not configured.
+      build_app(
+        scheme: "RandomTimer",
+        export_method: "app-store",
+        xcargs: "-allowProvisioningUpdates"
+      )
+    end
 
     # Upload to TestFlight
     upload_to_testflight(


### PR DESCRIPTION
## Summary
- force manual signing in CI with explicit match profile mapping for app + widget
- set Release signing identity to Apple Distribution in Xcode project
- keep local fallback path using automatic signing + -allowProvisioningUpdates

## Why
Latest iOS release run () failed at archive with:
- No Accounts on CI runner
- No profiles for com.igorganapolsky.randomtimer / widget

This patch removes account dependency in CI and signs via match-installed App Store profiles.

## Validation
- Syntax OK -> Syntax OK
- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild simulator build (no-signing) passes locally
-  passes locally