### PR TITLE
feat(gitflow): support hotfix/vX.Y.Z branches for main promotion

### DIFF
--- a/scripts/tests/test_validate_release_branch.py
+++ b/scripts/tests/test_validate_release_branch.py
@@ -32,7 +32,7 @@ def test_validate_release_branch_passes_when_versions_match(tmp_path):
 
 def test_validate_release_branch_rejects_invalid_branch_name(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.3")
-    with pytest.raises(ValidationError, match="release/vX.Y.Z"):
+    with pytest.raises(ValidationError, match="release/vX.Y.Z or hotfix/vX.Y.Z"):
         validate_release_branch(repo_root=tmp_path, head_ref="develop")
 
 
@@ -46,3 +46,29 @@ def test_validate_release_branch_rejects_branch_version_mismatch(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.3")
     with pytest.raises(ValidationError, match="branch expects 1.2.4"):
         validate_release_branch(repo_root=tmp_path, head_ref="release/v1.2.4")
+
+
+def test_validate_hotfix_branch_passes_when_versions_match(tmp_path):
+    _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.4")
+    result = validate_release_branch(repo_root=tmp_path, head_ref="hotfix/v1.2.4")
+    assert result["expected_version"] == "1.2.4"
+    assert result["android_version"] == "1.2.4"
+    assert result["ios_version"] == "1.2.4"
+
+
+def test_validate_hotfix_branch_rejects_platform_version_mismatch(tmp_path):
+    _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.5")
+    with pytest.raises(ValidationError, match="Version mismatch"):
+        validate_release_branch(repo_root=tmp_path, head_ref="hotfix/v1.2.4")
+
+
+def test_validate_hotfix_branch_rejects_branch_version_mismatch(tmp_path):
+    _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.4")
+    with pytest.raises(ValidationError, match="branch expects 1.2.5"):
+        validate_release_branch(repo_root=tmp_path, head_ref="hotfix/v1.2.5")
+
+
+def test_validate_release_branch_rejects_bare_hotfix_prefix(tmp_path):
+    _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.4")
+    with pytest.raises(ValidationError, match="release/vX.Y.Z or hotfix/vX.Y.Z"):
+        validate_release_branch(repo_root=tmp_path, head_ref="hotfix")

--- a/scripts/validate_release_branch.py
+++ b/scripts/validate_release_branch.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Validate release branch naming and platform version alignment.
+"""Validate release/hotfix branch naming and platform version alignment.
 
 Rules:
-1. Branch must be named `release/vX.Y.Z`.
+1. Branch must be named `release/vX.Y.Z` or `hotfix/vX.Y.Z`.
 2. Android `versionName` must equal iOS `MARKETING_VERSION`.
 3. Both platform versions must match X.Y.Z from the branch name.
 """
@@ -19,7 +19,7 @@ class ValidationError(RuntimeError):
     """Raised when release branch validation fails."""
 
 
-RELEASE_BRANCH_RE = re.compile(r"^release/v(?P<version>\d+\.\d+\.\d+)$")
+RELEASE_BRANCH_RE = re.compile(r"^(?:release|hotfix)/v(?P<version>\d+\.\d+\.\d+)$")
 ANDROID_VERSION_RE = re.compile(r'versionName\s*=\s*"([^"]+)"')
 IOS_VERSION_RE = re.compile(r"MARKETING_VERSION\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)\s*;")
 
@@ -52,7 +52,7 @@ def validate_release_branch(repo_root: Path, head_ref: str) -> dict:
     branch_match = RELEASE_BRANCH_RE.match(head_ref.strip())
     if not branch_match:
         raise ValidationError(
-            f"Only release/vX.Y.Z branches are allowed for main promotion. Received: '{head_ref}'"
+            f"Only release/vX.Y.Z or hotfix/vX.Y.Z branches are allowed for main promotion. Received: '{head_ref}'"
         )
 
     expected_version = branch_match.group("version")
@@ -79,7 +79,7 @@ def validate_release_branch(repo_root: Path, head_ref: str) -> dict:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Validate release branch vs app versions.")
-    parser.add_argument("--head-ref", required=True, help="Branch name, e.g. release/v1.2.0")
+    parser.add_argument("--head-ref", required=True, help="Branch name, e.g. release/v1.2.0 or hotfix/v1.2.1")
     parser.add_argument("--repo-root", default=".", help="Repository root")
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- Updates `validate_release_branch.py` regex to accept both `release/vX.Y.Z` and `hotfix/vX.Y.Z`
- 4 new test cases (8 total, all pass)
- Enables urgent production fixes via `hotfix/*` branches

## Test plan
- [x] `python -m pytest scripts/tests/test_validate_release_branch.py -v` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)