### PR TITLE
Fix public privacy policy page for store compliance

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,56 +1,18 @@
-# Random Tactical Timer
+Random Tactical Timer
 
-> A native iOS + Android timer app that goes off at a random time within a user-defined range.
+This site publishes a challenge-driven product landing page plus engineering updates.
+Preferred source format for agents: markdown URLs listed below.
 
-## Overview
+Base URL: https://igorganapolsky.github.io/Random-Timer
 
-Random Tactical Timer is a dual-platform mobile application for setting timers that fire at unpredictable moments. Users set a minimum and maximum duration, and the app picks a random time within that window. The user never knows exactly when the alarm will sound.
+Key resources:
+- https://igorganapolsky.github.io/Random-Timer
+- https://igorganapolsky.github.io/Random-Timer/download
+- https://igorganapolsky.github.io/Random-Timer/privacy-policy/
+- https://igorganapolsky.github.io/Random-Timer/agents.md
+- https://igorganapolsky.github.io/Random-Timer/amp.json
+- https://igorganapolsky.github.io/Random-Timer/sitemap.xml
 
-## Use Cases
-
-- Workout interval training with unpredictable rest periods
-- Reaction drills and team activities requiring surprise timing
-- Meditation sessions with organic transitions
-- Any scenario where predictable timing defeats the purpose
-
-## Technical Stack
-
-- **iOS**: Swift 6, SwiftUI, Live Activities (Lock Screen/Dynamic Island), MVVM with @Observable
-- **Android**: Kotlin 2.1, Jetpack Compose, Material Design 3, Hilt DI, Foreground Service, MVVM + Clean Architecture
-- **Shared patterns**: Glassmorphism dark UI, purple accent color scheme, persistent settings, alarm with sound + vibration
-
-## Key Features
-
-- Custom time range (min/max duration)
-- Hidden mode (conceals countdown from user)
-- Loop mode (auto-restart with new random duration)
-- Lock screen display (iOS Live Activity, Android notification with controls)
-- Multiple alarm sounds (intense/gentle) with volume control
-- Pause, resume, reset controls
-- Background operation with reliable notifications
-
-## Repository Structure
-
-- `native-ios/` — Swift/SwiftUI iOS app
-- `native-android/` — Kotlin/Compose Android app
-- `screenshots/` — App screenshots and demo GIFs
-- `.maestro/` — E2E test flows
-
-## Building
-
-### iOS
-```
-cd native-ios && xcodebuild -scheme RandomTimer build
-```
-
-### Android
-```
-cd native-android && ./gradlew assembleDebug
-```
-
-## Links
-
-- Repository: https://github.com/IgorGanapolsky/Random-Timer
-- Privacy Policy: https://github.com/IgorGanapolsky/Random-Timer/blob/main/PRIVACY_POLICY.md
-- Issues: https://github.com/IgorGanapolsky/Random-Timer/issues
-- License: MIT
+Posts:
+- How we implemented Agentic Merchant Protocol (AMP) for AI discovery: https://igorganapolsky.github.io/Random-Timer/md/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.md
+- The inspiration behind Random Tactical Timer: https://igorganapolsky.github.io/Random-Timer/md/2026-02-19-the-inspiration-behind-random-tactical-timer.md

