### PR TITLE
Fix ASC age rating verification for review submit

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -675,10 +675,43 @@ def verify_review_detail(client: ASCClient, version_id: str) -> None:
 
 
 def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = None) -> None:
-    # Current ASC API exposes a unified AgeRatingDeclaration relationship on the App Store Version:
-    #   GET /v1/appStoreVersions/{id}/ageRatingDeclaration
-    # Some older code paths used app/appInfo relationships which may not exist on newer APIs.
+    # Apple's current ASC docs expose Age Rating under App Info:
+    #   GET /v1/appInfos/{id}/relationships/ageRatingDeclaration
+    # Keep a legacy fallback to the older version-scoped read path because some older
+    # automation/tests still model it there.
     errors: list[str] = []
+    try:
+        app_infos = client.request(
+            "GET",
+            f"/apps/{app_id}/appInfos",
+            params={"limit": 50},
+        ).get("data") or []
+        app_info: dict[str, Any] | None = None
+        for item in app_infos:
+            if not isinstance(item, dict):
+                continue
+            if (item.get("attributes") or {}).get("platform") == "IOS":
+                app_info = item
+                break
+        if not app_info:
+            for item in app_infos:
+                if isinstance(item, dict):
+                    app_info = item
+                    break
+        app_info_id = str((app_info or {}).get("id") or "")
+        if app_info_id:
+            data = client.request("GET", f"/appInfos/{app_info_id}/relationships/ageRatingDeclaration")
+            rel_data = data.get("data") or {}
+            if isinstance(rel_data, dict) and rel_data.get("id"):
+                return
+            errors.append(
+                f"appInfo /appInfos/{app_info_id}/relationships/ageRatingDeclaration returned no data"
+            )
+        else:
+            errors.append("appInfo id missing (cannot verify ageRatingDeclaration).")
+    except Exception as e:
+        errors.append(f"appInfo ageRatingDeclaration relationship: {e}")
+
     if version_id:
         try:
             data = client.request("GET", f"/appStoreVersions/{version_id}/ageRatingDeclaration")

--- a/scripts/tests/test_asc_submit_for_review_age_rating.py
+++ b/scripts/tests/test_asc_submit_for_review_age_rating.py
@@ -4,14 +4,30 @@ from scripts.tests.router_client import RouterClient
 
 
 class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
-    def test_verify_age_rating_reads_age_rating_declaration_from_version(self):
+    def test_verify_age_rating_reads_age_rating_declaration_from_app_info_relationship(self):
         from scripts.asc_submit_for_review import verify_age_rating
 
         client = RouterClient(
             {
+                ("GET", "/apps/app1/appInfos"): {
+                    "data": [{"id": "info1", "type": "appInfos", "attributes": {"platform": "IOS"}}]
+                },
+                ("GET", "/appInfos/info1/relationships/ageRatingDeclaration"): {
+                    "data": {"id": "decl1", "type": "ageRatingDeclarations"}
+                }
+            }
+        )
+        verify_age_rating(client, "app1", "ver1")
+
+    def test_verify_age_rating_falls_back_to_legacy_version_relationship(self):
+        from scripts.asc_submit_for_review import verify_age_rating
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app1/appInfos"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/ageRatingDeclaration"): {
                     "data": {"id": "decl1", "type": "ageRatingDeclarations", "attributes": {}}
-                }
+                },
             }
         )
         verify_age_rating(client, "app1", "ver1")
@@ -21,6 +37,7 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
         client = RouterClient(
             {
+                ("GET", "/apps/app1/appInfos"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/ageRatingDeclaration"): RuntimeError("404"),
             }
         )
@@ -30,4 +47,3 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- update `verify_age_rating` to use the current App Store Connect app-info age-rating relationship first
- keep the legacy version-scoped read as a fallback for older flows
- extend the age-rating verifier tests to cover the new relationship and fallback behavior

## Verification
- `python3 -m pytest -q scripts/tests/test_asc_submit_for_review_age_rating.py scripts/tests/test_asc_remove_from_review.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_asc_resolve_version.py scripts/tests/test_asc_list_versions.py`

## Why
The live `iOS Submit For Review` run `23053428560` proved that metadata upload and readiness were green, but submit failed because `verify_age_rating` still called the deprecated version-level `ageRatingDeclaration` path and treated Apple’s 404 as fatal.