### PR TITLE
fix(release): let fastlane reject in-progress submissions

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -219,6 +219,7 @@ platform :ios do
       skip_screenshots: options.key?(:skip_screenshots) ? options[:skip_screenshots] : true,
       skip_metadata: options.key?(:skip_metadata) ? options[:skip_metadata] : true,
       force: true,
+      reject_if_possible: true,
       api_key: defined?(api_key) ? api_key : nil,
       submission_information: {
         export_compliance_uses_encryption: false,


### PR DESCRIPTION
## Summary
- allow Fastlane deliver to reject an in-progress submission before resubmitting
- keep release submit flow moving when ASC reports a submission already in progress

## Verification
- ruby -c native-ios/fastlane/Fastfile
- python3 -m pytest -q scripts/tests/test_asc_submit_for_review.py scripts/tests/test_asc_submit_for_review_age_rating.py scripts/tests/test_verify_release.py scripts/tests/test_asc_verify_ready.py scripts/tests/test_release_context.py