--- a/marketing/site/PRIVACY_POLICY/index.html
+++ b/marketing/site/PRIVACY_POLICY/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>Privacy Policy | Random Tactical Timer</title>
+          <meta name="description" content="Privacy policy for Random Tactical Timer." />
+          <meta name="robots" content="index,follow,max-image-preview:large" />
+          <link rel="canonical" href="https://igorganapolsky.github.io/Random-Timer/privacy-policy/" />
+          <meta property="og:type" content="website" />
+          <meta property="og:site_name" content="Random Tactical Timer" />
+          <meta property="og:title" content="Privacy Policy | Random Tactical Timer" />
+          <meta property="og:description" content="Privacy policy for Random Tactical Timer." />
+          <meta property="og:url" content="https://igorganapolsky.github.io/Random-Timer/privacy-policy/" />
+          <link rel="stylesheet" href="../styles.css" />
+
+        </head>
+        <body>
+          <main class="container">
+            <a class="back" href="../index.html">← Back to site</a>
+            <article>
+              <h1>Privacy Policy for Random Tactical Timer</h1>
+<p><strong>Last updated: February 13, 2026</strong></p>
+<h2>Overview</h2>
+<p>Random Tactical Timer ("the App") is developed by Igor Ganapolsky. This privacy policy explains how the App handles your data.</p>
+<h2>Data Collection</h2>
+<p>The App does <strong>not</strong> collect personal information such as your name, email, phone number, or address.
+The App may send limited, anonymous diagnostics and usage data through the services listed below.</p>
+<ul>
+<li><strong>No account required</strong> — the App works without sign-up or login</li>
+<li><strong>No location data</strong> — the App does not access your location</li>
+<li><strong>No advertising</strong> — the App contains no ads and no advertising ID usage</li>
+</ul>
+<h2>Analytics</h2>
+<p>The App may use <strong>PostHog</strong> for anonymous usage analytics to help improve the user experience when analytics is enabled. This data may include:</p>
+<ul>
+<li>Anonymous event data (e.g., timer started, timer completed)</li>
+<li>Device type and OS version</li>
+<li>App version</li>
+<li>No personally identifiable information is collected</li>
+</ul>
+<p>Analytics data is processed by PostHog and is not sold or shared with third parties for advertising purposes.</p>
+<h2>Firebase Analytics</h2>
+<p>The App uses <strong>Firebase Analytics</strong> to understand feature usage and improve the App. Firebase Analytics may automatically collect:</p>
+<ul>
+<li>App interactions and usage events (e.g., session start, screen views)</li>
+<li>Device and app information (device model, OS version, app version)</li>
+<li>A Firebase-generated app instance identifier</li>
+</ul>
+<p>This data is used for product analytics and is not used for advertising.</p>
+<h2>Firebase Crashlytics</h2>
+<p>The App uses Firebase Crashlytics to collect anonymous crash reports. This helps us fix bugs and improve stability. Crash reports may include:</p>
+<ul>
+<li>Device type and OS version</li>
+<li>App version</li>
+<li>Stack traces from crashes</li>
+<li>No personally identifiable information</li>
+</ul>
+<h2>Data Storage</h2>
+<p>All timer settings and preferences are stored locally on your device. Crash reports and analytics events (if enabled) are sent to their respective providers as described above.</p>
+<h2>Children's Privacy</h2>
+<p>The App does not knowingly collect data from children under 13. Since the App collects no personal data from any user, it is safe for all ages.</p>
+<h2>Changes to This Policy</h2>
+<p>If this policy changes, the updated version will be posted here with a new "Last updated" date.</p>
+<h2>Contact</h2>
+<p>If you have questions about this privacy policy, please open an issue at:
+https://github.com/IgorGanapolsky/Random-Timer/issues</p>
+            </article>
+          </main>
+        </body>
+        </html>

--- a/marketing/site/llms.txt
+++ b/marketing/site/llms.txt
@@ -8,6 +8,7 @@ Base URL: https://igorganapolsky.github.io/Random-Timer
 Key resources:
 - https://igorganapolsky.github.io/Random-Timer
 - https://igorganapolsky.github.io/Random-Timer/download
+- https://igorganapolsky.github.io/Random-Timer/privacy-policy/
 - https://igorganapolsky.github.io/Random-Timer/agents.md
 - https://igorganapolsky.github.io/Random-Timer/amp.json
 - https://igorganapolsky.github.io/Random-Timer/sitemap.xml

