### PR TITLE
fix(asc): tolerate screenshot delete state-lock during metadata reset

### DIFF
--- a/scripts/asc_reset_screenshots.py
+++ b/scripts/asc_reset_screenshots.py
@@ -7,6 +7,7 @@ This prevents duplicate/stale screenshots when fastlane deliver appends assets.
 from __future__ import annotations
 
 import argparse
+import json
 from typing import Any, Dict, List
 
 from scripts.asc_client import APP_STORE_CONNECT_API, AscClient, AscClientError
@@ -19,7 +20,7 @@ from scripts.asc_verify_ready import (
 )
 
 
-def _api_delete(client: AscClient, path: str) -> None:
+def _api_delete(client: AscClient, path: str) -> bool:
     try:
         import requests
     except ImportError:
@@ -34,13 +35,41 @@ def _api_delete(client: AscClient, path: str) -> None:
         timeout=30,
     )
     if response.status_code >= 400:
+        body_text = response.text[:2000]
+        if _is_submit_lock_delete_error(response.status_code, body_text):
+            print(
+                "⚠️ Skipping screenshot delete due to App Store Connect submit lock "
+                f"(DELETE {path})."
+            )
+            return False
         _die(
             2,
             "❌ App Store Connect API error\n"
             f"  DELETE {path}\n"
             f"  HTTP {response.status_code}\n"
-            f"  Body: {response.text[:2000]}",
+            f"  Body: {body_text}",
         )
+    return True
+
+
+def _is_submit_lock_delete_error(status_code: int, body_text: str) -> bool:
+    if status_code != 409:
+        return False
+    try:
+        payload = json.loads(body_text or "{}")
+    except json.JSONDecodeError:
+        return False
+    errors = payload.get("errors")
+    if not isinstance(errors, list):
+        return False
+    for item in errors:
+        if not isinstance(item, dict):
+            continue
+        code = str(item.get("code") or "").upper()
+        detail = str(item.get("detail") or "").lower()
+        if code == "STATE_ERROR" and "can't delete screenshot after submit for review" in detail:
+            return True
+    return False
 
 
 def list_screenshot_assets(client: AscClient, localization_id: str) -> List[Dict[str, str]]:
@@ -97,13 +126,19 @@ def reset_screenshots(version: str, locale: str, bundle_id: str, dry_run: bool) 
     localization_id = str(loc["id"])
     assets = list_screenshot_assets(client, localization_id)
     deleted = 0
+    skipped_locked = 0
     for asset in assets:
         shot_id = asset.get("screenshot_id") or ""
         if not shot_id:
             continue
         if not dry_run:
-            _api_delete(client, f"/appScreenshots/{shot_id}")
-        deleted += 1
+            deleted_ok = _api_delete(client, f"/appScreenshots/{shot_id}")
+            if deleted_ok:
+                deleted += 1
+            else:
+                skipped_locked += 1
+        else:
+            deleted += 1
 
     summary = {
         "bundle_id": bundle_id,
@@ -112,6 +147,7 @@ def reset_screenshots(version: str, locale: str, bundle_id: str, dry_run: bool) 
         "localization_id": localization_id,
         "found_assets": len(assets),
         "deleted_assets": deleted,
+        "skipped_locked_assets": skipped_locked,
         "dry_run": dry_run,
     }
     return summary

--- a/scripts/tests/test_asc_reset_screenshots.py
+++ b/scripts/tests/test_asc_reset_screenshots.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from types import SimpleNamespace
 from unittest import mock
@@ -120,7 +121,7 @@ class AscResetScreenshotsTests(unittest.TestCase):
             mock.patch("scripts.asc_reset_screenshots._list_app_store_versions", return_value=({}, fake_version)),
             mock.patch("scripts.asc_reset_screenshots._pick_localization", return_value={"id": "loc1"}),
             mock.patch("scripts.asc_reset_screenshots.list_screenshot_assets", return_value=fake_assets),
