### PR TITLE
fix(ci): stabilize Firebase internal distribution + required tester guard

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -13,8 +13,8 @@ on:
         type: string
 
 concurrency:
-  group: internal-distribution-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || inputs.ref || github.ref_name }}
-  cancel-in-progress: true
+  group: internal-distribution-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || inputs.ref || github.ref_name }}-${{ github.event.workflow_run.conclusion || 'manual' }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   gate:
@@ -302,11 +302,17 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           FIREBASE_INTERNAL_TESTERS: ${{ secrets.FIREBASE_INTERNAL_TESTERS }}
           FIREBASE_INTERNAL_GROUPS: ${{ secrets.FIREBASE_INTERNAL_GROUPS }}
+          FIREBASE_REQUIRED_TESTER_EMAIL: ${{ secrets.FIREBASE_REQUIRED_TESTER_EMAIL }}
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN || secrets.GMSAAS_APITOKEN }}
         run: |
           set -euo pipefail
+          normalize_csv() {
+            printf '%s' "${1-}" \
+              | tr $'\n\r;' ',' \
+              | sed -E 's/[[:space:]]*,[[:space:]]*/,/g; s/^[,[:space:]]+//; s/[,[:space:]]+$//; s/,+/,/g'
+          }
           for name in GOOGLE_SERVICES_JSON ANDROID_KEYSTORE_BASE64; do
             if [ -z "${!name:-}" ]; then
               echo "❌ Missing required secret: $name"
@@ -320,6 +326,21 @@ jobs:
           if [ -z "${FIREBASE_INTERNAL_TESTERS:-}" ] && [ -z "${FIREBASE_INTERNAL_GROUPS:-}" ]; then
             echo "INFO: No Firebase audience configured. Falling back to upload-only mode."
           fi
+          REQUIRED_TESTER="$(printf '%s' "${FIREBASE_REQUIRED_TESTER_EMAIL:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+          TESTERS_NORMALIZED="$(normalize_csv "${FIREBASE_INTERNAL_TESTERS:-}" | tr '[:upper:]' '[:lower:]')"
+          if [ -z "$REQUIRED_TESTER" ]; then
+            echo "❌ Missing required secret: FIREBASE_REQUIRED_TESTER_EMAIL"
+            exit 1
+          fi
+          case ",$TESTERS_NORMALIZED," in
+            *",$REQUIRED_TESTER,"*)
+              echo "Required Firebase tester is configured."
+              ;;
+            *)
+              echo "❌ FIREBASE_INTERNAL_TESTERS must include required tester: $REQUIRED_TESTER"
+              exit 1
+              ;;
+          esac
 
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
## What this fixes
- Prevents CI-triggered Internal Distribution runs from canceling in-flight Firebase distribution jobs.
- Adds a hard preflight guard requiring `FIREBASE_REQUIRED_TESTER_EMAIL` and verifies it is present in `FIREBASE_INTERNAL_TESTERS`.

## Why
Firebase releases became non-installable when distribution runs were canceled mid-step and when required tester email was missing from audience config.

## Changes
- `.github/workflows/internal-distribution.yml`
  - `cancel-in-progress` now applies only to manual dispatch.
  - concurrency group includes workflow_run conclusion to reduce collision between skip/failed/success paths.
  - fail-fast step validates required tester coverage before expensive build/distribution.

## Validation
- Workflow YAML parsed successfully (`ruby -e 'require "yaml"; YAML.load_file(".github/workflows/internal-distribution.yml")'`).
- Diff is scoped to one workflow file only.
