### PR TITLE
fix(ci): use absolute path for ASC key in submit-review workflow

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
           echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+          echo "$APPSTORE_PRIVATE_KEY" > /tmp/appstore_key.p8
 
       - name: Resolve iOS version
         id: version
@@ -89,7 +90,7 @@ jobs:
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-          APPSTORE_PRIVATE_KEY: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
+          APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
           PREFERRED_VERSION: ${{ steps.version.outputs.ios_version }}
         run: |
           python scripts/asc_resolve_version.py \
@@ -104,6 +105,7 @@ jobs:
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
           IOS_VERSION: ${{ steps.asc_version.outputs.selected_version }}
         run: |
           if ! echo "$IOS_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -134,6 +136,7 @@ jobs:
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
           LOCALE: ${{ inputs.locale }}
           WAIT_FOR_STATE: ${{ inputs.wait }}
           IOS_VERSION: ${{ steps.asc_version.outputs.selected_version }}
@@ -177,4 +180,4 @@ jobs:
 
       - name: Cleanup key
         if: always()
-        run: rm -f ~/.appstoreconnect/private_keys/AuthKey_*.p8 /tmp/asc_version.json
+        run: rm -f ~/.appstoreconnect/private_keys/AuthKey_*.p8 /tmp/appstore_key.p8 /tmp/asc_version.json


### PR DESCRIPTION
## Summary

- Fixes `ValueError: Unable to load PEM file. MalformedFraming` in iOS Submit For Review workflow
- Root cause: `APPSTORE_PRIVATE_KEY` was set to a tilde path (`~/.appstoreconnect/...`) which `os.path.isfile()` doesn't expand
- The script treated the path string as PEM content, causing the parse error
- Fix: write key to `/tmp/appstore_key.p8` and use absolute path (mirrors metadata-sync workflow)

## Evidence

Workflow runs #22235209272 and #22235532692 both failed at 'Resolve editable App Store version' with PEM error.

## Test plan

- [ ] CI passes
- [ ] Re-trigger iOS Submit For Review after merge

https://claude.ai/code/session_013JsweJK9DxgVETd2dq2ahG