### PR TITLE
fix(voice): remove random in-session callouts

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -9,7 +9,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.random.Random
 
 internal data class VoiceCandidate(
     val name: String,
@@ -26,6 +25,7 @@ internal fun selectPreferredVoice(candidates: List<VoiceCandidate>): VoiceCandid
         }
 
 internal const val PREVIEW_ELAPSED_CUE = "Thirty seconds. Stay locked in."
+internal const val PREVIEW_COMMAND_CUE = "Stay sharp."
 
 internal val ELAPSED_VOICE_CUES_BY_SECOND =
     mapOf(
@@ -38,13 +38,15 @@ internal val ELAPSED_VOICE_CUES_BY_SECOND =
         600 to "Ten minutes. Outstanding.",
     )
 
-internal val COMMAND_VOICE_CUES =
-    listOf(
-        "Stay sharp.",
-        "Reset. Breathe.",
-    )
+internal const val DEFAULT_VOICE_FALLBACK_CUE = PREVIEW_COMMAND_CUE
 
-internal const val DEFAULT_VOICE_FALLBACK_CUE = "Stay sharp."
+internal fun runtimeVoiceCueForElapsedSecond(
+    elapsedSeconds: Int,
+    lastElapsedMilestone: Int,
+): String? {
+    if (elapsedSeconds == lastElapsedMilestone) return null
+    return ELAPSED_VOICE_CUES_BY_SECOND[elapsedSeconds]
+}
 
 internal fun voiceResIdForText(text: String): Int? =
     when (text) {
@@ -56,13 +58,7 @@ internal fun voiceResIdForText(text: String): Int? =
         "Five minutes. Finish strong." -> R.raw.elapsed_300s
         "Ten minutes. Outstanding." -> R.raw.elapsed_600s
         PREVIEW_ELAPSED_CUE -> R.raw.preview_elapsed
-        "Move now." -> R.raw.cmd_move_now
-        "Stay sharp." -> R.raw.cmd_stay_sharp
-        "Reset. Breathe." -> R.raw.cmd_reset_breathe
-        "Push the pace." -> R.raw.cmd_push_pace
-        "Drive forward." -> R.raw.cmd_drive_forward
-        "Keep pressure." -> R.raw.cmd_keep_pressure
-        "Push through it." -> R.raw.cmd_push_through
+        PREVIEW_COMMAND_CUE -> R.raw.cmd_stay_sharp
         else -> null
     }
 
