### PR TITLE
ci(ios): unblock fastlane metadata uploads in CI

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -145,6 +145,9 @@ platform :ios do
       skip_binary_upload: true,
       skip_screenshots: false,
       force: true,
+      # Fastlane precheck can't inspect IAP via App Store Connect API keys; avoid blocking CI uploads.
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false,
       api_key: defined?(api_key) ? api_key : nil
     )
   end


### PR DESCRIPTION
deliver precheck fails when using App Store Connect API keys because it can't inspect IAP. Disable precheck (and IAP checks) for the metadata upload lane so the ios-submit-review workflow can proceed.