### PR TITLE
ci: fix android production retry auth token handling

### DIFF
--- a/.github/workflows/android-production-retry.yml
+++ b/.github/workflows/android-production-retry.yml
@@ -27,10 +27,12 @@ jobs:
       - name: Check if retry is required
         id: gate
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           ISSUE_TITLE: Android production publish blocked by Play FAILED_PRECONDITION
           FORCE_RETRY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_retry || 'false' }}
         run: |
+          set -euo pipefail
+
           if [ "$FORCE_RETRY" = "true" ]; then
             echo "should_retry=true" >> "$GITHUB_OUTPUT"
             echo "reason=manual_force_retry" >> "$GITHUB_OUTPUT"
@@ -56,8 +58,10 @@ jobs:
     steps:
       - name: Dispatch Native App Release (Android production)
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           gh workflow run native-release.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref develop \


### PR DESCRIPTION
## Summary
- use \ for Android production retry workflow GH CLI calls
- add strict shell mode (\) to gate/dispatch steps

## Why
Scheduled retry was skipping due 401 bad credentials in gate step when resolving open blocker issue.

## Validation
- trunk check .github/workflows/android-production-retry.yml
