### PR TITLE
fix(ios): harden timer state decoding + refresh README accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,10 @@
 
 To maximize system performance and cost-efficiency, all agents must adhere to the **Agent-Model Matching** standard defined in `.claude/rules/agent-model-matching.md`.
 
-- **Orchestration**: `claude-3-5-sonnet` (UltraBrain) for planning and coordination.
-- **Deep Specialist**: `claude-3-opus` or `gpt-4o` (Deep) for complex refactoring.
-- **Utility Runner**: `gemini-1.5-flash` or `claude-3-haiku` (Quick) for search, analysis, and scaffolding.
-- **UI/UX Specialist**: `gemini-1.5-pro` (Visual) for multimodal and layout tasks.
+- **Orchestration**: latest high-reasoning `Claude Sonnet` class model (UltraBrain) for planning and coordination.
+- **Deep Specialist**: latest `Claude Opus` class model or strongest available `GPT-4o/5` class model (Deep) for complex refactoring.
+- **Utility Runner**: latest fast, low-cost `Gemini Flash` or `Claude Haiku` class model (Quick) for search, analysis, and scaffolding.
+- **UI/UX Specialist**: strongest multimodal `Gemini Pro` class model (Visual) for layout and visual QA tasks.
 
 When delegating work via the `Task` tool, agents should specify the category (e.g., `subagent_type: "Quick"`) to ensure the correct model is selected from the fallback chain.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Built for fighters, operators, and serious athletes.**
 
-No ads. No tracking. No subscriptions. Pure performance.
+No ads. No subscriptions. Purpose-built performance training.
 
 ---
 
@@ -72,19 +72,21 @@ Use paid spend only when attribution is measurable and activation quality holds.
 
 ### iOS (SwiftUI + Live Activities)
 <p align="center">
-  <img src="screenshots/ios-setup.png" width="200" alt="iOS Setup" />
-  <img src="screenshots/ios-active.png" width="200" alt="iOS Active" />
-  <img src="screenshots/ios-alarm.png" width="200" alt="iOS Alarm" />
-  <img src="screenshots/ios-running.png" width="200" alt="iOS Running" />
+  <img src="screenshots/ios-setup.png" width="200" alt="iOS setup screen showing training window, alarm settings, and start button" />
+  <img src="screenshots/ios-active.png" width="200" alt="iOS active timer screen during a running random interval" />
+  <img src="screenshots/ios-alarm.png" width="200" alt="iOS alarm state with tactical alert controls" />
+  <img src="screenshots/ios-running.png" width="200" alt="iOS running state with countdown and loop mode indicators" />
 </p>
+<p align="center"><em>iOS flow: setup → run → alarm handling.</em></p>
 
 ### Android (Jetpack Compose + Material 3)
 <p align="center">
-  <img src="screenshots/android-setup.png" width="200" alt="Android Setup" />
-  <img src="screenshots/android-active.png" width="200" alt="Android Active" />
-  <img src="screenshots/android-settings.png" width="200" alt="Android Settings" />
-  <img src="screenshots/android-loop.png" width="200" alt="Android Loop" />
+  <img src="screenshots/android-setup.png" width="200" alt="Android setup screen with training window sliders and alarm controls" />
+  <img src="screenshots/android-active.png" width="200" alt="Android active timer screen while interval is running" />
+  <img src="screenshots/android-settings.png" width="200" alt="Android settings and tactical expansion options" />
+  <img src="screenshots/android-loop.png" width="200" alt="Android loop mode and repeated drill workflow" />
 </p>
+<p align="center"><em>Android flow: setup → active round → settings/loop.</em></p>
 
 ---
 
@@ -103,25 +105,55 @@ Use paid spend only when attribution is measurable and activation quality holds.
 - **Swift 6 + SwiftUI**
 - **Live Activities** for the Dynamic Island and Lock Screen
 - **AVAudioPlayer** for low-latency tactical alerts
+- **PostHog iOS SDK** for product analytics instrumentation
+- **StoreKit** for one-time Pro unlock + in-app review prompts
 
 ### Android
 - **Kotlin 2.1 + Jetpack Compose**
 - **Clean Architecture** with Hilt Dependency Injection
 - **Foreground Service** for bulletproof background reliability
 - **Material Design 3 Expressive** with spring-based motion
