### PR TITLE
fix(release): run ios-submit-review and attach build before submission

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -391,7 +391,8 @@ jobs:
 
   ios-submit-review:
     needs: [verify-releases]
-    if: ${{ inputs.submit_review && (inputs.platform == 'ios' || inputs.platform == 'both') && needs.verify-releases.result == 'success' }}
+    # workflow_dispatch inputs are delivered as strings; parse the boolean explicitly.
+    if: ${{ fromJSON(github.event.inputs.submit_review || 'false') && (github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both') && needs.verify-releases.result == 'success' }}
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -456,6 +457,14 @@ jobs:
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
           echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+
+      - name: Upload App Store metadata/screenshots + attach build
+        env:
+          CI: "true"
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        run: fastlane metadata version:${{ steps.versions.outputs.ios_version }}
+        working-directory: native-ios
 
       - name: Submit for App Review (App Store)
         env:

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -124,9 +124,24 @@ platform :ios do
     end
 
     version = options[:version] || get_version_number(xcodeproj: "RandomTimer.xcodeproj", target: "RandomTimer")
+    build_number = options[:build_number]
+
+    if (build_number.nil? || build_number.to_s.strip.empty?) && defined?(api_key)
+      begin
+        build_number = latest_testflight_build_number(
+          api_key: api_key,
+          app_identifier: "com.igorganapolsky.randomtimer",
+          version: version
+        )
+      rescue => e
+        UI.important("Could not determine latest TestFlight build number for v#{version}: #{e}")
+      end
+    end
+
     deliver(
       app_identifier: "com.igorganapolsky.randomtimer",
       app_version: version,
+      build_number: (build_number.to_s.strip.empty? ? nil : build_number.to_s),
       skip_binary_upload: true,
       skip_screenshots: false,
       force: true,
@@ -134,7 +149,7 @@ platform :ios do
     )
   end
 
-  desc "Submit a given version for App Review (uploads metadata + attaches build)"
+  desc "Submit a given version for App Review (attach build + submit)"
   lane :submit_review do |options|
     setup_ci if ENV["CI"] == "true"
 
@@ -174,7 +189,9 @@ platform :ios do
       submit_for_review: true,
       automatic_release: false,
       skip_binary_upload: true,
-      skip_screenshots: false,
+      # Upload screenshots/metadata in `metadata` lane first for deterministic gating.
+      skip_screenshots: options.key?(:skip_screenshots) ? options[:skip_screenshots] : true,
+      skip_metadata: options.key?(:skip_metadata) ? options[:skip_metadata] : true,
       force: true,
       api_key: defined?(api_key) ? api_key : nil
     )


### PR DESCRIPTION
Fixes the iOS App Store submission automation so it actually executes when submit_review=true, and ensures the App Store version has the VALID build attached before the readiness gate/submission.

- Parse workflow_dispatch boolean input reliably (inputs are strings)
- Run fastlane metadata before asc_verify_ready.py and submit_review
- Fastlane metadata lane now resolves/uses the latest TestFlight build_number so deliver attaches the build
