### PR TITLE
fix(android): restore release build Box import

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues


### PR DESCRIPTION
## Summary
- restore the missing Compose `Box` import in `TimerSetupScreen`
- unblock Android release AAB compilation on `release/v1.2.6`

## Verification
- `cd native-android && ./gradlew compileReleaseKotlin`
- `cd native-android && ./gradlew --no-daemon :app:bundleRelease`
