### PR TITLE
Harden Play release automation (fallback, triage, daily retry)

### DIFF
--- a/.github/workflows/android-production-retry.yml
+++ b/.github/workflows/android-production-retry.yml
@@ -1,0 +1,75 @@
+name: Android Production Retry
+
+on:
+  schedule:
+    - cron: "30 14 * * *"
+  workflow_dispatch:
+    inputs:
+      force_retry:
+        description: "Force retry even if no open blocker issue"
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
+        required: false
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_retry: ${{ steps.gate.outputs.should_retry }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - name: Check if retry is required
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+          ISSUE_TITLE: Android production publish blocked by Play FAILED_PRECONDITION
+          FORCE_RETRY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_retry || 'false' }}
+        run: |
+          if [ "$FORCE_RETRY" = "true" ]; then
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual_force_retry" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ISSUE_NUMBER="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "\"$ISSUE_TITLE\" in:title" --json number,title --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' | head -1)"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+            echo "reason=open_blocker_issue_$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_retry=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no_open_blocker_issue" >> "$GITHUB_OUTPUT"
+          fi
+
+  dispatch-production-retry:
+    needs: [gate]
+    if: ${{ needs.gate.outputs.should_retry == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Dispatch Native App Release (Android production)
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+        run: |
+          gh workflow run native-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref develop \
+            -f platform=android \
+            -f android_track=production \
+            -f submit_review=false
+          echo "✅ Dispatched native-release.yml (android production). reason=${{ needs.gate.outputs.reason }}"
+
+  skip:
+    needs: [gate]
+    if: ${{ needs.gate.outputs.should_retry != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip retry
+        run: echo "Skipping production retry. reason=${{ needs.gate.outputs.reason }}"

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -135,6 +135,13 @@ jobs:
     if: ${{ inputs.platform == 'android' || inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+    outputs:
+      requested_track: ${{ steps.play_result.outputs.requested_track }}
+      effective_track: ${{ steps.play_result.outputs.effective_track }}
+      fallback_used: ${{ steps.play_result.outputs.fallback_used }}
+      precondition_blocked: ${{ steps.play_result.outputs.precondition_blocked }}
     steps:
       - uses: actions/checkout@v4
 
@@ -218,6 +225,8 @@ jobs:
         env:
           GOOGLE_PLAY_JSON_KEY: /tmp/play-service-account.json
           PLAY_TRACK: ${{ inputs.android_track }}
+          PLAY_FALLBACK_TRACK: alpha
+          PLAY_RELEASE_STATUS: completed
           PLAY_UPLOAD_RETRY_WINDOW_SECONDS: "10800"
           PLAY_UPLOAD_RETRY_INTERVAL_SECONDS: "300"
         run: |
@@ -226,284 +235,54 @@ jobs:
             exit 1
           fi
           pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
-          python3 - <<'PYEOF'
-          import sys
-          import os
-          import json
-          import glob
-          import mimetypes
-          import time
+          python scripts/play_publish.py \
+            --service-account-json "$GOOGLE_PLAY_JSON_KEY" \
+            --package com.iganapolsky.randomtimer \
+            --aab-path native-android/app/build/outputs/bundle/release/app-release.aab \
+            --requested-track "$PLAY_TRACK" \
+            --fallback-track "$PLAY_FALLBACK_TRACK" \
+            --release-status "$PLAY_RELEASE_STATUS" \
+            --retry-window-seconds "$PLAY_UPLOAD_RETRY_WINDOW_SECONDS" \
+            --retry-interval-seconds "$PLAY_UPLOAD_RETRY_INTERVAL_SECONDS" \
+            --result-json /tmp/play-upload-result.json \
+            --error-json /tmp/play-upload-error.json
 
-          from google.oauth2 import service_account
-          from googleapiclient.discovery import build
-          from googleapiclient.errors import HttpError
-          from googleapiclient.http import MediaFileUpload
+      - name: Capture Play publish result outputs
+        id: play_result
+        if: always()
+        run: |
+          REQUESTED_TRACK="${{ inputs.android_track }}"
+          EFFECTIVE_TRACK="${{ inputs.android_track }}"
+          FALLBACK_USED="false"
+          PRECONDITION_BLOCKED="false"
 
-          SCOPES = ['https://www.googleapis.com/auth/androidpublisher']
-          PACKAGE = 'com.iganapolsky.randomtimer'
-          AAB_PATH = 'native-android/app/build/outputs/bundle/release/app-release.aab'
-          TRACK = (os.getenv("PLAY_TRACK", "") or "production").strip()
-          DEFAULT_STATUS = "completed"
-          RELEASE_STATUS = (os.getenv("PLAY_RELEASE_STATUS", "") or DEFAULT_STATUS).strip() or DEFAULT_STATUS
-          RETRY_WINDOW = int(os.getenv("PLAY_UPLOAD_RETRY_WINDOW_SECONDS", "10800"))
-          RETRY_INTERVAL = int(os.getenv("PLAY_UPLOAD_RETRY_INTERVAL_SECONDS", "300"))
-          RESET_ERROR_FRAGMENT = "certificate this apk is signed with is not yet valid because it has been recently reset"
-          TRANSIENT_ERROR_FRAGMENTS = (
-              "eof occurred in violation of protocol",
-              "connection reset",
-              "connection aborted",
-              "timed out",
-              "temporary failure",
-              "service unavailable",
-          )
+          if [ -f /tmp/play-upload-result.json ]; then
+            REQUESTED_TRACK="$(jq -r '.requested_track // empty' /tmp/play-upload-result.json)"
+            EFFECTIVE_TRACK="$(jq -r '.effective_track // empty' /tmp/play-upload-result.json)"
+            FALLBACK_USED="$(jq -r '.fallback_used // false' /tmp/play-upload-result.json)"
+            PRECONDITION_BLOCKED="$(jq -r '.precondition_blocked // false' /tmp/play-upload-result.json)"
+          fi
 
-          credentials = service_account.Credentials.from_service_account_file(
-              '/tmp/play-service-account.json', scopes=SCOPES
-          )
-          service = build('androidpublisher', 'v3', credentials=credentials)
+          if [ -z "$REQUESTED_TRACK" ] || [ "$REQUESTED_TRACK" = "null" ]; then
+            REQUESTED_TRACK="${{ inputs.android_track }}"
+          fi
+          if [ -z "$EFFECTIVE_TRACK" ] || [ "$EFFECTIVE_TRACK" = "null" ]; then
+            EFFECTIVE_TRACK="$REQUESTED_TRACK"
+          fi
 
-          deadline = time.time() + RETRY_WINDOW
-          attempt = 0
+          echo "requested_track=$REQUESTED_TRACK" >> "$GITHUB_OUTPUT"
+          echo "effective_track=$EFFECTIVE_TRACK" >> "$GITHUB_OUTPUT"
+          echo "fallback_used=$FALLBACK_USED" >> "$GITHUB_OUTPUT"
+          echo "precondition_blocked=$PRECONDITION_BLOCKED" >> "$GITHUB_OUTPUT"
+          echo "play_result requested=$REQUESTED_TRACK effective=$EFFECTIVE_TRACK fallback_used=$FALLBACK_USED precondition_blocked=$PRECONDITION_BLOCKED"
 
-          while True:
-              attempt += 1
-              try:
-                  edit = service.edits().insert(body={}, packageName=PACKAGE).execute()
-                  edit_id = edit['id']
-
-                  bundle = service.edits().bundles().upload(
-                      packageName=PACKAGE,
-                      editId=edit_id,
-                      media_body=MediaFileUpload(AAB_PATH, mimetype='application/octet-stream')
-                  ).execute()
-
-                  # Update store listing + images from fastlane metadata.
-                  # Play can block production submissions if the listing is incomplete.
-                  metadata_dir = os.path.join(
-                      "native-android",
-                      "fastlane",
-                      "metadata",
-                      "android",
-                      "en-US",
-                  )
-
-                  def read_text(rel_path: str) -> str:
-                      p = os.path.join(metadata_dir, rel_path)
-                      try:
-                          if os.path.isfile(p):
-                              with open(p, "r", encoding="utf-8") as f:
-                                  return f.read().strip()
-                      except Exception:
-                          return ""
-                      return ""
-
-                  title = read_text("title.txt")
-                  short_desc = read_text("short_description.txt")
-                  full_desc = read_text("full_description.txt")
-                  video = read_text("video.txt")
-
-                  listing = {}
-                  if title:
-                      listing["title"] = title
-                  if short_desc:
-                      listing["shortDescription"] = short_desc
-                  if full_desc:
-                      listing["fullDescription"] = full_desc
-                  if video:
-                      listing["video"] = video
-
-                  if listing:
-                      service.edits().listings().update(
-                          packageName=PACKAGE,
-                          editId=edit_id,
-                          language="en-US",
-                          body=listing,
-                      ).execute()
-
-                  # Best-effort: set details (contact + default language) if missing.
-                  details = {"defaultLanguage": "en-US"}
-                  support_url = ""
-                  try:
-                      support_path = os.path.join(
-                          "native-ios", "fastlane", "metadata", "en-US", "support_url.txt"
-                      )
-                      if os.path.isfile(support_path):
-                          with open(support_path, "r", encoding="utf-8") as f:
-                              support_url = f.read().strip()
-                  except Exception:
-                      support_url = ""
-                  if support_url:
-                      details["contactWebsite"] = support_url
-                  try:
-                      service.edits().details().patch(
-                          packageName=PACKAGE,
-                          editId=edit_id,
-                          body=details,
-                      ).execute()
-                  except Exception:
-                      # Non-fatal: some accounts/apps restrict patching details via API.
-                      pass
-
-                  def mime_for(path: str) -> str:
-                      mt, _ = mimetypes.guess_type(path)
-                      return mt or "application/octet-stream"
-
-                  def upload_images(image_type: str, pattern: str) -> None:
-                      files = sorted(glob.glob(pattern))
-                      if not files:
-                          return
-                      try:
-                          service.edits().images().deleteall(
-                              packageName=PACKAGE,
-                              editId=edit_id,
-                              language="en-US",
-                              imageType=image_type,
-                          ).execute()
-                      except Exception:
-                          pass
-                      for fp in files:
-                          service.edits().images().upload(
-                              packageName=PACKAGE,
-                              editId=edit_id,
-                              language="en-US",
-                              imageType=image_type,
-                              media_body=MediaFileUpload(fp, mimetype=mime_for(fp)),
-                          ).execute()
-
-                  upload_images(
-                      "icon",
-                      os.path.join(metadata_dir, "images", "icon.*"),
-                  )
-                  upload_images(
-                      "featureGraphic",
-                      os.path.join(metadata_dir, "images", "featureGraphic", "*.*"),
-                  )
-                  upload_images(
-                      "phoneScreenshots",
-                      os.path.join(metadata_dir, "images", "phoneScreenshots", "*.*"),
-                  )
-
-                  # Play Console can require release notes for first-time production submissions.
-                  notes_path = os.path.join(
-                      "native-android",
-                      "fastlane",
-                      "metadata",
-                      "android",
-                      "en-US",
-                      "changelogs",
-                      f"{bundle['versionCode']}.txt",
-                  )
-                  release_notes = ""
-                  try:
-                      if os.path.isfile(notes_path):
-                          with open(notes_path, "r", encoding="utf-8") as f:
-                              release_notes = f.read().strip()
-                  except Exception:
-                      release_notes = ""
-
-                  release = {
-                      "versionCodes": [bundle["versionCode"]],
-                      "status": RELEASE_STATUS,
-                      "name": f"v{bundle['versionCode']}",
-                  }
-                  if release_notes:
-                      release["releaseNotes"] = [{"language": "en-US", "text": release_notes}]
-                  if RELEASE_STATUS == "inProgress":
-                      # Staged rollout only. For full rollout use status=completed.
-                      # If not provided, default to 0.1 so we never send the invalid 1.0 value.
-                      user_fraction_raw = (os.getenv("PLAY_USER_FRACTION", "") or "0.1").strip()
-                      try:
-                          user_fraction = float(user_fraction_raw)
-                      except Exception:
-                          user_fraction = 0.1
-                      user_fraction = max(0.0, min(1.0, user_fraction))
-                      if user_fraction >= 1.0:
-                          user_fraction = 0.1
-                      release["userFraction"] = user_fraction
-
-                  service.edits().tracks().update(
-                      packageName=PACKAGE,
-                      editId=edit_id,
-                      track=TRACK,
-                      body={"releases": [release]},
-                  ).execute()
-
-                  service.edits().commit(packageName=PACKAGE, editId=edit_id).execute()
-                  print(
-                      f"✅ Uploaded version code {bundle['versionCode']} to '{TRACK}' track "
-                      f"(status={RELEASE_STATUS})"
-                  )
-                  break
-              except HttpError as e:
-                  message = str(e)
-                  is_recent_reset = RESET_ERROR_FRAGMENT in message.lower()
-                  status = getattr(getattr(e, "resp", None), "status", None)
-                  is_transient_http = status in (429, 500, 502, 503, 504)
-                  remaining = int(deadline - time.time())
-
-                  if (is_recent_reset or is_transient_http) and remaining > 0:
-                      sleep_for = min(RETRY_INTERVAL, remaining)
-                      reason = "key reset propagation" if is_recent_reset else f"transient HTTP {status}"
-                      print(
-                          f"⚠️ Play upload retry due to {reason} (attempt {attempt}). "
-                          f"Retrying in {sleep_for}s (remaining retry window: {remaining}s)...",
-                          file=sys.stderr,
-                      )
-                      time.sleep(sleep_for)
-                      continue
-
-                  content = ""
-                  try:
-                      raw = getattr(e, "content", b"") or b""
-                      if isinstance(raw, (bytes, bytearray)):
-                          content = raw.decode("utf-8", errors="ignore").strip()
-                      else:
-                          content = str(raw).strip()
-                  except Exception:
-                      content = ""
-
-                  # Persist the raw response to an artifact-backed file so we can debug
-                  # FAILED_PRECONDITION even when GitHub masks the log output.
-                  try:
-                      payload = {
-                          "package": PACKAGE,
-                          "track": TRACK,
-                          "release_status": RELEASE_STATUS,
-                          "attempt": attempt,
-                          "http_status": status,
-                          "error": str(e),
-                          "response": content,
-                      }
-                      with open("/tmp/play-upload-error.json", "w", encoding="utf-8") as f:
-                          json.dump(payload, f, indent=2, ensure_ascii=True)
-                      print("📦 Wrote /tmp/play-upload-error.json", file=sys.stderr)
-                  except Exception as write_err:
-                      print(f"⚠️ Failed to write /tmp/play-upload-error.json: {write_err}", file=sys.stderr)
-
-                  if content:
-                      print(f"❌ Google Play upload failed: {e}\n\nResponse:\n{content}", file=sys.stderr)
-                  else:
-                      print(f"❌ Google Play upload failed: {e}", file=sys.stderr)
-                  sys.exit(1)
-              except Exception as e:
-                  message = str(e).lower()
-                  remaining = int(deadline - time.time())
-                  is_transient_network = any(
-                      frag in message for frag in TRANSIENT_ERROR_FRAGMENTS
-                  )
-                  if is_transient_network and remaining > 0:
-                      sleep_for = min(RETRY_INTERVAL, remaining)
-                      print(
-                          f"⚠️ Play upload transient network error (attempt {attempt}): {e}. "
-                          f"Retrying in {sleep_for}s (remaining retry window: {remaining}s)...",
-                          file=sys.stderr,
-                      )
-                      time.sleep(sleep_for)
-                      continue
-
-                  print(f"❌ Google Play upload failed: {e}", file=sys.stderr)
-                  sys.exit(1)
-          PYEOF
+      - name: Upload Play upload result (if any)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: play-upload-result
+          path: /tmp/play-upload-result.json
+          if-no-files-found: ignore
 
       - name: Upload Play upload error (if any)
         uses: actions/upload-artifact@v4
@@ -524,6 +303,45 @@ jobs:
         if: always()
         run: |
           rm -f /tmp/release.keystore /tmp/play-service-account.json
+
+  play-precondition-triage:
+    needs: [android-release]
+    if: ${{ always() && (inputs.platform == 'android' || inputs.platform == 'both') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Play error artifact
+        uses: actions/download-artifact@v4
+        if: always()
+        continue-on-error: true
+        with:
+          name: play-upload-error
+          path: /tmp/play-upload-error
+
+      - name: Download Play result artifact
+        uses: actions/download-artifact@v4
+        if: always()
+        continue-on-error: true
+        with:
+          name: play-upload-result
+          path: /tmp/play-upload-result
+
+      - name: Upsert Play precondition triage issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/play_precondition_triage.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --run-url "$RUN_URL" \
+            --error-json /tmp/play-upload-error/play-upload-error.json \
+            --result-json /tmp/play-upload-result/play-upload-result.json
 
   verify-releases:
     needs: [ios-testflight, android-release]
@@ -577,7 +395,12 @@ jobs:
       - name: Determine Android track (no secrets)
         id: android_track
         run: |
-          TRACK=$(jq -r '.inputs.android_track // ""' "$GITHUB_EVENT_PATH")
+          TRACK="${{ needs.android-release.outputs.effective_track }}"
+          if [ -n "$TRACK" ] && [ "$TRACK" != "null" ]; then
+            echo "Using effective track from android-release output: $TRACK"
+          else
+            TRACK=$(jq -r '.inputs.android_track // ""' "$GITHUB_EVENT_PATH")
+          fi
           if [ -z "$TRACK" ] || [ "$TRACK" = "null" ]; then
             TRACK="${{ inputs.android_track }}"
           fi

--- a/scripts/play_precondition_triage.py
+++ b/scripts/play_precondition_triage.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Upsert a single GitHub triage issue for Play FAILED_PRECONDITION blockers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ISSUE_TITLE = "Android production publish blocked by Play FAILED_PRECONDITION"
+
+
+def load_json(path: str) -> dict[str, Any] | None:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.is_file():
+        return None
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def is_failed_precondition_payload(payload: dict[str, Any] | None) -> bool:
+    if not payload:
+        return False
+    text = f"{payload.get('error', '')}\n{payload.get('response', '')}".lower()
+    return "failed_precondition" in text or "precondition check failed" in text
+
+
+def should_close_issue(result_payload: dict[str, Any] | None) -> bool:
+    if not result_payload:
+        return False
+    requested = str(result_payload.get("requested_track", "")).lower()
+    effective = str(result_payload.get("effective_track", "")).lower()
+    fallback_used = bool(result_payload.get("fallback_used"))
+    precondition_blocked = bool(result_payload.get("precondition_blocked"))
+    return (
+        requested == "production"
+        and effective == "production"
+        and not fallback_used
+        and not precondition_blocked
+    )
+
+
+def _run_gh(args: list[str], *, capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+    cmd = ["gh", *args]
+    return subprocess.run(
+        cmd,
+        check=False,
+        capture_output=capture_output,
+        text=True,
+    )
+
+
+def _find_issue_number(repo: str, title: str, state: str) -> int | None:
+    proc = _run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state,
+            "--search",
+            f'"{title}" in:title',
+            "--json",
+            "number,title,state",
+            "--limit",
+            "20",
+        ]
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh issue list failed: {proc.stderr.strip()}")
+
+    issues = json.loads(proc.stdout or "[]")
+    for issue in issues:
+        if issue.get("title") == title:
+            return int(issue["number"])
+    return None
+
+
+def _write_body_file(content: str) -> str:
+    fd, path = tempfile.mkstemp(prefix="play-precondition-", suffix=".md")
+    with open(fd, "w", encoding="utf-8", closefd=True) as f:
+        f.write(content)
+    return path
+
+
+def build_issue_body(
+    *,
+    run_url: str,
+    error_payload: dict[str, Any],
+    result_payload: dict[str, Any] | None,
+) -> str:
+    details = {
+        "http_status": error_payload.get("http_status"),
+        "requested_track": error_payload.get("requested_track"),
+        "failed_track": error_payload.get("track"),
+        "release_status": error_payload.get("release_status"),
+        "attempt": error_payload.get("attempt"),
+        "effective_track": (result_payload or {}).get("effective_track"),
+        "fallback_used": (result_payload or {}).get("fallback_used"),
+        "version_code": (result_payload or {}).get("version_code"),
+    }
+    details_json = json.dumps(details, indent=2, ensure_ascii=True)
+    response_excerpt = str(error_payload.get("response", "")).strip()
+    if len(response_excerpt) > 2000:
+        response_excerpt = response_excerpt[:2000] + "\n... (truncated)"
+
+    body = [
+        "## Play Production Blocker",
+        "",
+        "Automated triage detected a Google Play production publish blocker (`FAILED_PRECONDITION`).",
+        "",
+        f"- Run: {run_url}",
+        "",
+        "### Structured details",
+        "```json",
+        details_json,
+        "```",
+        "",
+        "### Play response excerpt",
+        "```text",
+        response_excerpt or "(empty response)",
+        "```",
+        "",
+        "### Action",
+        "- Keep daily production retry enabled.",
+        "- Continue alpha fallback for continuity until production preconditions clear.",
+    ]
+    return "\n".join(body)
+
+
+def _comment_and_close(repo: str, issue_number: int, run_url: str, result_payload: dict[str, Any]) -> None:
+    message = (
+        "Production publish is now succeeding again. Closing blocker automatically.\n\n"
+        f"- Run: {run_url}\n"
+        f"- Effective track: {result_payload.get('effective_track')}\n"
+        f"- Version code: {result_payload.get('version_code')}"
+    )
+    comment = _run_gh(
+        [
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--body",
+            message,
+        ]
+    )
+    if comment.returncode != 0:
+        raise RuntimeError(f"gh issue comment failed: {comment.stderr.strip()}")
+
+    close = _run_gh(["issue", "close", str(issue_number), "--repo", repo])
+    if close.returncode != 0:
+        raise RuntimeError(f"gh issue close failed: {close.stderr.strip()}")
+
+
+def _upsert_open_issue(
+    repo: str,
+    title: str,
+    body: str,
+) -> int:
+    open_issue = _find_issue_number(repo, title, "open")
+    body_file = _write_body_file(body)
+    try:
+        if open_issue is not None:
+            edit = _run_gh(
+                [
+                    "issue",
+                    "edit",
+                    str(open_issue),
+                    "--repo",
+                    repo,
+                    "--title",
+                    title,
+                    "--body-file",
+                    body_file,
+                ]
+            )
+            if edit.returncode != 0:
+                raise RuntimeError(f"gh issue edit failed: {edit.stderr.strip()}")
+            return open_issue
+
+        closed_issue = _find_issue_number(repo, title, "closed")
+        if closed_issue is not None:
+            reopen = _run_gh(["issue", "reopen", str(closed_issue), "--repo", repo])
+            if reopen.returncode != 0:
+                raise RuntimeError(f"gh issue reopen failed: {reopen.stderr.strip()}")
+            edit = _run_gh(
+                [
+                    "issue",
+                    "edit",
+                    str(closed_issue),
+                    "--repo",
+                    repo,
+                    "--title",
+                    title,
+                    "--body-file",
+                    body_file,
+                ]
+            )
+            if edit.returncode != 0:
+                raise RuntimeError(f"gh issue edit failed: {edit.stderr.strip()}")
+            return closed_issue
+
+        create = _run_gh(
+            [
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--body-file",
+                body_file,
+            ]
+        )
+        if create.returncode != 0:
+            raise RuntimeError(f"gh issue create failed: {create.stderr.strip()}")
+        issue_url = (create.stdout or "").strip()
+        try:
+            return int(issue_url.rstrip("/").split("/")[-1])
+        except Exception:
+            return 0
+    finally:
+        Path(body_file).unlink(missing_ok=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Upsert Play precondition triage issue.")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--error-json", default="")
+    parser.add_argument("--result-json", default="")
+    parser.add_argument("--title", default=DEFAULT_ISSUE_TITLE)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    error_payload = load_json(args.error_json)
+    result_payload = load_json(args.result_json)
+
+    precondition_blocked = is_failed_precondition_payload(error_payload)
+    if precondition_blocked:
+        body = build_issue_body(
+            run_url=args.run_url,
+            error_payload=error_payload or {},
+            result_payload=result_payload,
+        )
+        issue_number = _upsert_open_issue(args.repo, args.title, body)
+        print(
+            f"updated_issue={issue_number}\n"
+            f"action=upsert\n"
+            f"precondition_blocked=true"
+        )
+        return 0
+
+    open_issue = _find_issue_number(args.repo, args.title, "open")
+    if open_issue is None:
+        print("action=noop\nprecondition_blocked=false")
+        return 0
+
+    if should_close_issue(result_payload):
+        _comment_and_close(args.repo, open_issue, args.run_url, result_payload or {})
+        print(f"closed_issue={open_issue}\naction=close\nprecondition_blocked=false")
+        return 0
+
+    print(
+        f"open_issue={open_issue}\naction=noop_open_issue_retained\nprecondition_blocked=false"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/play_publish.py
+++ b/scripts/play_publish.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Publish Android AAB to Google Play with production->alpha fallback support."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import mimetypes
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+RESET_ERROR_FRAGMENT = (
+    "certificate this apk is signed with is not yet valid because it has been recently reset"
+)
+TRANSIENT_ERROR_FRAGMENTS = (
+    "eof occurred in violation of protocol",
+    "connection reset",
+    "connection aborted",
+    "timed out",
+    "temporary failure",
+    "service unavailable",
+)
+FAILED_PRECONDITION_MARKERS = (
+    "failed_precondition",
+    "precondition check failed",
+)
+
+
+@dataclass
+class PublishError(RuntimeError):
+    """Structured publish error with response payload for workflow triage."""
+
+    message: str
+    http_status: int | None
+    response_text: str
+    attempt: int
+
+
+def _read_text(path: Path) -> str:
+    try:
+        if path.is_file():
+            return path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return ""
+    return ""
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True), encoding="utf-8")
+
+
+def _mime_for(path: str) -> str:
+    mime, _ = mimetypes.guess_type(path)
+    return mime or "application/octet-stream"
+
+
+def _extract_response_text(error: Exception) -> str:
+    raw = getattr(error, "content", b"") or b""
+    if isinstance(raw, (bytes, bytearray)):
+        return raw.decode("utf-8", errors="ignore").strip()
+    return str(raw).strip()
+
+
+def _is_failed_precondition(message: str, response_text: str, http_status: int | None) -> bool:
+    combined = f"{message}\n{response_text}".lower()
+    if any(marker in combined for marker in FAILED_PRECONDITION_MARKERS):
+        return True
+    return http_status == 400 and "precondition" in combined
+
+
+def _is_transient_http(http_status: int | None, message: str) -> bool:
+    if http_status in (429, 500, 502, 503, 504):
+        return True
+    lowered = message.lower()
+    return any(fragment in lowered for fragment in TRANSIENT_ERROR_FRAGMENTS)
+
+
+def _load_google_clients(credentials_path: Path):
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+
+    credentials = service_account.Credentials.from_service_account_file(
+        str(credentials_path), scopes=["https://www.googleapis.com/auth/androidpublisher"]
+    )
+    return build("androidpublisher", "v3", credentials=credentials)
+
+
+def _upload_images(service: Any, package: str, edit_id: str, language: str, image_type: str, pattern: str) -> None:
+    from googleapiclient.http import MediaFileUpload
+
+    files = sorted(glob.glob(pattern))
+    if not files:
+        return
+    try:
+        service.edits().images().deleteall(
+            packageName=package,
+            editId=edit_id,
+            language=language,
+            imageType=image_type,
+        ).execute()
+    except Exception:
+        pass
+
+    for fp in files:
+        service.edits().images().upload(
+            packageName=package,
+            editId=edit_id,
+            language=language,
+            imageType=image_type,
+            media_body=MediaFileUpload(fp, mimetype=_mime_for(fp)),
+        ).execute()
+
+
+def _update_listing_and_assets(
+    service: Any,
+    package: str,
+    edit_id: str,
+    metadata_dir: Path,
+    ios_support_url_path: Path,
+) -> None:
+    language = "en-US"
+    listing = {}
+    title = _read_text(metadata_dir / "title.txt")
+    short_desc = _read_text(metadata_dir / "short_description.txt")
+    full_desc = _read_text(metadata_dir / "full_description.txt")
+    video = _read_text(metadata_dir / "video.txt")
+
+    if title:
+        listing["title"] = title
+    if short_desc:
+        listing["shortDescription"] = short_desc
+    if full_desc:
+        listing["fullDescription"] = full_desc
+    if video:
+        listing["video"] = video
+
+    if listing:
+        service.edits().listings().update(
+            packageName=package,
+            editId=edit_id,
+            language=language,
+            body=listing,
+        ).execute()
+
+    details = {"defaultLanguage": language}
+    support_url = _read_text(ios_support_url_path)
+    if support_url:
+        details["contactWebsite"] = support_url
+    try:
+        service.edits().details().patch(
+            packageName=package,
+            editId=edit_id,
+            body=details,
+        ).execute()
+    except Exception:
+        pass
+
+    _upload_images(
+        service,
+        package,
+        edit_id,
+        language,
+        "icon",
+        str(metadata_dir / "images" / "icon.*"),
+    )
+    _upload_images(
+        service,
+        package,
+        edit_id,
+        language,
+        "featureGraphic",
+        str(metadata_dir / "images" / "featureGraphic" / "*.*"),
+    )
+    _upload_images(
+        service,
+        package,
+        edit_id,
+        language,
+        "phoneScreenshots",
+        str(metadata_dir / "images" / "phoneScreenshots" / "*.*"),
+    )
+
+
+def _release_payload(
+    version_code: str | int,
+    release_status: str,
+    release_notes: str,
+    user_fraction_raw: str,
+) -> dict[str, Any]:
+    release: dict[str, Any] = {
+        "versionCodes": [str(version_code)],
+        "status": release_status,
+        "name": f"v{version_code}",
+    }
+    if release_notes:
+        release["releaseNotes"] = [{"language": "en-US", "text": release_notes}]
+
+    if release_status == "inProgress":
+        try:
+            user_fraction = float(user_fraction_raw.strip() or "0.1")
+        except Exception:
+            user_fraction = 0.1
+        user_fraction = max(0.0, min(1.0, user_fraction))
+        if user_fraction >= 1.0:
+            user_fraction = 0.1
+        release["userFraction"] = user_fraction
+
+    return release
+
+
+def _publish_to_track(
+    *,
+    package: str,
+    aab_path: Path,
+    track: str,
+    release_status: str,
+    retry_window_seconds: int,
+    retry_interval_seconds: int,
+    metadata_dir: Path,
+    ios_support_url_path: Path,
+    changelog_dir: Path,
+    credentials_path: Path,
+    user_fraction_raw: str,
+) -> dict[str, Any]:
+    from googleapiclient.errors import HttpError
+    from googleapiclient.http import MediaFileUpload
+
+    service = _load_google_clients(credentials_path)
+    deadline = time.time() + retry_window_seconds
+    attempt = 0
+
+    while True:
+        attempt += 1
+        try:
+            edit = service.edits().insert(body={}, packageName=package).execute()
+            edit_id = edit["id"]
+
+            bundle = service.edits().bundles().upload(
+                packageName=package,
+                editId=edit_id,
+                media_body=MediaFileUpload(str(aab_path), mimetype="application/octet-stream"),
+            ).execute()
+            version_code = bundle["versionCode"]
+
+            _update_listing_and_assets(
+                service=service,
+                package=package,
+                edit_id=edit_id,
+                metadata_dir=metadata_dir,
+                ios_support_url_path=ios_support_url_path,
+            )
+
+            notes_path = changelog_dir / f"{version_code}.txt"
+            release_notes = _read_text(notes_path)
+            release = _release_payload(
+                version_code=version_code,
+                release_status=release_status,
+                release_notes=release_notes,
+                user_fraction_raw=user_fraction_raw,
+            )
+
+            service.edits().tracks().update(
+                packageName=package,
+                editId=edit_id,
+                track=track,
+                body={"releases": [release]},
+            ).execute()
+            service.edits().commit(packageName=package, editId=edit_id).execute()
+
+            return {
+                "version_code": str(version_code),
+                "attempt": attempt,
+            }
+        except HttpError as error:
+            message = str(error)
+            response_text = _extract_response_text(error)
+            status = getattr(getattr(error, "resp", None), "status", None)
+            is_recent_reset = RESET_ERROR_FRAGMENT in f"{message}\n{response_text}".lower()
+            if (is_recent_reset or _is_transient_http(status, message)) and int(deadline - time.time()) > 0:
+                remaining = int(deadline - time.time())
+                sleep_for = min(retry_interval_seconds, remaining)
+                reason = "key reset propagation" if is_recent_reset else f"transient HTTP {status}"
+                print(
+                    f"⚠️ Play upload retry due to {reason} (track={track}, attempt={attempt}). "
+                    f"Retrying in {sleep_for}s (remaining window: {remaining}s)...",
+                    file=sys.stderr,
+                )
+                time.sleep(sleep_for)
+                continue
+            raise PublishError(message=message, http_status=status, response_text=response_text, attempt=attempt)
+        except Exception as error:
+            message = str(error)
+            if _is_transient_http(None, message) and int(deadline - time.time()) > 0:
+                remaining = int(deadline - time.time())
+                sleep_for = min(retry_interval_seconds, remaining)
+                print(
+                    f"⚠️ Play upload transient network error (track={track}, attempt={attempt}): {message}. "
+                    f"Retrying in {sleep_for}s (remaining window: {remaining}s)...",
+                    file=sys.stderr,
+                )
+                time.sleep(sleep_for)
+                continue
+            raise PublishError(message=message, http_status=None, response_text="", attempt=attempt)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish AAB to Play with fallback.")
+    parser.add_argument("--service-account-json", required=True)
+    parser.add_argument("--package", required=True)
+    parser.add_argument("--aab-path", required=True)
+    parser.add_argument("--requested-track", default="production")
+    parser.add_argument("--fallback-track", default="alpha")
+    parser.add_argument("--release-status", default="completed")
+    parser.add_argument("--retry-window-seconds", type=int, default=10800)
+    parser.add_argument("--retry-interval-seconds", type=int, default=300)
+    parser.add_argument(
+        "--metadata-dir",
+        default="native-android/fastlane/metadata/android/en-US",
+    )
+    parser.add_argument(
+        "--ios-support-url-path",
+        default="native-ios/fastlane/metadata/en-US/support_url.txt",
+    )
+    parser.add_argument(
+        "--changelog-dir",
+        default="native-android/fastlane/metadata/android/en-US/changelogs",
+    )
+    parser.add_argument("--result-json", default="/tmp/play-upload-result.json")
+    parser.add_argument("--error-json", default="/tmp/play-upload-error.json")
+    parser.add_argument("--user-fraction", default=os.getenv("PLAY_USER_FRACTION", "0.1"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    requested_track = (args.requested_track or "production").strip()
+    fallback_track = (args.fallback_track or "alpha").strip()
+    tracks = [requested_track]
+    if requested_track == "production" and fallback_track and fallback_track != requested_track:
+        tracks.append(fallback_track)
+
+    package = args.package.strip()
+    aab_path = Path(args.aab_path)
+    if not aab_path.is_file():
+        print(f"❌ AAB not found: {aab_path}", file=sys.stderr)
+        return 2
+
+    service_account_json = Path(args.service_account_json)
+    if not service_account_json.is_file():
+        print(f"❌ Service account JSON not found: {service_account_json}", file=sys.stderr)
+        return 2
+
+    metadata_dir = Path(args.metadata_dir)
+    changelog_dir = Path(args.changelog_dir)
+    ios_support_url_path = Path(args.ios_support_url_path)
+    result_json_path = Path(args.result_json)
+    error_json_path = Path(args.error_json)
+    release_status = (args.release_status or "completed").strip() or "completed"
+
+    precondition_error_payload: dict[str, Any] | None = None
+    for idx, track in enumerate(tracks):
+        try:
+            outcome = _publish_to_track(
+                package=package,
+                aab_path=aab_path,
+                track=track,
+                release_status=release_status,
+                retry_window_seconds=args.retry_window_seconds,
+                retry_interval_seconds=args.retry_interval_seconds,
+                metadata_dir=metadata_dir,
+                ios_support_url_path=ios_support_url_path,
+                changelog_dir=changelog_dir,
+                credentials_path=service_account_json,
+                user_fraction_raw=args.user_fraction,
+            )
+            fallback_used = track != requested_track
+            result_payload = {
+                "requested_track": requested_track,
+                "effective_track": track,
+                "fallback_used": fallback_used,
+                "precondition_blocked": bool(precondition_error_payload),
+                "release_status": release_status,
+                "version_code": outcome["version_code"],
+                "attempt": outcome["attempt"],
+                "fallback_reason": "FAILED_PRECONDITION" if fallback_used else "",
+            }
+            if precondition_error_payload:
+                result_payload["production_precondition_error"] = precondition_error_payload
+            _write_json(result_json_path, result_payload)
+            print(
+                f"✅ Uploaded version code {outcome['version_code']} to '{track}' track "
+                f"(requested={requested_track}, status={release_status}, fallback_used={fallback_used})"
+            )
+            return 0
+        except PublishError as error:
+            payload = {
+                "package": package,
+                "requested_track": requested_track,
+                "track": track,
+                "release_status": release_status,
+                "attempt": error.attempt,
+                "http_status": error.http_status,
+                "error": error.message,
+                "response": error.response_text,
+            }
+            _write_json(error_json_path, payload)
+            is_production_precondition = (
+                idx == 0
+                and track == "production"
+                and _is_failed_precondition(error.message, error.response_text, error.http_status)
+            )
+            if is_production_precondition and len(tracks) > 1:
+                precondition_error_payload = payload
+                print(
+                    "⚠️ Production publish blocked by FAILED_PRECONDITION. "
+                    f"Falling back to '{tracks[1]}' for continuity.",
+                    file=sys.stderr,
+                )
+                continue
+            if error.response_text:
+                print(
+                    f"❌ Google Play upload failed on track '{track}': {error.message}\n\n"
+                    f"Response:\n{error.response_text}",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"❌ Google Play upload failed on track '{track}': {error.message}", file=sys.stderr)
+            return 1
+
+    print("❌ No publish tracks attempted.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_play_precondition_triage.py
+++ b/scripts/tests/test_play_precondition_triage.py
@@ -1,0 +1,66 @@
+import unittest
+
+from scripts.play_precondition_triage import (
+    build_issue_body,
+    is_failed_precondition_payload,
+    should_close_issue,
+)
+
+
+class PlayPreconditionTriageTests(unittest.TestCase):
+    def test_is_failed_precondition_payload_true(self):
+        payload = {
+            "error": "HttpError 400",
+            "response": '{"error":{"status":"FAILED_PRECONDITION","message":"Precondition check failed."}}',
+        }
+        self.assertTrue(is_failed_precondition_payload(payload))
+
+    def test_is_failed_precondition_payload_false(self):
+        payload = {
+            "error": "HttpError 403",
+            "response": '{"error":{"status":"PERMISSION_DENIED","message":"Forbidden"}}',
+        }
+        self.assertFalse(is_failed_precondition_payload(payload))
+
+    def test_should_close_issue_only_on_production_success(self):
+        self.assertTrue(
+            should_close_issue(
+                {
+                    "requested_track": "production",
+                    "effective_track": "production",
+                    "fallback_used": False,
+                    "precondition_blocked": False,
+                }
+            )
+        )
+        self.assertFalse(
+            should_close_issue(
+                {
+                    "requested_track": "production",
+                    "effective_track": "alpha",
+                    "fallback_used": True,
+                    "precondition_blocked": True,
+                }
+            )
+        )
+
+    def test_build_issue_body_contains_run_and_details(self):
+        body = build_issue_body(
+            run_url="https://github.com/org/repo/actions/runs/123",
+            error_payload={
+                "http_status": 400,
+                "requested_track": "production",
+                "track": "production",
+                "release_status": "completed",
+                "attempt": 1,
+                "response": "FAILED_PRECONDITION: Precondition check failed.",
+            },
+            result_payload={"effective_track": "alpha", "fallback_used": True, "version_code": "42"},
+        )
+        self.assertIn("https://github.com/org/repo/actions/runs/123", body)
+        self.assertIn("FAILED_PRECONDITION", body)
+        self.assertIn('"effective_track": "alpha"', body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_play_publish.py
+++ b/scripts/tests/test_play_publish.py
@@ -1,0 +1,56 @@
+import unittest
+
+from scripts.play_publish import _is_failed_precondition, _release_payload
+
+
+class PlayPublishTests(unittest.TestCase):
+    def test_detects_failed_precondition_marker(self):
+        self.assertTrue(
+            _is_failed_precondition(
+                "HttpError 400",
+                '{"error":{"status":"FAILED_PRECONDITION","message":"Precondition check failed."}}',
+                400,
+            )
+        )
+
+    def test_detects_precondition_phrase_for_400(self):
+        self.assertTrue(
+            _is_failed_precondition(
+                "Bad request",
+                "Precondition check failed for production publishing.",
+                400,
+            )
+        )
+
+    def test_does_not_false_positive_without_precondition(self):
+        self.assertFalse(
+            _is_failed_precondition(
+                "HttpError 403",
+                '{"error":{"status":"PERMISSION_DENIED","message":"No permission"}}',
+                403,
+            )
+        )
+
+    def test_release_payload_in_progress_clamps_invalid_fraction(self):
+        payload = _release_payload(
+            version_code="123",
+            release_status="inProgress",
+            release_notes="",
+            user_fraction_raw="1.0",
+        )
+        self.assertEqual(payload["userFraction"], 0.1)
+        self.assertEqual(payload["status"], "inProgress")
+
+    def test_release_payload_completed_skips_user_fraction(self):
+        payload = _release_payload(
+            version_code="123",
+            release_status="completed",
+            release_notes="notes",
+            user_fraction_raw="0.5",
+        )
+        self.assertNotIn("userFraction", payload)
+        self.assertEqual(payload["releaseNotes"][0]["text"], "notes")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/play_publish.py` to publish AABs with automatic `production -> alpha` fallback on `FAILED_PRECONDITION`
- add `scripts/play_precondition_triage.py` to auto upsert/close a single GitHub triage issue using Play error/result artifacts
- wire `native-release.yml` to use structured Play result outputs and verify against the effective track
- add scheduled workflow `android-production-retry.yml` to retry production publish daily while blocker issue is open
- add unit tests for fallback/precondition detection and triage issue lifecycle helpers

## Validation
- `python3 -m unittest scripts.tests.test_play_publish scripts.tests.test_play_precondition_triage`
- `python3 -m unittest scripts.tests.test_release_ops`
- `python3 -m py_compile scripts/play_publish.py scripts/play_precondition_triage.py`
- YAML parse checks for both workflows
