### PR TITLE
fix(growth): fix module import path in growth_content_pipeline

### DIFF
--- a/scripts/growth_content_pipeline.py
+++ b/scripts/growth_content_pipeline.py
@@ -20,8 +20,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-import scripts.growth_bot_analytics as bot_analytics
-import scripts.growth_keyword_engine as keyword_engine
+import importlib
+import sys
+
+# Support both `python scripts/growth_content_pipeline.py` and `python -m scripts.growth_content_pipeline`
+_scripts_dir = Path(__file__).resolve().parent
+if str(_scripts_dir) not in sys.path:
+    sys.path.insert(0, str(_scripts_dir))
+
+import growth_bot_analytics as bot_analytics  # noqa: E402
+import growth_keyword_engine as keyword_engine  # noqa: E402
 
 DEFAULT_TOPICS: Tuple[str, ...] = (
     "How we shipped faster with AI-assisted test triage",


### PR DESCRIPTION
## Summary
- Fixes `ModuleNotFoundError: No module named 'scripts'` in Daily Growth Publishing CI workflow
- The script uses absolute package imports (`import scripts.growth_bot_analytics`) but runs as a standalone script in CI
- Fix: adds the scripts directory to `sys.path` at runtime so sibling imports resolve correctly

## Test plan
- [ ] Daily Growth Publishing workflow passes on next scheduled run
- [ ] `python3 -c "import sys; sys.path.insert(0, 'scripts'); import growth_content_pipeline"` succeeds locally

Generated with [Claude Code](https://claude.com/claude-code)