### PR TITLE
ci(release): reliably gate ios-submit-review steps

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -406,23 +406,45 @@ jobs:
 
   ios-submit-review:
     needs: [verify-releases]
-    # `workflow_dispatch` inputs can be booleans (newer UI) or strings (API/CLI).
-    # Treat this as enabled only when explicitly true.
-    if: ${{ needs.verify-releases.result == 'success' && (github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' || inputs.platform == 'ios' || inputs.platform == 'both') && (github.event.inputs.submit_review == true || github.event.inputs.submit_review == 'true' || inputs.submit_review == true || inputs.submit_review == 'true') }}
+    # Run after verification. Gate privileged steps at runtime by reading the dispatch payload,
+    # because job-level `if:` on workflow_dispatch inputs has been brittle in practice.
+    if: ${{ needs.verify-releases.result == 'success' }}
     runs-on: ubuntu-latest
     environment: production
     steps:
       - uses: actions/checkout@v4
 
+      - name: Gate submit-for-review (no secrets)
+        id: gate
+        run: |
+          set -euo pipefail
+          PLATFORM=$(jq -r '.inputs.platform // ""' "$GITHUB_EVENT_PATH")
+          SUBMIT_REVIEW=$(jq -r '.inputs.submit_review // ""' "$GITHUB_EVENT_PATH")
+
+          ENABLED="false"
+          if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
+            if [[ "$SUBMIT_REVIEW" == "true" || "$SUBMIT_REVIEW" == "1" ]]; then
+              ENABLED="true"
+            fi
+          fi
+
+          echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+          echo "submit_review=$SUBMIT_REVIEW" >> "$GITHUB_OUTPUT"
+          echo "enabled=$ENABLED" >> "$GITHUB_OUTPUT"
+          echo "gate: platform=$PLATFORM submit_review=$SUBMIT_REVIEW enabled=$ENABLED"
+
       - name: Setup Python
+        if: steps.gate.outputs.enabled == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Install dependencies (ASC)
+        if: steps.gate.outputs.enabled == 'true'
         run: pip install pyjwt cryptography requests
 
       - name: Extract iOS version
+        if: steps.gate.outputs.enabled == 'true'
         id: versions
         run: |
           IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | grep -oP '[\\d.]+' || echo "")
@@ -433,12 +455,14 @@ jobs:
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Write App Store Connect key (for API)
+        if: steps.gate.outputs.enabled == 'true'
         env:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
         run: |
           echo "$APPSTORE_PRIVATE_KEY" > /tmp/appstore_key.p8
 
       - name: Setup Ruby
+        if: steps.gate.outputs.enabled == 'true'
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           ruby-version: '3.2'
@@ -446,10 +470,12 @@ jobs:
           working-directory: native-ios
 
       - name: Install Fastlane
+        if: steps.gate.outputs.enabled == 'true'
         run: gem install fastlane
         working-directory: native-ios
 
       - name: Write App Store Connect key (Fastlane convention)
+        if: steps.gate.outputs.enabled == 'true'
         env:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -458,6 +484,7 @@ jobs:
           echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
 
       - name: Upload App Store metadata/screenshots + attach build
+        if: steps.gate.outputs.enabled == 'true'
         env:
           CI: "true"
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -466,6 +493,7 @@ jobs:
         working-directory: native-ios
 
       - name: Verify App Store submission readiness (hard gate)
+        if: steps.gate.outputs.enabled == 'true'
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
@@ -477,12 +505,13 @@ jobs:
 
       - name: Upload readiness report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ${{ steps.gate.outputs.enabled == 'true' && always() }}
         with:
           name: asc-ready-report
           path: /tmp/asc_ready.json
 
       - name: Submit for App Review (App Store)
+        if: steps.gate.outputs.enabled == 'true'
         env:
           CI: "true"
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -491,6 +520,7 @@ jobs:
         working-directory: native-ios
 
       - name: Verify App Store submission state
+        if: steps.gate.outputs.enabled == 'true'
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}


### PR DESCRIPTION
Problem
- Even after fixing input types/conditions, `ios-submit-review` is still being skipped in workflow_dispatch runs where inputs show `platform=ios` and `submit_review=true`.

Evidence
- Run 22117260368: `verify-releases` printed `inputs.submit_review=true` and `github.event.inputs.submit_review=true`, yet `ios-submit-review` had 0 steps and was skipped.

Fix
- Avoid job-level `if:` on workflow_dispatch inputs.
- Always run the job after `verify-releases` succeeds, then gate all privileged steps by parsing the real dispatch payload from `GITHUB_EVENT_PATH` using `jq`.
- Ensure all steps that touch secrets or App Store Connect are conditional on `gate.outputs.enabled == 'true'`.

Outcome
- When `submit_review=true` and `platform in {ios,both}`, the submission steps will run reliably.
- When disabled, the job is a no-op and does not touch secrets.
