### PR TITLE
fix(ci): persist paid-pause updates via PR on protected develop

### DIFF
--- a/.github/workflows/pause-paid-campaigns.yml
+++ b/.github/workflows/pause-paid-campaigns.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   issues: write
 
 jobs:
@@ -52,23 +53,49 @@ jobs:
             --lookback-days 30 \
             --wqtu-window-days 7 || true
 
-      - name: Commit campaign state updates
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add marketing/data/paid_campaigns.json marketing/data/north_star.json
-          if git diff --cached --quiet; then
-            echo "No campaign state updates to commit"
-            exit 0
-          fi
-          git commit -m "chore(ads): pause Apple Search Ads due to no-scale lock"
-          git push
+      - name: Create/update PR with campaign state updates
+        id: create_pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PROJECT_PAT || github.token }}
+          commit-message: "chore(ads): pause Apple Search Ads due to no-scale lock"
+          title: "chore(ads): pause paid campaigns + north star snapshot"
+          body: |
+            Automated pause workflow output.
+            Reason: `${{ inputs.reason }}`
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          branch: auto/pause-paid-campaigns
+          branch-suffix: timestamp
+          base: develop
+          add-paths: |
+            marketing/data/paid_campaigns.json
+            marketing/data/north_star.json
+          labels: |
+            automation
 
       - name: Comment status issue
+        if: always()
+        env:
+          CREATE_PR_OUTCOME: ${{ steps.create_pr.outcome }}
+          CREATE_PR_OPERATION: ${{ steps.create_pr.outputs.pull-request-operation }}
+          CREATE_PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}
+          INPUT_REASON: ${{ inputs.reason }}
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            const prOutcome = process.env.CREATE_PR_OUTCOME || 'unknown';
+            const prOperation = process.env.CREATE_PR_OPERATION || '';
+            const prUrl = (process.env.CREATE_PR_URL || '').trim();
+            const reason = process.env.INPUT_REASON || 'no_scale_lock_active';
+            let prLine = '- Update PR: status unknown';
+            if (prUrl) {
+              prLine = `- Update PR: ${prUrl} (${prOperation || 'created'})`;
+            } else if (prOutcome !== 'success') {
+              prLine = `- Update PR: failed (${prOutcome})`;
+            } else if (prOperation === 'none') {
+              prLine = '- Update PR: none (no file diff)';
+            }
             const path = 'marketing/data/north_star.json';
             const issueNumber = 81;
             let payload = {};
@@ -82,13 +109,14 @@ jobs:
               '## Paid Campaign Pause + North Star Snapshot',
               '',
               `- Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              prLine,
               `- WQTU (7d): ${ns.wqtu_7d ?? 'n/a'}`,
               `- Checkpoint target (2026-03-31): ${(ns.targets || {}).checkpoint_2026_03_31 ?? 'n/a'}`,
               `- Paid attributed users (30d): ${paid.paid_distinct_users_30d ?? 'n/a'}`,
               `- Active campaign count: ${paid.active_campaign_count ?? 'n/a'}`,
               `- No-scale lock active: ${lock.active ?? paid.guardrail_violated ?? 'n/a'}`,
               '',
-              `Reason: ${'${{ inputs.reason }}'}`,
+              `Reason: ${reason}`,
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- replace direct push to protected `develop` in pause-paid workflow with `create-pull-request`
- use `PROJECT_PAT` (fallback to `github.token`) so bot PRs can trigger required checks
- always post issue #81 status and distinguish no-diff vs PR-failure

## Verification
- YAML parse check: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pause-paid-campaigns.yml'); puts 'yaml-ok'"`
- reproduced root cause from failed run `22600867210`: `GH013` push rejected on protected `develop`