-            mock.patch("scripts.asc_reset_screenshots._api_delete") as delete_mock,
+            mock.patch("scripts.asc_reset_screenshots._api_delete", return_value=True) as delete_mock,
         ):
             summary = asc_reset_screenshots.reset_screenshots(
                 version="1.2.3",
@@ -130,6 +131,7 @@ class AscResetScreenshotsTests(unittest.TestCase):
             )
 
         self.assertEqual(summary["deleted_assets"], 2)
+        self.assertEqual(summary["skipped_locked_assets"], 0)
         self.assertEqual(delete_mock.call_count, 2)
         delete_mock.assert_any_call(fake_client, "/appScreenshots/shot_a")
         delete_mock.assert_any_call(fake_client, "/appScreenshots/shot_b")
@@ -142,6 +144,56 @@ class AscResetScreenshotsTests(unittest.TestCase):
         with mock.patch.dict("sys.modules", {"requests": fake_requests}):
             with self.assertRaises(SystemExit):
                 asc_reset_screenshots._api_delete(fake_client, "/appScreenshots/shot_a")
+
+    def test_api_delete_ignores_submit_lock_state_error(self):
+        response_body = json.dumps(
+            {
+                "errors": [
+                    {
+                        "status": "409",
+                        "code": "STATE_ERROR",
+                        "detail": "Can't Delete Screenshot After Submit for review appScreenshots",
+                    }
+                ]
+            }
+        )
+        response = SimpleNamespace(status_code=409, text=response_body)
+        fake_requests = SimpleNamespace(delete=lambda *_args, **_kwargs: response)
+        fake_client = SimpleNamespace(token_value=lambda: "token")
+
+        with mock.patch.dict("sys.modules", {"requests": fake_requests}):
+            deleted = asc_reset_screenshots._api_delete(fake_client, "/appScreenshots/shot_locked")
+
+        self.assertFalse(deleted)
+
+    def test_reset_screenshots_counts_locked_delete_skips(self):
+        fake_client = SimpleNamespace(
+            get=lambda _path, params=None: {"data": [{"id": "loc1", "attributes": {"locale": "en-US"}}]}
+        )
+        fake_version = {
+            "id": "v1",
+            "relationships": {"appStoreVersionLocalizations": {"data": [{"id": "loc1"}]}},
+        }
+        fake_assets = [{"screenshot_id": "shot_locked"}, {"screenshot_id": "shot_ok"}]
+
+        with (
+            mock.patch("scripts.asc_reset_screenshots.AscClient.from_env", return_value=fake_client),
+            mock.patch("scripts.asc_reset_screenshots._get_app_id", return_value="app1"),
+            mock.patch("scripts.asc_reset_screenshots._list_app_store_versions", return_value=({}, fake_version)),
+            mock.patch("scripts.asc_reset_screenshots._pick_localization", return_value={"id": "loc1"}),
+            mock.patch("scripts.asc_reset_screenshots.list_screenshot_assets", return_value=fake_assets),
+            mock.patch("scripts.asc_reset_screenshots._api_delete", side_effect=[False, True]) as delete_mock,
+        ):
+            summary = asc_reset_screenshots.reset_screenshots(
+                version="1.2.3",
+                locale="en-US",
+                bundle_id="com.example.app",
+                dry_run=False,
+            )
+
+        self.assertEqual(delete_mock.call_count, 2)
+        self.assertEqual(summary["deleted_assets"], 1)
+        self.assertEqual(summary["skipped_locked_assets"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
- Handle App Store Connect `409 STATE_ERROR` when deleting screenshots after submit-for-review lock
- Treat this specific lock as a skip (non-fatal), while preserving hard-fail behavior for other API errors
- Add tests for lock detection and skipped-delete accounting

## Why
`iOS Metadata Sync` run `22418783530` failed at screenshot reset with:
- `HTTP 409`
- `code: STATE_ERROR`
- `detail: Can't Delete Screenshot After Submit for review appScreenshots`

This should not crash the pipeline before metadata upload/verification.

## Validation
- `python3 -m pytest scripts/tests/test_asc_reset_screenshots.py -q`
- `python3 -m py_compile scripts/asc_reset_screenshots.py`
