### PR TITLE
ci(release): fix native-release workflow YAML

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -335,20 +335,8 @@ jobs:
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
 
           # iOS version from app Info.plist (same source used by fastlane get_version_number)
-          # Use Python plistlib so this works on ubuntu-latest and macOS.
-          IOS_VERSION=$(python - <<'PY'
-import plistlib
-from pathlib import Path
-
-plist_path = Path("native-ios/RandomTimer/Info.plist")
-if not plist_path.exists():
-    print("")
-else:
-    with plist_path.open("rb") as f:
-        data = plistlib.load(f)
-    print(data.get("CFBundleShortVersionString", ""))
-PY
-)
+          # Use a one-liner so this stays valid YAML and works on ubuntu-latest and macOS.
+          IOS_VERSION=$(python -c "import plistlib; from pathlib import Path; p=Path('native-ios/RandomTimer/Info.plist'); print(plistlib.load(p.open('rb')).get('CFBundleShortVersionString','') if p.exists() else '')" 2>/dev/null || echo "")
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Determine platform flag


### PR DESCRIPTION
## Fix
`native-release.yml` was invalid YAML due to an unindented heredoc-style Python snippet inside a `run: |` block.

This broke GitHub’s workflow parser, causing:
- push runs to fail instantly with no jobs
- `workflow_dispatch` calls to return HTTP 422: "Workflow does not have 'workflow_dispatch' trigger"

## Change
Replace the multi-line `python - <<'PY'` snippet with a safe `python -c` one-liner to extract `CFBundleShortVersionString`.

## Evidence
- Before: PyYAML parse failed (ScannerError at the first unindented `import plistlib` line)
- After: PyYAML parse succeeds.
