### PR TITLE
fix(wiki): use github-wiki-action to init wiki

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -35,31 +35,12 @@ jobs:
       - name: Inject live data into dashboard
         run: python scripts/wiki_sync.py
 
-      - name: Clone wiki repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          WIKI_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git"
-          git clone --depth 1 "${WIKI_URL}" /tmp/wiki-clone || {
-            mkdir -p /tmp/wiki-clone
-            cd /tmp/wiki-clone
-            git init
-            git remote add origin "${WIKI_URL}"
-          }
-
-      - name: Copy wiki pages and push
-        run: |
-          cp wiki/*.md /tmp/wiki-clone/
-          cd /tmp/wiki-clone
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No wiki changes to push"
-            exit 0
-          fi
-          git commit -m "chore: sync wiki pages ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
-          git push origin master || git push origin main
+      - name: Publish wiki pages
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          strategy: init
+          path: wiki/
+          token: ${{ secrets.PROJECT_PAT }}
 
       - name: Upload dashboard snapshot
         if: always()


### PR DESCRIPTION
## Summary
- Replace manual git clone/push with `Andrew-Chen-Wang/github-wiki-action@v4` using `init` strategy
- Force-pushes wiki content, **creating the wiki repo from scratch** (no manual web UI needed)
- Uses `PROJECT_PAT` for wiki write access

## Problem
Wiki at https://github.com/IgorGanapolsky/Random-Timer/wiki was empty — the wiki git repo was never initialized. GitHub has no API to bootstrap a wiki; this action's `init` strategy works around it.

https://claude.ai/code/session_013JsweJK9DxgVETd2dq2ahG