### PR TITLE
chore(ads): pause paid campaigns + north star snapshot

### DIFF
--- a/marketing/data/north_star.json
+++ b/marketing/data/north_star.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-02T23:46:34+00:00",
+  "generated_at": "2026-03-03T00:08:07+00:00",
   "source": "posthog",
   "status": "ok",
   "status_reason": "",
@@ -60,6 +60,15 @@
     },
     {
       "timestamp": "2026-03-02T23:46:34+00:00",
+      "wqtu_7d": 0,
+      "timer_completed_7d": 0,
+      "completed_users_7d": 0,
+      "paid_distinct_users_30d": 0,
+      "active_campaign_count": 0,
+      "guardrail_violated": false
+    },
+    {
+      "timestamp": "2026-03-03T00:08:07+00:00",
       "wqtu_7d": 0,
       "timer_completed_7d": 0,
       "completed_users_7d": 0,

--- a/marketing/data/paid_campaigns.json
+++ b/marketing/data/paid_campaigns.json
@@ -185,7 +185,7 @@
         "clock widget"
       ],
       "target_cpa_usd": 3.0,
-      "paused_at": "2026-03-02T23:46:34Z"
+      "paused_at": "2026-03-03T00:08:07Z"
     },
     {
       "platform": "google_uac",
@@ -332,6 +332,13 @@
       "action": "apple_search_ads_paused",
       "campaign_id": 2143440089,
       "reason": "no_scale_lock_active",
+      "status": "PAUSED"
+    },
+    {
+      "timestamp": "2026-03-03T00:08:07Z",
+      "action": "apple_search_ads_paused",
+      "campaign_id": 2143440089,
+      "reason": "post_merge_validation",
       "status": "PAUSED"
     }
   ],


### PR DESCRIPTION
Automated pause workflow output.
Reason: `post_merge_validation`
Run: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/22601728091