### PR TITLE
ci(ios): fix ASC inline local id for pricing schedule creation

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -661,7 +661,9 @@ def verify_pricing(client: ASCClient, app_id: str) -> None:
         die("Pricing not set (could not find Free price point and legacy /prices is unavailable).")
 
     info(f"Pricing not set; creating Free price schedule (base territory {territory})…")
-    manual_price_id = "manualPrice-0"
+    # App Store Connect requires JSON:API "local ids" for inline-created included resources.
+    # The API validates local ids using the "${local-id}" format (i.e. ids must start with "$").
+    manual_price_id = "$manualPrice0"
     payload = {
         "data": {
             "type": "appPriceSchedules",
@@ -675,7 +677,6 @@ def verify_pricing(client: ASCClient, app_id: str) -> None:
             {
                 "type": "appPrices",
                 "id": manual_price_id,
-                "attributes": {"startDate": None},
                 "relationships": {"appPricePoint": {"data": {"type": "appPricePoints", "id": free_point_id}}},
             }
         ],

--- a/scripts/tests/test_asc_submit_for_review_pricing.py
+++ b/scripts/tests/test_asc_submit_for_review_pricing.py
@@ -93,7 +93,11 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
         self.assertIn("/appPriceSchedules", paths)
         self.assertIn("/apps/app1/appPricePoints", paths)
         self.assertIn("/appPriceSchedules", paths)
-        self.assertTrue(any(c["method"] == "POST" and c["path"] == "/appPriceSchedules" for c in client.calls))
+        post = next((c for c in client.calls if c["method"] == "POST" and c["path"] == "/appPriceSchedules"), None)
+        self.assertIsNotNone(post, "expected verify_pricing() to POST /appPriceSchedules")
+        # ASC enforces inline-created included entities to use a JSON:API local id with the '$' prefix.
+        self.assertEqual(post["payload"]["included"][0]["id"], "$manualPrice0")
+        self.assertEqual(post["payload"]["data"]["relationships"]["manualPrices"]["data"][0]["id"], "$manualPrice0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes App Store Connect 409 ENTITY_ERROR.INCLUDED.INVALID_ID during inline creation of Free AppPriceSchedule by using a JSON:API local id with the required '$' prefix and adds a unit test to prevent regression.