### PR TITLE
chore(ads): pause paid campaigns + north star snapshot

### DIFF
--- a/marketing/data/north_star.json
+++ b/marketing/data/north_star.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-26T18:28:59+00:00",
+  "generated_at": "2026-03-02T23:46:34+00:00",
   "source": "posthog",
   "status": "ok",
   "status_reason": "",
@@ -9,10 +9,10 @@
     "name": "Weekly Qualified Training Users",
     "key": "WQTU",
     "definition": "distinct users with >=3 timer_completed events in trailing 7 days",
-    "wqtu_7d": 2,
-    "timer_completed_7d": 47,
-    "completed_users_7d": 4,
-    "sessions_per_completed_user_7d": 11.75,
+    "wqtu_7d": 0,
+    "timer_completed_7d": 0,
+    "completed_users_7d": 0,
+    "sessions_per_completed_user_7d": 0.0,
     "targets": {
       "checkpoint_2026_03_31": 8,
       "quarter_2026_06_30": 25
@@ -23,15 +23,8 @@
   "paid": {
     "paid_distinct_users_30d": 0,
     "paid_events_by_source_30d": [],
-    "active_campaigns": [
-      {
-        "platform": "apple_search_ads",
-        "status": "active",
-        "daily_budget_usd": 10.0,
-        "launched_at": "2026-02-24T16:30:00Z"
-      }
-    ],
-    "active_campaign_count": 1,
+    "active_campaigns": [],
+    "active_campaign_count": 0,
     "active_statuses": [
       "active",
       "enabled",
@@ -42,10 +35,15 @@
     ],
     "campaign_grace_days": 7,
     "active_campaigns_outside_grace_count": 0,
-    "paid_traffic_signal": true,
-    "paid_traffic_signal_detail": "apple_30d taps=11, spend_usd=10.00, installs=3",
-    "guardrail_violated": true,
-    "guardrail_reason": "active campaigns exist, paid-attributed users over lookback window is zero, outside_grace=0, signal=True (apple_30d taps=11, spend_usd=10.00, installs=3)"
+    "paid_traffic_signal": false,
+    "paid_traffic_signal_detail": "no active paid campaigns",
+    "guardrail_violated": false,
+    "guardrail_reason": "",
+    "no_scale_lock": {
+      "active": false,
+      "reasons": [],
+      "enforceable_status": "not_applicable"
+    }
   },
   "query_diagnostics": {
     "errors": []
@@ -59,6 +57,15 @@
       "paid_distinct_users_30d": 0,
       "active_campaign_count": 1,
       "guardrail_violated": true
+    },
+    {
+      "timestamp": "2026-03-02T23:46:34+00:00",
+      "wqtu_7d": 0,
+      "timer_completed_7d": 0,
+      "completed_users_7d": 0,
+      "paid_distinct_users_30d": 0,
+      "active_campaign_count": 0,
+      "guardrail_violated": false
     }
   ]
 }

--- a/marketing/data/paid_campaigns.json
+++ b/marketing/data/paid_campaigns.json
@@ -185,7 +185,7 @@
         "clock widget"
       ],
       "target_cpa_usd": 3.0,
-      "paused_at": "2026-03-02T23:27:38Z"
+      "paused_at": "2026-03-02T23:46:34Z"
     },
     {
       "platform": "google_uac",
@@ -326,6 +326,13 @@
       "reason": "no_scale_lock_active",
       "status": "paused",
       "daily_budget_usd": 0.0
+    },
+    {
+      "timestamp": "2026-03-02T23:46:34Z",
+      "action": "apple_search_ads_paused",
+      "campaign_id": 2143440089,
+      "reason": "no_scale_lock_active",
+      "status": "PAUSED"
     }
   ],
   "budget_allocation": {


### PR DESCRIPTION
Automated pause workflow output.
Reason: `no_scale_lock_active`
Run: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/22601101078