### PR TITLE
fix(asc): use ${...} local id for inline Free pricing

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -661,7 +661,8 @@ def verify_pricing(client: ASCClient, app_id: str) -> None:
         die("Pricing not set (could not find Free price point and legacy /prices is unavailable).")
 
     info(f"Pricing not set; creating Free price schedule (base territory {territory})…")
-    manual_price_id = "manualPrice-0"
+    # Inline creation IDs must be local IDs in the form '${local-id}'.
+    manual_price_id = "${manualPrice0}"
     payload = {
         "data": {
             "type": "appPriceSchedules",

--- a/scripts/tests/test_asc_submit_for_review_pricing.py
+++ b/scripts/tests/test_asc_submit_for_review_pricing.py
@@ -93,7 +93,17 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
         self.assertIn("/appPriceSchedules", paths)
         self.assertIn("/apps/app1/appPricePoints", paths)
         self.assertIn("/appPriceSchedules", paths)
-        self.assertTrue(any(c["method"] == "POST" and c["path"] == "/appPriceSchedules" for c in client.calls))
+        post = next((c for c in client.calls if c["method"] == "POST" and c["path"] == "/appPriceSchedules"), None)
+        self.assertIsNotNone(post)
+        payload = (post or {}).get("payload") or {}
+        included = payload.get("included") or []
+        self.assertTrue(included and isinstance(included[0], dict))
+        local_id = (included[0].get("id") or "")
+        self.assertTrue(isinstance(local_id, str) and local_id.startswith("${") and local_id.endswith("}"))
+        rel_id = (
+            (((payload.get("data") or {}).get("relationships") or {}).get("manualPrices") or {}).get("data") or [{}]
+        )[0].get("id")
+        self.assertEqual(rel_id, local_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes App Store Connect 409 ENTITY_ERROR.INCLUDED.INVALID_ID when creating Free appPriceSchedule during submission. Apple requires inline included entity ids to be local ids in the form '${local-id}'; we now use '${manualPrice0}' and assert relationship id matches included id.