### PR TITLE
fix(asc): autofill Support URL/Privacy URL during submission

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, Iterable, Optional
 
 APP_STORE_CONNECT_API = "https://api.appstoreconnect.apple.com/v1"
 
+FASTLANE_METADATA_DIR = os.path.join("native-ios", "fastlane", "metadata")
+
 
 def die(msg: str, code: int = 1) -> "None":
     print(f"❌ {msg}", file=sys.stderr)
@@ -25,6 +27,80 @@ def die(msg: str, code: int = 1) -> "None":
 def info(msg: str) -> None:
     print(f"▸ {msg}")
 
+
+def _read_text_file(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+
+def resolve_metadata_url(*, locale: str, kind: str) -> str:
+    """Resolve a URL from env override or fastlane metadata file.
+
+    kind: "support_url" | "privacy_url" | "marketing_url"
+    """
+    env_key = {
+        "support_url": "ASC_SUPPORT_URL",
+        "privacy_url": "ASC_PRIVACY_URL",
+        "marketing_url": "ASC_MARKETING_URL",
+    }.get(kind)
+    if not env_key:
+        return ""
+
+    env_val = (os.environ.get(env_key) or "").strip()
+    if env_val:
+        return env_val
+
+    path = os.path.join(FASTLANE_METADATA_DIR, locale, f"{kind}.txt")
+    return _read_text_file(path)
+
+
+def patch_resource_attributes(client: "ASCClient", *, path: str, type_name: str, resource_id: str, attrs: dict) -> None:
+    client.request(
+        "PATCH",
+        path,
+        payload={
+            "data": {
+                "type": type_name,
+                "id": resource_id,
+                "attributes": attrs,
+            }
+        },
+    )
+
+
+def ensure_app_info_urls(client: "ASCClient", *, loc_id: str, locale: str, attrs: dict[str, Any]) -> dict[str, Any]:
+    """Ensure support/privacy URLs are set on the App Info localization.
+
+    If missing, try to fill from env/fastlane metadata and read back.
+    """
+    desired_support = resolve_metadata_url(locale=locale, kind="support_url")
+    desired_privacy = resolve_metadata_url(locale=locale, kind="privacy_url")
+
+    to_set: dict[str, str] = {}
+    if not (attrs.get("supportUrl") or "").strip() and desired_support:
+        to_set["supportUrl"] = desired_support
+    if not (attrs.get("privacyPolicyUrl") or "").strip() and desired_privacy:
+        to_set["privacyPolicyUrl"] = desired_privacy
+
+    if to_set:
+        info(f"Filling missing App Info URL fields for {locale}: {', '.join(sorted(to_set.keys()))}")
+        try:
+            patch_resource_attributes(
+                client,
+                path=f"/appInfoLocalizations/{loc_id}",
+                type_name="appInfoLocalizations",
+                resource_id=loc_id,
+                attrs=to_set,
+            )
+            refreshed = client.request("GET", f"/appInfoLocalizations/{loc_id}").get("data") or {}
+            return (refreshed.get("attributes") or {}) if isinstance(refreshed, dict) else attrs
+        except Exception as e:
+            die(f"Failed to update App Info URLs for locale {locale}: {e}")
+
+    return attrs
 
 def _read_private_key_material(key_id: str) -> str:
     key = (os.environ.get("APPSTORE_PRIVATE_KEY") or "").strip()
@@ -383,8 +459,13 @@ def verify_app_info(client: ASCClient, app_id: str, locale: str) -> dict[str, An
     if not loc:
         die(f"Missing app info localization for {locale} (App Information).")
 
+    loc_id = str(loc.get("id") or "").strip()
+    if not loc_id:
+        die(f"Missing app info localization id for {locale} (App Information).")
+
     loc_attrs = loc.get("attributes") or {}
     info_attrs = app_info.get("attributes") or {}
+    loc_attrs = ensure_app_info_urls(client, loc_id=loc_id, locale=locale, attrs=loc_attrs)
     privacy = (loc_attrs.get("privacyPolicyUrl") or info_attrs.get("privacyPolicyUrl") or "").strip()
     support = (loc_attrs.get("supportUrl") or info_attrs.get("supportUrl") or "").strip()
     ensure_https(privacy, "Privacy Policy URL")

--- a/scripts/tests/test_asc_submit_for_review.py
+++ b/scripts/tests/test_asc_submit_for_review.py
@@ -91,8 +91,76 @@ class AscSubmitForReviewVerifyAppInfoTests(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit):
-            with contextlib.redirect_stderr(io.StringIO()):
-                verify_app_info(client, "6758355312", "en-US")
+            with contextlib.redirect_stdout(io.StringIO()):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    verify_app_info(client, "6758355312", "en-US")
+
+    def test_verify_app_info_autofills_support_url_when_missing(self):
+        import os
+        import io as _io
+        import contextlib as _contextlib
+        from scripts.asc_submit_for_review import verify_app_info
+
+        class _RouterClient:
+            def __init__(self):
+                self.calls = []
+
+            def request(self, method, path, *, params=None, payload=None):
+                self.calls.append({"method": method, "path": path, "params": params, "payload": payload})
+                if method == "GET" and path == "/apps/app1/appInfos":
+                    return {
+                        "data": [
+                            {
+                                "id": "info1",
+                                "type": "appInfos",
+                                "attributes": {},
+                                "relationships": {
+                                    "primaryCategory": {"data": {"type": "appCategories", "id": "cat1"}},
+                                    "appInfoLocalizations": {"data": [{"type": "appInfoLocalizations", "id": "loc1"}]},
+                                },
+                            }
+                        ],
+                        "included": [
+                            {
+                                "id": "loc1",
+                                "type": "appInfoLocalizations",
+                                "attributes": {
+                                    "locale": "en-US",
+                                    "privacyPolicyUrl": "https://example.com/privacy",
+                                    "supportUrl": "",
+                                },
+                            }
+                        ],
+                    }
+                if method == "PATCH" and path == "/appInfoLocalizations/loc1":
+                    return {}
+                if method == "GET" and path == "/appInfoLocalizations/loc1":
+                    # Return the updated object
+                    return {
+                        "data": {
+                            "id": "loc1",
+                            "type": "appInfoLocalizations",
+                            "attributes": {
+                                "locale": "en-US",
+                                "privacyPolicyUrl": "https://example.com/privacy",
+                                "supportUrl": os.environ.get("ASC_SUPPORT_URL"),
+                            },
+                        }
+                    }
+                raise RuntimeError(f"unhandled {method} {path}")
+
+        prev = os.environ.get("ASC_SUPPORT_URL")
+        os.environ["ASC_SUPPORT_URL"] = "https://example.com/support"
+        try:
+            client = _RouterClient()
+            with _contextlib.redirect_stdout(_io.StringIO()):
+                verify_app_info(client, "app1", "en-US")
+            self.assertTrue(any(c["method"] == "PATCH" and c["path"] == "/appInfoLocalizations/loc1" for c in client.calls))
+        finally:
+            if prev is None:
+                os.environ.pop("ASC_SUPPORT_URL", None)
+            else:
+                os.environ["ASC_SUPPORT_URL"] = prev
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Unblocks App Store submission when App Store Connect is missing Support URL (and/or Privacy Policy URL).

Why:
- Workflow run `22119756739` failed with `❌ Support URL is empty` after metadata upload.

What:
- `scripts/asc_submit_for_review.py` now auto-fills missing `supportUrl`/`privacyPolicyUrl` on the `appInfoLocalization` using:
  1) env overrides (`ASC_SUPPORT_URL`, `ASC_PRIVACY_URL`), else
  2) Fastlane metadata files (`native-ios/fastlane/metadata/<locale>/support_url.txt`, `privacy_url.txt`).
- Adds unit test coverage so this can’t regress.

After merge:
- Re-run workflow `iOS Submit For Review` on `develop` for version `1.1.1`.
