### PR TITLE
fix(android): avoid duplicate versionCode in internal delivery

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -255,6 +255,7 @@ jobs:
       - name: Build release Bundle (AAB)
         working-directory: native-android
         env:
+          ANDROID_VERSION_CODE: ${{ github.run_number }}
           KEYSTORE_PATH: /tmp/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
@@ -349,6 +350,7 @@ jobs:
       - name: Build release APK
         working-directory: native-android
         env:
+          ANDROID_VERSION_CODE: ${{ github.run_number }}
           KEYSTORE_PATH: /tmp/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -35,6 +35,7 @@ if (enableFirebasePlugins) {
 
 val ciCompileSdk = providers.gradleProperty("ciCompileSdk").orNull?.toIntOrNull()
 val ciTargetSdk = providers.gradleProperty("ciTargetSdk").orNull?.toIntOrNull()
+val ciVersionCode = System.getenv("ANDROID_VERSION_CODE")?.toIntOrNull()
 
 android {
     namespace = "com.iganapolsky.randomtimer"
@@ -44,7 +45,7 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = 11
+        versionCode = ciVersionCode ?: 11
         versionName = "1.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/native-android/fastlane/Fastfile
+++ b/native-android/fastlane/Fastfile
@@ -47,7 +47,7 @@ platform :android do
   desc "Verify release landed on the expected track"
   lane :verify do |options|
     track = options[:track] || "alpha"
-    version_code = options[:version_code] || sh("sed -n 's/.*versionCode *= *//p' ../app/build.gradle.kts").strip
+    version_code = options[:version_code] || ENV["ANDROID_VERSION_CODE"] || sh("sed -n 's/.*versionCode *= *//p' ../app/build.gradle.kts").strip
     sh("python3 #{File.expand_path('../../scripts/verify_release.py', __dir__)} " \
        "--platform android --track #{track} --version-code #{version_code}")
   end


### PR DESCRIPTION
## Summary
- drive Android `versionCode` from `ANDROID_VERSION_CODE` env in Gradle
- set `ANDROID_VERSION_CODE: ${{ github.run_number }}` in both internal AAB and APK build steps
- align Fastlane verify lane to use `ANDROID_VERSION_CODE` when present

## Why
Latest Internal Distribution run on `develop` (`22735650722`) failed with:
- Google Play: `Version code 11 has already been used`
- Firebase distribution also failed at distribute step after successful APK build

This removes static `versionCode=11` collisions in CI-generated release artifacts.

## Validation
- `ruby -c native-android/fastlane/Fastfile` -> `Syntax OK`
- workflow YAML parse -> `yaml_ok`
