### PR TITLE
fix(ci): fail fast on Play API auth in internal distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -230,6 +230,21 @@ jobs:
           set -euo pipefail
           echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
 
+      - name: Write Google Play service account key
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
+
+      - name: Verify Google Play API access
+        env:
+          GOOGLE_PLAY_JSON_KEY_PATH: /tmp/play-service-account.json
+        run: |
+          set -euo pipefail
+          python -m pip install google-api-python-client==2.190.0 google-auth==2.48.0 google-auth-httplib2==0.3.0 google-auth-oauthlib==1.2.4 requests==2.32.5
+          python scripts/check_store_access.py --platform android
+
       - name: Decode keystore
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -251,11 +266,8 @@ jobs:
 
       - name: Distribute to Google Play Internal
         working-directory: native-android
-        env:
-          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
         run: |
           set -euo pipefail
-          echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
           export GOOGLE_PLAY_JSON_KEY_PATH="/tmp/play-service-account.json"
           fastlane internal
 


### PR DESCRIPTION
## What this fixes
- Internal Distribution now validates Google Play API access before building the Android AAB.
- This fails fast on deleted/misconfigured Play service-account projects instead of spending ~8 minutes building before failing.

## Why
- Current `GOOGLE_PLAY_JSON_KEY` is valid JSON but points to a deleted GCP project, causing `supply` to fail late.
- This patch surfaces that root cause immediately and cuts CI waste.

## Scope
- `.github/workflows/internal-distribution.yml` only.
