### PR TITLE
Harden workflow guardrail and PR reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,8 @@ jobs:
             --repo-root . \
             --lookback-days 30 \
             --wqtu-window-days 7 \
-            --require-posthog
+            --enforce-guardrail \
+            --require-posthog-when-active
 
       - name: Warn if paid attribution guardrail is violated
         if: always()

--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   check_suite:
     types: [completed]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -12,7 +15,7 @@ on:
         required: false
 
 concurrency:
-  group: pr-state-machine-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
+  group: pr-state-machine-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.workflow_run.pull_requests[0].number || github.event.check_suite.head_sha || github.event.workflow_run.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -488,8 +491,27 @@ jobs:
                   }
                 }
               }
+            } else if (context.eventName === "workflow_run") {
+              const workflowRun = context.payload.workflow_run || {};
+              for (const pr of workflowRun.pull_requests || []) {
+                prCandidates.push(pr.number);
+              }
+
+              if (prCandidates.length === 0 && workflowRun.head_sha) {
+                const associatedPrs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                  owner,
+                  repo,
+                  commit_sha: workflowRun.head_sha,
+                  per_page: 100
+                });
+                for (const pr of associatedPrs) {
+                  if (pr.state === "open") {
+                    prCandidates.push(pr.number);
+                  }
+                }
+              }
             } else if (context.eventName === "workflow_dispatch") {
-              const raw = core.getInput("pr_number");
+              const raw = context.payload.inputs?.pr_number ?? "";
               if (raw && raw.trim()) {
                 const parsed = Number.parseInt(raw, 10);
                 if (Number.isInteger(parsed) && parsed > 0) {

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -16,6 +17,14 @@ def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():
     assert "python -m pytest scripts/tests/ -q" in source
     assert "pytest -q tests/python" not in source
     assert "No tests/python directory found; skipping legacy pytest suite." not in source
+
+
+def test_ci_workflow_only_fails_north_star_on_real_guardrail_enforcement_conditions():
+    source = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--enforce-guardrail" in source
+    assert "--require-posthog-when-active" in source
+    assert re.search(r"(?<!-when-active)\b--require-posthog\b", source) is None
 
 
 def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evidence():

--- a/scripts/tests/test_pr_state_machine_workflow.py
+++ b/scripts/tests/test_pr_state_machine_workflow.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PR_STATE_MACHINE_WORKFLOW = ROOT / ".github/workflows/pr-state-machine.yml"
+
+
+def test_pr_state_machine_reconciles_when_ci_workflow_completes():
+    source = PR_STATE_MACHINE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_run:" in source
+    assert 'workflows: ["CI"]' in source
+    assert "types: [completed]" in source
+    assert 'context.eventName === "workflow_run"' in source
+    assert "workflowRun.head_sha" in source
+    assert "listPullRequestsAssociatedWithCommit" in source
+
+
+def test_pr_state_machine_reads_manual_dispatch_input_from_event_payload():
+    source = PR_STATE_MACHINE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "context.payload.inputs?.pr_number ?? \"\"" in source
+    assert 'core.getInput("pr_number")' not in source


### PR DESCRIPTION
## Summary
- make CI fail North Star only on real guardrail enforcement conditions instead of transient PostHog degradation
- add a deterministic PR state machine reconciliation path when the CI workflow completes
- fix manual PR reconciliation input handling and add workflow contract coverage

## Verification
- .venv/bin/python -m pytest -q scripts/tests/test_north_star_guardrail.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_pr_state_machine_workflow.py