### PR TITLE
ci(release): make submit_review dispatch reliable

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -14,9 +14,15 @@ on:
         default: 'both'
       submit_review:
         description: 'iOS only: submit the App Store version for App Review after verification'
-        type: boolean
+        # `type: boolean` can be unreliable when dispatched via `gh workflow run -f submit_review=true`
+        # (we've observed the `ios-submit-review` job being skipped). Use a string choice so UI/CLI/API
+        # always pass consistent values.
+        type: choice
+        options:
+          - 'false'
+          - 'true'
         required: false
-        default: false
+        default: 'false'
 
 jobs:
   ios-testflight:
@@ -343,6 +349,15 @@ jobs:
           IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | grep -oP '[\d.]+' || echo "")
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Debug workflow inputs (no secrets)
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "inputs.platform=${{ inputs.platform }}"
+          echo "inputs.submit_review=${{ inputs.submit_review }}"
+          echo "github.event.inputs.platform=${{ github.event.inputs.platform }}"
+          echo "github.event.inputs.submit_review=${{ github.event.inputs.submit_review }}"
+          echo "github.event.inputs(json)=${{ toJSON(github.event.inputs) }}"
+
       - name: Determine platform flag
         id: platform
         run: |
@@ -398,7 +413,6 @@ jobs:
         needs.verify-releases.result == 'success' &&
         (inputs.platform == 'ios' || inputs.platform == 'both') &&
         (
-          inputs.submit_review == true ||
           inputs.submit_review == 'true' ||
           github.event.inputs.submit_review == 'true'
         )


### PR DESCRIPTION
Problem
- `ios-submit-review` was repeatedly skipped even when dispatching `native-release.yml` with `submit_review=true` from the GitHub CLI.

Root cause
- `workflow_dispatch` boolean inputs are not reliably represented across UI/CLI/API (observed in real runs). That caused the job-level `if:` to evaluate false.

Changes
- Switch `submit_review` input from boolean to a string choice: `'false' | 'true'`.
- Add a safe debug step (no secrets) to print the resolved input values in `verify-releases`.
- Simplify the submit condition to only accept `'true'`.

Verification plan
1. Dispatch `Native App Release` on `develop` with `platform=ios` and `submit_review=true`.
2. Confirm logs show the debug step resolving `submit_review` to `'true'`.
3. Confirm `ios-submit-review` runs, uploads metadata/attaches build, passes `asc_verify_ready.py`, and submits for review.
