### PR TITLE
fix(asc): pricing schedule inline id must be a local-id

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -653,7 +653,8 @@ def verify_pricing(client: ASCClient, app_id: str) -> None:
 
     if free_point_id:
         info(f"Pricing not set; creating Free price schedule (base territory {territory})…")
-        manual_price_id = "manualPrice-0"
+        # Inline creation IDs must be local IDs in the form '${local-id}'.
+        manual_price_id = "$manualPrice0"
         payload = {
             "data": {
                 "type": "appPriceSchedules",

--- a/scripts/tests/test_asc_submit_for_review_pricing.py
+++ b/scripts/tests/test_asc_submit_for_review_pricing.py
@@ -91,7 +91,13 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
         self.assertIn("/appPriceSchedules", paths)
         self.assertIn("/apps/app1/appPricePoints", paths)
         self.assertIn("/appPriceSchedules", paths)
-        self.assertTrue(any(c["method"] == "POST" and c["path"] == "/appPriceSchedules" for c in client.calls))
+        post = next((c for c in client.calls if c["method"] == "POST" and c["path"] == "/appPriceSchedules"), None)
+        self.assertIsNotNone(post)
+        payload = (post or {}).get("payload") or {}
+        included = payload.get("included") or []
+        self.assertTrue(included and isinstance(included[0], dict))
+        local_id = (included[0].get("id") or "")
+        self.assertTrue(isinstance(local_id, str) and local_id.startswith("$"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Unblocks `iOS Submit For Review` when pricing is missing and the script tries to create a Free price schedule.

Evidence:
- Workflow run `22120260259` failed:
  - `HTTP 409 ENTITY_ERROR.INCLUDED.INVALID_ID`: included id must be local id `${local-id}`.

Fix:
- `scripts/asc_submit_for_review.py`: use `$manualPrice0` (local id) for inline `included` `appPrices` creation.
- `scripts/tests/test_asc_submit_for_review_pricing.py`: assert POST payload uses a `$...` local id.

After merge: re-run workflow `iOS Submit For Review` on `develop` (version `1.1.1`).
