### PR TITLE
fix(ci): restore internal-distribution workflow parsing

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -382,7 +382,6 @@ jobs:
           ./gradlew assembleRelease --no-daemon
 
       - name: Write Firebase service account key
-        if: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON != '' || secrets.GOOGLE_PLAY_JSON_KEY != '' }}
         env:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}


### PR DESCRIPTION
## Summary
- remove invalid step-level `if` expression that referenced the `secrets` context
- keep existing runtime credential fallback logic inside the shell step

## Root cause
GitHub rejected the workflow at parse time on push/dispatch:

`Unrecognized named-value: 'secrets'` in step `if` expression on line 385.

## Validation
- `YAML.load_file('.github/workflows/internal-distribution.yml')` => `yaml_ok`
- commit pushed: `ba05dbbb`
- ready for CI + internal-distribution execution on merge
