### PR TITLE
fix(ios): trim keywords to 100-char ASO limit

### DIFF
--- a/native-ios/fastlane/metadata/en-US/keywords.txt
+++ b/native-ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-boxing,bjj,mma,combatives,drills,sparring,interval,coach,hiit,crossfit,rounds,fighter,workout,tabata
+boxing,bjj,mma,combatives,drills,sparring,interval,coach,crossfit,rounds,fighter,workout,tabata


### PR DESCRIPTION
## Summary
- Removed `hiit` from iOS keywords (generic, high competition, not combat-niche)
- Brings keywords from 101 → 95 chars (under 100-char App Store limit)
- Fixes CI preflight release gate failure

## Test plan
- [ ] CI preflight passes (release readiness gate)
- [ ] Verify keywords still cover core combat niche terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)