### PR TITLE
fix(ci): install fastlane via brew in iOS metadata sync

### DIFF
--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -25,8 +25,11 @@ jobs:
           bundler-cache: true
           working-directory: native-ios
 
-      - name: Verify Fastlane availability
-        run: fastlane --version
+      - name: Install Fastlane (Homebrew)
+        run: |
+          brew update
+          brew install fastlane
+          fastlane --version
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Use Homebrew fastlane installation in ios-metadata-sync to avoid RubyGems executable/dependency conflicts.