### PR TITLE
fix(ci): isolate gems for iOS metadata sync

### DIFF
--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -25,8 +25,14 @@ jobs:
           bundler-cache: true
           working-directory: native-ios
 
+      - name: Configure isolated RubyGems path
+        run: |
+          echo "GEM_HOME=${RUNNER_TEMP}/gems" >> "$GITHUB_ENV"
+          echo "GEM_PATH=${RUNNER_TEMP}/gems" >> "$GITHUB_ENV"
+          echo "${RUNNER_TEMP}/gems/bin" >> "$GITHUB_PATH"
+
       - name: Install Fastlane
-        run: gem install fastlane --force --no-document
+        run: gem install fastlane --no-document
         working-directory: native-ios
 
       - name: Setup Python


### PR DESCRIPTION
Use isolated GEM_HOME/GEM_PATH in ios-metadata-sync to avoid RubyGems conflicts on runners when installing fastlane.