+- **PostHog Android SDK** for analytics instrumentation
+- **Google Play Billing** for one-time Pro unlocks
+- **In-App Review API** for review prompts
+- **Firebase Crashlytics + Firebase Analytics** for crash/health telemetry
+
+### Automation & Tooling
+- **Python automation layer** in [`scripts/`](scripts/) drives release ops, analytics snapshots, growth reporting, and store metadata workflows.
+- **GitHub Actions pipelines** in [`.github/workflows/`](.github/workflows/) run CI, release automation, metadata sync, and guardrail checks.
+- **Fastlane metadata** lives under [`native-ios/fastlane`](native-ios/fastlane) and [`native-android/fastlane`](native-android/fastlane).
 
 ## Build & Test
+
+The [`Makefile`](Makefile) is the canonical task entrypoint.
+
+### Quick Verification
+```bash
+make verify
+```
 
 ### iOS
 ```bash
 cd native-ios
-xcodebuild test -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+xcodebuild -scheme RandomTimer -showdestinations
+xcodebuild test -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1'
 ```
+Note: simulator names vary by Xcode version. If `iPhone 17` is unavailable on your machine, use any available iPhone simulator from `-showdestinations` (for example `iPhone 16 Pro` on older Xcode).
 
 ### Android
 ```bash
 cd native-android
-./gradlew test
+./gradlew testDebugUnitTest assembleDebug lint
+```
+
+### More Useful Day-to-Day Commands
+```bash
+make run-ios-sim
+make run-android-emulator
+make verify-ios
+make verify-android
+make maestro-ios
+make maestro-android
 ```
 
 ## License

