### PR TITLE
fastlane: auto-release after App Review

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -191,7 +191,8 @@ platform :ios do
 	      app_version: version,
 	      build_number: build_number.to_s,
 	      submit_for_review: true,
-	      automatic_release: false,
+	      # Auto-release once Apple approves the submission (no manual "Release This Version" step).
+	      automatic_release: true,
 	      skip_binary_upload: true,
 	      # Upload screenshots/metadata in `metadata` lane first for deterministic gating.
 	      skip_screenshots: options.key?(:skip_screenshots) ? options[:skip_screenshots] : true,


### PR DESCRIPTION
Sets `automatic_release: true` in `native-ios/fastlane/Fastfile` for the `submit_review` lane.

Result: once Apple approves the submission, the version should release automatically (no manual "Release This Version" step).
