### PR TITLE
ci: auto-retry iOS internal upload when Apple daily cap hits

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -5,27 +5,39 @@ on:
     workflows: ["CI"]
     types: [completed]
     branches: [develop]
+  schedule:
+    - cron: "20 */3 * * *"
   workflow_dispatch:
     inputs:
       ref:
         description: "Git ref to distribute (optional, defaults to develop)"
         required: false
         type: string
+      platform:
+        description: "Platform to distribute"
+        required: false
+        default: "both"
+        type: choice
+        options:
+          - ios
+          - android
+          - both
 
 concurrency:
-  group: internal-distribution-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || inputs.ref || github.ref_name }}-${{ github.event.workflow_run.conclusion || 'manual' }}
+  group: internal-distribution-${{ github.event_name }}-${{ inputs.platform || 'both' }}-${{ github.event.workflow_run.head_branch || inputs.ref || github.ref_name || 'develop' }}-${{ github.event.workflow_run.conclusion || 'manual' }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   gate:
     name: Gate Internal Distribution
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       ref: ${{ steps.decide.outputs.ref }}
       sha: ${{ steps.decide.outputs.sha }}
       reason: ${{ steps.decide.outputs.reason }}
+      platform: ${{ steps.decide.outputs.platform }}
     steps:
       - name: Decide whether to run
         id: decide
@@ -35,6 +47,7 @@ jobs:
           WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
           WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
           INPUT_REF: ${{ inputs.ref }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
         run: |
           set -euo pipefail
 
@@ -42,30 +55,55 @@ jobs:
           REF=""
           SHA=""
           REASON="not_eligible"
+          PLATFORM="both"
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             REF="${INPUT_REF:-develop}"
             SHOULD_RUN="true"
             REASON="manual_dispatch"
+            PLATFORM="${INPUT_PLATFORM:-both}"
           elif [[ "$EVENT_NAME" == "workflow_run" && "$WORKFLOW_CONCLUSION" == "success" && "$WORKFLOW_BRANCH" == "develop" ]]; then
             REF="$WORKFLOW_SHA"
             SHA="$WORKFLOW_SHA"
             SHOULD_RUN="true"
             REASON="ci_green_on_develop"
+            PLATFORM="both"
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            REF="develop"
+            SHOULD_RUN="true"
+            REASON="scheduled_ios_retry"
+            PLATFORM="ios"
           fi
+
+          case "$PLATFORM" in
+            ios|android|both) ;;
+            *)
+              echo "::warning::Invalid platform '$PLATFORM'; defaulting to both"
+              PLATFORM="both"
+              ;;
+          esac
 
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "reason=$REASON" >> "$GITHUB_OUTPUT"
-          echo "gate: should_run=$SHOULD_RUN reason=$REASON ref=$REF sha=$SHA"
+          echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+          MSG="gate: should_run=$SHOULD_RUN reason=$REASON"
+          MSG="$MSG platform=$PLATFORM ref=$REF sha=$SHA"
+          echo "$MSG"
 
   ios-testflight-internal:
     name: iOS TestFlight (Internal)
     needs: [gate]
-    if: needs.gate.outputs.should_run == 'true'
+    if: >-
+      needs.gate.outputs.should_run == 'true' &&
+      (needs.gate.outputs.platform == 'ios' ||
+      needs.gate.outputs.platform == 'both')
     runs-on: macos-26
     environment: production
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,6 +190,8 @@ jobs:
         working-directory: native-ios
 
       - name: Build and upload to TestFlight
