### PR TITLE
fix(ci): add PYTHONPATH to ios-submit-review workflow

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -27,6 +27,8 @@ jobs:
   submit:
     runs-on: macos-15
     environment: production
+    env:
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Adds `PYTHONPATH: ${{ github.workspace }}` to the `submit` job env in `ios-submit-review.yml`
- Fixes `ModuleNotFoundError: No module named 'scripts'` when `asc_resolve_version.py` tries to import from `scripts.asc_submit_for_review`
- Mirrors the same fix already present in `ios-metadata-sync.yml`

## Evidence

Workflow run #22235209272 failed at 'Resolve editable App Store version' step with:
```
ModuleNotFoundError: No module named 'scripts'
```

## Test plan

- [ ] CI passes on this PR
- [ ] Re-trigger iOS Submit For Review workflow after merge

https://claude.ai/code/session_013JsweJK9DxgVETd2dq2ahG