### PR TITLE
fix(ci): make weekly attribution workflow compatible with branch protection

### DIFF
--- a/.github/workflows/weekly-attribution-feedback.yml
+++ b/.github/workflows/weekly-attribution-feedback.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create PR with feedback data
         if: inputs.dry_run != true
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ github.token }}
           commit-message: "chore(analytics): weekly attribution feedback from PostHog"


### PR DESCRIPTION
- replace direct push with create-pull-request\n- add pull-requests permission\n- use unique branch suffix for automation PR branches\n\nThis removes protected-branch push failures in weekly attribution jobs.