### PR TITLE
feat(analytics): fix UTM attribution, cap default duration, add abandonment tracking

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -180,6 +180,8 @@ object AnalyticsEvents {
     const val TIMER_STOPPED = "timer_stopped"
     const val ALARM_TRIGGERED = "alarm_triggered"
     const val ALARM_DISMISSED = "alarm_dismissed"
+    const val TIMER_ABANDONED = "timer_abandoned"
+    const val TIMER_COUNTDOWN_FINISHED = "timer_countdown_finished"
     const val SETTINGS_CHANGED = "settings_changed"
     const val REVIEW_PROMPT_REQUESTED = "review_prompt_requested"
     const val WRITE_REVIEW_TAPPED = "write_review_tapped"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
@@ -28,7 +28,7 @@ class TimerRepositoryImpl @Inject constructor(
         return dataStore.data.map { preferences ->
             TimerConfig(
                 minSeconds = preferences[KEY_MIN_SECONDS] ?: 0,
-                maxSeconds = preferences[KEY_MAX_SECONDS] ?: 300,
+                maxSeconds = preferences[KEY_MAX_SECONDS] ?: 60,
                 alarmDuration = preferences[KEY_ALARM_DURATION] ?: 10,
                 hiddenMode = preferences[KEY_HIDDEN_MODE] ?: false,
                 repeatEnabled = preferences[KEY_REPEAT_ENABLED] ?: false,
@@ -63,7 +63,7 @@ class TimerRepositoryImpl @Inject constructor(
 
             val config = TimerConfig(
                 minSeconds = preferences[KEY_MIN_SECONDS] ?: 0,
-                maxSeconds = preferences[KEY_MAX_SECONDS] ?: 300,
+                maxSeconds = preferences[KEY_MAX_SECONDS] ?: 60,
                 alarmDuration = preferences[KEY_ALARM_DURATION] ?: 10,
                 hiddenMode = preferences[KEY_HIDDEN_MODE] ?: false,
                 repeatEnabled = preferences[KEY_REPEAT_ENABLED] ?: false,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -53,7 +53,7 @@ data class TimerConfig(
     companion object {
         val DEFAULT = TimerConfig(
             minSeconds = 0,
-            maxSeconds = 300,
+            maxSeconds = 60,
             alarmDuration = 10,
             hiddenMode = false,
             repeatEnabled = false, // Default to LOOP OFF

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -123,7 +123,18 @@ class TimerViewModel
         }
 
         fun cancelTimer() {
+            val state = _timerState.value
             analyticsService.track(AnalyticsEvents.TIMER_STOPPED)
+            if (state != null && state.status != TimerStatus.ALARM && state.status != TimerStatus.COMPLETE) {
+                analyticsService.track(
+                    AnalyticsEvents.TIMER_ABANDONED,
+                    mapOf(
+                        "target_duration" to state.targetDuration.inWholeSeconds,
+                        "remaining_duration" to state.remainingDuration.inWholeSeconds,
+                        "status" to state.status.name,
+                    ),
+                )
+            }
             viewModelScope.launch {
                 repository.clearActiveTimer()
                 _timerState.value = null
@@ -198,6 +209,10 @@ class TimerViewModel
             val currentStatus = state?.status ?: return
 
             if (previousStatus != null && previousStatus != TimerStatus.ALARM && currentStatus == TimerStatus.ALARM) {
+                analyticsService.track(
+                    AnalyticsEvents.TIMER_COUNTDOWN_FINISHED,
+                    mapOf("target_duration" to state.targetDuration.inWholeSeconds),
+                )
                 analyticsService.track(
                     AnalyticsEvents.ALARM_TRIGGERED,
                     mapOf("target_duration" to state.targetDuration.inWholeSeconds),

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
@@ -12,7 +12,7 @@ class TimerConfigTest {
         val config = TimerConfig.DEFAULT
 
         assertThat(config.minSeconds).isEqualTo(0)
-        assertThat(config.maxSeconds).isEqualTo(300)
+        assertThat(config.maxSeconds).isEqualTo(60)
         assertThat(config.volume).isEqualTo(0.5f)
         assertThat(config.vibrationEnabled).isFalse()
     }

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -187,6 +187,8 @@ enum AnalyticsEvents {
     static let timerStopped = "timer_stopped"
     static let alarmTriggered = "alarm_triggered"
     static let alarmDismissed = "alarm_dismissed"
+    static let timerAbandoned = "timer_abandoned"
+    static let timerCountdownFinished = "timer_countdown_finished"
     static let settingsChanged = "settings_changed"
     static let reviewPromptRequested = "review_prompt_requested"
     static let writeReviewTapped = "write_review_tapped"

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -143,6 +143,13 @@ final class TimerManager: ObservableObject {
 
     func cancelTimer() async {
         AnalyticsService.shared.track(AnalyticsEvents.timerStopped)
+        if let state = timerState, state.status != .alarm, state.status != .complete {
+            AnalyticsService.shared.track(AnalyticsEvents.timerAbandoned, properties: [
+                "target_duration": state.targetDuration,
+                "remaining_duration": state.remainingDuration,
+                "status": state.status.rawValue,
+            ])
+        }
         stopCountdown()
         timerState = nil
 
@@ -508,6 +515,9 @@ final class TimerManager: ObservableObject {
 
             stopCountdown()
 
+            AnalyticsService.shared.track(AnalyticsEvents.timerCountdownFinished, properties: [
+                "target_duration": state.targetDuration,
+            ])
             AnalyticsService.shared.track(AnalyticsEvents.alarmTriggered, properties: [
                 "target_duration": state.targetDuration,
             ])
@@ -566,7 +576,9 @@ final class TimerManager: ObservableObject {
             notificationService.stopAlarmSound()
             notificationService.stopVibration()
             StoreReviewManager.shared.recordCompletion()
-            AnalyticsService.shared.track(AnalyticsEvents.timerCompleted)
+            AnalyticsService.shared.track(AnalyticsEvents.timerCompleted, properties: [
+                "target_duration": state.targetDuration,
+            ])
             AnalyticsService.shared.trackFirstTimerCompletedIfNeeded()
 
             // Auto-repeat if enabled

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -8,7 +8,7 @@ final class TimerConfigTests: XCTestCase {
         let config = TimerConfig.default
 
         XCTAssertEqual(config.minSeconds, 0)
-        XCTAssertEqual(config.maxSeconds, 300)
+        XCTAssertEqual(config.maxSeconds, 60)
         XCTAssertEqual(config.volume, 0.5)
         XCTAssertFalse(config.vibrationEnabled)
     }

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -39,7 +39,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
 
     public init(
         minSeconds: Int = 0,
-        maxSeconds: Int = 300,
+        maxSeconds: Int = 60,
         alarmDuration: Int = 10,
         hiddenMode: Bool = false,
         repeatEnabled: Bool = false, // Default to LOOP OFF

--- a/scripts/growth_content_pipeline.py
+++ b/scripts/growth_content_pipeline.py
@@ -487,6 +487,11 @@ def add_utm(url: str, source: str, campaign: str, medium: str = "organic") -> st
     )
 
 
+# Deep link base URL — routes through the app's verified domain so UTM params
+# are captured by the PostHog deep_link_opened handler before redirecting to stores.
+DEEP_LINK_BASE = "https://igorganapolsky.github.io/Random-Timer/download"
+
+
 def compose_markdown(
     *,
     title: str,
@@ -501,8 +506,8 @@ def compose_markdown(
     android_review_url: str,
     campaign: str,
 ) -> str:
-    blog_ios = add_utm(app_store_url, "github_pages", campaign)
-    blog_android = add_utm(play_store_url, "github_pages", campaign)
+    blog_ios = add_utm(DEEP_LINK_BASE + "?platform=ios", "github_pages", campaign)
+    blog_android = add_utm(DEEP_LINK_BASE + "?platform=android", "github_pages", campaign)
     frontmatter = (
         "---\n"
         f"title: {title}\n"

--- a/wiki/Analytics-Events-Reference.md
+++ b/wiki/Analytics-Events-Reference.md
@@ -14,6 +14,8 @@ All events tracked via **PostHog** on both platforms. Firebase Analytics is expl
 | `timer_stopped` | `TIMER_STOPPED` | `timerStopped` | User cancels running timer | — |
 | `alarm_triggered` | `ALARM_TRIGGERED` | `alarmTriggered` | Timer reaches zero, alarm fires | `target_duration` |
 | `alarm_dismissed` | `ALARM_DISMISSED` | `alarmDismissed` | User dismisses alarm (tap or power button on iOS) | — |
+| `timer_abandoned` | `TIMER_ABANDONED` | `timerAbandoned` | User cancels before countdown finishes | `target_duration`, `remaining_duration`, `status` |
+| `timer_countdown_finished` | `TIMER_COUNTDOWN_FINISHED` | `timerCountdownFinished` | Countdown reaches zero (before alarm phase) | `target_duration` |
 | `settings_changed` | `SETTINGS_CHANGED` | `settingsChanged` | User modifies timer config | `min_duration`, `max_duration`, `sound_type`, `repeat_enabled` |
 | `review_prompt_requested` | `REVIEW_PROMPT_REQUESTED` | `reviewPromptRequested` | In-app review dialog shown | — |
 | `write_review_tapped` | `WRITE_REVIEW_TAPPED` | `writeReviewTapped` | User taps "Write Review" | — |


### PR DESCRIPTION
## Summary
- **Fix UTM attribution** — Blog CTAs now route through deep links (`igorganapolsky.github.io/Random-Timer/download?platform=...`) so PostHog captures UTM params. Previously linked directly to App Store/Play Store where UTM params were lost.
- **Cap default max duration** — Changed from 300s (5 min) to 60s (1 min) for first-time users. Reduces the configured-to-completed drop-off (currently 52.5%).
- **Add `timer_abandoned` event** — Fires when user cancels before countdown finishes, with `target_duration`, `remaining_duration`, `status` properties. Now we can measure where/why users quit.
- **Add `timer_countdown_finished` event** — Fires at countdown=0, before the alarm phase. Distinguishes "user waited for full timer" from the stricter `timer_completed` (alarm resolved).
- **Fix iOS `timer_completed` parity** — Now sends `target_duration` property like Android does.

## Files Changed (11)
- `scripts/growth_content_pipeline.py` — Deep link URL builder
- `native-android/.../TimerConfig.kt` — Default max 300→60
- `native-android/.../TimerRepositoryImpl.kt` — Fallback max 300→60
- `native-android/.../AnalyticsService.kt` — New event constants
- `native-android/.../TimerViewModel.kt` — Fire abandoned + countdown_finished
- `native-android/.../TimerConfigTest.kt` — Updated assertion
- `native-ios/SharedModels/TimerModels.swift` — Default max 300→60
- `native-ios/.../AnalyticsService.swift` — New event constants
- `native-ios/.../TimerManager.swift` — Fire abandoned + countdown_finished + timer_completed w/ properties
- `native-ios/RandomTimerTests/TimerModelsTests.swift` — Updated assertion
- `wiki/Analytics-Events-Reference.md` — Document new events

## Test plan
- [ ] Android unit tests pass (`TimerConfigTest` updated for new default)
- [ ] iOS unit tests pass (`TimerModelsTests` updated for new default)
- [ ] Verify `timer_abandoned` fires on cancel in PostHog
- [ ] Verify `timer_countdown_finished` fires at countdown=0
- [ ] Verify blog post links use deep link URLs in generated markdown

https://claude.ai/code/session_011tjPAdbUnqUWcbCAbtGjBH