### PR TITLE
fix(ci): allow release/* and hotfix/* refs in internal-distribution gate

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -117,8 +117,8 @@ jobs:
           SHOULD_RUN="true"
           REASON="manual_dispatch_budget_ack"
 
-          if [[ "$REF" != "develop" ]]; then
-            echo "❌ Budget-safe guard: internal distribution is restricted to ref=develop."
+          if [[ "$REF" != "develop" && ! "$REF" =~ ^release/ && ! "$REF" =~ ^hotfix/ ]]; then
+            echo "❌ Budget-safe guard: internal distribution is restricted to develop, release/*, or hotfix/* refs."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "sha=" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Gate previously hard-blocked any ref that wasn't `develop`
- Now allows `release/*` and `hotfix/*` in addition to `develop`

## Why
Running `internal-distribution.yml` against a release branch (e.g. `release/v1.2.6`) was impossible — the gate rejected it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)