### PR TITLE
fix(ui): clarify free voice callout preview

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -390,6 +390,14 @@ fun TimerSetupScreen(
                                         fontWeight = FontWeight.SemiBold,
                                         color = TimerColors.TextPrimary,
                                     )
+                                    if (!isPro) {
+                                        Text(
+                                            text = "Free preview: tap Countdown or Focus. Pro adds them during training.",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = TimerColors.TextMuted,
+                                            modifier = Modifier.padding(top = 2.dp, end = 8.dp),
+                                        )
+                                    }
                                 }
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Surface(

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -92,6 +92,12 @@ struct TimerSetupScreen: View {
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
                                     .foregroundColor(.textPrimary)
+
+                                if !proManager.isPro {
+                                    Text("Free preview: tap Countdown or Focus. Pro adds them during training.")
+                                        .font(.caption2)
+                                        .foregroundColor(.textMuted)
+                                }
                             }
 
                             Spacer()
@@ -144,7 +150,6 @@ struct TimerSetupScreen: View {
                         }
                         .padding(.vertical, 8)
                         .contentShape(Rectangle())
-                        .opacity(proManager.isPro ? 1.0 : 0.6)
 
                         Spacer().frame(height: 20)
 


### PR DESCRIPTION
## Summary
- make free voice callout preview discoverable again on Android and iOS
- explain that free users can still tap `Countdown` or `Focus` to preview samples
- stop dimming the iOS preview row so it no longer looks disabled in free mode

## Verification
- `cd native-android && ./gradlew assembleDebug`
- `cd native-ios && xcodebuild -project RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,id=9162C6C2-BB3F-44DC-ACA5-33780E2AD988' -derivedDataPath /tmp/rt-voice-preview-dd4 -clonedSourcePackagesDirPath /tmp/rt-voice-preview-spm build`
- Android live proof: free-state screen shows helper copy in `/tmp/android-free-voice-callouts-fixed2.png`
- Android live proof: tapping `Countdown` logged `Speaking: Thirty seconds. Stay locked in.` in `/tmp/android-voice-preview-countdown.log`
- Android live proof: tapping `Focus` logged `Speaking: Stay sharp.` in `/tmp/android-voice-preview-focus.log`
- iOS live proof: free-state screen shows helper copy in `/tmp/ios-free-voice-callouts-fixed.png`
- iOS live proof: Maestro tapped both chips successfully; debug output in `/tmp/maestro-voice-preview-ios/.maestro/tests/2026-03-12_005719/maestro.log`
