### PR TITLE
fix(asc): autofill missing App Store localization fields from fastlane

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -353,7 +353,36 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
     loc = first(locs)
     if not loc:
         die(f"Missing App Store version localization for {locale}. Run fastlane metadata upload first.")
+    loc_id = loc.get("id") or ""
     attrs = loc.get("attributes") or {}
+
+    # Autocomplete missing fields from fastlane metadata if present.
+    fastlane_files = {
+        "description": "description.txt",
+        "keywords": "keywords.txt",
+        "whatsNew": "release_notes.txt",
+    }
+    patch: dict[str, str] = {}
+    for field, filename in fastlane_files.items():
+        if not (attrs.get(field) or "").strip():
+            val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, locale, filename))
+            if val:
+                patch[field] = val
+
+    if patch and loc_id:
+        info(f"Filling missing App Store version localization fields for {locale}: {', '.join(sorted(patch.keys()))}")
+        patch_resource_attributes(
+            client,
+            path=f"/appStoreVersionLocalizations/{loc_id}",
+            type_name="appStoreVersionLocalizations",
+            resource_id=loc_id,
+            attrs=patch,
+        )
+        refreshed = client.request("GET", f"/appStoreVersionLocalizations/{loc_id}").get("data") or {}
+        if isinstance(refreshed, dict):
+            loc = refreshed
+            attrs = loc.get("attributes") or {}
+
     for field in ("description", "keywords", "whatsNew"):
         if not (attrs.get(field) or "").strip():
             die(f"App Store version localization {locale} missing required field: {field}")

--- a/scripts/tests/test_asc_submit_for_review_version_localization.py
+++ b/scripts/tests/test_asc_submit_for_review_version_localization.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+import unittest
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def get_all(self, path, *, params=None):
+        self.calls.append({"method": "GET_ALL", "path": path, "params": params})
+        return [
+            {
+                "id": "loc1",
+                "type": "appStoreVersionLocalizations",
+                "attributes": {"description": "desc", "keywords": "kw", "whatsNew": ""},
+            }
+        ]
+
+    def request(self, method, path, *, params=None, payload=None):
+        self.calls.append({"method": method, "path": path, "params": params, "payload": payload})
+        if method == "PATCH" and path == "/appStoreVersionLocalizations/loc1":
+            return {}
+        if method == "GET" and path == "/appStoreVersionLocalizations/loc1":
+            return {
+                "data": {
+                    "id": "loc1",
+                    "type": "appStoreVersionLocalizations",
+                    "attributes": {"description": "desc", "keywords": "kw", "whatsNew": "Hello"},
+                }
+            }
+        raise RuntimeError(f"unhandled {method} {path}")
+
+
+class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
+    def test_get_version_localization_autofills_whats_new_from_fastlane(self):
+        import scripts.asc_submit_for_review as asc
+
+        client = _FakeClient()
+
+        with tempfile.TemporaryDirectory() as td:
+            os.makedirs(os.path.join(td, "en-US"), exist_ok=True)
+            with open(os.path.join(td, "en-US", "release_notes.txt"), "w", encoding="utf-8") as f:
+                f.write("Hello")
+
+            prev = asc.FASTLANE_METADATA_DIR
+            asc.FASTLANE_METADATA_DIR = td
+            try:
+                loc = asc.get_version_localization(client, "ver1", "en-US")
+            finally:
+                asc.FASTLANE_METADATA_DIR = prev
+
+        patch = next((c for c in client.calls if c["method"] == "PATCH"), None)
+        self.assertIsNotNone(patch)
+        attrs = (((patch or {}).get("payload") or {}).get("data") or {}).get("attributes") or {}
+        self.assertEqual(attrs, {"whatsNew": "Hello"})
+        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "Hello")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Submission failed because App Store version localization en-US had empty whatsNew.

This change:
- patches missing localization fields (description/keywords/whatsNew) from fastlane metadata files (description.txt/keywords.txt/release_notes.txt)
- re-fetches the localization and re-validates
- adds a unit test to ensure only missing fields are patched