--- a/marketing/site/privacy-policy/index.html
+++ b/marketing/site/privacy-policy/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>Privacy Policy | Random Tactical Timer</title>
+          <meta name="description" content="Privacy policy for Random Tactical Timer." />
+          <meta name="robots" content="index,follow,max-image-preview:large" />
+          <link rel="canonical" href="https://igorganapolsky.github.io/Random-Timer/privacy-policy/" />
+          <meta property="og:type" content="website" />
+          <meta property="og:site_name" content="Random Tactical Timer" />
+          <meta property="og:title" content="Privacy Policy | Random Tactical Timer" />
+          <meta property="og:description" content="Privacy policy for Random Tactical Timer." />
+          <meta property="og:url" content="https://igorganapolsky.github.io/Random-Timer/privacy-policy/" />
+          <link rel="stylesheet" href="../styles.css" />
+
+        </head>
+        <body>
+          <main class="container">
+            <a class="back" href="../index.html">← Back to site</a>
+            <article>
+              <h1>Privacy Policy for Random Tactical Timer</h1>
+<p><strong>Last updated: February 13, 2026</strong></p>
+<h2>Overview</h2>
+<p>Random Tactical Timer ("the App") is developed by Igor Ganapolsky. This privacy policy explains how the App handles your data.</p>
+<h2>Data Collection</h2>
+<p>The App does <strong>not</strong> collect personal information such as your name, email, phone number, or address.
+The App may send limited, anonymous diagnostics and usage data through the services listed below.</p>
+<ul>
+<li><strong>No account required</strong> — the App works without sign-up or login</li>
+<li><strong>No location data</strong> — the App does not access your location</li>
+<li><strong>No advertising</strong> — the App contains no ads and no advertising ID usage</li>
+</ul>
+<h2>Analytics</h2>
+<p>The App may use <strong>PostHog</strong> for anonymous usage analytics to help improve the user experience when analytics is enabled. This data may include:</p>
+<ul>
+<li>Anonymous event data (e.g., timer started, timer completed)</li>
+<li>Device type and OS version</li>
+<li>App version</li>
+<li>No personally identifiable information is collected</li>
+</ul>
+<p>Analytics data is processed by PostHog and is not sold or shared with third parties for advertising purposes.</p>
+<h2>Firebase Analytics</h2>
+<p>The App uses <strong>Firebase Analytics</strong> to understand feature usage and improve the App. Firebase Analytics may automatically collect:</p>
+<ul>
+<li>App interactions and usage events (e.g., session start, screen views)</li>
+<li>Device and app information (device model, OS version, app version)</li>
+<li>A Firebase-generated app instance identifier</li>
+</ul>
+<p>This data is used for product analytics and is not used for advertising.</p>
+<h2>Firebase Crashlytics</h2>
+<p>The App uses Firebase Crashlytics to collect anonymous crash reports. This helps us fix bugs and improve stability. Crash reports may include:</p>
+<ul>
+<li>Device type and OS version</li>
+<li>App version</li>
+<li>Stack traces from crashes</li>
+<li>No personally identifiable information</li>
+</ul>
+<h2>Data Storage</h2>
+<p>All timer settings and preferences are stored locally on your device. Crash reports and analytics events (if enabled) are sent to their respective providers as described above.</p>
+<h2>Children's Privacy</h2>
+<p>The App does not knowingly collect data from children under 13. Since the App collects no personal data from any user, it is safe for all ages.</p>
+<h2>Changes to This Policy</h2>
+<p>If this policy changes, the updated version will be posted here with a new "Last updated" date.</p>
+<h2>Contact</h2>
+<p>If you have questions about this privacy policy, please open an issue at:
+https://github.com/IgorGanapolsky/Random-Timer/issues</p>
+            </article>
+          </main>
+        </body>
+        </html>

--- a/marketing/site/sitemap.xml
+++ b/marketing/site/sitemap.xml
@@ -2,6 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://igorganapolsky.github.io/Random-Timer</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/download</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/privacy-policy/</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/PRIVACY_POLICY/</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/posts/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.html</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/md/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.md</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/posts/2026-02-19-the-inspiration-behind-random-tactical-timer.html</loc></url>

--- a/native-ios/fastlane/metadata/en-US/privacy_url.txt
+++ b/native-ios/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/IgorGanapolsky/Random-Timer/blob/main/PRIVACY_POLICY.md
+https://igorganapolsky.github.io/Random-Timer/privacy-policy/

