### PR TITLE
fix(ci): force ADC auth by clearing FIREBASE_TOKEN env

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -440,6 +440,9 @@ jobs:
           AUTH_MODE="service-account"
           if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
             echo "Firebase auth mode: service-account-file"
+            # firebase-tools auto-reads FIREBASE_TOKEN from env even without --token.
+            # Clear it to force ADC/service-account auth for this path.
+            unset FIREBASE_TOKEN
           elif [ -n "${FIREBASE_TOKEN:-}" ]; then
             AUTH_MODE="token"
             unset GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
## Summary
- unset `FIREBASE_TOKEN` when service-account mode is selected
- prevent firebase-tools from silently preferring token env auth over ADC

## Why
Run `22757148274` showed `Firebase auth mode: service-account-file` but firebase-tools still logged `Authenticating with FIREBASE_TOKEN`, causing repeated 401 failures. This patch enforces the intended auth path.

## Evidence
- failing job: `66004461640`
- log line: `Firebase auth mode: service-account-file`
- subsequent log line before fix: `Authenticating with FIREBASE_TOKEN is deprecated`
