### PR TITLE
fix(release): make ios-submit-review actually run

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -391,8 +391,18 @@ jobs:
 
   ios-submit-review:
     needs: [verify-releases]
-    # workflow_dispatch inputs are delivered as strings; parse the boolean explicitly.
-    if: ${{ fromJSON(github.event.inputs.submit_review || 'false') && (github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both') && needs.verify-releases.result == 'success' }}
+    # `workflow_dispatch` inputs can be booleans (newer UI) or strings (API/CLI).
+    # Treat this as enabled only when explicitly true.
+    if: >-
+      ${{
+        needs.verify-releases.result == 'success' &&
+        (inputs.platform == 'ios' || inputs.platform == 'both') &&
+        (
+          inputs.submit_review == true ||
+          inputs.submit_review == 'true' ||
+          github.event.inputs.submit_review == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -422,23 +432,6 @@ jobs:
         run: |
           echo "$APPSTORE_PRIVATE_KEY" > /tmp/appstore_key.p8
 
-      - name: Verify App Store submission readiness (hard gate)
-        env:
-          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
-          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-          APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
-        run: |
-          python scripts/asc_verify_ready.py \
-            --version "${{ steps.versions.outputs.ios_version }}" \
-            --json /tmp/asc_ready.json
-
-      - name: Upload readiness report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: asc-ready-report
-          path: /tmp/asc_ready.json
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
@@ -465,6 +458,23 @@ jobs:
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
         run: fastlane metadata version:${{ steps.versions.outputs.ios_version }}
         working-directory: native-ios
+
+      - name: Verify App Store submission readiness (hard gate)
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
+        run: |
+          python scripts/asc_verify_ready.py \
+            --version "${{ steps.versions.outputs.ios_version }}" \
+            --json /tmp/asc_ready.json
+
+      - name: Upload readiness report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: asc-ready-report
+          path: /tmp/asc_ready.json
 
       - name: Submit for App Review (App Store)
         env:


### PR DESCRIPTION
Fixes Native App Release so ios-submit-review actually executes when submit_review=true, and ensures the readiness gate runs after metadata/build attachment.

- Robust boolean parsing for workflow_dispatch inputs (boolean vs string)
- Run fastlane metadata first, then scripts/asc_verify_ready.py, then fastlane submit_review

Evidence: run 22115666316 had App Store state NOT_SUBMITTED and ios-submit-review was skipped.
