### PR TITLE
ci(ios): fix version resolution in submit-for-review workflow

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -75,7 +75,12 @@ jobs:
           fi
           # Info.plist commonly contains build-setting placeholders like $(MARKETING_VERSION).
           # Read MARKETING_VERSION directly from the Xcode project for a stable X.Y.Z value.
-          IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | sed -n 's/.*= *\\([0-9]*\\.[0-9]*\\.[0-9]*\\).*/\\1/p' || true)
+          IOS_VERSION=$(
+            grep -Eo 'MARKETING_VERSION = [0-9]+\\.[0-9]+\\.[0-9]+' native-ios/RandomTimer.xcodeproj/project.pbxproj \
+              | head -n 1 \
+              | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' \
+              || true
+          )
           if [ -z "$IOS_VERSION" ]; then
             echo "❌ Could not determine iOS version (MARKETING_VERSION) from Xcode project"
             exit 1


### PR DESCRIPTION
Fix
- `iOS Submit For Review` workflow failed at "Resolve iOS version" because `grep -m1 MARKETING_VERSION` can hit a placeholder/empty config first.

Change
- Extract the first `MARKETING_VERSION = X.Y.Z` match anywhere in `native-ios/RandomTimer.xcodeproj/project.pbxproj`.

Evidence
- Failed run: 22118058014 (could not determine MARKETING_VERSION).

Next
- Re-run `iOS Submit For Review` on `develop` with `dry_run=false` to submit once preflight passes.
