### PR TITLE
fix(ios): remove beta sync_screenshots dependency in metadata sync

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -150,7 +150,6 @@ platform :ios do
       # a fastlane queue_worker crash in CI ("Enqueue Array instead of NilClass").
       skip_metadata: true,
       overwrite_screenshots: true,
-      sync_screenshots: true,
       # Fastlane precheck can't validate IAP via App Store Connect API keys and will fail the lane.
       # We do our own hard preflight checks before submission (see scripts/asc_submit_for_review.py).
       run_precheck_before_submit: false,


### PR DESCRIPTION
## Summary\n- remove  from iOS metadata lane\n- keep screenshot-only live update path (, )\n- avoids fastlane beta gate requiring FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS\n\n## Validation\n- ruby -c native-ios/fastlane/Fastfile\n- failed run reference: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/22161046553