### PR TITLE
fix(asc): supportURL schema + resilient URL autofill

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -57,6 +57,19 @@ def resolve_metadata_url(*, locale: str, kind: str) -> str:
     return _read_text_file(path)
 
 
+def _get_url(attrs: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        val = (attrs.get(key) or "").strip()
+        if val:
+            return val
+    return ""
+
+
+def _is_unknown_attr_error(exc: Exception, *, attr_key: str) -> bool:
+    msg = str(exc)
+    return ("ATTRIBUTE.UNKNOWN" in msg) and (f"/data/attributes/{attr_key}" in msg or f"'{attr_key}'" in msg)
+
+
 def patch_resource_attributes(client: "ASCClient", *, path: str, type_name: str, resource_id: str, attrs: dict) -> None:
     client.request(
         "PATCH",
@@ -71,6 +84,45 @@ def patch_resource_attributes(client: "ASCClient", *, path: str, type_name: str,
     )
 
 
+def _patch_first_supported_attr(
+    client: "ASCClient",
+    *,
+    path: str,
+    type_name: str,
+    resource_id: str,
+    attrs: dict[str, Any],
+    desired: dict[str, str],
+    candidates: list[str],
+) -> dict[str, Any]:
+    """Try to PATCH using the first attribute key supported by ASC's current schema.
+
+    We prefer keys present in the current attributes payload; otherwise we attempt each candidate
+    key and continue on ATTRIBUTE.UNKNOWN errors.
+    """
+    # Prefer keys that already exist in the schema payload.
+    for key in candidates:
+        if key in attrs and desired.get(key):
+            patch_resource_attributes(client, path=path, type_name=type_name, resource_id=resource_id, attrs={key: desired[key]})
+            refreshed = client.request("GET", path).get("data") or {}
+            return (refreshed.get("attributes") or {}) if isinstance(refreshed, dict) else attrs
+
+    # Otherwise, probe each candidate.
+    for key in candidates:
+        val = desired.get(key)
+        if not val:
+            continue
+        try:
+            patch_resource_attributes(client, path=path, type_name=type_name, resource_id=resource_id, attrs={key: val})
+            refreshed = client.request("GET", path).get("data") or {}
+            return (refreshed.get("attributes") or {}) if isinstance(refreshed, dict) else attrs
+        except Exception as e:
+            if _is_unknown_attr_error(e, attr_key=key):
+                continue
+            raise
+
+    return attrs
+
+
 def ensure_app_info_urls(client: "ASCClient", *, loc_id: str, locale: str, attrs: dict[str, Any]) -> dict[str, Any]:
     """Ensure support/privacy URLs are set on the App Info localization.
 
@@ -79,24 +131,41 @@ def ensure_app_info_urls(client: "ASCClient", *, loc_id: str, locale: str, attrs
     desired_support = resolve_metadata_url(locale=locale, kind="support_url")
     desired_privacy = resolve_metadata_url(locale=locale, kind="privacy_url")
 
-    to_set: dict[str, str] = {}
-    if not (attrs.get("supportUrl") or "").strip() and desired_support:
-        to_set["supportUrl"] = desired_support
-    if not (attrs.get("privacyPolicyUrl") or "").strip() and desired_privacy:
-        to_set["privacyPolicyUrl"] = desired_privacy
+    support_val = _get_url(attrs, "supportUrl", "supportURL")
+    privacy_val = _get_url(attrs, "privacyPolicyUrl", "privacyPolicyURL")
 
-    if to_set:
-        info(f"Filling missing App Info URL fields for {locale}: {', '.join(sorted(to_set.keys()))}")
+    desired: dict[str, str] = {}
+    if not support_val and desired_support:
+        desired["supportURL"] = desired_support
+        desired["supportUrl"] = desired_support
+    if not privacy_val and desired_privacy:
+        desired["privacyPolicyUrl"] = desired_privacy
+        desired["privacyPolicyURL"] = desired_privacy
+
+    keys = []
+    if not support_val and desired_support:
+        keys.append("support")
+    if not privacy_val and desired_privacy:
+        keys.append("privacy")
+
+    if keys:
+        info(f"Filling missing App Info URL fields for {locale}: {', '.join(keys)}")
         try:
-            patch_resource_attributes(
+            updated = _patch_first_supported_attr(
                 client,
                 path=f"/appInfoLocalizations/{loc_id}",
                 type_name="appInfoLocalizations",
                 resource_id=loc_id,
-                attrs=to_set,
+                attrs=attrs,
+                desired=desired,
+                candidates=["supportURL", "supportUrl", "privacyPolicyUrl", "privacyPolicyURL"],
             )
-            refreshed = client.request("GET", f"/appInfoLocalizations/{loc_id}").get("data") or {}
-            return (refreshed.get("attributes") or {}) if isinstance(refreshed, dict) else attrs
+            # Preserve the resolved values even if ASC uses different key casing.
+            if desired_support and not _get_url(updated, "supportUrl", "supportURL"):
+                updated["supportURL"] = desired_support
+            if desired_privacy and not _get_url(updated, "privacyPolicyUrl", "privacyPolicyURL"):
+                updated["privacyPolicyUrl"] = desired_privacy
+            return updated
         except Exception as e:
             die(f"Failed to update App Info URLs for locale {locale}: {e}")
 
@@ -466,8 +535,8 @@ def verify_app_info(client: ASCClient, app_id: str, locale: str) -> dict[str, An
     loc_attrs = loc.get("attributes") or {}
     info_attrs = app_info.get("attributes") or {}
     loc_attrs = ensure_app_info_urls(client, loc_id=loc_id, locale=locale, attrs=loc_attrs)
-    privacy = (loc_attrs.get("privacyPolicyUrl") or info_attrs.get("privacyPolicyUrl") or "").strip()
-    support = (loc_attrs.get("supportUrl") or info_attrs.get("supportUrl") or "").strip()
+    privacy = _get_url(loc_attrs, "privacyPolicyUrl", "privacyPolicyURL") or _get_url(info_attrs, "privacyPolicyUrl", "privacyPolicyURL")
+    support = _get_url(loc_attrs, "supportUrl", "supportURL") or _get_url(info_attrs, "supportUrl", "supportURL")
     ensure_https(privacy, "Privacy Policy URL")
     ensure_https(support, "Support URL")
 
@@ -475,8 +544,8 @@ def verify_app_info(client: ASCClient, app_id: str, locale: str) -> dict[str, An
     resolved = dict(loc_attrs)
     if privacy and not resolved.get("privacyPolicyUrl"):
         resolved["privacyPolicyUrl"] = privacy
-    if support and not resolved.get("supportUrl"):
-        resolved["supportUrl"] = support
+    if support and not _get_url(resolved, "supportUrl", "supportURL"):
+        resolved["supportURL"] = support
     return resolved
 
 

--- a/scripts/tests/test_asc_submit_for_review.py
+++ b/scripts/tests/test_asc_submit_for_review.py
@@ -61,7 +61,8 @@ class AscSubmitForReviewVerifyAppInfoTests(unittest.TestCase):
         self.assertEqual(params.get("include"), "appInfoLocalizations,primaryCategory")
 
     def test_verify_app_info_requires_support_and_privacy_urls(self):
-        from scripts.asc_submit_for_review import verify_app_info
+        import scripts.asc_submit_for_review as asc
+        verify_app_info = asc.verify_app_info
 
         client = _FakeClient(
             {
@@ -90,10 +91,15 @@ class AscSubmitForReviewVerifyAppInfoTests(unittest.TestCase):
             }
         )
 
-        with self.assertRaises(SystemExit):
-            with contextlib.redirect_stdout(io.StringIO()):
-                with contextlib.redirect_stderr(io.StringIO()):
-                    verify_app_info(client, "6758355312", "en-US")
+        prev_dir = asc.FASTLANE_METADATA_DIR
+        asc.FASTLANE_METADATA_DIR = "/__missing_fastlane_metadata__"
+        try:
+            with self.assertRaises(SystemExit):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    with contextlib.redirect_stderr(io.StringIO()):
+                        verify_app_info(client, "6758355312", "en-US")
+        finally:
+            asc.FASTLANE_METADATA_DIR = prev_dir
 
     def test_verify_app_info_autofills_support_url_when_missing(self):
         import os
@@ -127,12 +133,15 @@ class AscSubmitForReviewVerifyAppInfoTests(unittest.TestCase):
                                 "attributes": {
                                     "locale": "en-US",
                                     "privacyPolicyUrl": "https://example.com/privacy",
-                                    "supportUrl": "",
+                                    "supportURL": "",
                                 },
                             }
                         ],
                     }
                 if method == "PATCH" and path == "/appInfoLocalizations/loc1":
+                    # Newer schema uses supportURL.
+                    if "supportURL" not in (payload or {}).get("data", {}).get("attributes", {}):
+                        raise RuntimeError("expected supportURL patch")
                     return {}
                 if method == "GET" and path == "/appInfoLocalizations/loc1":
                     # Return the updated object
@@ -143,7 +152,7 @@ class AscSubmitForReviewVerifyAppInfoTests(unittest.TestCase):
                             "attributes": {
                                 "locale": "en-US",
                                 "privacyPolicyUrl": "https://example.com/privacy",
-                                "supportUrl": os.environ.get("ASC_SUPPORT_URL"),
+                                "supportURL": os.environ.get("ASC_SUPPORT_URL"),
                             },
                         }
                     }


### PR DESCRIPTION
Unblocks `iOS Submit For Review` when App Store Connect uses `supportURL` (not `supportUrl`) on `appInfoLocalizations`.

Evidence:
- Workflow run `22120044882` failed with ASC API error:
  - `HTTP 409 ENTITY_ERROR.ATTRIBUTE.UNKNOWN` (`supportUrl` not an attribute on `appInfoLocalizations`).

Fix:
- `scripts/asc_submit_for_review.py`
  - reads support/privacy URLs from both `supportUrl`/`supportURL` and `privacyPolicyUrl`/`privacyPolicyURL`.
  - autofill PATCH probes supported attribute keys (continues on ATTRIBUTE.UNKNOWN).
  - keeps fastlane metadata fallback (`native-ios/fastlane/metadata/<locale>/support_url.txt`, `privacy_url.txt`).
- Unit tests updated to cover `supportURL` schema.

After merge:
- Re-run workflow `iOS Submit For Review` on `develop` for version `1.1.1`.
