### PR TITLE
docs(wiki): add Mermaid diagrams + cleanup summary

### DIFF
--- a/wiki/Growth-Systems-Overview.md
+++ b/wiki/Growth-Systems-Overview.md
@@ -17,30 +17,27 @@ Automated growth infrastructure running via GitHub Actions on fixed schedules.
 
 ## System Architecture
 
-```
-                        ┌─────────────────────┐
-                        │   PostHog Analytics  │
-                        │  (us.i.posthog.com)  │
-                        └──────────┬──────────┘
-                                   │ HogQL queries
-                                   ▼
-┌──────────────────┐    ┌──────────────────────┐    ┌──────────────────┐
-│ Content Pipeline │◄───│ Attribution Feedback  │───►│  ASO Keyword     │
-│ (daily blog)     │    │ (Sunday pipeline)     │    │  Rotation        │
-└────────┬─────────┘    └──────────────────────┘    └────────┬─────────┘
-         │                                                    │
-         ▼                                                    ▼
-┌──────────────────┐    ┌──────────────────────┐    ┌──────────────────┐
-│ GitHub Pages     │    │  CRO Experiments     │    │ iOS keywords.txt │
-│ Site + llms.txt  │    │  (store A/B tests)   │    │ Play Store title │
-└──────────────────┘    └──────────────────────┘    └──────────────────┘
-                                   │
-         ┌─────────────────────────┼────────────────────────┐
-         ▼                         ▼                         ▼
-┌──────────────────┐    ┌──────────────────────┐    ┌──────────────────┐
-│ Review Velocity  │    │  Paid Acquisition    │    │ Referral Content │
-│ Tracker          │    │  (ASA + UAC)         │    │ (Reddit, PH)     │
-└──────────────────┘    └──────────────────────┘    └──────────────────┘
+```mermaid
+graph TD
+    PH[PostHog Analytics<br/>us.i.posthog.com] -->|HogQL queries| ATT[Attribution Feedback<br/>Sunday pipeline]
+
+    ATT -->|content feedback| CP[Content Pipeline<br/>daily blog]
+    ATT -->|keyword feedback| ASO[ASO Keyword Rotation]
+
+    CP --> GP[GitHub Pages<br/>Site + llms.txt]
+    ASO --> KW[iOS keywords.txt<br/>Play Store title]
+
+    ATT --> CRO[CRO Experiments<br/>store A/B tests]
+
+    CRO --> RV[Review Velocity Tracker]
+    CRO --> PA[Paid Acquisition<br/>ASA + UAC]
+    CRO --> REF[Referral Content<br/>Reddit, PH]
+
+    style PH fill:#4a9eff,color:#fff
+    style ATT fill:#ff6b6b,color:#fff
+    style CP fill:#51cf66,color:#fff
+    style ASO fill:#ffd43b,color:#000
+    style CRO fill:#cc5de8,color:#fff
 ```
 
 ## Data Files (marketing/data/)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,6 +2,42 @@
 
 Welcome to the Random Timer project wiki. These pages are **auto-updated daily** by GitHub Actions from live PostHog analytics and marketing pipeline data.
 
+## Project Architecture
+
+```mermaid
+graph TD
+    subgraph Apps
+        A[Android<br/>Kotlin/Compose] -->|PostHog SDK| P[PostHog Analytics]
+        I[iOS<br/>Swift/SwiftUI] -->|PostHog SDK| P
+    end
+
+    subgraph CI/CD
+        GH[GitHub Actions] -->|assembleDebug| APK[Debug APK Artifact]
+        GH -->|xcodebuild| IPA[iOS Build Check]
+        GH -->|wiki-sync| W[GitHub Wiki]
+    end
+
+    subgraph Growth Automation
+        GP[Content Pipeline] -->|daily| BLOG[Blog + Pages]
+        ASO[ASO Rotation] -->|weekly| KW[App Store Keywords]
+        ATT[Attribution Feedback] -->|weekly| UTM[UTM Reports]
+        CRO[CRO Experiments] -->|weekly| AB[Store A/B Tests]
+    end
+
+    P -->|HogQL| ATT
+    ATT -->|keyword feedback| ASO
+    ATT -->|content feedback| GP
+    GP -->|DEV.to + X| PUB[Cross-Platform Publishing]
+```
+
+## Budget Allocation
+
+```mermaid
+pie title Daily Ad Budget - $10/day
+    "Apple Search Ads" : 6
+    "Google UAC" : 4
+```
+
 ## Navigation
 
 ### Analytics & Measurement
@@ -22,6 +58,16 @@ Welcome to the Random Timer project wiki. These pages are **auto-updated daily**
 
 ### Daily Dashboard
 - [[Daily Metrics Dashboard]] — Auto-generated summary with live data from PostHog + marketing JSON
+
+## Recent Cleanup (2026-02-23)
+
+| Action | Branch | Result |
+|--------|--------|--------|
+| Merged | `fix/metadata-gaps` via PR #439 | Metadata sync rewrite + localized descriptions + A/B pilot |
+| Deleted | `claude/power-button-silence-alarm-TxDrs` | Feature already on develop; overloaded branch removed |
+| Deleted | `auto/growth-publishing-20260222-1331` | Auto-generated content with broken links |
+
+**Repo health:** 2 core branches (`main`, `develop`), both CI green.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Mermaid architecture diagram and budget pie chart to wiki Home page
- Replace ASCII art with colored Mermaid flowchart in Growth Systems Overview
- Document PR management cleanup (2026-02-23): merged PR #439, deleted 2 stale branches

## Test plan

- [ ] Verify Mermaid diagrams render on GitHub wiki after wiki-sync runs
- [ ] Confirm cleanup summary is accurate

https://claude.ai/code/session_011tjPAdbUnqUWcbCAbtGjBH