### PR TITLE
fix(release): remove invalid get_build_number target option

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -19,8 +19,7 @@ platform :ios do
       target: "RandomTimer"
     )
     current_build_number = get_build_number(
-      xcodeproj: "RandomTimer.xcodeproj",
-      target: "RandomTimer"
+      xcodeproj: "RandomTimer.xcodeproj"
     ).to_i
     next_build_number = current_build_number + 1
 


### PR DESCRIPTION
## Summary
- keep explicit target for get_version_number to avoid interactive prompt
- remove unsupported target option from get_build_number action

## Verification
- ruby -c native-ios/fastlane/Fastfile

## Context
Release run 22102587376 failed with: "Could not find option target in get_build_number".