+        id: fastlane_beta
+        continue-on-error: true
         env:
           CI: "true"
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -160,8 +200,117 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-        run: fastlane beta
+        run: |
+          set +e
+          fastlane beta 2>&1 | tee /tmp/fastlane-beta.log
+          lane_rc=${PIPESTATUS[0]}
+          set -e
+          echo "exit_code=$lane_rc" >> "$GITHUB_OUTPUT"
+
+          if [ "$lane_rc" -eq 0 ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if grep -qi "IOS_UPLOAD_LIMIT_REACHED" /tmp/fastlane-beta.log \
+            || grep -qi "Upload limit reached" /tmp/fastlane-beta.log \
+            || grep -qi "wait 1 day" /tmp/fastlane-beta.log \
+            || grep -qi "Validation failed (409)" /tmp/fastlane-beta.log; then
+            echo "::warning::ASC upload cap hit; deferring to retry workflow."
+            echo "result=deferred_upload_cap" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "result=failure" >> "$GITHUB_OUTPUT"
+          exit "$lane_rc"
         working-directory: native-ios
+
+      - name: Fail on non-cap iOS upload error
+        if: steps.fastlane_beta.outputs.result == 'failure'
+        run: |
+          EXIT_CODE="${{ steps.fastlane_beta.outputs.exit_code }}"
+          MSG="❌ iOS upload failed for a non-retryable reason."
+          echo "${MSG} exit=${EXIT_CODE}."
+          exit 1
+
+      - name: Record deferred iOS upload blocker
+        if: steps.fastlane_beta.outputs.result == 'deferred_upload_cap'
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          ISSUE_TITLE: "iOS internal distribution deferred: Apple upload cap"
+          TARGET_REF: ${{ needs.gate.outputs.ref }}
+        run: |
+          set -euo pipefail
+          WORKFLOW_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          BODY=$(cat <<EOF
+          Apple rejected TestFlight upload with a daily upload cap.
+
+          - Workflow: [${GITHUB_WORKFLOW}](${WORKFLOW_RUN_URL})
+          - Run ID: ${GITHUB_RUN_ID}
+          - Ref/SHA: ${TARGET_REF}
+          - UTC: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Auto-retry runs via \`.github/workflows/ios-internal-retry.yml\`.
+          EOF
+          )
+
+          ISSUE_NUMBER="$(
+            gh issue list --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --search "\"$ISSUE_TITLE\" in:title" \
+              --json number,title \
+              --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' \
+              | head -1
+          )"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "$BODY"
+            echo "Updated blocker issue #$ISSUE_NUMBER"
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$ISSUE_TITLE" \
+              --body "$BODY" \
+              >/tmp/ios_upload_cap_issue_url.txt
+            ISSUE_URL="$(cat /tmp/ios_upload_cap_issue_url.txt)"
+            echo "Created blocker issue: ${ISSUE_URL}"
+          fi
+
+      - name: Close deferred iOS upload blocker on success
+        if: steps.fastlane_beta.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          ISSUE_TITLE: "iOS internal distribution deferred: Apple upload cap"
+        run: |
+          set -euo pipefail
+          WORKFLOW_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          ISSUE_NUMBER="$(
+            gh issue list --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --search "\"$ISSUE_TITLE\" in:title" \
+              --json number,title \
+              --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' \
+              | head -1
+          )"
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No open deferred-upload issue to close."
+            exit 0
+          fi
+          COMMENT="Resolved by iOS internal distribution run."
+          COMMENT="${COMMENT} ${WORKFLOW_RUN_URL}"
+          gh issue close "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --comment "$COMMENT"
+          echo "Closed blocker issue #$ISSUE_NUMBER"
+
+      - name: Upload Fastlane beta log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ios-fastlane-beta-log
+          path: /tmp/fastlane-beta.log
+          if-no-files-found: warn
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
@@ -174,7 +323,10 @@ jobs:
   android-internal:
     name: Android Google Play (Internal)
     needs: [gate]
-    if: needs.gate.outputs.should_run == 'true'
+    if: >-
+      needs.gate.outputs.should_run == 'true' &&
+      (needs.gate.outputs.platform == 'android' ||
+      needs.gate.outputs.platform == 'both')
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -194,7 +346,7 @@ jobs:
             exit 1
           fi
           if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
-            echo "❌ Missing required secret: ANDROID_KEYSTORE_BASE64"
+            echo "❌ Missing required Android keystore secret"
             exit 1
           fi
           if [ -z "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
@@ -288,7 +440,10 @@ jobs:
   android-firebase-internal:
     name: Android Firebase App Distribution (Internal)
     needs: [gate]
-    if: needs.gate.outputs.should_run == 'true'
+    if: >-
+      needs.gate.outputs.should_run == 'true' &&
+      (needs.gate.outputs.platform == 'android' ||
+      needs.gate.outputs.platform == 'both')
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/ios-internal-retry.yml
+++ b/.github/workflows/ios-internal-retry.yml
@@ -1,0 +1,80 @@
+---
+name: iOS Internal Retry
+
+"on":
+  schedule:
+    - cron: "35 */3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_retry: ${{ steps.check.outputs.should_retry }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      - name: Check if retry is required
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          ISSUE_TITLE: "iOS internal distribution deferred: Apple upload cap"
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual_dispatch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ISSUE_NUMBER="$(
+            gh issue list --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --search "\"$ISSUE_TITLE\" in:title" \
+              --json number,title \
+              --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' \
+              | head -1
+          )"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+            echo "reason=open_blocker_issue_${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_retry=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no_open_blocker_issue" >> "$GITHUB_OUTPUT"
+          fi
+
+  dispatch-ios-retry:
+    needs: [gate]
+    if: needs.gate.outputs.should_retry == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Dispatch Internal Distribution (iOS only)
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run internal-distribution.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref develop \
+            -f ref=develop \
+            -f platform=ios
+          MSG="✅ Dispatched internal-distribution.yml for iOS retry."
+          MSG="$MSG reason=${{ needs.gate.outputs.reason }}"
+          echo "$MSG"
+
+  skip:
+    needs: [gate]
+    if: needs.gate.outputs.should_retry != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip retry
+        run: echo "Skipping iOS retry. reason=${{ needs.gate.outputs.reason }}"

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -8,6 +8,14 @@ platform :ios do
     false
   end
 
+  def testflight_upload_limit_reached_error?(error)
+    msg = error.to_s
+    return true if msg.include?("Upload limit reached")
+    return true if msg.include?("Please wait 1 day and try again")
+    return true if msg.include?("Validation failed (409)")
+    false
+  end
+
   desc "Build and upload to TestFlight"
   lane :beta do
     setup_ci if ENV["CI"] == "true"
@@ -102,10 +110,17 @@ platform :ios do
     end
 
     # Upload to TestFlight
-    upload_to_testflight(
-      skip_waiting_for_build_processing: false,
-      api_key: defined?(api_key) ? api_key : nil
-    )
+    begin
+      upload_to_testflight(
+        skip_waiting_for_build_processing: false,
+        api_key: defined?(api_key) ? api_key : nil
+      )
+    rescue => e
+      if testflight_upload_limit_reached_error?(e)
+        UI.user_error!("IOS_UPLOAD_LIMIT_REACHED: #{e}")
+      end
+      raise
+    end
   end
 
   desc "Create app in App Store Connect"


### PR DESCRIPTION
## Summary
- make internal distribution platform-selective (`ios|android|both`)
- classify App Store Connect 409/upload-cap as deferred (not hard-fail)
- auto-open/auto-close blocker issue for deferred iOS uploads
- add scheduled `ios-internal-retry` workflow to dispatch iOS-only internal distribution
- add deterministic Fastlane marker `IOS_UPLOAD_LIMIT_REACHED` for upload-cap detection

## Validation
- `trunk check .github/workflows/internal-distribution.yml .github/workflows/ios-internal-retry.yml native-ios/fastlane/Fastfile`
- `ruby -c native-ios/fastlane/Fastfile`

## Expected behavior
- Android Firebase/Play internal publishing continues unaffected
- iOS upload-cap events are deferred and retried automatically every 3 hours
- issue closes automatically once an iOS upload succeeds
