### PR TITLE
fix(ci): add --auto-next-patch to submit-review version resolution

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -96,6 +96,7 @@ jobs:
           python scripts/asc_resolve_version.py \
             --preferred-version "$PREFERRED_VERSION" \
             --create-if-needed \
+            --auto-next-patch \
             --json-out /tmp/asc_version.json
           SELECTED_VERSION=$(python -c 'import json; print(json.load(open("/tmp/asc_version.json"))["selected_version"])')
           echo "selected_version=$SELECTED_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Adds `--auto-next-patch` flag to `asc_resolve_version.py` call in ios-submit-review workflow
- Mirrors the same flag already used in ios-metadata-sync workflow
- Prevents HTTP 409 when the preferred version can't be found by the API (falls back to highest editable version)

## Evidence

Run #22236307624 failed at 'Resolve editable App Store version' with:
```
RuntimeError: POST /appStoreVersions failed: HTTP 409 - You cannot create a new version of the App in the current state.
```

https://claude.ai/code/session_013JsweJK9DxgVETd2dq2ahG