### PR TITLE
fix(release): harden iOS signing recovery + Play key path consistency

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Verify Google Play API access
         env:
-          GOOGLE_PLAY_JSON_KEY: /tmp/play-service-account.json
+          GOOGLE_PLAY_JSON_KEY_PATH: /tmp/play-service-account.json
         run: |
           python -m pip install google-api-python-client==2.190.0 google-auth==2.48.0 google-auth-httplib2==0.3.0 google-auth-oauthlib==1.2.4 requests==2.32.5
           python scripts/check_store_access.py --platform android
@@ -261,20 +261,20 @@ jobs:
 
       - name: Upload to Google Play (track)
         env:
-          GOOGLE_PLAY_JSON_KEY: /tmp/play-service-account.json
+          GOOGLE_PLAY_JSON_KEY_PATH: /tmp/play-service-account.json
           PLAY_TRACK: ${{ inputs.android_track }}
           PLAY_FALLBACK_TRACK: alpha
           PLAY_RELEASE_STATUS: completed
           PLAY_UPLOAD_RETRY_WINDOW_SECONDS: "10800"
           PLAY_UPLOAD_RETRY_INTERVAL_SECONDS: "300"
         run: |
-          if [ ! -f "$GOOGLE_PLAY_JSON_KEY" ]; then
-            echo "❌ Google Play key file not found at $GOOGLE_PLAY_JSON_KEY"
+          if [ ! -f "$GOOGLE_PLAY_JSON_KEY_PATH" ]; then
+            echo "❌ Google Play key file not found at $GOOGLE_PLAY_JSON_KEY_PATH"
             exit 1
           fi
           pip install google-api-python-client==2.190.0 google-auth==2.48.0 google-auth-httplib2==0.3.0 google-auth-oauthlib==1.2.4
           python scripts/play_publish.py \
-            --service-account-json "$GOOGLE_PLAY_JSON_KEY" \
+            --service-account-json "$GOOGLE_PLAY_JSON_KEY_PATH" \
             --package com.iganapolsky.randomtimer \
             --aab-path native-android/app/build/outputs/bundle/release/app-release.aab \
             --requested-track "$PLAY_TRACK" \

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -248,13 +248,29 @@ platform :ios do
         )
       end
 
-      # Distribution profiles for App Store export
-      match(
-        type: "appstore",
-        app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
-        readonly: false,
-        api_key: api_key
-      )
+      # Distribution profiles for App Store export.
+      # If Apple revoked/deleted a cert referenced by the saved profile, retry once
+      # with profile regeneration to self-heal CI instead of requiring manual cleanup.
+      begin
+        match(
+          type: "appstore",
+          app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
+          readonly: false,
+          api_key: api_key
+        )
+      rescue => e
+        message = e.to_s
+        raise unless message.include?("not available on the Developer Portal")
+
+        UI.important("Detected stale App Store profile certificate reference. Retrying match with forced profile regeneration.")
+        match(
+          type: "appstore",
+          app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
+          readonly: false,
+          force: true,
+          api_key: api_key
+        )
+      end
     else
       UI.message("No MATCH_GIT_URL set - using Xcode automatic signing")
     end


### PR DESCRIPTION
## Summary
- add iOS `fastlane setup` self-heal retry when App Store profile references a deleted Apple certificate
- standardize Android release workflow to use `GOOGLE_PLAY_JSON_KEY_PATH` consistently

## Why
- reduce release pipeline tech debt from flaky signing state and ambiguous key env usage
- fail deterministically with actionable output

## Validation
- `ruby -c native-ios/fastlane/Fastfile`
- `python3 -m pytest scripts/tests/test_check_store_access.py scripts/tests/test_release_ops.py -q`
- `bash scripts/preflight-release.sh --platform both --layer 1`
