### PR TITLE
fix(ios-submit): repair ASC state parse shell in submit workflow

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -185,7 +185,7 @@ jobs:
           # Read current ASC state first so reruns are safe/idempotent.
           STATE_JSON="$(python scripts/asc_poll_version_state.py --version "$IOS_VERSION" --json)"
           echo "ASC state (pre-submit): $STATE_JSON"
-          STATE="$(python - <<'PY'\nimport json,sys\nprint(json.loads(sys.argv[1])[\"state\"])\nPY\n\"$STATE_JSON\")"
+          STATE="$(python -c 'import json,sys; print(json.loads(sys.argv[1])["state"])' "$STATE_JSON")"
 
           if [[ "$STATE" == "WAITING_FOR_REVIEW" || "$STATE" == "IN_REVIEW" || "$STATE" == "PENDING_DEVELOPER_RELEASE" || "$STATE" == "READY_FOR_SALE" ]]; then
             echo "Already submitted ($STATE); skipping submit_review."


### PR DESCRIPTION
## What
- Fix malformed shell command substitution in `ios-submit-review.yml` submit step.
- Replace heredoc-in-substitution string with a safe one-line parser:
  - `python -c 'import json,sys; print(json.loads(sys.argv[1])["state"])' "$STATE_JSON"`

## Why
Run `22425360606` failed at submit step with:
- `syntax error near unexpected token '('`
- while parsing pre-submit ASC state JSON

## Validation
- Static check of workflow command block in branch.
- Re-run of `iOS Submit For Review` will be executed after merge.