--- a/scripts/growth_content_pipeline.py
+++ b/scripts/growth_content_pipeline.py
@@ -61,6 +61,8 @@ DEFAULT_IOS_REVIEW_URL = f"{DEFAULT_APP_STORE_URL}?action=write-review"
 DEFAULT_ANDROID_REVIEW_URL = f"{DEFAULT_PLAY_STORE_URL}&reviewId=0"
 LEGACY_MARKETING_SITE_SEGMENT = "/marketing/site"
 AB_PILOT_WINDOW_DAYS = 14
+CANONICAL_PRIVACY_POLICY_SEGMENT = "/privacy-policy/"
+LEGACY_PRIVACY_POLICY_SEGMENT = "/PRIVACY_POLICY/"
 
 
 @dataclass
@@ -237,6 +239,10 @@ def resolve_blog_base_url(output_root: Path) -> str:
     if configured:
         return configured.rstrip("/")
     return DEFAULT_BLOG_BASE_URL.rstrip("/")
+
+
+def resolve_public_site_base_url(output_root: Path) -> str:
+    return resolve_blog_base_url(output_root).removesuffix(LEGACY_MARKETING_SITE_SEGMENT)
 
 
 def _safe_numeric_id(value: Any) -> Optional[str]:
@@ -750,6 +756,72 @@ def markdown_to_html(markdown_text: str) -> str:
     return "\n".join(rendered)
 
 
