### PR TITLE
fix(ios): avoid fastlane live metadata crash during screenshot sync

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -138,21 +138,26 @@ platform :ios do
       end
     end
 
-		    deliver(
-		      app_identifier: "com.igorganapolsky.randomtimer",
-		      app_version: version,
-		      build_number: (build_number.to_s.strip.empty? ? nil : build_number.to_s),
-		      edit_live: true,
-		      skip_app_version_update: true,
-		      skip_binary_upload: true,
-		      skip_screenshots: false,
-	      # Fastlane precheck can't validate IAP via App Store Connect API keys and will fail the lane.
-	      # We do our own hard preflight checks before submission (see scripts/asc_submit_for_review.py).
-	      run_precheck_before_submit: false,
-	      precheck_include_in_app_purchases: false,
-	      force: true,
-	      api_key: defined?(api_key) ? api_key : nil
-	    )
+    deliver(
+      app_identifier: "com.igorganapolsky.randomtimer",
+      app_version: version,
+      build_number: (build_number.to_s.strip.empty? ? nil : build_number.to_s),
+      edit_live: true,
+      skip_app_version_update: true,
+      skip_binary_upload: true,
+      skip_screenshots: false,
+      # Keep this lane screenshot-only. Metadata updates on live versions can trigger
+      # a fastlane queue_worker crash in CI ("Enqueue Array instead of NilClass").
+      skip_metadata: true,
+      overwrite_screenshots: true,
+      sync_screenshots: true,
+      # Fastlane precheck can't validate IAP via App Store Connect API keys and will fail the lane.
+      # We do our own hard preflight checks before submission (see scripts/asc_submit_for_review.py).
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false,
+      force: true,
+      api_key: defined?(api_key) ? api_key : nil
+    )
 	  end
 
   desc "Submit a given version for App Review (attach build + submit)"


### PR DESCRIPTION
## Summary\n- keep iOS metadata lane screenshot-only\n- avoid fastlane deliver crash in live metadata upload path (Enqueue Array instead of NilClass)\n- force screenshot replacement/sync so App Store listing images are updated deterministically\n\n## Validation\n- ruby -c native-ios/fastlane/Fastfile\n- failing run reference: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/22158207067