### PR TITLE
fix(distribution): recover TestFlight signing + add Firebase internal delivery

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -283,3 +283,101 @@ jobs:
         if: always()
         run: |
           rm -f /tmp/release.keystore /tmp/play-service-account.json
+
+  android-firebase-internal:
+    name: Android Firebase App Distribution (Internal)
+    needs: [gate]
+    if: needs.gate.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.ref }}
+
+      - name: Fail fast on Firebase distribution inputs
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_INTERNAL_TESTERS: ${{ secrets.FIREBASE_INTERNAL_TESTERS }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          for name in GOOGLE_SERVICES_JSON ANDROID_KEYSTORE_BASE64 FIREBASE_ANDROID_APP_ID FIREBASE_INTERNAL_TESTERS GOOGLE_PLAY_JSON_KEY; do
+            if [ -z "${!name:-}" ]; then
+              echo "❌ Missing required secret: $name"
+              exit 1
+            fi
+          done
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Create google-services.json
+        working-directory: native-android
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Decode keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > /tmp/release.keystore
+
+      - name: Build release APK
+        working-directory: native-android
+        env:
+          KEYSTORE_PATH: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+        run: |
+          set -euo pipefail
+          ./gradlew assembleRelease --no-daemon
+
+      - name: Write Firebase service account key
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/firebase-service-account.json
+
+      - name: Distribute APK to Firebase App Distribution
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-service-account.json
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_INTERNAL_TESTERS: ${{ secrets.FIREBASE_INTERNAL_TESTERS }}
+        run: |
+          set -euo pipefail
+          npx --yes firebase-tools appdistribution:distribute \
+            native-android/app/build/outputs/apk/release/app-release.apk \
+            --app "$FIREBASE_ANDROID_APP_ID" \
+            --testers "$FIREBASE_INTERNAL_TESTERS" \
+            --release-notes "Internal CI build ${GITHUB_SHA}"
+
+      - name: Upload Android APK artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-apk-firebase-internal
+          path: native-android/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: warn
+
+      - name: Cleanup Firebase secrets
+        if: always()
+        run: |
+          rm -f /tmp/release.keystore /tmp/firebase-service-account.json

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -249,8 +249,8 @@ platform :ios do
       end
 
       # Distribution profiles for App Store export.
-      # If Apple revoked/deleted a cert referenced by the saved profile, retry once
-      # with profile regeneration to self-heal CI instead of requiring manual cleanup.
+      # If match storage references a stale/revoked cert, self-heal by nuking
+      # stale appstore profiles/certs and recreating a clean appstore state.
       begin
         match(
           type: "appstore",
@@ -260,9 +260,18 @@ platform :ios do
         )
       rescue => e
         message = e.to_s
-        raise unless message.include?("not available on the Developer Portal")
+        should_recover = message.include?("not available on the Developer Portal") ||
+                         message.include?("match nuke") ||
+                         message.include?("stored in your storage")
+        raise unless should_recover
 
-        UI.important("Detected stale App Store profile certificate reference. Retrying match with forced profile regeneration.")
+        UI.important("Detected stale match state. Running appstore match_nuke + fresh match regeneration.")
+        match_nuke(
+          type: "appstore",
+          app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
+          skip_confirmation: true,
+          api_key: api_key
+        )
         match(
           type: "appstore",
           app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],


### PR DESCRIPTION
## Summary
- add Android Firebase App Distribution internal job to `Internal Distribution`
- harden iOS signing setup recovery by auto-running `match_nuke` on stale match cert state, then regenerating appstore profiles/certs

## Validation
- `ruby -c native-ios/fastlane/Fastfile`
- `python3 -m pytest scripts/tests/test_check_store_access.py scripts/tests/test_release_ops.py -q`
- `bash scripts/preflight-release.sh --platform both --layer 1`

## Live Evidence (pre-PR baseline)
- Internal Distribution run on latest develop failed:
  - iOS: `Setup signing certificates and profiles (match)` with stale cert `CH7ZPZ9AQ7`
  - Android: `Verify Google Play API access` with `Project #710216278770 has been deleted`
