### PR TITLE
fix(ios-metadata): prevent screenshot duplication and unblock ASC version resolution

### DIFF
--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -12,6 +12,8 @@ jobs:
   sync-metadata:
     runs-on: macos-15
     environment: production
+    env:
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/asc_resolve_version.py
+++ b/scripts/asc_resolve_version.py
@@ -71,7 +71,6 @@ def _list_ios_versions(client: ASCClient, app_id: str) -> List[Dict[str, Any]]:
             "filter[platform]": "IOS",
             "limit": 200,
             "fields[appStoreVersions]": "versionString,appStoreState,platform,createdDate",
-            "sort": "-createdDate",
         },
     )
 
@@ -81,6 +80,34 @@ def _find_version(versions: List[Dict[str, Any]], version: str) -> Optional[Dict
         attrs = v.get("attributes") or {}
         if str(attrs.get("versionString") or "") == version:
             return v
+    return None
+
+
+def _semver_or_none(value: str) -> Optional[Tuple[int, int, int]]:
+    try:
+        return _parse_semver(value)
+    except ValueError:
+        return None
+
+
+def _pick_highest_editable_version(versions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    editable: List[Tuple[Tuple[int, int, int], Dict[str, Any]]] = []
+    fallback: List[Dict[str, Any]] = []
+    for item in versions:
+        attrs = item.get("attributes") or {}
+        state = str(attrs.get("appStoreState") or "UNKNOWN")
+        if not _is_editable_state(state):
+            continue
+        fallback.append(item)
+        parsed = _semver_or_none(str(attrs.get("versionString") or ""))
+        if parsed is not None:
+            editable.append((parsed, item))
+
+    if editable:
+        editable.sort(key=lambda x: x[0], reverse=True)
+        return editable[0][1]
+    if fallback:
+        return fallback[0]
     return None
 
 
@@ -121,6 +148,7 @@ def resolve_version(
     auto_next_patch: bool,
 ) -> Resolution:
     versions = _list_ios_versions(client, app_id)
+    highest_editable = _pick_highest_editable_version(versions)
     current = _find_version(versions, preferred_version)
     if current:
         attrs = current.get("attributes") or {}
@@ -140,6 +168,19 @@ def resolve_version(
                 f"Preferred App Store version {preferred_version} exists but is not editable (state={state}). "
                 "Provide an editable version or enable --auto-next-patch.",
                 code=1,
+            )
+
+        if highest_editable:
+            editable_attrs = highest_editable.get("attributes") or {}
+            editable_version = str(editable_attrs.get("versionString") or "")
+            editable_state = str(editable_attrs.get("appStoreState") or "UNKNOWN")
+            return Resolution(
+                selected_version=editable_version,
+                selected_state=editable_state,
+                created=False,
+                reason=f"preferred_non_editable_{state}_reused_highest_editable",
+                selected_id=str(highest_editable.get("id") or ""),
+                preferred_version=preferred_version,
             )
 
         candidate = _bump_patch(preferred_version)
@@ -173,6 +214,19 @@ def resolve_version(
                     preferred_version=preferred_version,
                 )
             candidate = _bump_patch(candidate)
+
+    if auto_next_patch and highest_editable:
+        editable_attrs = highest_editable.get("attributes") or {}
+        editable_version = str(editable_attrs.get("versionString") or "")
+        editable_state = str(editable_attrs.get("appStoreState") or "UNKNOWN")
+        return Resolution(
+            selected_version=editable_version,
+            selected_state=editable_state,
+            created=False,
+            reason="preferred_missing_reused_highest_editable",
+            selected_id=str(highest_editable.get("id") or ""),
+            preferred_version=preferred_version,
+        )
 
     if not create_if_needed:
         die(f"Preferred App Store version {preferred_version} does not exist and create_if_needed is disabled.", code=1)

--- a/scripts/tests/test_asc_resolve_version.py
+++ b/scripts/tests/test_asc_resolve_version.py
@@ -3,6 +3,7 @@ import unittest
 from scripts.asc_resolve_version import (
     _bump_patch,
     _is_editable_state,
+    _list_ios_versions,
     _parse_semver,
     resolve_version,
 )
@@ -95,7 +96,38 @@ class AscResolveVersionUnitTests(unittest.TestCase):
         )
         self.assertEqual(result.selected_version, "1.1.2")
         self.assertFalse(result.created)
-        self.assertIn("reused_existing_patch", result.reason)
+        self.assertIn("reused", result.reason)
+
+    def test_reuses_highest_existing_editable_even_when_not_next_patch(self):
+        client = _FakeClient(
+            [
+                _version("1.1.1", "READY_FOR_SALE"),
+                _version("1.2.0", "PREPARE_FOR_SUBMISSION"),
+            ]
+        )
+        result = resolve_version(
+            client=client,
+            app_id="app1",
+            preferred_version="1.1.1",
+            create_if_needed=True,
+            auto_next_patch=True,
+        )
+        self.assertEqual(result.selected_version, "1.2.0")
+        self.assertFalse(result.created)
+        self.assertIn("reused_highest_editable", result.reason)
+
+    def test_reuses_existing_editable_when_preferred_missing_and_auto_next_patch(self):
+        client = _FakeClient([_version("1.2.0", "PREPARE_FOR_SUBMISSION")])
+        result = resolve_version(
+            client=client,
+            app_id="app1",
+            preferred_version="1.1.2",
+            create_if_needed=True,
+            auto_next_patch=True,
+        )
+        self.assertEqual(result.selected_version, "1.2.0")
+        self.assertFalse(result.created)
+        self.assertEqual(result.reason, "preferred_missing_reused_highest_editable")
 
     def test_creates_preferred_when_missing(self):
         client = _FakeClient([])
@@ -109,6 +141,20 @@ class AscResolveVersionUnitTests(unittest.TestCase):
         self.assertEqual(result.selected_version, "1.1.2")
         self.assertTrue(result.created)
         self.assertEqual(result.reason, "preferred_missing_created")
+
+    def test_list_ios_versions_does_not_send_disallowed_sort_param(self):
+        captured = {}
+
+        class _CaptureClient:
+            def get_all(self, path, params=None):
+                captured["path"] = path
+                captured["params"] = dict(params or {})
+                return []
+
+        _list_ios_versions(_CaptureClient(), "app123")
+        self.assertEqual(captured["path"], "/apps/app123/appStoreVersions")
+        self.assertNotIn("sort", captured["params"])
+        self.assertEqual(captured["params"].get("filter[platform]"), "IOS")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Live listing showed duplicate screenshots because screenshot reset workflow could not run reliably, and version resolution failed against current ASC API behavior.

## What changed
- Set `PYTHONPATH: ${{ github.workspace }}` in `ios-metadata-sync` workflow so `scripts.*` imports work in CI.
- Removed unsupported `sort` parameter from ASC version listing request.
- Enhanced version resolver to reuse highest editable existing version (e.g. `1.2.0`) when preferred live version (`1.1.1`) is non-editable.
- Added unit tests to lock behavior and guard against reintroducing disallowed query params.

## Verified
- `python3 -m pytest -q scripts/tests/test_asc_resolve_version.py scripts/tests/test_asc_reset_screenshots.py` → `10 passed`.
- Reproduced prior import failure (`ModuleNotFoundError: No module named 'scripts'`) with `PYTHONPATH` unset, then confirmed import succeeds with workflow env set.
- ASC read-back after reset/upload: version `1.2.0` now has exactly `3` iPhone + `3` iPad screenshots.
