### PR TITLE
Harden ASC screenshot readiness verification

### DIFF
--- a/scripts/asc_verify_ready.py
+++ b/scripts/asc_verify_ready.py
@@ -559,6 +559,12 @@ def verify_ready(
         iphone_ok = any(_is_iphone_large(dt) and c >= min_iphone for dt, c in screenshot_counts.items())
         ipad_ok = any(_is_ipad_large(dt) and c >= min_ipad for dt, c in screenshot_counts.items())
 
+        screenshot_evidence = {
+            "complete_counts": screenshot_counts,
+            "total_counts": screenshot_total_counts,
+            "state_counts": screenshot_asset_states,
+            "incomplete_assets": screenshot_incomplete_assets,
+        }
         checks.append(
             Check(
                 name="Screenshots (iPhone)",
@@ -567,12 +573,7 @@ def verify_ready(
                     f"need >= {min_iphone} COMPLETE in a large iPhone set; "
                     f"complete={screenshot_counts} total={screenshot_total_counts}"
                 ),
-                evidence={
-                    "complete_counts": screenshot_counts,
-                    "total_counts": screenshot_total_counts,
-                    "state_counts": screenshot_asset_states,
-                    "incomplete_assets": screenshot_incomplete_assets,
-                },
+                evidence=screenshot_evidence,
             )
         )
         checks.append(
@@ -583,12 +584,7 @@ def verify_ready(
                     f"need >= {min_ipad} COMPLETE in a large iPad set; "
                     f"complete={screenshot_counts} total={screenshot_total_counts}"
                 ),
-                evidence={
-                    "complete_counts": screenshot_counts,
-                    "total_counts": screenshot_total_counts,
-                    "state_counts": screenshot_asset_states,
-                    "incomplete_assets": screenshot_incomplete_assets,
-                },
+                evidence=screenshot_evidence,
             )
         )
     else:

--- a/scripts/tests/test_asc_verify_ready.py
+++ b/scripts/tests/test_asc_verify_ready.py
@@ -103,50 +103,28 @@ class _FakeAscClient:
 
 
 class AscVerifyReadyScreenshotStateTests(unittest.TestCase):
-    def test_verify_ready_fails_when_screenshots_are_not_complete(self):
+    @staticmethod
+    def _shots(states, prefix):
+        return [
+            {
+                "id": f"{prefix}{i}",
+                "type": "appScreenshots",
+                "attributes": {"fileName": f"{prefix}{i}.png", "assetDeliveryState": {"state": state}},
+            }
+            for i, state in enumerate(states, start=1)
+        ]
+
+    def _run_verify(self, iphone_states, ipad_states):
         from scripts import asc_verify_ready
 
         fake = _FakeAscClient(
             app_screenshots_by_set={
-                "set_iphone": [
-                    {
-                        "id": "ph1",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "1.png", "assetDeliveryState": {"state": "AWAITING_UPLOAD"}},
-                    },
-                    {
-                        "id": "ph2",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "2.png", "assetDeliveryState": {"state": "AWAITING_UPLOAD"}},
-                    },
-                    {
-                        "id": "ph3",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "3.png", "assetDeliveryState": {"state": "AWAITING_UPLOAD"}},
-                    },
-                ],
-                "set_ipad": [
-                    {
-                        "id": "pd1",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "a.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                    {
-                        "id": "pd2",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "b.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                    {
-                        "id": "pd3",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "c.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                ],
+                "set_iphone": self._shots(iphone_states, "ph"),
+                "set_ipad": self._shots(ipad_states, "pd"),
             }
         )
-
         with mock.patch("scripts.asc_verify_ready.AscClient", return_value=fake):
-            passed, report = asc_verify_ready.verify_ready(
+            return asc_verify_ready.verify_ready(
                 bundle_id="com.igorganapolsky.randomtimer",
                 version="1.1.1",
                 locale="en-US",
@@ -154,62 +132,21 @@ class AscVerifyReadyScreenshotStateTests(unittest.TestCase):
                 min_ipad=3,
             )
 
+    def test_verify_ready_fails_when_screenshots_are_not_complete(self):
+        passed, report = self._run_verify(
+            iphone_states=["AWAITING_UPLOAD", "AWAITING_UPLOAD", "AWAITING_UPLOAD"],
+            ipad_states=["COMPLETE", "COMPLETE", "COMPLETE"],
+        )
         self.assertFalse(passed)
         self.assertEqual(report["screenshot_counts"]["APP_IPHONE_67"], 0)
         self.assertEqual(report["screenshot_total_counts"]["APP_IPHONE_67"], 3)
         self.assertEqual(report["screenshot_asset_states"]["APP_IPHONE_67"]["AWAITING_UPLOAD"], 3)
 
     def test_verify_ready_passes_when_required_complete_counts_exist(self):
-        from scripts import asc_verify_ready
-
-        fake = _FakeAscClient(
-            app_screenshots_by_set={
-                "set_iphone": [
-                    {
-                        "id": "ph1",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "1.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                    {
-                        "id": "ph2",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "2.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                    {
-                        "id": "ph3",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "3.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                ],
-                "set_ipad": [
-                    {
-                        "id": "pd1",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "a.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                    {
-                        "id": "pd2",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "b.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                    {
-                        "id": "pd3",
-                        "type": "appScreenshots",
-                        "attributes": {"fileName": "c.png", "assetDeliveryState": {"state": "COMPLETE"}},
-                    },
-                ],
-            }
+        passed, report = self._run_verify(
+            iphone_states=["COMPLETE", "COMPLETE", "COMPLETE"],
+            ipad_states=["COMPLETE", "COMPLETE", "COMPLETE"],
         )
-
-        with mock.patch("scripts.asc_verify_ready.AscClient", return_value=fake):
-            passed, report = asc_verify_ready.verify_ready(
-                bundle_id="com.igorganapolsky.randomtimer",
-                version="1.1.1",
-                locale="en-US",
-                min_iphone=3,
-                min_ipad=3,
-            )
-
         self.assertTrue(passed)
         self.assertEqual(report["screenshot_counts"]["APP_IPHONE_67"], 3)
         self.assertEqual(report["screenshot_counts"]["APP_IPAD_PRO_3GEN_129"], 3)


### PR DESCRIPTION
## Summary
- require screenshot readiness checks to count only assets with `assetDeliveryState.state == COMPLETE`
- include `total_counts`, per-set `state_counts`, and incomplete asset evidence in readiness output
- add unit tests for ready/not-ready screenshot delivery states

## Why
The previous verifier counted screenshot records without validating delivery state, which could report false readiness while screenshots were still pending upload/processing.

## Validation
- `python3 -m unittest scripts.tests.test_asc_verify_ready -v`
- `python3 -m unittest discover -s scripts/tests -v`
