### PR TITLE
ci(release): ensure ios-submit-review runs when submit_review=true

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -408,15 +408,7 @@ jobs:
     needs: [verify-releases]
     # `workflow_dispatch` inputs can be booleans (newer UI) or strings (API/CLI).
     # Treat this as enabled only when explicitly true.
-    if: >-
-      ${{
-        needs.verify-releases.result == 'success' &&
-        (inputs.platform == 'ios' || inputs.platform == 'both') &&
-        (
-          inputs.submit_review == 'true' ||
-          github.event.inputs.submit_review == 'true'
-        )
-      }}
+    if: ${{ needs.verify-releases.result == 'success' && (github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' || inputs.platform == 'ios' || inputs.platform == 'both') && (github.event.inputs.submit_review == true || github.event.inputs.submit_review == 'true' || inputs.submit_review == true || inputs.submit_review == 'true') }}
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
Problem
- `ios-submit-review` is still being skipped even when workflow dispatch inputs clearly show `platform=ios` and `submit_review=true`.

Evidence
- Run 22116941317: `verify-releases` printed `inputs.submit_review=true` and `github.event.inputs.submit_review=true`, but `ios-submit-review` had 0 steps and was skipped.

Fix
- Make the job `if:` robust to either boolean `true` or string `'true'` for both `inputs.*` and `github.event.inputs.*`, and keep the expression on a single line to avoid YAML block-scalar quirks.

Verification
1. Dispatch `Native App Release` on `develop` with `platform=ios` and `submit_review=true`.
2. Confirm `ios-submit-review` runs (not skipped) and executes metadata upload, ASC readiness gate, and submission.
