### PR TITLE
Harden internal distribution with manual budget and lane gating

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -555,7 +555,12 @@ jobs:
             echo "❌ APK not found at $APK_PATH"
             exit 1
           fi
-          if [ -n "$REQUIRED_TESTER" ] && [ -n "$TESTERS" ]; then
+          if [ -n "$REQUIRED_TESTER" ]; then
+            if [ -z "$TESTERS" ]; then
+              echo "❌ FIREBASE_REQUIRED_TESTER_EMAIL is set but FIREBASE_INTERNAL_TESTERS is empty."
+              echo "required tester: $REQUIRED_TESTER"
+              exit 1
+            fi
             case ",$TESTERS," in
               *",$REQUIRED_TESTER,"*) ;;
               *)


### PR DESCRIPTION
## Summary
- remove CI `workflow_run` auto-trigger from internal distribution
- require explicit `workflow_dispatch` with `budget_ack`
- add lane targeting (`all|ios|android_play|android_firebase`) and per-lane job gating
- restrict dispatch ref to `develop`
- fail Firebase distribution when app-id secret mismatches `google-services.json`
- enforce required tester membership via `FIREBASE_REQUIRED_TESTER_EMAIL`

## Why
- prevent unintended auto distribution runs and tighten budget-control guardrails
- prevent Firebase uploads to wrong app id and wrong tester audience

## Validation
- YAML parse passed locally for `.github/workflows/internal-distribution.yml`
- branch pushed and ready for CI/workflow verification
