### PR TITLE
fix(wiki): refresh legacy dashboard footer timestamp

### DIFF
--- a/scripts/tests/test_wiki_sync.py
+++ b/scripts/tests/test_wiki_sync.py
@@ -186,3 +186,16 @@ def test_budget_allocation_nested_format(data_dir: Path, dashboard_template: str
     assert "$8.00" in result
     assert "$5.00" in result
     assert "$13.00" in result
+
+
+def test_refreshes_legacy_footer_timestamp(data_dir: Path) -> None:
+    template = (
+        "# Dashboard\n\n"
+        "_Dashboard generated at: `2026-02-21T16:30:28+00:00`. "
+        "Data refreshed daily by [`wiki-sync.yml`]"
+        "(https://github.com/IgorGanapolsky/Random-Timer/actions/workflows/wiki-sync.yml)._\n"
+    )
+    result = inject_dashboard_data(template, data_dir)
+    assert "2026-02-21T16:30:28+00:00" not in result
+    assert "_Dashboard generated at: `" in result
+    assert "wiki-sync.yml" in result

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -207,6 +207,13 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
     """Replace placeholder sections in the dashboard with live data."""
     now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
     dashboard = dashboard.replace("<!-- TIMESTAMP -->", now)
+    # Keep the footer timestamp current even when legacy templates contain
+    # a literal date string instead of the TIMESTAMP marker.
+    dashboard = re.sub(
+        r"_Dashboard generated at: `[^`]+`\. Data refreshed daily by \[`wiki-sync\.yml`\]\([^)]*\)\._",
+        f"_Dashboard generated at: `{now}`. Data refreshed daily by [`wiki-sync.yml`](https://github.com/IgorGanapolsky/Random-Timer/actions/workflows/wiki-sync.yml)._",
+        dashboard,
+    )
 
     # --- Downloads & Active Users ---
     dl = load_json(data_dir / "store_downloads.json")


### PR DESCRIPTION
## Summary
- fix `scripts/wiki_sync.py` to refresh legacy dashboard footer timestamp on each sync
- add regression test for legacy footer timestamp replacement

## Verification
- `pytest -q scripts/tests/test_wiki_sync.py scripts/tests/test_sync_android_metadata.py`
- Triggered and verified Wiki Sync workflow on develop: run `22327462092` (success), including PostHog snapshot steps and wiki publish