--- a/native-ios/RandomTimer/Sources/Services/StorageService.swift
+++ b/native-ios/RandomTimer/Sources/Services/StorageService.swift
@@ -31,21 +31,19 @@ actor StorageService: TimerStorage {
     }
 
     func loadConfig() -> TimerConfig? {
-        guard let data = defaults.value.data(forKey: Keys.config),
-              let config = try? decoder.decode(TimerConfig.self, from: data) else {
+        guard let data = defaults.value.data(forKey: Keys.config) else {
             return nil
         }
-        return config
+        return decodeOrClear(TimerConfig.self, from: data, key: Keys.config, decoder: decoder)
     }
 
     /// Synchronous config load for use in initializers (avoids async race condition)
     nonisolated func loadConfigSync() -> TimerConfig? {
         let defaults = self.defaults
-        guard let data = defaults.value.data(forKey: Keys.config),
-              let config = try? JSONDecoder().decode(TimerConfig.self, from: data) else {
+        guard let data = defaults.value.data(forKey: Keys.config) else {
             return nil
         }
-        return config
+        return decodeOrClear(TimerConfig.self, from: data, key: Keys.config, decoder: JSONDecoder())
     }
 
     // MARK: - Timer State
@@ -56,11 +54,10 @@ actor StorageService: TimerStorage {
     }
 
     func loadTimerState() -> TimerState? {
-        guard let data = defaults.value.data(forKey: Keys.timerState),
-              let state = try? decoder.decode(TimerState.self, from: data) else {
+        guard let data = defaults.value.data(forKey: Keys.timerState) else {
             return nil
         }
-        return state
+        return decodeOrClear(TimerState.self, from: data, key: Keys.timerState, decoder: decoder)
     }
 
     func clearTimerState() {
@@ -70,15 +67,28 @@ actor StorageService: TimerStorage {
     /// Synchronous timer state load for use in initializers
     nonisolated func loadTimerStateSync() -> TimerState? {
         let defaults = self.defaults
-        guard let data = defaults.value.data(forKey: Keys.timerState),
-              let state = try? JSONDecoder().decode(TimerState.self, from: data) else {
+        guard let data = defaults.value.data(forKey: Keys.timerState) else {
             return nil
         }
-        return state
+        return decodeOrClear(TimerState.self, from: data, key: Keys.timerState, decoder: JSONDecoder())
     }
 
     /// Synchronous clear for use in initializers
     nonisolated func clearTimerStateSync() {
         defaults.value.removeObject(forKey: Keys.timerState)
+    }
+
+    private nonisolated func decodeOrClear<T: Decodable>(
+        _ type: T.Type,
+        from data: Data,
+        key: String,
+        decoder: JSONDecoder
+    ) -> T? {
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            defaults.value.removeObject(forKey: key)
+            return nil
+        }
     }
 }

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -70,6 +70,38 @@ final class TimerConfigTests: XCTestCase {
         XCTAssertEqual(config.maxDuration, 180.0)
         XCTAssertEqual(config.alarmDurationInterval, 10.0)
     }
+
+    func testConfigDecodingSupportsLegacyKeysAndLooseSoundNames() throws {
+        let payload = """
+        {
+          "min_time": -5,
+          "max_time": 9000,
+          "alarm_duration": 0,
+          "hidden_mode": "true",
+          "repeat_enabled": "1",
+          "sound_type": "DRUM_ROLL",
+          "soundVolume": "1.5",
+          "vibration": "yes"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(TimerConfig.self, from: payload)
+
+        XCTAssertEqual(decoded.minSeconds, 0)
+        XCTAssertEqual(decoded.maxSeconds, TimerConfig.maxSecondsPro)
+        XCTAssertEqual(decoded.alarmDuration, 1)
+        XCTAssertTrue(decoded.hiddenMode)
+        XCTAssertTrue(decoded.repeatEnabled)
+        XCTAssertEqual(decoded.soundType, .drumRoll)
+        XCTAssertEqual(decoded.volume, 1.0, accuracy: 0.0001)
+        XCTAssertTrue(decoded.vibrationEnabled)
+    }
+
+    func testConfigDecodingFallsBackToDefaultsWhenFieldsMissing() throws {
+        let payload = "{}".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(TimerConfig.self, from: payload)
+        XCTAssertEqual(decoded, .default)
+    }
 }
 
 final class TimerStateTests: XCTestCase {
@@ -162,6 +194,36 @@ final class TimerStateTests: XCTestCase {
         )
 
         XCTAssertEqual(state.timeRemainingSeconds, 125)
+    }
+
+    func testStateDecodingSupportsLegacyKeysAndStatusNormalization() throws {
+        let payload = """
+        {
+          "config": {
+            "minSeconds": 15,
+            "maxSeconds": 120,
+            "alarmDuration": 10,
+            "hiddenMode": false,
+            "repeatEnabled": false,
+            "soundType": "GENTLE",
+            "volume": 0.4,
+            "vibrationEnabled": true
+          },
+          "target_duration": "90",
+          "started_at": "2026-03-02T00:00:00Z",
+          "remaining_duration": "45",
+          "timerStatus": "PAUSED",
+          "alarm_time_remaining": "5"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(TimerState.self, from: payload)
+
+        XCTAssertEqual(decoded.config.soundType, .gentle)
+        XCTAssertEqual(decoded.targetDuration, 90, accuracy: 0.0001)
+        XCTAssertEqual(decoded.remainingDuration, 45, accuracy: 0.0001)
+        XCTAssertEqual(decoded.status, .paused)
+        XCTAssertEqual(decoded.alarmTimeRemaining, 5, accuracy: 0.0001)
     }
 }
 
@@ -826,6 +888,24 @@ final class StorageServiceTests: XCTestCase {
         XCTAssertNil(storageService.loadTimerStateSync())
         let clearedAsync = await storageService.loadTimerState()
         XCTAssertNil(clearedAsync)
+    }
+
+    func testLoadConfigSyncClearsCorruptPayload() {
+        UserDefaults.standard.set(Data([0xFF, 0x00, 0xFE]), forKey: configKey)
+
+        let loaded = storageService.loadConfigSync()
+
+        XCTAssertNil(loaded)
+        XCTAssertNil(UserDefaults.standard.data(forKey: configKey))
+    }
+
+    func testLoadTimerStateSyncClearsCorruptPayload() {
+        UserDefaults.standard.set(Data([0xAA, 0xBB, 0xCC]), forKey: timerStateKey)
+
+        let loaded = storageService.loadTimerStateSync()
+
+        XCTAssertNil(loaded)
+        XCTAssertNil(UserDefaults.standard.data(forKey: timerStateKey))
     }
 }
 

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -48,6 +48,41 @@ public enum SoundType: String, Codable, Sendable, CaseIterable {
         case .bell: return "bell.mp3"
         }
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let soundType = Self.fromLoose(rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unknown sound type: \(rawValue)"
+            )
+        }
+        self = soundType
+    }
+
+    static func fromLoose(_ rawValue: String) -> SoundType? {
+        let normalized = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        switch normalized {
+        case "intense": return .intense
+        case "gentle": return .gentle
+        case "klaxon": return .klaxon
+        case "whistle": return .whistle
+        case "buzzer": return .buzzer
+        case "gong": return .gong
+        case "airhorn": return .airhorn
+        case "drumroll": return .drumRoll
+        case "siren": return .siren
+        case "bell": return .bell
+        default: return nil
+        }
+    }
 }
 
 // MARK: - Timer Configuration
