### PR TITLE
ci: add merge_group event trigger for GitHub merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    branches: [develop, main]
   push:
     branches: [develop, main]
     paths-ignore:


### PR DESCRIPTION
## Summary
- Adds `merge_group` event to CI workflow triggers
- Required for GitHub's merge queue feature to run checks on queued PRs
- Strict status checks already disabled via ruleset API update

## Test plan
- [ ] Verify CI runs on merge_group events
- [ ] PRs can merge without rebase requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)