+def resolve_privacy_policy_source(output_root: Path) -> Optional[Path]:
+    candidates = [
+        output_root.parent / "PRIVACY_POLICY.md",
+        output_root / "PRIVACY_POLICY.md",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def build_privacy_policy_page(
+    output_root: Path,
+    site_root: Path,
+    public_base_url: str,
+    analytics_block: str,
+) -> Optional[str]:
+    privacy_source = resolve_privacy_policy_source(output_root)
+    if privacy_source is None:
+        return None
+
+    privacy_markdown = privacy_source.read_text(encoding="utf-8")
+    privacy_html = markdown_to_html(privacy_markdown)
+    canonical_url = f"{public_base_url}{CANONICAL_PRIVACY_POLICY_SEGMENT}"
+
+    page_html = textwrap.dedent(
+        f"""
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>Privacy Policy | Random Tactical Timer</title>
+          <meta name="description" content="Privacy policy for Random Tactical Timer." />
+          <meta name="robots" content="index,follow,max-image-preview:large" />
+          <link rel="canonical" href="{html.escape(canonical_url)}" />
+          <meta property="og:type" content="website" />
+          <meta property="og:site_name" content="Random Tactical Timer" />
+          <meta property="og:title" content="Privacy Policy | Random Tactical Timer" />
+          <meta property="og:description" content="Privacy policy for Random Tactical Timer." />
+          <meta property="og:url" content="{html.escape(canonical_url)}" />
+          <link rel="stylesheet" href="../styles.css" />
+          {analytics_block}
+        </head>
+        <body>
+          <main class="container">
+            <a class="back" href="../index.html">← Back to site</a>
+            <article>
+              {privacy_html}
+            </article>
+          </main>
+        </body>
+        </html>
+        """
+    ).strip()
+
+    canonical_dir = site_root / "privacy-policy"
+    legacy_dir = site_root / "PRIVACY_POLICY"
+    ensure_dir(canonical_dir)
+    ensure_dir(legacy_dir)
+    for target in (canonical_dir / "index.html", legacy_dir / "index.html"):
+        target.write_text(page_html + "\n", encoding="utf-8")
+
+    return canonical_url
+
+
 def mirror_public_site(site_root: Path, public_root: Path) -> None:
     file_names = [
         "index.html",
@@ -812,6 +884,7 @@ def build_site(output_root: Path) -> Dict[str, Any]:
     clear_generated_files(diagrams_out, "*.svg")
     clear_generated_files(md_out, "*.md")
     base_url = resolve_blog_base_url(output_root)
+    public_base_url = resolve_public_site_base_url(output_root)
     shared_social_image = resolve_social_image_url(output_root, site_root, base_url)
 
     ga4_id = os.getenv("GA4_MEASUREMENT_ID", "").strip()
@@ -833,6 +906,8 @@ def build_site(output_root: Path) -> Dict[str, Any]:
         )
     if plausible_domain:
         analytics_block += f'<script defer data-domain="{html.escape(plausible_domain)}" src="{html.escape(plausible_src)}"></script>\n'
+
+    privacy_policy_url = build_privacy_policy_page(output_root, site_root, public_base_url, analytics_block)
 
     posts_data: List[Dict[str, Any]] = []
     for md_path in sorted(posts_src.glob("*.md"), reverse=True):
@@ -1223,7 +1298,7 @@ def build_site(output_root: Path) -> Dict[str, Any]:
           <meta name="twitter:description" content="{html.escape(DEFAULT_LANDING_DESCRIPTION)}" />
           <meta name="twitter:image" content="{html.escape(index_og_image)}" />
           <link rel="stylesheet" href="styles.css" />
-          <link rel="alternate" type="application/json" title="Agentic Merchant Protocol Data" href="{base_url}/amp.json" />
+          <link rel="alternate" type="application/json" title="Agentic Merchant Protocol Data" href="{html.escape(base_url)}/amp.json" />
           <script type="application/ld+json">{index_structured_json}</script>
           {analytics_block}
         </head>
@@ -1407,6 +1482,9 @@ def build_site(output_root: Path) -> Dict[str, Any]:
     sitemap = ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"]
     sitemap.append(f"  <url><loc>{base_url}</loc></url>")
     sitemap.append(f"  <url><loc>{download_base_url}</loc></url>")
+    if privacy_policy_url:
+        sitemap.append(f"  <url><loc>{privacy_policy_url}</loc></url>")
+        sitemap.append(f"  <url><loc>{public_base_url}{LEGACY_PRIVACY_POLICY_SEGMENT}</loc></url>")
     for post in posts_data:
         sitemap.append(f"  <url><loc>{base_url}/{post['url']}</loc></url>")
         sitemap.append(f"  <url><loc>{base_url}/{post['markdown_url']}</loc></url>")
@@ -1432,6 +1510,7 @@ def build_site(output_root: Path) -> Dict[str, Any]:
         "Key resources:",
         f"- {base_url}",
         f"- {download_base_url}",
+        f"- {public_base_url}{CANONICAL_PRIVACY_POLICY_SEGMENT}",
         f"- {base_url}/agents.md",
         f"- {base_url}/amp.json",
         f"- {base_url}/sitemap.xml",

--- a/scripts/tests/test_growth_content_pipeline.py
+++ b/scripts/tests/test_growth_content_pipeline.py
@@ -108,6 +108,32 @@ class GrowthContentPipelineTests(unittest.TestCase):
             self.assertTrue((root / "site" / "md" / "2026-02-19-sample.md").is_file())
             self.assertTrue((root / "site" / "download" / "index.html").is_file())
 
+    def test_build_site_renders_privacy_policy_page_and_legacy_alias(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            output_root = repo / "marketing"
+            (output_root / "posts").mkdir(parents=True, exist_ok=True)
+            (output_root / "diagrams").mkdir(parents=True, exist_ok=True)
+            (repo / "PRIVACY_POLICY.md").write_text(
+                "# Privacy Policy\n\nWe do not sell your data.\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict("os.environ", {"BLOG_BASE_URL": "https://example.com/app"}, clear=False):
+                pipeline.build_site(output_root)
+
+            canonical_page = (output_root / "site" / "privacy-policy" / "index.html").read_text(encoding="utf-8")
+            legacy_page = (output_root / "site" / "PRIVACY_POLICY" / "index.html").read_text(encoding="utf-8")
+            sitemap = (output_root / "site" / "sitemap.xml").read_text(encoding="utf-8")
+            llms = (output_root / "site" / "llms.txt").read_text(encoding="utf-8")
+
+            self.assertIn("Privacy Policy", canonical_page)
+            self.assertIn("We do not sell your data.", canonical_page)
+            self.assertEqual(canonical_page, legacy_page)
+            self.assertIn("https://example.com/app/privacy-policy/", sitemap)
+            self.assertIn("https://example.com/app/PRIVACY_POLICY/", sitemap)
+            self.assertIn("https://example.com/app/privacy-policy/", llms)
+
     def test_build_site_writes_social_meta_structured_data_and_robots(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -199,6 +225,10 @@ class GrowthContentPipelineTests(unittest.TestCase):
             marketing_root = repo_root / "marketing"
             (marketing_root / "posts").mkdir(parents=True, exist_ok=True)
             (marketing_root / "diagrams").mkdir(parents=True, exist_ok=True)
+            (repo_root / "PRIVACY_POLICY.md").write_text(
+                "# Privacy Policy\n\nWe do not sell your data.\n",
+                encoding="utf-8",
+            )
             (marketing_root / "posts" / "2026-02-19-sample.md").write_text(
                 "---\n"
                 "title: Sample\n"
@@ -225,6 +255,51 @@ class GrowthContentPipelineTests(unittest.TestCase):
             self.assertIn("Start the 7-day challenge", public_index)
             self.assertIn("randomtimer://open", public_download)
             self.assertIn("Continue to App Store", public_download)
+
+    def test_resolve_public_site_base_url_strips_legacy_marketing_segment(self):
+        with tempfile.TemporaryDirectory() as td:
+            output_root = Path(td) / "marketing"
+            output_root.mkdir(parents=True, exist_ok=True)
+
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(
+                    pipeline.resolve_public_site_base_url(output_root),
+                    "https://igorganapolsky.github.io/Random-Timer",
+                )
+
+    def test_build_site_renders_privacy_policy_page_and_legacy_alias(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            marketing_root = repo_root / "marketing"
+            (marketing_root / "posts").mkdir(parents=True, exist_ok=True)
+            (marketing_root / "diagrams").mkdir(parents=True, exist_ok=True)
+            (marketing_root / "posts" / "2026-02-19-sample.md").write_text(
+                "---\n"
+                "title: Sample\n"
+                "description: Desc\n"
+                "date: 2026-02-19\n"
+                "tags: [ai, mobile]\n"
+                "---\n\n"
+                "## Body\n",
+                encoding="utf-8",
+            )
+            (marketing_root / "diagrams" / "2026-02-19-sample.svg").write_text("<svg></svg>", encoding="utf-8")
+            (repo_root / "PRIVACY_POLICY.md").write_text("# Privacy Policy\n\nWe respect your data.\n", encoding="utf-8")
+
+            with patch.dict("os.environ", {"BLOG_BASE_URL": "https://example.com/marketing/site"}, clear=False):
+                pipeline.build_site(marketing_root)
+
+            canonical_page = (marketing_root / "site" / "privacy-policy" / "index.html").read_text(encoding="utf-8")
+            legacy_page = (marketing_root / "site" / "PRIVACY_POLICY" / "index.html").read_text(encoding="utf-8")
+            sitemap = (marketing_root / "site" / "sitemap.xml").read_text(encoding="utf-8")
+            llms = (marketing_root / "site" / "llms.txt").read_text(encoding="utf-8")
+
+            self.assertIn("Privacy Policy", canonical_page)
+            self.assertIn("We respect your data.", canonical_page)
+            self.assertEqual(canonical_page, legacy_page)
+            self.assertIn("https://example.com/privacy-policy/", sitemap)
+            self.assertIn("https://example.com/PRIVACY_POLICY/", sitemap)
+            self.assertIn("https://example.com/privacy-policy/", llms)
 
     def test_publish_post_uses_channel_specific_utm_links(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- generate a public privacy policy page from 
- publish both  and  so the exact rejected Play URL becomes valid
- update store-facing privacy policy metadata to use the public Pages URL

## Verification
- ...................                                                      [100%]
19 passed in 0.07s
- local HTTP check:  -> 200 and  -> 200 from 
- live pre-fix evidence:  returned 404