### PR TITLE
fix(ci): update claude-code-action to fix SDK crash and allow bot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,10 +21,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@29214eeb6626cb5b6abf73a380c90ca849259729 # v1
+        uses: anthropics/claude-code-action@ea5a04005c9fd4deed2ed803c15a64d0e6eb65d0 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
+          allowed_bots: 'trunk-io,dependabot[bot],github-actions[bot]'
           prompt: |
             Review this PR for the Random Timer app. This is a native mobile project:
             - Android: Kotlin + Jetpack Compose (native-android/)
@@ -54,7 +55,6 @@ jobs:
             - Provide fix suggestions for each issue
           claude_args: |
             --max-turns 10
-            --model claude-sonnet-4-5-20250929
             --setting-sources user
 
   # Auto-approve after Claude review passes (satisfies required 1 approval)
@@ -88,10 +88,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Claude Code Assist
-        uses: anthropics/claude-code-action@29214eeb6626cb5b6abf73a380c90ca849259729 # v1
+        uses: anthropics/claude-code-action@ea5a04005c9fd4deed2ed803c15a64d0e6eb65d0 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
+          allowed_bots: 'trunk-io,dependabot[bot],github-actions[bot]'
           prompt: |
             A reviewer mentioned @claude with the following comment:
 


### PR DESCRIPTION
## Summary
- Updates `claude-code-action` from stale pinned SHA (`29214ee`) to latest v1 (`ea5a040`) — fixes deterministic SDK crash (`is_error: true, duration_ms: 174`)
- Adds `allowed_bots: 'trunk-io,dependabot[bot],github-actions[bot]'` to allow bot-initiated PRs
- Removes `--model claude-sonnet-4-5-20250929` (invalid model ID) — action uses sensible default

## Root Cause
The `claude-agent-sdk` bundled in the pinned SHA had an AJV schema validation crash during initialization. Every Claude Review run was failing in <200ms with exit code 1 before doing any work.

Bot-initiated PRs (from trunk-io merge queue) were also rejected with "non-human actor" error.

## Impact
Claude Review was failing on every PR but was **not blocking merges** since it's not a required status check. Still, the red X was noise and `ai-auto-approve` never ran.

## Test plan
- [ ] Create a test PR and verify Claude Review passes
- [ ] Verify bot-initiated PRs no longer get rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)