@@ -75,8 +71,6 @@ class AIVoiceCalloutManager
         @ApplicationContext private val context: Context,
     ) {
         private var lastElapsedMilestone = 0
-        private var nextCommandCueAt = 0
-        private var lastCommandCueAt = 0
 
         companion object {
             val preferredVoiceNames = listOf("en-us-x-tpf", "en-us-x-sfg", "en-US-language")
@@ -113,8 +107,6 @@ class AIVoiceCalloutManager
 
         fun resetSession() {
             lastElapsedMilestone = 0
-            nextCommandCueAt = 0
-            lastCommandCueAt = 0
         }
 
         fun preview() {
@@ -122,7 +114,7 @@ class AIVoiceCalloutManager
         }
 
         fun previewCommandCue() {
-            speak(randomCommandCue())
+            speak(PREVIEW_COMMAND_CUE)
         }
 
         fun previewCountdownCue() {
@@ -132,34 +124,11 @@ class AIVoiceCalloutManager
 
         // Called every second with elapsed seconds since timer started.
         fun triggerCallout(elapsedSeconds: Int) {
-            // Elapsed milestone callouts — fire once per milestone
-            elapsedMilestone(elapsedSeconds)?.let {
+            runtimeVoiceCueForElapsedSecond(elapsedSeconds, lastElapsedMilestone)?.let {
                 speak(it)
                 lastElapsedMilestone = elapsedSeconds
-                return
-            }
-
-            // Random command cues fire throughout the session
-            if (shouldFireCommandCue(elapsedSeconds)) {
-                speak(randomCommandCue())
-                lastCommandCueAt = elapsedSeconds
-                nextCommandCueAt = elapsedSeconds + Random.nextInt(12, 26)
             }
         }
-
-        private fun elapsedMilestone(elapsed: Int): String? {
-            if (elapsed == lastElapsedMilestone) return null
-            return ELAPSED_VOICE_CUES_BY_SECOND[elapsed]
-        }
-
-        private fun shouldFireCommandCue(elapsedSeconds: Int): Boolean {
-            if (nextCommandCueAt == 0) {
-                nextCommandCueAt = Random.nextInt(8, 21)
-            }
-            return elapsedSeconds >= nextCommandCueAt
-        }
-
-        private fun randomCommandCue(): String = COMMAND_VOICE_CUES[Random.nextInt(COMMAND_VOICE_CUES.size)]
 
         fun shutdown() {
             // No-op: drill sergeant callouts use bundled audio clips instead of system TTS.

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -390,6 +390,14 @@ fun TimerSetupScreen(
                                         fontWeight = FontWeight.SemiBold,
                                         color = TimerColors.TextPrimary,
                                     )
+                                    if (!isPro) {
+                                        Text(
+                                            text = "Free preview: tap Countdown or Focus to hear sample clips. Pro adds timed callouts during training.",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = TimerColors.TextMuted,
+                                            modifier = Modifier.padding(top = 2.dp, end = 8.dp),
+                                        )
+                                    }
                                 }
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Surface(

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerCueMappingTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerCueMappingTest.kt
@@ -14,19 +14,16 @@ class AIVoiceCalloutManagerCueMappingTest {
     }
 
     @Test
-    fun `every command cue used by runtime has bundled audio`() {
-        val allCommandCueResIds = COMMAND_VOICE_CUES.map(::voiceResIdForText)
-
-        assertThat(allCommandCueResIds).doesNotContain(null)
+    fun `preview command cue has bundled audio`() {
+        assertThat(voiceResIdForText(PREVIEW_COMMAND_CUE)).isEqualTo(R.raw.cmd_stay_sharp)
     }
 
     @Test
-    fun `runtime command cues stay neutral and non prescriptive`() {
-        assertThat(COMMAND_VOICE_CUES)
-            .containsExactly(
-                "Stay sharp.",
-                "Reset. Breathe.",
-            ).inOrder()
+    fun `runtime callouts are elapsed milestones only`() {
+        assertThat(runtimeVoiceCueForElapsedSecond(elapsedSeconds = 18, lastElapsedMilestone = 0)).isNull()
+        assertThat(runtimeVoiceCueForElapsedSecond(elapsedSeconds = 30, lastElapsedMilestone = 0))
+            .isEqualTo("Thirty seconds.")
+        assertThat(runtimeVoiceCueForElapsedSecond(elapsedSeconds = 30, lastElapsedMilestone = 30)).isNull()
     }
 
     @Test

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -1,10 +1,10 @@
 import Foundation
 import AVFoundation
 import os
-import Security
 
 internal let previewElapsedCue = "Thirty seconds. Stay locked in."
-internal let defaultFallbackVoiceCue = "Stay sharp."
+internal let previewCommandVoiceCue = "Stay sharp."
+internal let defaultFallbackVoiceCue = previewCommandVoiceCue
 
 internal let elapsedVoiceCuesBySecond: [Int: String] = [
     30: "Thirty seconds.",
@@ -16,11 +16,6 @@ internal let elapsedVoiceCuesBySecond: [Int: String] = [
     600: "Ten minutes. Outstanding."
 ]
 
-internal let commandVoiceCues = [
-    "Stay sharp.",
-    "Reset. Breathe."
-]
-
 internal let voiceFilenamesByText: [String: String] = [
     "Thirty seconds.": "elapsed_30s",
     "One minute. Keep moving.": "elapsed_60s",
@@ -30,13 +25,7 @@ internal let voiceFilenamesByText: [String: String] = [
     "Five minutes. Finish strong.": "elapsed_300s",
     "Ten minutes. Outstanding.": "elapsed_600s",
     previewElapsedCue: "preview_elapsed",
-    "Move now.": "cmd_move_now",
-    "Stay sharp.": "cmd_stay_sharp",
-    "Reset. Breathe.": "cmd_reset_breathe",
-    "Push the pace.": "cmd_push_pace",
-    "Drive forward.": "cmd_drive_forward",
-    "Keep pressure.": "cmd_keep_pressure",
-    "Push through it.": "cmd_push_through",
+    previewCommandVoiceCue: "cmd_stay_sharp",
 ]
 
 internal func voiceFilename(for text: String) -> String? {
@@ -52,6 +41,11 @@ internal func voiceFilenameOrFallback(for text: String) -> String {
     voiceFilename(for: text) ?? voiceFilename(for: defaultFallbackVoiceCue) ?? "cmd_stay_sharp"
 }
 
+internal func runtimeVoiceCue(for elapsedSeconds: Int, lastElapsedMilestone: Int) -> String? {
+    guard elapsedSeconds != lastElapsedMilestone else { return nil }
+    return elapsedVoiceCuesBySecond[elapsedSeconds]
+}
+
 @MainActor
 final class AIVoiceCalloutService {
     static let shared = AIVoiceCalloutService()
@@ -59,8 +53,6 @@ final class AIVoiceCalloutService {
     private var audioPlayer: AVAudioPlayer?
     private static let log = Logger(subsystem: "com.iganapolsky.randomtimer", category: "voice")
     private var lastElapsedMilestone = 0
-    private var nextCommandCueAt = 0
-    private var lastCommandCueAt = 0
 
     private init() {
         do {
@@ -93,8 +85,6 @@ final class AIVoiceCalloutService {
 
     func resetSession() {
         lastElapsedMilestone = 0
-        nextCommandCueAt = 0
-        lastCommandCueAt = 0
     }
 
     func preview() {
@@ -102,7 +92,7 @@ final class AIVoiceCalloutService {
     }
 
     func previewCommandCue() {
-        speak(randomCommandCue())
+        speak(previewCommandVoiceCue)
     }
 
     func previewCountdownCue() {
@@ -112,48 +102,9 @@ final class AIVoiceCalloutService {
 
     // Called every second with elapsed seconds since timer started.
     func triggerCallout(elapsedSeconds: Int) {
-        // Elapsed milestone callouts — fire once per milestone
-        if let callout = elapsedMilestone(for: elapsedSeconds) {
+        if let callout = runtimeVoiceCue(for: elapsedSeconds, lastElapsedMilestone: lastElapsedMilestone) {
             speak(callout)
             lastElapsedMilestone = elapsedSeconds
-            return
-        }
-
-        // Random command cues fire throughout the session
-        if shouldFireCommandCue(elapsedSeconds: elapsedSeconds) {
-            speak(randomCommandCue())
-            lastCommandCueAt = elapsedSeconds
-            nextCommandCueAt = elapsedSeconds + secureRandomInt(in: 12...25)
-        }
-    }
-
-    private func elapsedMilestone(for elapsed: Int) -> String? {
-        // Fire each milestone exactly once
-        guard let text = elapsedVoiceCuesBySecond[elapsed], elapsed != lastElapsedMilestone else { return nil }
-        return text
-    }
-
-    private func shouldFireCommandCue(elapsedSeconds: Int) -> Bool {
-        if nextCommandCueAt == 0 {
-            // First cue fires between 8–20s in
-            nextCommandCueAt = secureRandomInt(in: 8...20)
-        }
-        return elapsedSeconds >= nextCommandCueAt
-    }
-
-    private func randomCommandCue() -> String {
-        let index = secureRandomInt(in: 0...(commandVoiceCues.count - 1))
-        return commandVoiceCues[index]
-    }
-
-    private func secureRandomInt(in range: ClosedRange<Int>) -> Int {
-        let count = range.upperBound - range.lowerBound + 1
-        var randomValue: UInt32 = 0
-        let status = SecRandomCopyBytes(kSecRandomDefault, MemoryLayout<UInt32>.size, &randomValue)
-        if status == errSecSuccess {
-            return range.lowerBound + Int(randomValue % UInt32(count))
-        } else {
-            return Int.random(in: range)
         }
     }
 }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -92,6 +92,15 @@ struct TimerSetupScreen: View {
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
                                     .foregroundColor(.textPrimary)
+
+                                if !proManager.isPro {
+                                    Text(
+                                        "Free preview: tap Countdown or Focus to hear sample clips. "
+                                        + "Pro adds timed callouts during training."
+                                    )
+                                        .font(.caption2)
+                                        .foregroundColor(.textMuted)
+                                }
                             }
 
                             Spacer()
@@ -144,7 +153,6 @@ struct TimerSetupScreen: View {
                         }
                         .padding(.vertical, 8)
                         .contentShape(Rectangle())
-                        .opacity(proManager.isPro ? 1.0 : 0.6)
 
                         Spacer().frame(height: 20)
 

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -31,12 +31,10 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         sut.triggerCallout(elapsedSeconds: 30)
     }
 
-    func testCommandCueFiredAtRandomInterval() {
-        // Command cues should fire without crashing across many ticks
-        let sut = makeSut()
-        for elapsed in 1...120 {
-            sut.triggerCallout(elapsedSeconds: elapsed)
-        }
+    func testRuntimeCalloutsAreElapsedMilestonesOnly() {
+        XCTAssertNil(runtimeVoiceCue(for: 18, lastElapsedMilestone: 0))
+        XCTAssertEqual(runtimeVoiceCue(for: 30, lastElapsedMilestone: 0), "Thirty seconds.")
+        XCTAssertNil(runtimeVoiceCue(for: 30, lastElapsedMilestone: 30))
     }
 
     func testEveryRuntimeElapsedCueHasBundledFilename() {
@@ -44,15 +42,12 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertTrue(elapsedVoiceCuesBySecond.values.allSatisfy { voiceFilename(for: $0) != nil })
     }
 
-    func testEveryRuntimeCommandCueHasBundledFilename() {
-        XCTAssertTrue(commandVoiceCues.allSatisfy { voiceFilename(for: $0) != nil })
+    func testPreviewCommandCueHasBundledFilename() {
+        XCTAssertEqual(voiceFilename(for: previewCommandVoiceCue), "cmd_stay_sharp")
     }
 
-    func testRuntimeCommandCuesStayNeutralAndNonPrescriptive() {
-        XCTAssertEqual(commandVoiceCues, [
-            "Stay sharp.",
-            "Reset. Breathe."
-        ])
+    func testPreviewCommandCueStaysDeterministic() {
+        XCTAssertEqual(previewCommandVoiceCue, "Stay sharp.")
     }
 
     func testBundledVoiceAudioResolvesFromMainBundle() {
@@ -61,7 +56,7 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
                 [previewElapsedCue]
                     .compactMap(voiceFilename(for:))
                     + elapsedVoiceCuesBySecond.values.compactMap(voiceFilename(for:))
-                    + commandVoiceCues.compactMap(voiceFilename(for:))
+                    + [previewCommandVoiceCue].compactMap(voiceFilename(for:))
             )
 
         let missing = filenames.filter { voiceAudioURL(for: $0, bundle: .main) == nil }.sorted()

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -126,6 +126,21 @@ def test_voice_preview_actions_and_copy_match_across_mobile_platforms():
         assert snippet in ios_setup, f"Missing '{snippet}' in iOS setup screen"
 
 
+def test_voice_runtime_callouts_are_elapsed_only_on_both_platforms():
+    android_voice_service = ANDROID_VOICE_SERVICE.read_text(encoding="utf-8")
+    ios_voice_service = IOS_VOICE_SERVICE.read_text(encoding="utf-8")
+
+    assert "runtimeVoiceCueForElapsedSecond" in android_voice_service
+    assert "shouldFireCommandCue" not in android_voice_service
+    assert "Random.nextInt(" not in android_voice_service
+    assert "PREVIEW_COMMAND_CUE" in android_voice_service
+
+    assert "runtimeVoiceCue(for elapsedSeconds:" in ios_voice_service
+    assert "shouldFireCommandCue" not in ios_voice_service
+    assert "secureRandomInt" not in ios_voice_service
+    assert "previewCommandVoiceCue" in ios_voice_service
+
+
 def test_voice_profile_configured_on_both_platforms():
     android_voice_service = ANDROID_VOICE_SERVICE.read_text(encoding="utf-8")
     ios_voice_service = IOS_VOICE_SERVICE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove random in-session command callouts on Android and iOS so runtime voice cues are elapsed-milestone only
- keep deterministic free preview clips and clarify the free-state Voice Callouts copy on both setup screens
- add parity and platform tests that lock the new behavior down

## Verification
- `cd native-android && ./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerCueMappingTest --tests com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest`
- `cd native-ios && xcodebuild -project RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:RandomTimerTests/AIVoiceCalloutServiceTests test`
- `python3 -m pytest -q scripts/tests/test_mobile_feature_parity.py scripts/tests/test_timer_defaults_parity.py`
- Android emulator live proof: free-state setup screen screenshot and `AIVoiceCallout: Speaking: Stay sharp.` log after tapping `Focus` preview
- iOS simulator live proof: free-state setup screen screenshot with preview affordance visible