### PR TITLE
fix(ci): prefer service-account auth for Firebase distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -388,13 +388,14 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN || secrets.GMSAAS_APITOKEN }}
         run: |
           set -euo pipefail
-          if [ -n "${FIREBASE_TOKEN:-}" ]; then
-            echo "Firebase token provided; skipping service account key file."
-            rm -f /tmp/firebase-service-account.json
-          elif [ -n "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
+          # Prefer service-account auth because firebase --token is legacy and often less reliable in CI.
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
             echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-service-account.json
           elif [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
             echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/firebase-service-account.json
+          elif [ -n "${FIREBASE_TOKEN:-}" ]; then
+            echo "Firebase token provided; no service account key file will be written."
+            rm -f /tmp/firebase-service-account.json
           else
             echo "No service account payload provided; expecting token auth."
             rm -f /tmp/firebase-service-account.json
@@ -437,12 +438,12 @@ jobs:
           fi
 
           AUTH_MODE="service-account"
-          if [ -n "${FIREBASE_TOKEN:-}" ]; then
+          if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+            echo "Firebase auth mode: service-account-file"
+          elif [ -n "${FIREBASE_TOKEN:-}" ]; then
             AUTH_MODE="token"
             unset GOOGLE_APPLICATION_CREDENTIALS
             echo "Firebase auth mode: token"
-          elif [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
-            echo "Firebase auth mode: service-account-file"
           else
             echo "❌ No usable Firebase auth mode: missing token and service account file."
             exit 1
@@ -467,7 +468,7 @@ jobs:
             --non-interactive
             --debug
           )
-          if [ -n "${FIREBASE_TOKEN:-}" ]; then
+          if [ "$AUTH_MODE" = "token" ]; then
             BASE_CMD+=(--token "$FIREBASE_TOKEN")
             echo "Using Firebase token authentication."
           fi


### PR DESCRIPTION
## Summary
- prefer service-account credentials over `FIREBASE_TOKEN` for Firebase App Distribution
- keep token auth as fallback only when no service-account payload exists
- only pass `--token` to firebase-tools when token auth mode is explicitly selected

## Why
Latest run `22755788418` failed Firebase distribution with `401 UNAUTHENTICATED` using token auth, while other distribution jobs succeeded. Service-account auth is more reliable for CI and avoids legacy token path issues.

## Evidence
- failing Firebase job: `65999975466`
- failure line: `Request had invalid authentication credentials ... status: UNAUTHENTICATED`
- workflow now chooses `service-account-file` first when available
