### PR TITLE
fix(asc): use ageRatingDeclaration (version-scoped) endpoint

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -732,49 +732,21 @@ def verify_review_detail(client: ASCClient, version_id: str) -> None:
 
 
 def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = None) -> None:
-    # Age rating declarations have moved across resources over time (apps vs versions).
-    # Try multiple known relationship endpoints; pass if any returns a declaration object.
-    attempts: list[tuple[str, str]] = []
-
-    for path in (f"/apps/{app_id}/appInfoAgeRatingDeclaration", f"/apps/{app_id}/appStoreAgeRatingDeclaration"):
-        attempts.append(("app", path))
-
-    if version_id:
-        for path in (
-            f"/appStoreVersions/{version_id}/appInfoAgeRatingDeclaration",
-            f"/appStoreVersions/{version_id}/appStoreAgeRatingDeclaration",
-        ):
-            attempts.append(("version", path))
-
-    # Some accounts expose age rating declarations off AppInfo.
-    app_info_id: str | None = None
+    # Current ASC API exposes a unified AgeRatingDeclaration relationship on the App Store Version:
+    #   GET /v1/appStoreVersions/{id}/ageRatingDeclaration
+    # Some older code paths used app/appInfo relationships which may not exist on newer APIs.
     errors: list[str] = []
-    try:
-        payload = client.request("GET", f"/apps/{app_id}/appInfos", params={"limit": 1})
-        info_obj = first(payload.get("data") or [])
-        if isinstance(info_obj, dict) and info_obj.get("id"):
-            app_info_id = info_obj["id"]
-    except Exception as e:
-        errors.append(f"app /apps/{app_id}/appInfos: {e}")
-
-    if app_info_id:
-        for path in (
-            f"/appInfos/{app_info_id}/appInfoAgeRatingDeclaration",
-            f"/appInfos/{app_info_id}/appStoreAgeRatingDeclaration",
-        ):
-            attempts.append(("appInfo", path))
-
-    for scope, path in attempts:
+    if version_id:
         try:
-            data = client.request("GET", path)
+            data = client.request("GET", f"/appStoreVersions/{version_id}/ageRatingDeclaration")
+            if data.get("data"):
+                return
         except Exception as e:
-            errors.append(f"{scope} {path}: {e}")
-            continue
-        decl = data.get("data")
-        if decl:
-            return
+            errors.append(f"version /appStoreVersions/{version_id}/ageRatingDeclaration: {e}")
+    else:
+        errors.append("version_id missing (cannot verify ageRatingDeclaration).")
 
-    detail = "\n  ".join(errors) if errors else "(no endpoints attempted)"
+    detail = "\n  ".join(errors)
     die("Age Rating declaration not found. Complete Age Rating in App Store Connect.\n  " + detail)
 
 

--- a/scripts/tests/test_asc_submit_for_review_age_rating.py
+++ b/scripts/tests/test_asc_submit_for_review_age_rating.py
@@ -4,43 +4,14 @@ from scripts.tests.router_client import RouterClient
 
 
 class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
-    def test_verify_age_rating_accepts_app_scoped_declaration(self):
+    def test_verify_age_rating_reads_age_rating_declaration_from_version(self):
         from scripts.asc_submit_for_review import verify_age_rating
 
         client = RouterClient(
             {
-                ("GET", "/apps/app1/appInfos"): {"data": []},
-                ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): {"data": {"id": "decl1", "type": "appStoreAgeRatingDeclarations"}},
-            }
-        )
-        verify_age_rating(client, "app1", None)
-
-    def test_verify_age_rating_falls_back_to_version_scoped_declaration(self):
-        from scripts.asc_submit_for_review import verify_age_rating
-
-        client = RouterClient(
-            {
-                ("GET", "/apps/app1/appInfos"): {"data": []},
-                ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appStoreVersions/ver1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appStoreVersions/ver1/appStoreAgeRatingDeclaration"): {"data": {"id": "decl1", "type": "appStoreAgeRatingDeclarations"}},
-            }
-        )
-        verify_age_rating(client, "app1", "ver1")
-
-    def test_verify_age_rating_falls_back_to_app_info_scoped_declaration(self):
-        from scripts.asc_submit_for_review import verify_age_rating
-
-        client = RouterClient(
-            {
-                ("GET", "/apps/app1/appInfos"): {"data": [{"id": "info1", "type": "appInfos"}]},
-                ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appStoreVersions/ver1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appStoreVersions/ver1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appInfos/info1/appInfoAgeRatingDeclaration"): {"data": {"id": "decl1", "type": "appInfoAgeRatingDeclarations"}},
+                ("GET", "/appStoreVersions/ver1/ageRatingDeclaration"): {
+                    "data": {"id": "decl1", "type": "ageRatingDeclarations", "attributes": {}}
+                }
             }
         )
         verify_age_rating(client, "app1", "ver1")
@@ -50,13 +21,7 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
         client = RouterClient(
             {
-                ("GET", "/apps/app1/appInfos"): {"data": []},
-                ("GET", "/apps/app1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/apps/app1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appStoreVersions/ver1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appStoreVersions/ver1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appInfos/info1/appInfoAgeRatingDeclaration"): RuntimeError("404"),
-                ("GET", "/appInfos/info1/appStoreAgeRatingDeclaration"): RuntimeError("404"),
+                ("GET", "/appStoreVersions/ver1/ageRatingDeclaration"): RuntimeError("404"),
             }
         )
         with self.assertRaises(SystemExit):
@@ -65,3 +30,4 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
Submission is failing because our age rating check was hitting non-existent relationship endpoints (PATH_ERROR).

Apple's current App Store Connect OpenAPI defines age rating as:
- GET /v1/appStoreVersions/{id}/ageRatingDeclaration

This change updates asc_submit_for_review.py to verify via that endpoint and updates unit tests accordingly.