### PR TITLE
Fix Android Pro backdoor hold target

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -72,9 +72,14 @@ fun PaywallSheet(
                 textAlign = TextAlign.Center,
                 modifier =
                     if (onDebugUnlock != null) {
-                        Modifier.holdForHiddenUnlock(holdDurationMs = 8_000L, onHoldComplete = onDebugUnlock)
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .holdForHiddenUnlock(holdDurationMs = 8_000L, onHoldComplete = onDebugUnlock)
                     } else {
                         Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
                     },
             )
 

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -112,6 +112,16 @@ def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():
     assert "proManager.unlockProForDebug()" in ios_paywall
 
 
+def test_android_hidden_debug_unlock_uses_full_width_hold_target():
+    android_paywall = ANDROID_PAYWALL.read_text(encoding="utf-8")
+
+    assert re.search(
+        r'Text\(\s*text = "Upgrade to Pro".*?Modifier\s*\.\s*fillMaxWidth\(\)\s*\.\s*padding\(vertical = 8\.dp\)\s*\.\s*holdForHiddenUnlock',
+        android_paywall,
+        re.S,
+    )
+
+
 def test_voice_preview_actions_and_copy_match_across_mobile_platforms():
     android_setup = ANDROID_SETUP_SCREEN.read_text(encoding="utf-8")
     ios_setup = IOS_SETUP_SCREEN.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- widen the Android hidden paywall unlock gesture target for the `Upgrade to Pro` title
- keep the 8-second backdoor behavior unchanged while making the title area full-width and padded
- add a parity regression test that enforces the widened hit target

## Verification
- `python3 -m pytest -q scripts/tests/test_timer_defaults_parity.py scripts/tests/test_mobile_feature_parity.py`
- `cd native-android && ./gradlew assembleDebug`
- Android emulator live proof on a clean reset app state:
  - locked setup screenshot captured before unlock
  - paywall screenshot captured with `Upgrade to Pro` visible
  - `adb shell input swipe 540 1325 540 1325 8500` dismissed the paywall and unlocked Pro
  - after-unlock UI read-back showed `TACTICAL EXPANSION (PRO) 🔓` and `Voice Callouts` changed from `PRO 🔒` to `ON`

## Evidence
- before: `.agent-device/artifacts/android-pro-backdoor/before-locked.png`
- paywall: `.agent-device/artifacts/android-pro-backdoor/paywall-open.png`
- after: `.agent-device/artifacts/android-pro-backdoor/after-unlock.png`