### PR TITLE
ci: fix deferred iOS upload issue auth in workflows

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Record deferred iOS upload blocker
         if: steps.fastlane_beta.outputs.result == 'deferred_upload_cap'
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           ISSUE_TITLE: "iOS internal distribution deferred: Apple upload cap"
           TARGET_REF: ${{ needs.gate.outputs.ref }}
         run: |
@@ -280,7 +280,7 @@ jobs:
       - name: Close deferred iOS upload blocker on success
         if: steps.fastlane_beta.outputs.result == 'success'
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           ISSUE_TITLE: "iOS internal distribution deferred: Apple upload cap"
         run: |
           set -euo pipefail

--- a/.github/workflows/ios-internal-retry.yml
+++ b/.github/workflows/ios-internal-retry.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check if retry is required
         id: check
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           ISSUE_TITLE: "iOS internal distribution deferred: Apple upload cap"
         run: |
           set -euo pipefail
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Dispatch Internal Distribution (iOS only)
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh workflow run internal-distribution.yml \


### PR DESCRIPTION
## Summary
- switch deferred iOS blocker issue automation to `github.token`
- remove dependency on `ADMIN_TOKEN` for `gh issue list/comment/create` and retry dispatcher workflow calls

## Why
Internal distribution run `22774019183` correctly detected Apple 409 upload-cap, but failed on issue automation with `401 Bad credentials` from `GH_TOKEN`.

## Validation
- `trunk check .github/workflows/internal-distribution.yml .github/workflows/ios-internal-retry.yml`
