### PR TITLE
Unblock iOS metadata sync by removing locked review submission

### DIFF
--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -22,6 +22,11 @@ on:
         required: true
         type: boolean
         default: true
+      remove_from_review_if_locked:
+        description: "If the selected version is waiting for review, remove it from review before metadata sync."
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ios-metadata-sync-${{ github.ref_name }}-${{ inputs.version || 'auto' }}-${{ inputs.locale }}
@@ -36,6 +41,7 @@ jobs:
       IOS_METADATA_LOCALE: ${{ inputs.locale }}
       IOS_METADATA_ONLY: ${{ inputs.metadata_only }}
       IOS_STRICT_RETRY_ON_EDITABLE: ${{ inputs.strict_retry_on_editable }}
+      IOS_REMOVE_FROM_REVIEW_IF_LOCKED: ${{ inputs.remove_from_review_if_locked }}
     steps:
       - uses: actions/checkout@v4
 
@@ -128,6 +134,21 @@ jobs:
           echo "selected_version=$SELECTED_VERSION" >> "$GITHUB_OUTPUT"
           echo "Using editable App Store version: $SELECTED_VERSION"
 
+      - name: Remove App Store version from review when locked
+        if: ${{ inputs.remove_from_review_if_locked }}
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
+          SELECTED_VERSION: ${{ steps.asc_version.outputs.selected_version }}
+        run: |
+          python scripts/asc_remove_from_review.py \
+            --version "$SELECTED_VERSION" \
+            --wait \
+            --timeout 300 \
+            --poll-interval 10 \
+            --json-out /tmp/asc_remove_from_review.json
+
       - name: Strict screenshot replacement + metadata upload
         env:
           CI: "true"
@@ -178,6 +199,14 @@ jobs:
           name: asc-version-resolution
           path: /tmp/asc_version.json
 
+      - name: Upload remove-from-review report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: asc-remove-from-review
+          path: /tmp/asc_remove_from_review.json
+          if-no-files-found: ignore
+
       - name: Upload version inventory report
         if: always()
         uses: actions/upload-artifact@v4
@@ -187,4 +216,4 @@ jobs:
 
       - name: Cleanup secrets
         if: always()
-        run: rm -f /tmp/appstore_key.p8 /tmp/asc_ready.json /tmp/asc_version.json /tmp/asc_screenshot_sync.json /tmp/asc_versions.json
+        run: rm -f /tmp/appstore_key.p8 /tmp/asc_ready.json /tmp/asc_version.json /tmp/asc_screenshot_sync.json /tmp/asc_versions.json /tmp/asc_remove_from_review.json

