### PR TITLE
fix(asc): detect age rating via appInfos relationship

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -746,7 +746,24 @@ def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = N
         ):
             attempts.append(("version", path))
 
+    # Some accounts expose age rating declarations off AppInfo.
+    app_info_id: str | None = None
     errors: list[str] = []
+    try:
+        payload = client.request("GET", f"/apps/{app_id}/appInfos", params={"limit": 1})
+        info_obj = first(payload.get("data") or [])
+        if isinstance(info_obj, dict) and info_obj.get("id"):
+            app_info_id = info_obj["id"]
+    except Exception as e:
+        errors.append(f"app /apps/{app_id}/appInfos: {e}")
+
+    if app_info_id:
+        for path in (
+            f"/appInfos/{app_info_id}/appInfoAgeRatingDeclaration",
+            f"/appInfos/{app_info_id}/appStoreAgeRatingDeclaration",
+        ):
+            attempts.append(("appInfo", path))
+
     for scope, path in attempts:
         try:
             data = client.request("GET", path)

--- a/scripts/tests/test_asc_submit_for_review_age_rating.py
+++ b/scripts/tests/test_asc_submit_for_review_age_rating.py
@@ -9,6 +9,7 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
         client = RouterClient(
             {
+                ("GET", "/apps/app1/appInfos"): {"data": []},
                 ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): {"data": {"id": "decl1", "type": "appStoreAgeRatingDeclarations"}},
             }
@@ -20,10 +21,26 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
         client = RouterClient(
             {
+                ("GET", "/apps/app1/appInfos"): {"data": []},
                 ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/appStoreAgeRatingDeclaration"): {"data": {"id": "decl1", "type": "appStoreAgeRatingDeclarations"}},
+            }
+        )
+        verify_age_rating(client, "app1", "ver1")
+
+    def test_verify_age_rating_falls_back_to_app_info_scoped_declaration(self):
+        from scripts.asc_submit_for_review import verify_age_rating
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app1/appInfos"): {"data": [{"id": "info1", "type": "appInfos"}]},
+                ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/appStoreVersions/ver1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/appStoreVersions/ver1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/appInfos/info1/appInfoAgeRatingDeclaration"): {"data": {"id": "decl1", "type": "appInfoAgeRatingDeclarations"}},
             }
         )
         verify_age_rating(client, "app1", "ver1")
@@ -33,10 +50,13 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
         client = RouterClient(
             {
+                ("GET", "/apps/app1/appInfos"): {"data": []},
                 ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/appInfos/info1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/appInfos/info1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
             }
         )
         with self.assertRaises(SystemExit):
@@ -45,4 +65,3 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
The submission workflow still reports PATH_ERROR for age rating relationships on apps and appStoreVersions. Some accounts expose age rating declarations off AppInfo instead.

This change:
- resolves the appInfo id via GET /apps/{app_id}/appInfos
- checks /appInfos/{id}/appInfoAgeRatingDeclaration and /appInfos/{id}/appStoreAgeRatingDeclaration
- updates unit tests