### PR TITLE
fix(ci): unblock iOS metadata sync fastlane install

### DIFF
--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -26,7 +26,7 @@ jobs:
           working-directory: native-ios
 
       - name: Install Fastlane
-        run: gem install fastlane
+        run: gem install fastlane --force --no-document
         working-directory: native-ios
 
       - name: Setup Python


### PR DESCRIPTION
Fixes RubyGems executable conflict in ios-metadata-sync workflow by forcing fastlane gem install.