--- a/scripts/asc_remove_from_review.py
+++ b/scripts/asc_remove_from_review.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Remove an App Store version submission from review and wait until editable."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from scripts.asc_client import ASCClient, AscClientError
+from scripts.asc_poll_version_state import find_app_store_version_id
+from scripts.asc_resolve_version import _is_editable_state
+from scripts.asc_submit_for_review import die, get_app, get_version_state, info
+
+
+def _submission_id(payload: dict[str, object]) -> str:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        return str(data.get("id") or "")
+    return ""
+
+
+def _wait_for_editable_state(
+    client: ASCClient,
+    *,
+    version_id: str,
+    timeout: int,
+    poll_interval: int,
+) -> str:
+    deadline = time.time() + timeout
+    state = get_version_state(client, version_id)
+    while True:
+        if _is_editable_state(state):
+            return state
+        if time.time() >= deadline:
+            return state
+        time.sleep(poll_interval)
+        state = get_version_state(client, version_id)
+
+
+@dataclass
+class RemovalResult:
+    bundle_id: str
+    app_id: str
+    version: str
+    version_id: str
+    initial_state: str
+    final_state: str
+    submission_id: str
+    removed: bool
+    became_editable: bool
+    reason: str
+
+
+def remove_from_review(
+    client: ASCClient,
+    *,
+    bundle_id: str,
+    version: str,
+    wait: bool,
+    timeout: int,
+    poll_interval: int,
+) -> RemovalResult:
+    app = get_app(client, bundle_id)
+    app_id = str(app.get("id") or "")
+    if not app_id:
+        die(f"Could not resolve app id for bundleId={bundle_id}", code=2)
+
+    version_id, initial_state = find_app_store_version_id(client, app_id=app_id, version=version)
+    submission_payload = client.request("GET", f"/appStoreVersions/{version_id}/appStoreVersionSubmission")
+    submission_id = _submission_id(submission_payload)
+
+    if not submission_id:
+        final_state = get_version_state(client, version_id)
+        return RemovalResult(
+            bundle_id=bundle_id,
+            app_id=app_id,
+            version=version,
+            version_id=version_id,
+            initial_state=initial_state,
+            final_state=final_state,
+            submission_id="",
+            removed=False,
+            became_editable=_is_editable_state(final_state),
+            reason="no_submission_found",
+        )
+
+    client.request("DELETE", f"/appStoreVersionSubmissions/{submission_id}")
+
+    if wait:
+        final_state = _wait_for_editable_state(
+            client,
+            version_id=version_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+    else:
+        final_state = get_version_state(client, version_id)
+
+    return RemovalResult(
+        bundle_id=bundle_id,
+        app_id=app_id,
+        version=version,
+        version_id=version_id,
+        initial_state=initial_state,
+        final_state=final_state,
+        submission_id=submission_id,
+        removed=True,
+        became_editable=_is_editable_state(final_state),
+        reason="submission_deleted",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Remove an App Store version submission from review.")
+    parser.add_argument("--bundle-id", default="com.igorganapolsky.randomtimer")
+    parser.add_argument("--version", required=True, help="Marketing version to remove from review (e.g. 1.2.6)")
+    parser.add_argument("--wait", action="store_true", help="Wait until the App Store version becomes editable.")
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--poll-interval", type=int, default=10)
+    parser.add_argument("--json-out", help="Write the result JSON to this path.")
+    parser.add_argument("--json", action="store_true", help="Print compact JSON instead of human-readable text.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        client = ASCClient.from_env(timeout=30)
+    except AscClientError as exc:
+        die(str(exc), code=2)
+
+    result = remove_from_review(
+        client,
+        bundle_id=args.bundle_id,
+        version=args.version,
+        wait=args.wait,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+    )
+    payload = asdict(result)
+
+    if args.json_out:
+        out = Path(args.json_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=True))
+    else:
+        info(
+            f"version={result.version} initial={result.initial_state} final={result.final_state} "
+            f"removed={result.removed} editable={result.became_editable} reason={result.reason}"
+        )
+
+    if args.wait and not result.became_editable:
+        die(
+            f"App Store version {result.version} is still not editable after remove-from-review "
+            f"(final state={result.final_state}).",
+            code=1,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_asc_remove_from_review.py
+++ b/scripts/tests/test_asc_remove_from_review.py
@@ -1,0 +1,121 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import asc_remove_from_review
+
+
+class _FakeClient:
+    def __init__(self, *, initial_state="WAITING_FOR_REVIEW", final_state="DEVELOPER_REJECTED", submission_id="sub-1"):
+        self.initial_state = initial_state
+        self.final_state = final_state
+        self.state = initial_state
+        self.submission_id = submission_id
+        self.deleted = []
+
+    def request(self, method, path, params=None, payload=None):
+        if method == "GET" and path.endswith("/appStoreVersionSubmission"):
+            if self.submission_id:
+                return {"data": {"id": self.submission_id, "type": "appStoreVersionSubmissions"}}
+            return {"data": None}
+        if method == "DELETE" and path == f"/appStoreVersionSubmissions/{self.submission_id}":
+            self.deleted.append(path)
+            self.state = self.final_state
+            return {}
+        raise AssertionError(f"Unhandled request: {method} {path}")
+
+
+class AscRemoveFromReviewTests(unittest.TestCase):
+    def test_submission_id_extracts_dict_payload(self):
+        self.assertEqual(
+            asc_remove_from_review._submission_id({"data": {"id": "sub-123"}}),
+            "sub-123",
+        )
+        self.assertEqual(asc_remove_from_review._submission_id({"data": None}), "")
+
+    def test_remove_from_review_deletes_submission_and_waits_for_editable_state(self):
+        client = _FakeClient()
+        with (
+            patch.object(asc_remove_from_review, "get_app", return_value={"id": "app-1"}),
+            patch.object(
+                asc_remove_from_review,
+                "find_app_store_version_id",
+                return_value=("version-1", "WAITING_FOR_REVIEW"),
+            ),
+            patch.object(asc_remove_from_review, "get_version_state", side_effect=["WAITING_FOR_REVIEW", "DEVELOPER_REJECTED"]),
+            patch.object(asc_remove_from_review.time, "sleep", return_value=None),
+        ):
+            result = asc_remove_from_review.remove_from_review(
+                client,
+                bundle_id="com.example.app",
+                version="1.2.6",
+                wait=True,
+                timeout=10,
+                poll_interval=1,
+            )
+
+        self.assertTrue(result.removed)
+        self.assertTrue(result.became_editable)
+        self.assertEqual(result.final_state, "DEVELOPER_REJECTED")
+        self.assertEqual(result.submission_id, "sub-1")
+        self.assertEqual(client.deleted, ["/appStoreVersionSubmissions/sub-1"])
+
+    def test_remove_from_review_is_noop_when_submission_is_missing(self):
+        client = _FakeClient(initial_state="PREPARE_FOR_SUBMISSION", final_state="PREPARE_FOR_SUBMISSION", submission_id="")
+        with (
+            patch.object(asc_remove_from_review, "get_app", return_value={"id": "app-1"}),
+            patch.object(
+                asc_remove_from_review,
+                "find_app_store_version_id",
+                return_value=("version-1", "PREPARE_FOR_SUBMISSION"),
+            ),
+            patch.object(asc_remove_from_review, "get_version_state", return_value="PREPARE_FOR_SUBMISSION"),
+        ):
+            result = asc_remove_from_review.remove_from_review(
+                client,
+                bundle_id="com.example.app",
+                version="1.2.6",
+                wait=False,
+                timeout=0,
+                poll_interval=1,
+            )
+
+        self.assertFalse(result.removed)
+        self.assertTrue(result.became_editable)
+        self.assertEqual(result.reason, "no_submission_found")
+
+    def test_main_writes_json_output(self):
+        client = _FakeClient()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "remove.json"
+            with (
+                patch.object(asc_remove_from_review.ASCClient, "from_env", return_value=client),
+                patch.object(asc_remove_from_review, "get_app", return_value={"id": "app-1"}),
+                patch.object(
+                    asc_remove_from_review,
+                    "find_app_store_version_id",
+                    return_value=("version-1", "WAITING_FOR_REVIEW"),
+                ),
+                patch.object(asc_remove_from_review, "get_version_state", side_effect=["DEVELOPER_REJECTED"]),
+                patch(
+                    "sys.argv",
+                    [
+                        "asc_remove_from_review.py",
+                        "--version",
+                        "1.2.6",
+                        "--json-out",
+                        str(out),
+                    ],
+                ),
+            ):
+                self.assertEqual(asc_remove_from_review.main(), 0)
+
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(payload["version"], "1.2.6")
+            self.assertEqual(payload["submission_id"], "sub-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -45,6 +45,14 @@ def test_internal_distribution_workflow_emits_platform_specific_release_artifact
     assert "android-release-verification" in source
 
 
+def test_ios_metadata_sync_can_remove_locked_waiting_for_review_version_and_upload_evidence():
+    source = (ROOT / ".github/workflows/ios-metadata-sync.yml").read_text(encoding="utf-8")
+
+    assert "remove_from_review_if_locked" in source
+    assert "python scripts/asc_remove_from_review.py" in source
+    assert "asc-remove-from-review" in source
+
+
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():
     source = NORTH_STAR_GUARDRAIL_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add an App Store Connect remove-from-review script that deletes the active appStoreVersionSubmission and waits for the version to become editable
- add focused unit tests for the new removal flow and a workflow contract test for metadata sync
- let `ios-metadata-sync` optionally remove a locked `WAITING_FOR_REVIEW` version before screenshot replacement and upload the removal artifact

## Verification
- `python3 -m pytest -q scripts/tests/test_asc_remove_from_review.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_asc_resolve_version.py scripts/tests/test_asc_list_versions.py`

## Why
Current live ASC evidence on `develop` shows the metadata sync resolves version `1.2.6` and then fails because the version is locked:
- `selected_version = 1.2.6`
- `app_store_state = WAITING_FOR_REVIEW`
- `result = failed_locked_before_replacement`

This change gives the workflow a supported path to clear that lock with the ASC API and proceed with the listing refresh.