### PR TITLE
fix(release): avoid interactive target prompt in fastlane

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -14,8 +14,14 @@ platform :ios do
       )
     end
 
-    marketing_version = get_version_number(xcodeproj: "RandomTimer.xcodeproj")
-    current_build_number = get_build_number(xcodeproj: "RandomTimer.xcodeproj").to_i
+    marketing_version = get_version_number(
+      xcodeproj: "RandomTimer.xcodeproj",
+      target: "RandomTimer"
+    )
+    current_build_number = get_build_number(
+      xcodeproj: "RandomTimer.xcodeproj",
+      target: "RandomTimer"
+    ).to_i
     next_build_number = current_build_number + 1
 
     if defined?(api_key)


### PR DESCRIPTION
## Summary
- set explicit target "RandomTimer" for get_version_number and get_build_number
- prevents fastlane from prompting to choose a target in non-interactive CI

## Verification
- ruby -c native-ios/fastlane/Fastfile

## Context
Release run 22102371381 failed at get_version_number with: "Could not retrieve response as fastlane runs in non-interactive mode".