### PR TITLE
fix(analytics): restore live install/open attribution tags

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -35,7 +35,8 @@ class AnalyticsService
                     apiKey = apiKey,
                     host = "https://us.i.posthog.com",
                 ).apply {
-                    captureApplicationLifecycleEvents = true
+                    // Emit lifecycle events manually so every event includes our live/dev context tags.
+                    captureApplicationLifecycleEvents = false
                     captureDeepLinks = true
                     captureScreenViews = false // We track manually for better control
                 }
@@ -55,6 +56,7 @@ class AnalyticsService
                 userId = getOrCreateDistinctId(application),
                 properties = analyticsContextProperties,
             )
+            trackApplicationLifecycleEvents()
 
             trackFirstOpenIfNeeded()
         }
@@ -128,6 +130,15 @@ class AnalyticsService
         }
 
         // --- Onboarding Funnel ---
+
+        private fun trackApplicationLifecycleEvents() {
+            track(AnalyticsEvents.APPLICATION_OPENED)
+            val hasTrackedInstall = prefs?.getBoolean(KEY_HAS_TRACKED_APPLICATION_INSTALLED, false) ?: false
+            if (!hasTrackedInstall) {
+                track(AnalyticsEvents.APPLICATION_INSTALLED)
+                prefs?.edit()?.putBoolean(KEY_HAS_TRACKED_APPLICATION_INSTALLED, true)?.apply()
+            }
+        }
 
         private fun trackFirstOpenIfNeeded() {
             val hasOpened = prefs?.getBoolean(KEY_HAS_OPENED, false) ?: false
@@ -217,6 +228,7 @@ class AnalyticsService
             private const val KEY_HAS_OPENED = "has_first_opened"
             private const val KEY_HAS_CONFIGURED = "has_first_configured"
             private const val KEY_HAS_COMPLETED = "has_first_completed"
+            private const val KEY_HAS_TRACKED_APPLICATION_INSTALLED = "has_tracked_application_installed"
             private val UTM_KEYS =
                 listOf(
                     "utm_source",
@@ -230,6 +242,8 @@ class AnalyticsService
 
 // Event names for consistency
 object AnalyticsEvents {
+    const val APPLICATION_INSTALLED = "Application Installed"
+    const val APPLICATION_OPENED = "Application Opened"
     const val TIMER_STARTED = "timer_started"
     const val TIMER_COMPLETED = "timer_completed"
     const val TIMER_PAUSED = "timer_paused"

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -19,6 +19,7 @@ final class AnalyticsService {
     private let hasFirstOpenedKey = "has_first_opened"
     private let hasFirstConfiguredKey = "has_first_configured"
     private let hasFirstCompletedKey = "has_first_completed"
+    private let hasTrackedApplicationInstalledKey = "has_tracked_application_installed"
     private let utmKeys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]
     private let appleAdsAttributionFetchedKey = "apple_ads_attribution_fetched"
 
@@ -97,13 +98,15 @@ final class AnalyticsService {
 
 #if canImport(PostHog)
         let config = PostHogConfig(apiKey: apiKey, host: host)
-        config.captureApplicationLifecycleEvents = true
+        // Emit lifecycle events manually so every event includes our live/dev context tags.
+        config.captureApplicationLifecycleEvents = false
         config.captureScreenViews = false
         PostHogSDK.shared.setup(config)
 #endif
         initialized = true
         let distinctId = getOrCreateDistinctId()
         identify(userId: distinctId, properties: analyticsContextProperties)
+        trackApplicationLifecycleEvents()
         logger.info("PostHog initialized")
 
         trackFirstOpenIfNeeded()
@@ -262,6 +265,14 @@ final class AnalyticsService {
 
     // MARK: - Onboarding Funnel
 
+    private func trackApplicationLifecycleEvents() {
+        let defaults = UserDefaults.standard
+        track(AnalyticsEvents.applicationOpened)
+        guard !defaults.bool(forKey: hasTrackedApplicationInstalledKey) else { return }
+        track(AnalyticsEvents.applicationInstalled)
+        defaults.set(true, forKey: hasTrackedApplicationInstalledKey)
+    }
+
     private func trackFirstOpenIfNeeded() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: hasFirstOpenedKey) else { return }
@@ -313,6 +324,8 @@ final class AnalyticsService {
 
 // Event names for consistency
 enum AnalyticsEvents {
+    static let applicationInstalled = "Application Installed"
+    static let applicationOpened = "Application Opened"
     static let timerStarted = "timer_started"
     static let timerCompleted = "timer_completed"
     static let timerPaused = "timer_paused"

--- a/scripts/tests/test_mobile_analytics_parity.py
+++ b/scripts/tests/test_mobile_analytics_parity.py
@@ -70,6 +70,22 @@ class MobileAnalyticsParityTests(unittest.TestCase):
         self.assertIn('const val RESULT = "result"', android_source)
         self.assertIn('static let result = "result"', ios_source)
 
+    def test_lifecycle_autocapture_disabled_on_both_platforms(self):
+        android_source = ANDROID_ANALYTICS.read_text(encoding="utf-8")
+        ios_source = IOS_ANALYTICS.read_text(encoding="utf-8")
+        self.assertIn("captureApplicationLifecycleEvents = false", android_source)
+        self.assertIn("config.captureApplicationLifecycleEvents = false", ios_source)
+
+    def test_manual_lifecycle_events_tracked_on_initialize(self):
+        android_source = ANDROID_ANALYTICS.read_text(encoding="utf-8")
+        ios_source = IOS_ANALYTICS.read_text(encoding="utf-8")
+        self.assertIn("trackApplicationLifecycleEvents()", android_source)
+        self.assertIn("trackApplicationLifecycleEvents()", ios_source)
+        self.assertIn('const val APPLICATION_INSTALLED = "Application Installed"', android_source)
+        self.assertIn('const val APPLICATION_OPENED = "Application Opened"', android_source)
+        self.assertIn('static let applicationInstalled = "Application Installed"', ios_source)
+        self.assertIn('static let applicationOpened = "Application Opened"', ios_source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
Live-only PostHog queries for `Application Installed` / `Application Opened` returned 0 because SDK auto lifecycle events were emitted without our context tags (`environment`, `build_audience`, `build_type`, `runtime_target`).

## Changes
- iOS: disable SDK lifecycle autocapture and emit `Application Installed`/`Application Opened` manually through `AnalyticsService.track(...)` so merged context tags are always present.
- Android: same approach as iOS.
- Added regression checks in `scripts/tests/test_mobile_analytics_parity.py`:
  - lifecycle autocapture disabled on both platforms
  - manual lifecycle tracking wired in initialize
  - lifecycle event constants present on both platforms

## Verification
- `python3 -m unittest scripts.tests.test_mobile_analytics_parity -v` ✅ (7 tests)
- `cd native-android && ./gradlew testDebugUnitTest --no-daemon` ✅
- iOS compile path blocked by existing unrelated `LiveActivityService.swift` strict-concurrency errors and local signing profile mismatch (not introduced by this PR).

## PostHog Evidence (live query run)
- `Application Installed` distinct users (30d): 22
- `environment` / `runtime_target` / `build_type` / `build_audience` were all null on those install events before this fix.
