### PR TITLE
ci: fix internal-distribution workflow parse failure

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -237,11 +237,16 @@ jobs:
       - name: Install Firebase CLI
         run: npm install --global firebase-tools
 
-      - name: Authenticate Google Cloud (fallback for Firebase)
-        if: ${{ secrets.GOOGLE_PLAY_JSON_KEY != '' }}
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+      - name: Prepare Google auth fallback for Firebase
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
+            CREDENTIALS_FILE="${RUNNER_TEMP}/gcp-sa.json"
+            echo "$GOOGLE_PLAY_JSON_KEY" > "$CREDENTIALS_FILE"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$CREDENTIALS_FILE" >> "$GITHUB_ENV"
+          fi
 
       - name: Distribute to internal Firebase tester(s)
         env:
@@ -261,7 +266,7 @@ jobs:
           )
           if [ -n "${FIREBASE_TOKEN:-}" ]; then
             "${CMD[@]}" --token "$FIREBASE_TOKEN"
-          elif [ -n "${GOOGLE_GHA_CREDS_PATH:-}" ] || [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] || [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
+          elif [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] || [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
             "${CMD[@]}"
           else
             echo "❌ Missing Firebase auth. Set FIREBASE_TOKEN or GOOGLE_PLAY_JSON_KEY."


### PR DESCRIPTION
## Why
Internal Distribution never executed and sent no tester email because the workflow failed to parse at runtime:

- `Line 241, Col 13`: `Unrecognized named-value: 'secrets'` in step-level `if:`

## What changed
- Removed `if: ${{ secrets.GOOGLE_PLAY_JSON_KEY != '' }}`.
- Replaced it with shell-based fallback credential setup in a run step.
- Preserved Firebase auth fallback behavior: `FIREBASE_TOKEN` OR service-account JSON.

## Verification
- Local YAML parse: `yaml-ok`.
- Pre-fix dispatch proof: `gh workflow run 239542738 --ref develop -f ref=develop` returned HTTP 422 with the parser error above.
