### PR TITLE
ci(release): align iOS verify version source with fastlane

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -335,7 +335,20 @@ jobs:
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
 
           # iOS version from app Info.plist (same source used by fastlane get_version_number)
-          IOS_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" native-ios/RandomTimer/Info.plist 2>/dev/null || echo "")
+          # Use Python plistlib so this works on ubuntu-latest and macOS.
+          IOS_VERSION=$(python - <<'PY'
+import plistlib
+from pathlib import Path
+
+plist_path = Path("native-ios/RandomTimer/Info.plist")
+if not plist_path.exists():
+    print("")
+else:
+    with plist_path.open("rb") as f:
+        data = plistlib.load(f)
+    print(data.get("CFBundleShortVersionString", ""))
+PY
+)
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Determine platform flag


### PR DESCRIPTION
## Summary
- read iOS verification version from `native-ios/RandomTimer/Info.plist`
- use the same source as fastlane `get_version_number` to avoid false `NOT_FOUND`

## Why
Release uploads succeeded, but `verify-releases` failed because it checked `1.1.1` from `project.pbxproj` while the uploaded marketing version was `1.1.0` from Info.plist.

## Validation
- inspected failing run `22110073099`
- confirmed fastlane uploaded version `1.1.0` and verifier expected `1.1.1`
