### PR TITLE
Keep screen awake during active timer sessions

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
@@ -35,7 +35,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,6 +65,9 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+internal fun shouldKeepScreenAwake(state: TimerState?): Boolean =
+    state != null && state.status != TimerStatus.IDLE && state.status != TimerStatus.COMPLETE
+
 @Composable
 fun ActiveTimerScreen(
     state: TimerState,
@@ -75,6 +81,7 @@ fun ActiveTimerScreen(
     modifier: Modifier = Modifier,
 ) {
     val haptic = LocalHapticFeedback.current
+    val view = LocalView.current
     val isComplete = state.status == TimerStatus.COMPLETE || state.status == TimerStatus.ALARM
     val isPaused = state.status == TimerStatus.PAUSED
     var loopEnabled by remember(state.config.repeatEnabled) { mutableStateOf(state.config.repeatEnabled) }
@@ -88,7 +95,14 @@ fun ActiveTimerScreen(
             onStop()
         }
     }
-
+    SideEffect {
+        view.keepScreenOn = shouldKeepScreenAwake(state)
+    }
+    DisposableEffect(view) {
+        onDispose {
+            view.keepScreenOn = false
+        }
+    }
     LaunchedEffect(resetFeedbackCounter) {
         if (resetFeedbackCounter == 0) return@LaunchedEffect
         showResetFeedback = true

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/ScreenWakePolicyTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/ScreenWakePolicyTest.kt
@@ -1,0 +1,45 @@
+package com.iganapolsky.randomtimer.ui.screens
+
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.TimerState
+import com.iganapolsky.randomtimer.domain.model.TimerStatus
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+class ScreenWakePolicyTest {
+    @Test
+    fun `keeps screen awake while timer state exists`() {
+        TimerStatus.entries
+            .filter { it != TimerStatus.IDLE && it != TimerStatus.COMPLETE }
+            .forEach { status ->
+                val state =
+                    TimerState(
+                        config = TimerConfig.DEFAULT,
+                        targetDuration = 30.seconds,
+                        remainingDuration = 15.seconds,
+                        status = status,
+                    )
+
+                assertThat(shouldKeepScreenAwake(state)).isTrue()
+            }
+    }
+
+    @Test
+    fun `allows screen sleep when timer is complete`() {
+        val completeState =
+            TimerState(
+                config = TimerConfig.DEFAULT,
+                targetDuration = 30.seconds,
+                remainingDuration = 0.seconds,
+                status = TimerStatus.COMPLETE,
+            )
+
+        assertThat(shouldKeepScreenAwake(completeState)).isFalse()
+    }
+
+    @Test
+    fun `allows screen sleep when timer state is absent`() {
+        assertThat(shouldKeepScreenAwake(null)).isFalse()
+    }
+}

--- a/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
+++ b/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
@@ -1,4 +1,12 @@
 import SwiftUI
+import UIKit
+
+// swiftlint:disable no_environment_object
+@MainActor
+func shouldKeepScreenAwake(timerState: TimerState?) -> Bool {
+    guard let timerState else { return false }
+    return timerState.status != .idle && timerState.status != .complete
+}
 
 @main
 struct RandomTimerApp: App {
@@ -22,6 +30,7 @@ struct RandomTimerApp: App {
         .onChange(of: scenePhase) { _, newPhase in
             switch newPhase {
             case .active:
+                UIApplication.shared.isIdleTimerDisabled = shouldKeepScreenAwake(timerState: timerManager.timerState)
                 Task {
                     await timerManager.handleForeground()
                 }
@@ -57,6 +66,7 @@ struct ContentView: View {
         }
         .onAppear {
             syncNavigationState()
+            updateIdleTimerState()
 #if DEBUG
             guard didApplyUITestSeed == false else { return }
             didApplyUITestSeed = true
@@ -64,7 +74,7 @@ struct ContentView: View {
             Task {
                 // Short delay to ensure environment is fully ready
                 try? await Task.sleep(for: .seconds(0.5))
-                
+
                 let args = ProcessInfo.processInfo.arguments
                 guard let index = args.firstIndex(of: "-ui-test-state"),
                       args.indices.contains(index + 1) else { return }
@@ -128,6 +138,10 @@ struct ContentView: View {
         }
         .onChange(of: timerManager.timerState?.status) { _, _ in
             syncNavigationState()
+            updateIdleTimerState()
+        }
+        .onDisappear {
+            UIApplication.shared.isIdleTimerDisabled = false
         }
     }
 
@@ -148,6 +162,10 @@ struct ContentView: View {
         hadActiveTimer = hasActiveTimer
         previousTimerStatus = currentStatus
     }
+
+    private func updateIdleTimerState() {
+        UIApplication.shared.isIdleTimerDisabled = shouldKeepScreenAwake(timerState: timerManager.timerState)
+    }
 }
 
 #Preview {
@@ -155,3 +173,4 @@ struct ContentView: View {
         .environmentObject(TimerManager())
         .environmentObject(ProManager.shared)
 }
+// swiftlint:enable no_environment_object

--- a/native-ios/RandomTimerTests/SilenceAndStopAlarmTests.swift
+++ b/native-ios/RandomTimerTests/SilenceAndStopAlarmTests.swift
@@ -171,7 +171,7 @@ final class SilenceAndStopAlarmTests: XCTestCase {
 }
 
 @MainActor
-final class NotificationServiceMediaButtonBehaviorTests: XCTestCase {
+final class NotificationMediaButtonTests: XCTestCase {
 
     func testMediaButtonSilenceActionInvokesSilenceCallbackOnly() {
         let service = NotificationService()
@@ -220,5 +220,53 @@ final class NotificationServiceMediaButtonBehaviorTests: XCTestCase {
         service.handleNotificationSilenceAction()
 
         XCTAssertTrue(didSilence)
+    }
+}
+
+@MainActor
+final class ScreenWakePolicyTests: XCTestCase {
+
+    func testKeepsScreenAwakeDuringActiveTimerStatuses() {
+        let activeState = RandomTimer.TimerState(
+            config: .default,
+            targetDuration: 30,
+            remainingDuration: 10,
+            status: .running
+        )
+
+        XCTAssertTrue(shouldKeepScreenAwake(timerState: activeState))
+        XCTAssertTrue(shouldKeepScreenAwake(timerState: activeState.withStatus(.paused)))
+        XCTAssertTrue(shouldKeepScreenAwake(timerState: activeState.withStatus(.alarm)))
+        XCTAssertTrue(shouldKeepScreenAwake(timerState: activeState.withStatus(.warning)))
+        XCTAssertTrue(shouldKeepScreenAwake(timerState: activeState.withStatus(.danger)))
+    }
+
+    func testAllowsScreenSleepWhenTimerIsComplete() {
+        let completeState = RandomTimer.TimerState(
+            config: .default,
+            targetDuration: 30,
+            remainingDuration: 0,
+            status: .complete
+        )
+
+        XCTAssertFalse(shouldKeepScreenAwake(timerState: completeState))
+    }
+
+    func testAllowsScreenSleepWhenTimerIsAbsent() {
+        XCTAssertFalse(shouldKeepScreenAwake(timerState: nil))
+    }
+}
+
+private extension RandomTimer.TimerState {
+    func withStatus(_ status: RandomTimer.TimerStatus) -> RandomTimer.TimerState {
+        RandomTimer.TimerState(
+            config: config,
+            targetDuration: targetDuration,
+            startedAt: startedAt,
+            remainingDuration: remainingDuration,
+            status: status,
+            alarmTimeRemaining: alarmTimeRemaining,
+            alarmStartedAt: alarmStartedAt
+        )
     }
 }


### PR DESCRIPTION
## Summary
- keep the Android screen awake while an active timer session or alarm is on screen, and release it once the session is complete or the screen disappears
- mirror the same idle-timer behavior on iOS via `UIApplication.shared.isIdleTimerDisabled`
- add wake-policy regression tests on both platforms

## Verification
- `cd native-ios && xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,id=FB1D04C9-33DF-40E5-9F56-466FE9D1495B' -only-testing:RandomTimerTests/ScreenWakePolicyTests test`
  - result: `Executed 3 tests, with 0 failures`
- `cd native-android && ./gradlew assembleDebug`
  - result: `BUILD SUCCESSFUL`
- `cd native-android && ./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.ui.screens.ScreenWakePolicyTest`
  - blocked by unrelated existing unit-test compile failures in `AIVoiceCalloutManagerCueMappingTest.kt` and `TimerSetupScreenSliderScaleTest.kt`

## Notes
- Android wake policy intentionally excludes `COMPLETE`, so the screen can sleep again once the timer has actually finished.
- iOS test xcresult: `/Users/ganapolsky_i/Library/Developer/Xcode/DerivedData/RandomTimer-aektyxrseljyuugbocahxgxshgti/Logs/Test/Test-RandomTimer-2026.03.13_16-13-31--0400.xcresult`