@@ -112,6 +147,111 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     public static let `default` = TimerConfig()
 
     public static let alarmDurationOptions = [5, 10, 15, 30, 60]
+
+    fileprivate enum DecodingKeys: String, CodingKey {
+        case minSeconds
+        case maxSeconds
+        case alarmDuration
+        case hiddenMode
+        case repeatEnabled
+        case soundType
+        case volume
+        case vibrationEnabled
+
+        // Legacy / compatibility keys
+        case minDuration
+        case maxDuration
+        case min_time
+        case max_time
+        case alarm_duration
+        case hidden_mode
+        case repeat_enabled
+        case loopEnabled
+        case sound_type
+        case alarmSound
+        case sound
+        case soundVolume
+        case vibration
+        case vibration_enabled
+    }
+
+    private enum EncodingKeys: String, CodingKey {
+        case minSeconds
+        case maxSeconds
+        case alarmDuration
+        case hiddenMode
+        case repeatEnabled
+        case soundType
+        case volume
+        case vibrationEnabled
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DecodingKeys.self)
+
+        let rawMin = container.decodeFirstInt(
+            forKeys: [.minSeconds, .minDuration, .min_time],
+            defaultValue: 0
+        )
+        let rawMax = container.decodeFirstInt(
+            forKeys: [.maxSeconds, .maxDuration, .max_time],
+            defaultValue: 60
+        )
+        let rawAlarm = container.decodeFirstInt(
+            forKeys: [.alarmDuration, .alarm_duration],
+            defaultValue: 10
+        )
+        let hiddenMode = container.decodeFirstBool(
+            forKeys: [.hiddenMode, .hidden_mode],
+            defaultValue: false
+        )
+        let repeatEnabled = container.decodeFirstBool(
+            forKeys: [.repeatEnabled, .repeat_enabled, .loopEnabled],
+            defaultValue: false
+        )
+        let volume = container.decodeFirstFloat(
+            forKeys: [.volume, .soundVolume],
+            defaultValue: 0.5
+        )
+        let vibrationEnabled = container.decodeFirstBool(
+            forKeys: [.vibrationEnabled, .vibration_enabled, .vibration],
+            defaultValue: false
+        )
+
+        let soundType = container.decodeFirstSoundType(
+            forKeys: [.soundType, .sound_type, .alarmSound, .sound],
+            defaultValue: .intense
+        )
+
+        let clampedMin = max(0, rawMin)
+        let cappedMax = min(rawMax, TimerConfig.maxSecondsPro)
+        let clampedMax = max(clampedMin, cappedMax)
+        let clampedAlarm = max(1, rawAlarm)
+        let clampedVolume = min(max(volume, 0), 1)
+
+        self.init(
+            minSeconds: clampedMin,
+            maxSeconds: clampedMax,
+            alarmDuration: clampedAlarm,
+            hiddenMode: hiddenMode,
+            repeatEnabled: repeatEnabled,
+            soundType: soundType,
+            volume: clampedVolume,
+            vibrationEnabled: vibrationEnabled
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: EncodingKeys.self)
+        try container.encode(minSeconds, forKey: .minSeconds)
+        try container.encode(maxSeconds, forKey: .maxSeconds)
+        try container.encode(alarmDuration, forKey: .alarmDuration)
+        try container.encode(hiddenMode, forKey: .hiddenMode)
+        try container.encode(repeatEnabled, forKey: .repeatEnabled)
+        try container.encode(soundType, forKey: .soundType)
+        try container.encode(volume, forKey: .volume)
+        try container.encode(vibrationEnabled, forKey: .vibrationEnabled)
+    }
 
     /// Returns a copy of this config with values clamped to the caller's Pro entitlement.
     /// Call this at deserialization time to enforce feature gating after subscription expiry.
@@ -213,6 +353,18 @@ public enum TimerStatus: String, Codable, Sendable {
     case danger     // < 10 seconds remaining
     case complete   // Timer finished, transitioning to alarm
     case alarm      // Alarm is playing
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let status = Self(rawValue: rawValue.lowercased()) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unknown timer status: \(rawValue)"
+            )
+        }
+        self = status
+    }
 }
 
 // MARK: - Timer State
