### PR TITLE
fix(release): allow rejected app store state before resubmit

### DIFF
--- a/scripts/tests/test_verify_release.py
+++ b/scripts/tests/test_verify_release.py
@@ -63,3 +63,63 @@ def test_print_results_returns_true_only_when_all_pass():
     assert vr.print_results([
         {"platform": "Android", "track": "alpha", "version": "1", "passed": False, "status": "bad", "details": "x"}
     ]) is False
+
+
+def test_appstore_rejected_state_is_allowed_before_submission(monkeypatch):
+    asc = vr.AppStoreVerifier()
+    monkeypatch.setattr(asc, "_get_app_id", lambda: "app123")
+    monkeypatch.setattr(
+        asc,
+        "_request",
+        lambda *_a, **_k: {
+            "data": [
+                {
+                    "attributes": {
+                        "versionString": "1.2.6",
+                        "appStoreState": "REJECTED",
+                    }
+                }
+            ]
+        },
+    )
+
+    result = asc.verify_app_store_version("1.2.6")
+    assert result["passed"] is True
+    assert result["status"] == "REJECTED"
+
+
+def test_appstore_rejected_state_fails_when_submission_required(monkeypatch):
+    asc = vr.AppStoreVerifier()
+    monkeypatch.setattr(asc, "_get_app_id", lambda: "app123")
+    monkeypatch.setattr(
+        asc,
+        "_request",
+        lambda *_a, **_k: {
+            "data": [
+                {
+                    "attributes": {
+                        "versionString": "1.2.6",
+                        "appStoreState": "REJECTED",
+                    }
+                }
+            ]
+        },
+    )
+
+    result = asc.verify_app_store_version("1.2.6", require_submission=True)
+    assert result["passed"] is False
+    assert result["status"] == "REJECTED"
+
+
+def test_appstore_missing_version_only_fails_when_submission_required(monkeypatch):
+    asc = vr.AppStoreVerifier()
+    monkeypatch.setattr(asc, "_get_app_id", lambda: "app123")
+    monkeypatch.setattr(asc, "_request", lambda *_a, **_k: {"data": []})
+
+    pre_submit = asc.verify_app_store_version("1.2.6")
+    post_submit = asc.verify_app_store_version("1.2.6", require_submission=True)
+
+    assert pre_submit["passed"] is True
+    assert pre_submit["status"] == "NOT_SUBMITTED"
+    assert post_submit["passed"] is False
+    assert post_submit["status"] == "NOT_SUBMITTED"

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -382,8 +382,14 @@ class AppStoreVerifier:
                 "details": f"App Store Connect API error: {e}",
             }
 
-    def verify_app_store_version(self, version: str) -> dict:
-        """Check the App Store version submission state."""
+    def verify_app_store_version(self, version: str, require_submission: bool = False) -> dict:
+        """Check the App Store version submission state.
+
+        Before submission, editable states like REJECTED / DEVELOPER_REJECTED are
+        acceptable because the release workflow still needs to push metadata and
+        resubmit that exact version. After submission, callers can set
+        require_submission=True to demand a submitted state.
+        """
         try:
             app_id = self._get_app_id()
 
@@ -399,15 +405,18 @@ class AppStoreVerifier:
             versions = data.get("data", [])
             if not versions:
                 return {
-                    "passed": True,  # Not submitted yet is OK for TestFlight
+                    "passed": not require_submission,
                     "status": "NOT_SUBMITTED",
                     "details": f"No App Store version '{version}' submitted (TestFlight only)",
                 }
 
             attrs = versions[0].get("attributes", {})
             state = attrs.get("appStoreState", "UNKNOWN")
+            failed_states = {"REMOVED_FROM_SALE", "DEVELOPER_REMOVED_FROM_SALE"}
+            if require_submission:
+                failed_states |= {"REJECTED", "DEVELOPER_REJECTED"}
             return {
-                "passed": state not in ("REJECTED", "REMOVED_FROM_SALE", "DEVELOPER_REMOVED_FROM_SALE"),
+                "passed": state not in failed_states,
                 "status": state,
                 "details": f"App Store version {version}: appStoreState={state}",
             }
@@ -452,7 +461,12 @@ def print_results(results: list[dict]):
 # Polling
 # ---------------------------------------------------------------------------
 
-def poll_until_done(verify_fn, poll_interval: int, timeout: int, terminal_statuses: set[str] | None = None) -> dict:
+def poll_until_done(
+    verify_fn,
+    poll_interval: int,
+    timeout: int,
+    terminal_statuses: Optional[set[str]] = None,
+) -> dict:
     """Call verify_fn repeatedly until it passes or times out."""
     deadline = time.time() + timeout
     attempt = 0
@@ -598,7 +612,10 @@ def main():
         })
 
         # Also check App Store version state
-        asv = asc.verify_app_store_version(args.version)
+        asv = asc.verify_app_store_version(
+            args.version,
+            require_submission=args.require_appstore_submission,
+        )
         if args.require_appstore_submission and asv.get("status") == "NOT_SUBMITTED":
             asv = {
                 "passed": False,


### PR DESCRIPTION
## Summary
- allow editable App Store states such as REJECTED before resubmission
- keep post-submit verification strict when submission is required
- cover the resubmission cases in verifier tests

## Verification
- python3 -m pytest -q scripts/tests/test_verify_release.py scripts/tests/test_asc_verify_ready.py scripts/tests/test_release_context.py
