### PR TITLE
fix(release): query ASC builds without unsupported version filter

### DIFF
--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -316,19 +316,22 @@ class AppStoreVerifier:
         try:
             app_id = self._get_app_id()
 
-            # Query builds filtered by version
+            # App Store Connect /builds does not consistently support filter[version].
+            # Query by app and filter by version client-side.
             data = self._request(
                 "/builds",
                 params={
                     "filter[app]": app_id,
-                    "filter[version]": version,
                     "sort": "-uploadedDate",
-                    "limit": 5,
+                    "limit": 50,
                     "fields[builds]": "version,processingState,uploadedDate,buildNumber",
                 },
             )
 
-            builds = data.get("data", [])
+            builds = [
+                b for b in data.get("data", [])
+                if (b.get("attributes", {}).get("version") == version)
+            ]
             if not builds:
                 return {
                     "passed": False,


### PR DESCRIPTION
## Summary
- remove  from App Store Connect  request in 
- fetch recent builds for app and filter by  client-side

## Why
Release run  had successful iOS upload but  failed with HTTP 400 from ASC builds endpoint due unsupported/invalid filter parameter.

## Validation
- 