### PR TITLE
fix(release): resolve dynamic match profile names in iOS CI

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -18,8 +18,17 @@ platform :ios do
     if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"]
       # CI runners do not have Apple ID accounts configured; force manual signing
       # with match-managed App Store profiles for deterministic archives.
-      app_profile = "match AppStore com.igorganapolsky.randomtimer"
-      widget_profile = "match AppStore com.igorganapolsky.randomtimer.widget"
+      match(
+        type: "appstore",
+        app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
+        readonly: true,
+        api_key: defined?(api_key) ? api_key : nil
+      )
+
+      app_profile = ENV["sigh_com.igorganapolsky.randomtimer_appstore_profile-name"] ||
+                    "match AppStore com.igorganapolsky.randomtimer"
+      widget_profile = ENV["sigh_com.igorganapolsky.randomtimer.widget_appstore_profile-name"] ||
+                       "match AppStore com.igorganapolsky.randomtimer.widget"
 
       update_code_signing_settings(
         path: "RandomTimer.xcodeproj",


### PR DESCRIPTION
## Summary
- run  inside [20:31:33]: [33mGet started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile[0m
[20:31:34]: Could not find fastlane in current directory. Make sure to have your fastlane configuration files inside a folder called "fastlane". Would you like to set fastlane up?

Looking for related GitHub issues on fastlane/fastlane...

➡️  /opt/homebrew/Cellar/fastlane/2.211.0_1/libexec/gems/fastlane-2.211.0/fastlane_core/lib/fastlane_core/ui/interface.rb:129:in `crash!': [!] Could not retrieve response as fastlane runs in non-interactive mode (FastlaneCore::Interface::FastlaneCrash)
    https://github.com/fastlane/fastlane/issues/20974 [open] 15 💬
    22 Jul 2025

➡️  Can not Publish to the App Store Production track
    https://github.com/fastlane/fastlane/issues/19674 [open] 29 💬
    09 Aug 2024

➡️   Could not retrieve response as fastlane runs in non-interactive mode\e[0m (FastlaneCore::Interface::FastlaneCrash)
    https://github.com/fastlane/fastlane/issues/20607 [closed] 8 💬
    28 Dec 2025

and 58 more at: https://github.com/fastlane/fastlane/search?q=Could%20not%20retrieve%20response%20as%20fastlane%20runs%20in%20non-interactive%20mode&type=Issues&utf8=✓

🔗  You can ⌘ + double-click on links to open them directly in your browser. CI path
- read actual installed profile names from  env vars
- use resolved names for manual signing + export mapping

## Root cause fixed
 produced profile name with suffix (example: ) but build was pinned to unsuffixed name, causing archive failure:
.

## Validation
- Syntax OK => Syntax OK