### PR TITLE
Handle Google Play changesNotSentForReview fallback

### DIFF
--- a/scripts/play_publish.py
+++ b/scripts/play_publish.py
@@ -34,6 +34,10 @@ EDIT_DELETED_MARKERS = (
     "edit has been deleted",
     "edit was deleted",
 )
+MANUAL_REVIEW_REQUIRED_MARKERS = (
+    "changes cannot be sent for review automatically",
+    "changesnotsentforreview",
+)
 
 
 @dataclass
@@ -96,6 +100,11 @@ def _is_transient_http(http_status: int | None, message: str) -> bool:
     return any(fragment in lowered for fragment in TRANSIENT_ERROR_FRAGMENTS)
 
 
+def _requires_manual_review_submission(message: str, response_text: str, http_status: int | None) -> bool:
+    combined = f"{message}\n{response_text}".lower()
+    return http_status == 400 and any(marker in combined for marker in MANUAL_REVIEW_REQUIRED_MARKERS)
+
+
 def _load_google_clients(credentials_path: Path):
     from google.oauth2 import service_account
     from googleapiclient.discovery import build
@@ -130,6 +139,31 @@ def _upload_images(service: Any, package: str, edit_id: str, language: str, imag
             imageType=image_type,
             media_body=MediaFileUpload(fp, mimetype=_mime_for(fp)),
         ).execute()
+
+
+def _commit_edit(edits_service: Any, package: str, edit_id: str) -> bool:
+    """Commit a Play edit.
+
+    Returns True when Google requires `changesNotSentForReview=true`, which means
+    the edit was committed successfully but still needs a manual "Send for review"
+    action in Play Console.
+    """
+
+    try:
+        edits_service.commit(packageName=package, editId=edit_id).execute()
+        return False
+    except Exception as error:
+        message = str(error)
+        response_text = _extract_response_text(error)
+        status = getattr(getattr(error, "resp", None), "status", None)
+        if not _requires_manual_review_submission(message, response_text, status):
+            raise
+        edits_service.commit(
+            packageName=package,
+            editId=edit_id,
+            changesNotSentForReview=True,
+        ).execute()
+        return True
 
 
 def _update_listing_and_assets(
@@ -286,11 +320,12 @@ def _publish_to_track(
                 track=track,
                 body={"releases": [release]},
             ).execute()
-            service.edits().commit(packageName=package, editId=edit_id).execute()
+            changes_not_sent_for_review = _commit_edit(service.edits(), package, edit_id)
 
             return {
                 "version_code": str(version_code),
                 "attempt": attempt,
+                "changes_not_sent_for_review": changes_not_sent_for_review,
             }
         except HttpError as error:
             message = str(error)
@@ -415,6 +450,7 @@ def main() -> int:
                 "release_status": release_status,
                 "version_code": outcome["version_code"],
                 "attempt": outcome["attempt"],
+                "changes_not_sent_for_review": bool(outcome.get("changes_not_sent_for_review")),
                 "fallback_reason": "FAILED_PRECONDITION" if fallback_used else "",
             }
             if precondition_error_payload:
@@ -424,6 +460,12 @@ def main() -> int:
                 f"✅ Uploaded version code {outcome['version_code']} to '{track}' track "
                 f"(requested={requested_track}, status={release_status}, fallback_used={fallback_used})"
             )
+            if outcome.get("changes_not_sent_for_review"):
+                print(
+                    "ℹ️ Google Play committed the edit with changesNotSentForReview=true. "
+                    "Open Play Console and click 'Send for review' for this release.",
+                    file=sys.stderr,
+                )
             return 0
         except PublishError as error:
             payload = {

--- a/scripts/tests/test_play_publish.py
+++ b/scripts/tests/test_play_publish.py
@@ -1,6 +1,19 @@
 import unittest
+from unittest.mock import call
+from unittest.mock import Mock
 
-from scripts.play_publish import _is_deleted_edit_error, _is_failed_precondition, _release_payload
+from scripts.play_publish import _commit_edit
+from scripts.play_publish import _is_deleted_edit_error
+from scripts.play_publish import _is_failed_precondition
+from scripts.play_publish import _release_payload
+from scripts.play_publish import _requires_manual_review_submission
+
+
+class _FakeHttpError(Exception):
+    def __init__(self, status: int, content: str, message: str = "HttpError"):
+        super().__init__(message)
+        self.resp = type("Resp", (), {"status": status})()
+        self.content = content.encode("utf-8")
 
 
 class PlayPublishTests(unittest.TestCase):
@@ -68,6 +81,61 @@ class PlayPublishTests(unittest.TestCase):
         )
         self.assertNotIn("userFraction", payload)
         self.assertEqual(payload["releaseNotes"][0]["text"], "notes")
+
+    def test_detects_manual_review_required_marker(self):
+        self.assertTrue(
+            _requires_manual_review_submission(
+                "HttpError 400",
+                '{"error":{"message":"Changes cannot be sent for review automatically. '
+                'Please set the query parameter changesNotSentForReview to true."}}',
+                400,
+            )
+        )
+
+    def test_commit_edit_returns_false_when_normal_commit_succeeds(self):
+        edits_service = Mock()
+        edits_service.commit.return_value.execute.return_value = {}
+
+        result = _commit_edit(edits_service, "pkg", "edit-1")
+
+        self.assertFalse(result)
+        edits_service.commit.assert_called_once_with(packageName="pkg", editId="edit-1")
+
+    def test_commit_edit_retries_with_changes_not_sent_for_review(self):
+        edits_service = Mock()
+        edits_service.commit.side_effect = [
+            Mock(
+                execute=Mock(
+                    side_effect=_FakeHttpError(
+                        400,
+                        '{"error":{"message":"Changes cannot be sent for review automatically. '
+                        'Please set the query parameter changesNotSentForReview to true."}}',
+                    )
+                )
+            ),
+            Mock(execute=Mock(return_value={})),
+        ]
+
+        result = _commit_edit(edits_service, "pkg", "edit-1")
+
+        self.assertTrue(result)
+        self.assertEqual(
+            edits_service.commit.call_args_list,
+            [
+                call(packageName="pkg", editId="edit-1"),
+                call(packageName="pkg", editId="edit-1", changesNotSentForReview=True),
+            ],
+        )
+
+    def test_commit_edit_reraises_unrelated_error(self):
+        edits_service = Mock()
+        edits_service.commit.return_value.execute.side_effect = _FakeHttpError(
+            403,
+            '{"error":{"message":"Permission denied"}}',
+        )
+
+        with self.assertRaises(_FakeHttpError):
+            _commit_edit(edits_service, "pkg", "edit-1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry Play edit commit with `changesNotSentForReview=true` when Google rejects automatic review submission
- surface the fallback in the publish result payload and stderr guidance
- add focused regression coverage for the manual-review-required commit path

## Verification
- `python3 -m pytest -q scripts/tests/test_play_publish.py`
