### PR TITLE
fix(security): scope workflow permissions to job level

### DIFF
--- a/.github/workflows/weekly-attribution-feedback.yml
+++ b/.github/workflows/weekly-attribution-feedback.yml
@@ -16,10 +16,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: attribution-feedback
   cancel-in-progress: false
@@ -27,6 +23,9 @@ concurrency:
 jobs:
   attribution-feedback:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Moves `permissions` block from workflow-level to job-level in `weekly-attribution-feedback.yml`
- Tighter security scoping per GitHub Actions best practices
- Follow-up to PRs #443, #444, #445

https://claude.ai/code/session_011tjPAdbUnqUWcbCAbtGjBH