### PR TITLE
fix(android-release): ensure unique versionCode in native release workflow

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -249,8 +249,16 @@ jobs:
             -storepass "$KEYSTORE_PASSWORD" \
             -alias "$KEY_ALIAS" | grep -E "Alias name:|Valid from:|SHA1:|SHA-256:"
 
+      - name: Set unique Android version code
+        run: |
+          set -euo pipefail
+          VERSION_CODE="$(date +%s)"
+          echo "ANDROID_VERSION_CODE=$VERSION_CODE" >> "$GITHUB_ENV"
+          echo "Using ANDROID_VERSION_CODE=$VERSION_CODE"
+
       - name: Build release AAB
         env:
+          ANDROID_VERSION_CODE: ${{ env.ANDROID_VERSION_CODE }}
           KEYSTORE_PATH: /tmp/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}


### PR DESCRIPTION
## Problem
`Native App Release` now finds `scripts/play_publish.py`, but Play upload can still fail because the workflow builds with default `versionCode=11` when `ANDROID_VERSION_CODE` is unset.

## Fix
- Add a workflow step to set a unique `ANDROID_VERSION_CODE` using epoch seconds.
- Pass `ANDROID_VERSION_CODE` into the `Build release AAB` step in `.github/workflows/native-release.yml`.

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/native-release.yml'); puts 'yaml_ok'"`
- `Native App Release` run `22782806140` showed previous blocker removed (script executed) and surfaced the real version-code collision (`Version code 11 has already been used`), which this PR addresses.