@@ -243,6 +395,87 @@ public struct TimerState: Codable, Sendable, Equatable {
         self.status = status
         self.alarmTimeRemaining = alarmTimeRemaining
         self.alarmStartedAt = alarmStartedAt
+    }
+
+    fileprivate enum DecodingKeys: String, CodingKey {
+        case config
+        case targetDuration
+        case startedAt
+        case remainingDuration
+        case status
+        case alarmTimeRemaining
+        case alarmStartedAt
+
+        // Legacy / compatibility keys
+        case target_duration
+        case started_at
+        case remaining_duration
+        case timerStatus
+        case alarm_time_remaining
+        case alarm_started_at
+    }
+
+    private enum EncodingKeys: String, CodingKey {
+        case config
+        case targetDuration
+        case startedAt
+        case remainingDuration
+        case status
+        case alarmTimeRemaining
+        case alarmStartedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DecodingKeys.self)
+
+        let config = container.decodeFirstConfig(
+            forKeys: [.config],
+            defaultValue: .default
+        )
+        let targetDuration = container.decodeFirstTimeInterval(
+            forKeys: [.targetDuration, .target_duration],
+            defaultValue: max(TimeInterval(config.maxSeconds), 1)
+        )
+        let startedAt = container.decodeFirstDate(
+            forKeys: [.startedAt, .started_at],
+            defaultValue: Date()
+        )
+        let remainingDuration = container.decodeFirstTimeInterval(
+            forKeys: [.remainingDuration, .remaining_duration],
+            defaultValue: targetDuration
+        )
+        let status = container.decodeFirstTimerStatus(
+            forKeys: [.status, .timerStatus],
+            defaultValue: .running
+        )
+        let alarmTimeRemaining = container.decodeFirstTimeInterval(
+            forKeys: [.alarmTimeRemaining, .alarm_time_remaining],
+            defaultValue: 0
+        )
+        let alarmStartedAt = container.decodeFirstDateOptional(
+            forKeys: [.alarmStartedAt, .alarm_started_at]
+        )
+
+        self.init(
+            config: config,
+            targetDuration: max(targetDuration, 1),
+            startedAt: startedAt,
+            remainingDuration: max(remainingDuration, 0),
+            status: status,
+            alarmTimeRemaining: max(alarmTimeRemaining, 0),
+            alarmStartedAt: alarmStartedAt
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: EncodingKeys.self)
+        try container.encode(config, forKey: .config)
+        try container.encode(targetDuration, forKey: .targetDuration)
+        try container.encode(startedAt, forKey: .startedAt)
+        try container.encode(remainingDuration, forKey: .remainingDuration)
+        try container.encode(status, forKey: .status)
+        try container.encode(alarmTimeRemaining, forKey: .alarmTimeRemaining)
+        try container.encodeIfPresent(alarmStartedAt, forKey: .alarmStartedAt)
     }
 
     public var progress: Double {
@@ -372,5 +605,159 @@ extension TimerStatus {
             return .complete
         }
         return currentStatus == .paused ? .paused : .running
+    }
+}
+
+// MARK: - Decoding Helpers
+
+private extension KeyedDecodingContainer {
+    func decodeFirstString(forKeys keys: [Key]) -> String? {
+        for key in keys {
+            if let value = try? decodeIfPresent(String.self, forKey: key) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    func decodeFirstInt(forKeys keys: [Key], defaultValue: Int) -> Int {
+        for key in keys {
+            if let value = try? decodeIfPresent(Int.self, forKey: key) {
+                return value
+            }
+            if let value = try? decodeIfPresent(Double.self, forKey: key) {
+                return Int(value)
+            }
+            if let value = decodeFirstString(forKeys: [key]), let parsed = Int(value) {
+                return parsed
+            }
+        }
+        return defaultValue
+    }
+
+    func decodeFirstFloat(forKeys keys: [Key], defaultValue: Float) -> Float {
+        for key in keys {
+            if let value = try? decodeIfPresent(Float.self, forKey: key) {
+                return value
+            }
+            if let value = try? decodeIfPresent(Double.self, forKey: key) {
+                return Float(value)
+            }
+            if let value = decodeFirstString(forKeys: [key]), let parsed = Float(value) {
+                return parsed
+            }
+        }
+        return defaultValue
+    }
+
+    func decodeFirstBool(forKeys keys: [Key], defaultValue: Bool) -> Bool {
+        for key in keys {
+            if let value = try? decodeIfPresent(Bool.self, forKey: key) {
+                return value
+            }
+            if let value = decodeFirstString(forKeys: [key]) {
+                let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                if ["true", "1", "yes"].contains(normalized) { return true }
+                if ["false", "0", "no"].contains(normalized) { return false }
+            }
+            if let value = try? decodeIfPresent(Int.self, forKey: key) {
+                return value != 0
+            }
+        }
+        return defaultValue
+    }
+
+    func decodeFirstTimeInterval(forKeys keys: [Key], defaultValue: TimeInterval) -> TimeInterval {
+        for key in keys {
+            if let value = try? decodeIfPresent(TimeInterval.self, forKey: key) {
+                return value
+            }
+            if let value = try? decodeIfPresent(Int.self, forKey: key) {
+                return TimeInterval(value)
+            }
+            if let value = decodeFirstString(forKeys: [key]), let parsed = Double(value) {
+                return parsed
+            }
+        }
+        return defaultValue
+    }
+
+    func decodeFirstDate(forKeys keys: [Key], defaultValue: Date) -> Date {
+        for key in keys {
+            if let value = try? decodeIfPresent(Date.self, forKey: key) {
+                return value
+            }
+            if let value = try? decodeIfPresent(TimeInterval.self, forKey: key) {
+                return Date(timeIntervalSince1970: value)
+            }
+            if let value = decodeFirstString(forKeys: [key]) {
+                if let date = ISO8601DateFormatter().date(from: value) {
+                    return date
+                }
+                if let seconds = Double(value) {
+                    return Date(timeIntervalSince1970: seconds)
+                }
+            }
+        }
+        return defaultValue
+    }
+
+    func decodeFirstDateOptional(forKeys keys: [Key]) -> Date? {
+        for key in keys {
+            if let value = try? decodeIfPresent(Date.self, forKey: key) {
+                return value
+            }
+            if let value = try? decodeIfPresent(TimeInterval.self, forKey: key) {
+                return Date(timeIntervalSince1970: value)
+            }
+            if let value = decodeFirstString(forKeys: [key]) {
+                if let date = ISO8601DateFormatter().date(from: value) {
+                    return date
+                }
+                if let seconds = Double(value) {
+                    return Date(timeIntervalSince1970: seconds)
+                }
+            }
+        }
+        return nil
+    }
+}
+
+private extension KeyedDecodingContainer where Key == TimerConfig.DecodingKeys {
+    func decodeFirstSoundType(forKeys keys: [Key], defaultValue: SoundType) -> SoundType {
+        for key in keys {
+            if let value = try? decodeIfPresent(SoundType.self, forKey: key) {
+                return value
+            }
+            if let rawValue = decodeFirstString(forKeys: [key]),
+               let value = SoundType.fromLoose(rawValue) {
+                return value
+            }
+        }
+        return defaultValue
+    }
+}
+
+private extension KeyedDecodingContainer where Key == TimerState.DecodingKeys {
+    func decodeFirstConfig(forKeys keys: [Key], defaultValue: TimerConfig) -> TimerConfig {
+        for key in keys {
+            if let value = try? decodeIfPresent(TimerConfig.self, forKey: key) {
+                return value
+            }
+        }
+        return defaultValue
+    }
+
+    func decodeFirstTimerStatus(forKeys keys: [Key], defaultValue: TimerStatus) -> TimerStatus {
+        for key in keys {
+            if let value = try? decodeIfPresent(TimerStatus.self, forKey: key) {
+                return value
+            }
+            if let rawValue = decodeFirstString(forKeys: [key]),
+               let value = TimerStatus(rawValue: rawValue.lowercased()) {
+                return value
+            }
+        }
+        return defaultValue
     }
 }


### PR DESCRIPTION
## Summary
- harden iOS persisted model decoding with legacy key support, sane defaults, clamping, and tolerant enum parsing
- clear corrupt persisted payloads in StorageService to prevent repeated restore failures
- add regression tests for legacy/messy payload decoding and corrupt storage cleanup
- update README to reflect real architecture/tooling, improve screenshot accessibility/captions, and modernize build/test instructions
- update AGENTS model naming to version-agnostic latest-class labels

## Validation
- xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' test -only-testing:RandomTimerTests/TimerConfigTests -only-testing:RandomTimerTests/TimerStateTests -only-testing:RandomTimerTests/StorageServiceTests
  - 24 passed, 0 failed
- xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' test
  - unit tests passed (99)
  - RandomTimerUITests had 2 existing failures unrelated to this diff
