### PR TITLE
fix(ci): restore verify_release.py steps lost in PR #622 merge

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -234,6 +234,7 @@ jobs:
         working-directory: native-ios
 
       - name: Build and upload to TestFlight
+        id: fastlane_beta
         env:
           CI: "true"
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -244,6 +245,29 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: fastlane beta
         working-directory: native-ios
+
+      - name: Install iOS release verification dependencies
+        if: steps.fastlane_beta.outcome == 'success'
+        run: python -m pip install pyjwt==2.10.1 cryptography==44.0.2 requests==2.32.5
+
+      - name: Verify TestFlight processing
+        if: steps.fastlane_beta.outcome == 'success'
+        env:
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          IOS_VERSION="$(sed -n 's/.*MARKETING_VERSION = \([^;]*\);/\1/p' native-ios/RandomTimer.xcodeproj/project.pbxproj | head -1)"
+          python scripts/verify_release.py --platform ios --version "$IOS_VERSION" --wait --timeout 900 --json-out /tmp/ios-release-verification.json
+
+      - name: Upload iOS release verification
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: internal-distribution-verification-ios
+          path: /tmp/ios-release-verification.json
+          if-no-files-found: warn
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
@@ -348,11 +372,33 @@ jobs:
           ./gradlew bundleRelease --no-daemon
 
       - name: Distribute to Google Play Internal
+        id: fastlane_internal
         working-directory: native-android
         run: |
           set -euo pipefail
           export GOOGLE_PLAY_JSON_KEY_PATH="/tmp/play-service-account.json"
           fastlane internal
+
+      - name: Install Android release verification dependencies
+        if: steps.fastlane_internal.outcome == 'success'
+        run: python -m pip install google-api-python-client==2.190.0 google-auth==2.48.0 google-auth-httplib2==0.3.0 google-auth-oauthlib==1.2.4 requests==2.32.5
+
+      - name: Verify Google Play Internal processing
+        if: steps.fastlane_internal.outcome == 'success'
+        env:
+          GOOGLE_PLAY_JSON_KEY_PATH: /tmp/play-service-account.json
+        run: |
+          set -euo pipefail
+          ANDROID_VERSION_NAME="$(grep -m1 'versionName' native-android/app/build.gradle.kts | grep -o '"[^"]*"' | tr -d '"')"
+          python scripts/verify_release.py --platform android --track internal --version-code "${{ github.run_number }}" --version "$ANDROID_VERSION_NAME" --wait --timeout 900 --json-out /tmp/android-release-verification.json
+
+      - name: Upload Android release verification
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: internal-distribution-verification-android
+          path: /tmp/android-release-verification.json
+          if-no-files-found: warn
 
       - name: Upload Android AAB artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Restores iOS TestFlight verification step (`verify_release.py --platform ios`) lost when PR #622 (fix/budget-lockdown) merged with `--theirs` conflict resolution
- Restores Android Google Play Internal verification step (`verify_release.py --platform android`) similarly lost
- Adds `id: fastlane_beta` and `id: fastlane_internal` to Fastlane steps (required for `steps.<id>.outcome` condition checks)
- Re-adds both verification artifact uploads: `internal-distribution-verification-ios` and `internal-distribution-verification-android`

## Root Cause

PR #622 was created before `verify_release.py` steps were added to `develop`. When it rebased, the conflict on `internal-distribution.yml` was resolved with `--theirs`, which kept the branch version (without verify steps) and dropped the develop version (with verify steps).

## Test plan

- [ ] CI passes on this PR (Python Script Tests green)
- [ ] `internal-distribution.yml` contains `verify_release.py` in both iOS and Android jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)