### PR TITLE
fix(asc): handle HTTP 409 in version resolution for submit-review

### DIFF
--- a/scripts/asc_resolve_version.py
+++ b/scripts/asc_resolve_version.py
@@ -192,7 +192,22 @@ def resolve_version(
                         f"Next patch version {candidate} does not exist and create_if_needed is disabled.",
                         code=1,
                     )
-                created = _create_ios_version(client, app_id, candidate)
+                try:
+                    created = _create_ios_version(client, app_id, candidate)
+                except RuntimeError as exc:
+                    if "409" in str(exc):
+                        # ASC won't allow creating new versions while another is in review.
+                        # Return the preferred version as-is so downstream steps can check its state.
+                        info(f"Cannot create {candidate} (HTTP 409). Returning preferred {preferred_version} (state={state}).")
+                        return Resolution(
+                            selected_version=preferred_version,
+                            selected_state=state,
+                            created=False,
+                            reason=f"preferred_non_editable_{state}_create_blocked_409",
+                            selected_id=str(current.get("id") or ""),
+                            preferred_version=preferred_version,
+                        )
+                    raise
                 created_state = str((created.get("attributes") or {}).get("appStoreState") or "UNKNOWN")
                 return Resolution(
                     selected_version=candidate,


### PR DESCRIPTION
## Summary

- Handles HTTP 409 error in `asc_resolve_version.py` when creating a new version fails because the app has a version in review
- Returns the preferred version as-is with reason `create_blocked_409`, letting downstream steps decide
- Prevents the submit-review workflow from crashing when 1.2.0 is already in WAITING_FOR_REVIEW

## Evidence

Runs #22236307624 and #22236796326 both crashed at 'Resolve editable' because version 1.2.0 is in a non-editable state and ASC won't allow creating 1.2.1

https://claude.ai/code/session_013JsweJK9DxgVETd2dq2ahG