### PR TITLE
fix(android): restore release build for Play production

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -246,22 +246,37 @@ fun TimerSetupScreen(
                                                 if (!newExtended && config.maxSeconds > TimerConfig.MAX_SECONDS_FREE) {
                                                     // Clamp if shrinking
                                                     val clampedMax = TimerConfig.MAX_SECONDS_FREE
-                                                    val clampedMin = minOf(config.minSeconds, clampedMax - TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS)
+                                                    val clampedMin =
+                                                        minOf(
+                                                            config.minSeconds,
+                                                            clampedMax - TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS,
+                                                        )
                                                     updateConfig(useExtendedRange = false, minSeconds = clampedMin, maxSeconds = clampedMax)
                                                 } else {
                                                     updateConfig(useExtendedRange = newExtended)
                                                 }
                                             },
                                             shape = RoundedCornerShape(4.dp),
-                                            color = if (config.useExtendedRange) TimerColors.AccentPrimary.copy(alpha = 0.2f) else TimerColors.GlassBackground,
-                                            border = BorderStroke(0.5.dp, if (config.useExtendedRange) TimerColors.AccentPrimary else TimerColors.GlassBorder)
+                                            color =
+                                                if (config.useExtendedRange) {
+                                                    TimerColors.AccentPrimary.copy(
+                                                        alpha = 0.2f,
+                                                    )
+                                                } else {
+                                                    TimerColors.GlassBackground
+                                                },
+                                            border =
+                                                BorderStroke(
+                                                    0.5.dp,
+                                                    if (config.useExtendedRange) TimerColors.AccentPrimary else TimerColors.GlassBorder,
+                                                ),
                                         ) {
                                             Text(
                                                 text = if (config.useExtendedRange) "60M MODE" else "5M MODE",
                                                 style = MaterialTheme.typography.labelSmall,
                                                 fontWeight = FontWeight.Bold,
                                                 color = if (config.useExtendedRange) TimerColors.AccentPrimary else TimerColors.TextSecondary,
-                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                                             )
                                         }
                                     } else {
@@ -284,7 +299,14 @@ fun TimerSetupScreen(
                                 }
                                 Spacer(modifier = Modifier.height(spacing.headerToContent))
 
-                                val maxRange = if (isPro && config.useExtendedRange) TimerConfig.MAX_SECONDS_PRO else TimerConfig.MAX_SECONDS_FREE
+                                val maxRange =
+                                    if (isPro &&
+                                        config.useExtendedRange
+                                    ) {
+                                        TimerConfig.MAX_SECONDS_PRO
+                                    } else {
+                                        TimerConfig.MAX_SECONDS_FREE
+                                    }
                                 TimeRangeSliders(
                                     minValue = config.minSeconds,
                                     maxValue = config.maxSeconds,


### PR DESCRIPTION
## Summary
- restore the missing Compose Box import in TimerSetupScreen
- keep the formatter-applied same-file cleanup produced by the repo hook
- unblock Android release and internal distribution builds on release/v1.2.6

## Verification
- `cd native-android && ./gradlew compileReleaseKotlin`
- `cd native-android && ./gradlew --no-daemon :app:bundleRelease --stacktrace`
