### PR TITLE
feat(ci): auto-distribute to Firebase App Distribution on every release

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -350,9 +350,127 @@ jobs:
         run: |
           rm -f /tmp/release.keystore /tmp/play-service-account.json
 
+  android-firebase:
+    name: Android Firebase App Distribution
+    needs: [android-release]
+    if: needs.android-release.result == 'success' && (${{ inputs.platform == 'android' || inputs.platform == 'both' }})
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Create google-services.json
+        working-directory: native-android
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
+            echo "❌ Missing GOOGLE_SERVICES_JSON secret — skipping Firebase distribution"
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Resolve Firebase Android app id
+        id: resolve_firebase_app_id
+        working-directory: native-android
+        env:
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+        run: |
+          set -euo pipefail
+          APP_ID_FROM_FILE="$(python3 -c 'import json; print(json.load(open("app/google-services.json")).get("client", [{}])[0].get("client_info", {}).get("mobilesdk_app_id", ""))')"
+          RESOLVED_APP_ID="${APP_ID_FROM_FILE:-${FIREBASE_ANDROID_APP_ID:-}}"
+          if [ -z "$RESOLVED_APP_ID" ]; then
+            echo "❌ Could not resolve Firebase app id"
+            exit 1
+          fi
+          echo "firebase_android_app_id=$RESOLVED_APP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Decode keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > /tmp/release.keystore
+
+      - name: Build release APK
+        working-directory: native-android
+        env:
+          ANDROID_VERSION_CODE: ${{ github.run_number }}
+          KEYSTORE_PATH: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+        run: |
+          set -euo pipefail
+          ./gradlew assembleRelease --no-daemon
+
+      - name: Write Firebase service account key
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-service-account.json
+          elif [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
+            echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/firebase-service-account.json
+          else
+            echo "❌ No Firebase credentials available (FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_PLAY_JSON_KEY)"
+            exit 1
+          fi
+
+      - name: Distribute APK to Firebase App Distribution
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-service-account.json
+          FIREBASE_ANDROID_APP_ID: ${{ steps.resolve_firebase_app_id.outputs.firebase_android_app_id }}
+          FIREBASE_INTERNAL_TESTERS: ${{ secrets.FIREBASE_INTERNAL_TESTERS }}
+          FIREBASE_INTERNAL_GROUPS: ${{ secrets.FIREBASE_INTERNAL_GROUPS }}
+        run: |
+          set -euo pipefail
+          APK_PATH="native-android/app/build/outputs/apk/release/app-release.apk"
+          if [ ! -f "$APK_PATH" ]; then
+            echo "❌ APK not found at $APK_PATH"
+            exit 1
+          fi
+
+          TESTERS_ARG=""
+          if [ -n "${FIREBASE_INTERNAL_TESTERS:-}" ]; then
+            TESTERS_ARG="--testers \"${FIREBASE_INTERNAL_TESTERS}\""
+          fi
+          GROUPS_ARG=""
+          if [ -n "${FIREBASE_INTERNAL_GROUPS:-}" ]; then
+            GROUPS_ARG="--groups \"${FIREBASE_INTERNAL_GROUPS}\""
+          fi
+
+          npx firebase-tools@latest appdistribution:distribute "$APK_PATH" \
+            --app "$FIREBASE_ANDROID_APP_ID" \
+            ${TESTERS_ARG} \
+            ${GROUPS_ARG} \
+            --release-notes "v$(grep versionName native-android/app/build.gradle.kts | grep -oP '[\d.]+')" \
+            --debug
+
+          echo "✅ Firebase App Distribution upload complete"
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/release.keystore /tmp/firebase-service-account.json
+
   verify-releases:
-    needs: [ios-testflight, android-release]
-    if: always() && (needs.ios-testflight.result == 'success' || needs.android-release.result == 'success')
+    needs: [ios-testflight, android-release, android-firebase]
+    if: always() && (needs.ios-testflight.result == 'success' || needs.android-release.result == 'success' || needs.android-firebase.result == 'success')
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## Summary
- Adds `android-firebase` job to `native-release.yml` that auto-runs after `android-release` succeeds
- Firebase distribution now fires automatically on every release — no separate manual workflow needed
- Uses same secrets as `internal-distribution.yml` (FIREBASE_SERVICE_ACCOUNT_JSON, FIREBASE_INTERNAL_TESTERS, FIREBASE_INTERNAL_GROUPS)
- Updates `verify-releases` needs to include `android-firebase`

## Why
Previous Firebase builds required manually triggering `internal-distribution.yml` — users were missing builds.

## Test plan
- [ ] Trigger `native-release.yml` with `platform=android` or `platform=both`
- [ ] Verify `android-firebase` job runs after `android-release` succeeds
- [ ] Verify APK appears in Firebase App Distribution console

🤖 Generated with [Claude Code](https://claude.com/claude-code)