### PR TITLE
ci: replace gitleaks action with OSS CLI scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
 
           if [[ -n "$RANGE" ]]; then
             echo "Scanning commit range: $RANGE"
-            gitleaks git --no-banner --redact --exit-code 1 --log-opts "$RANGE"
+            gitleaks git --no-banner --redact --exit-code 1 --log-opts "--all $RANGE"
           else
             echo "Scanning full git history fallback"
             gitleaks git --no-banner --redact --exit-code 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -107,11 +107,11 @@ jobs:
           if [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
             RANGE="${BEFORE_SHA}..${HEAD_SHA}"
             echo "Scanning commit range: $RANGE"
-            gitleaks git --no-banner --redact --exit-code 1 --log-opts "$RANGE"
+            gitleaks git --no-banner --redact --exit-code 1 --log-opts "--all $RANGE"
           elif git rev-parse "${HEAD_SHA}~1" >/dev/null 2>&1; then
             RANGE="${HEAD_SHA}~1..${HEAD_SHA}"
             echo "Scanning fallback range: $RANGE"
-            gitleaks git --no-banner --redact --exit-code 1 --log-opts "$RANGE"
+            gitleaks git --no-banner --redact --exit-code 1 --log-opts "--all $RANGE"
           else
             echo "Scanning full git history fallback"
             gitleaks git --no-banner --redact --exit-code 1


### PR DESCRIPTION
## Summary
- replace `gitleaks/gitleaks-action@v2` in CI workflow with OSS gitleaks CLI install + run
- replace `gitleaks/gitleaks-action@v2` in Security Pipeline with OSS gitleaks CLI install + run
- scan bounded commit ranges for push/PR events with fallback to previous commit/full history

## Why
Recent CI failures were caused by gitleaks action license checks, not actual secret findings. This keeps secret scanning enabled without requiring a paid action license.

## Validation
- parsed workflow YAML locally for `.github/workflows/ci.yml` and `.github/workflows/security.yml`
- reviewed generated diff for only intended files