### PR TITLE
fix(asc): make Free pricing creation read-back robust

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -681,19 +681,37 @@ def verify_pricing(client: ASCClient, app_id: str) -> None:
             }
         ],
     }
+    created_schedule_id: str | None = None
     try:
-        client.request("POST", "/appPriceSchedules", payload=payload)
+        created = client.request("POST", "/appPriceSchedules", payload=payload)
+        if isinstance(created, dict):
+            data = created.get("data")
+            if isinstance(data, dict):
+                created_schedule_id = data.get("id")
     except Exception as e:
         die(f"Pricing not set and failed to create Free price schedule: {e}")
 
-    # Read-back verification.
-    try:
-        data = client.request("GET", "/appPriceSchedules", params={"filter[app]": app_id, "limit": 1})
-        schedules = data.get("data") or []
-    except Exception:
-        schedules = []
-    if schedules:
-        return
+    # Read-back verification: prefer direct GET by id (list filtering can be eventually consistent).
+    if created_schedule_id:
+        for _ in range(6):
+            try:
+                created_obj = client.request("GET", f"/appPriceSchedules/{created_schedule_id}")
+                if (created_obj.get("data") or {}).get("id") == created_schedule_id:
+                    return
+            except Exception:
+                pass
+            time.sleep(2)
+
+    # Fallback: poll list until the new schedule appears.
+    for _ in range(6):
+        try:
+            data = client.request("GET", "/appPriceSchedules", params={"filter[app]": app_id, "limit": 10})
+            schedules = data.get("data") or []
+        except Exception:
+            schedules = []
+        if schedules:
+            return
+        time.sleep(2)
 
     die("Pricing not set (Free schedule creation did not appear in read-back).")
 

--- a/scripts/tests/test_asc_submit_for_review_pricing.py
+++ b/scripts/tests/test_asc_submit_for_review_pricing.py
@@ -59,18 +59,9 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
     def test_verify_pricing_creates_free_schedule_when_missing(self):
         from scripts.asc_submit_for_review import verify_pricing
 
-        get_after_create = {"n": 0}
-
-        def _get_schedules():
-            # First call: empty. Second call: present (after POST).
-            get_after_create["n"] += 1
-            if get_after_create["n"] == 1:
-                return {"data": []}
-            return {"data": [{"id": "sched1", "type": "appPriceSchedules"}]}
-
         client = _RouterClient(
             {
-                ("GET", "/appPriceSchedules"): _get_schedules,
+                ("GET", "/appPriceSchedules"): {"data": []},
                 ("GET", "/apps/app1/appPriceSchedule"): RuntimeError("404"),
                 ("GET", "/apps/app1/prices"): RuntimeError("404"),
                 (
@@ -83,6 +74,7 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
                     ]
                 },
                 ("POST", "/appPriceSchedules"): {"data": {"id": "sched1", "type": "appPriceSchedules"}},
+                ("GET", "/appPriceSchedules/sched1"): {"data": {"id": "sched1", "type": "appPriceSchedules"}},
             }
         )
 
@@ -92,7 +84,7 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
         paths = [c["path"] for c in client.calls]
         self.assertIn("/appPriceSchedules", paths)
         self.assertIn("/apps/app1/appPricePoints", paths)
-        self.assertIn("/appPriceSchedules", paths)
+        self.assertIn("/appPriceSchedules/sched1", paths)
         post = next((c for c in client.calls if c["method"] == "POST" and c["path"] == "/appPriceSchedules"), None)
         self.assertIsNotNone(post)
         payload = (post or {}).get("payload") or {}


### PR DESCRIPTION
The iOS Submit For Review workflow failed with: 'Pricing not set (Free schedule creation did not appear in read-back)'.

After creating an appPriceSchedule, list filters can lag. We now:
- capture the created schedule id from POST /appPriceSchedules
- verify via GET /appPriceSchedules/{id} with short retries
- fall back to polling the list filter as a secondary check

Includes unit test updates.