### PR TITLE
fix: harden internal distribution trigger + wait for TestFlight processing

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+    branches: [develop]
   workflow_dispatch:
     inputs:
       ref:
@@ -18,6 +19,7 @@ concurrency:
 jobs:
   gate:
     name: Gate Internal Distribution
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -103,7 +103,7 @@ platform :ios do
 
     # Upload to TestFlight
     upload_to_testflight(
-      skip_waiting_for_build_processing: true,
+      skip_waiting_for_build_processing: false,
       api_key: defined?(api_key) ? api_key : nil
     )
   end


### PR DESCRIPTION
## What
- Restrict `internal-distribution` auto trigger to CI runs on `develop` only.
- Add gate-level `if` so only manual dispatch or successful CI `workflow_run` executes the gate.
- Change iOS fastlane beta upload to wait for TestFlight build processing before returning success.

## Why
- Prevent misleading green runs with skipped distribution jobs from non-eligible branches.
- Reduce false-positive success where upload completes but build is not yet visible in TestFlight.

## Validation
- `ruby -c native-ios/fastlane/Fastfile`
- YAML parse check for `.github/workflows/internal-distribution.yml`
