### PR TITLE
fix(ios): align Info.plist versioning with MARKETING_VERSION

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -408,9 +408,9 @@ jobs:
       - name: Extract iOS version
         id: versions
         run: |
-          IOS_VERSION=$(python -c "import plistlib; from pathlib import Path; p=Path('native-ios/RandomTimer/Info.plist'); print(plistlib.load(p.open('rb')).get('CFBundleShortVersionString','') if p.exists() else '')" 2>/dev/null || echo "")
+          IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | grep -oP '[\\d.]+' || echo "")
           if [ -z "$IOS_VERSION" ]; then
-            echo "❌ Could not read iOS version from native-ios/RandomTimer/Info.plist"
+            echo "❌ Could not read iOS version from native-ios/RandomTimer.xcodeproj/project.pbxproj"
             exit 1
           fi
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"

--- a/native-ios/RandomTimer/Info.plist
+++ b/native-ios/RandomTimer/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSSupportsLiveActivities</key>

--- a/native-ios/RandomTimerWidget/Info.plist
+++ b/native-ios/RandomTimerWidget/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Fixes CI/TestFlight verification mismatch by making CFBundleShortVersionString and CFBundleVersion follow Xcode build settings.

- native-ios/RandomTimer/Info.plist: use $(MARKETING_VERSION) and $(CURRENT_PROJECT_VERSION)
- native-ios/RandomTimerWidget/Info.plist: same
- native-release workflow: ios-submit-review job now derives version from MARKETING_VERSION (pbxproj)

This ensures fastlane (get_version_number), the built app bundle version, and release verification all agree.
