### PR TITLE
chore(release): bump mobile versions to 1.2.0

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = 35
-        versionCode = 5
-        versionName = "1.1.1"
+        versionCode = 6
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-android/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,3 @@
+v1.2.0
+- Improved timer setup flow and listing clarity
+- Stability and performance improvements

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -543,7 +543,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -565,7 +565,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -653,7 +653,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -675,7 +675,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,5 +1,4 @@
-v1.1.1 — Random Tactical Timer
-- Removed AD_ID permission for improved privacy
-- Range slider drag now pushes/pulls to maintain 30s minimum gap
-- Anonymous analytics integration
-- Stability improvements and bug fixes
+v1.2.0 — Random Tactical Timer
+- Refreshed App Store screenshots and listing metadata for clearer onboarding
+- Improved timer setup and alarm flow copy for faster first-session use
+- Stability fixes and performance improvements


### PR DESCRIPTION
## Why
The clean screenshot set is now correctly synced to App Store version `1.2.0`, but that version still needs a matching binary before it can be submitted and eventually replace live `1.1.1` storefront assets.

## What changed
- Bumped Android version to `1.2.0` and versionCode to `6`
- Bumped iOS `MARKETING_VERSION` to `1.2.0`
- Added Android changelog `native-android/fastlane/metadata/android/en-US/changelogs/6.txt`
- Updated iOS release notes for `1.2.0`

## Verification
- `bash scripts/preflight-release.sh --platform ios --layer 1` ✅
- `bash scripts/preflight-release.sh --platform android --layer 1` ✅
