### PR TITLE
fix(ui): remove top-nav share CTA from setup flow

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
@@ -1,7 +1,5 @@
 package com.iganapolsky.randomtimer.ui.screens
 
-import android.content.Context
-import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -45,7 +43,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -77,7 +74,6 @@ fun ActiveTimerScreen(
     modifier: Modifier = Modifier,
 ) {
     val haptic = LocalHapticFeedback.current
-    val context = LocalContext.current
     val isComplete = state.status == TimerStatus.COMPLETE || state.status == TimerStatus.ALARM
     val isPaused = state.status == TimerStatus.PAUSED
     var loopEnabled by remember(state.config.repeatEnabled) { mutableStateOf(state.config.repeatEnabled) }
@@ -382,17 +378,6 @@ private fun LoopBadge(
             )
         }
     }
-}
-
-private fun shareWithTrainingPartner(context: Context) {
-    val shareText = "This is the timer I use for random fight drills. It goes off unpredictably so you can't game it. Train for chaos, not comfort.\nhttps://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer"
-    val sendIntent =
-        Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, shareText)
-            type = "text/plain"
-        }
-    context.startActivity(Intent.createChooser(sendIntent, "Tell a Training Partner"))
 }
 
 private fun formatDurationReadable(duration: kotlin.time.Duration): String {

--- a/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 /// Screen shown when a timer is actively counting down
 struct ActiveTimerScreen: View {
@@ -8,9 +7,6 @@ struct ActiveTimerScreen: View {
     @State private var loopEnabled: Bool = false // Default to LOOP OFF
     @State private var showResetFeedback: Bool = false
     @State private var resetFeedbackTask: Task<Void, Never>?
-    @State private var showShareSheet: Bool = false
-
-    private let shareMessage = "This is the timer I use for random fight drills. It goes off unpredictably so you can't game it. Train for chaos, not comfort.\nhttps://apps.apple.com/us/app/random-tactical-timer/id6758355312"
 
     private var state: TimerState? {
         timerManager.timerState
@@ -350,17 +346,6 @@ struct ActiveTimerScreen: View {
             showResetFeedback = false
         }
     }
-}
-
-/// UIKit share sheet wrapper for SwiftUI
-private struct ActivityViewController: UIViewControllerRepresentable {
-    let activityItems: [Any]
-
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-    }
-
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 #Preview("Running") {

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct TimerSetupScreen: View {
     @EnvironmentObject var timerManager: TimerManager
     @EnvironmentObject var proManager: ProManager
-    @State private var showShareSheet = false
     @State private var showPaywall = false
     @State private var showArsenal = false
     @AppStorage("hasCompletedFirstTimer") private var hasCompletedFirstTimer = false
@@ -14,13 +13,6 @@ struct TimerSetupScreen: View {
 
     private var maxSliderRange: Double { Double(proManager.maxSecondsLimit) }
     private var minSliderMax: Double { maxSliderRange - 30 }
-
-    private static let shareMessage = """
-        This is the timer I use for random fight drills. \
-        It goes off unpredictably so you can't game it. \
-        Train for chaos, not comfort.
-        https://apps.apple.com/us/app/random-tactical-timer/id6758355312
-        """
 
     var body: some View {
         ScrollView {
@@ -244,20 +236,6 @@ struct TimerSetupScreen: View {
         .background(Color.backgroundDark.ignoresSafeArea())
         .navigationTitle("Random Tactical Timer")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    showShareSheet = true
-                } label: {
-                    Image(systemName: "square.and.arrow.up")
-                        .foregroundColor(.accentPrimary)
-                }
-                .accessibilityLabel("Share app")
-            }
-        }
-        .sheet(isPresented: $showShareSheet) {
-            ShareSheet(items: [Self.shareMessage])
-        }
         .sheet(isPresented: $showPaywall) {
             PaywallSheet()
                 .environmentObject(proManager)


### PR DESCRIPTION
## Problem
Top-nav share CTA on the setup screen competes with the core training action and hurts focus.

## Root cause (history)
- Introduced by commit `432c0881d0a421f9f385a31d4514467eaa991c6b` (`Add persuasive SMS share button to both platforms (#471)`)
- File-level blame confirms top-right nav share in `TimerSetupScreen.swift` lines was added in that commit.

## Changes
- Removed top-right share button from iOS setup screen:
  - `native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift`
- Removed unused/dead share code left in active screens:
  - iOS: removed unused share state/message + unused `ActivityViewController` wrapper from `ActiveTimerScreen.swift`
  - Android: removed unused `shareWithTrainingPartner` helper and now-unused imports/context reference from `ActiveTimerScreen.kt`

## Validation
- iOS build:
  - `xcodebuild -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'generic/platform=iOS Simulator' build` ✅
- Android compile:
  - `./gradlew :app:compileDebugKotlin` ✅
  - Note: local compile requires a `google-services.json`; used CI-style dummy config for local compile parity only.

## Scope
No functional timer behavior changes; this is UI focus cleanup + dead-code removal.
