### PR TITLE
Handle dynamic Android versionCode definitions

### DIFF
--- a/scripts/compute_android_release_version_code.py
+++ b/scripts/compute_android_release_version_code.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -15,11 +16,11 @@ ANDROID_PACKAGE_DEFAULT = "com.iganapolsky.randomtimer"
 DEFAULT_TRACKS = ("production", "beta", "alpha", "internal")
 
 
-def _read_gradle_version_code(gradle_file: Path) -> int:
+def _read_gradle_version_code(gradle_file: Path) -> int | None:
     content = gradle_file.read_text(encoding="utf-8")
     match = re.search(r"versionCode\s*=\s*(\d+)", content)
     if not match:
-        raise ValueError(f"Unable to find versionCode in {gradle_file}")
+        return None
     return int(match.group(1))
 
 
@@ -78,12 +79,16 @@ def _fetch_existing_track_codes(service: Any, package_name: str, tracks: list[st
                 pass
 
 
-def compute_next_version_code(base_version_code: int, existing_track_codes: dict[str, list[int]]) -> int:
+def compute_next_version_code(
+    base_version_code: int | None,
+    existing_track_codes: dict[str, list[int]],
+    minimum_floor: int | None = None,
+) -> int:
     highest_existing = max(
         (code for codes in existing_track_codes.values() for code in codes),
         default=0,
     )
-    return max(base_version_code, highest_existing) + 1
+    return max(base_version_code or 0, highest_existing, minimum_floor or 0) + 1
 
 
 def _parse_args() -> argparse.Namespace:
@@ -114,7 +119,12 @@ def main() -> int:
         base_version_code = _read_gradle_version_code(gradle_file)
         service = _load_play_service(service_account_json)
         existing_track_codes = _fetch_existing_track_codes(service, args.package, tracks)
-        next_version_code = compute_next_version_code(base_version_code, existing_track_codes)
+        minimum_floor = int(time.time())
+        next_version_code = compute_next_version_code(
+            base_version_code,
+            existing_track_codes,
+            minimum_floor=minimum_floor,
+        )
     except Exception as error:
         print(f"❌ Failed to compute Android release versionCode: {error}", file=sys.stderr)
         return 1
@@ -124,6 +134,7 @@ def main() -> int:
             "package": args.package,
             "gradle_file": str(gradle_file),
             "base_version_code": base_version_code,
+            "minimum_floor": minimum_floor,
             "tracks": tracks,
             "existing_track_codes": existing_track_codes,
             "next_version_code": next_version_code,

--- a/scripts/tests/test_compute_android_release_version_code.py
+++ b/scripts/tests/test_compute_android_release_version_code.py
@@ -23,6 +23,13 @@ def test_read_gradle_version_code_extracts_integer(tmp_path: Path):
     assert calc._read_gradle_version_code(gradle_file) == 1774400000
 
 
+def test_read_gradle_version_code_returns_none_for_dynamic_expression(tmp_path: Path):
+    gradle_file = tmp_path / "build.gradle.kts"
+    gradle_file.write_text("versionCode = ciVersionCode ?: 11", encoding="utf-8")
+
+    assert calc._read_gradle_version_code(gradle_file) is None
+
+
 def test_extract_release_codes_skips_invalid_values():
     payload = {
         "releases": [
@@ -43,6 +50,7 @@ def test_compute_next_version_code_prefers_higher_play_code():
             "beta": [],
             "internal": [1774399999],
         },
+        minimum_floor=1773596673,
     )
 
     assert next_code == 1774400006
@@ -55,9 +63,23 @@ def test_compute_next_version_code_prefers_higher_gradle_code_when_tracks_lower(
             "production": [1773900000],
             "alpha": [1773899999],
         },
+        minimum_floor=1773596673,
     )
 
     assert next_code == 1774400001
+
+
+def test_compute_next_version_code_uses_time_floor_when_gradle_is_dynamic():
+    next_code = calc.compute_next_version_code(
+        None,
+        {
+            "production": [1773900000],
+            "alpha": [],
+        },
+        minimum_floor=1773901000,
+    )
+
+    assert next_code == 1773901001
 
 
 def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
@@ -116,7 +138,7 @@ def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
 
 def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     gradle_file = tmp_path / "build.gradle.kts"
-    gradle_file.write_text("versionCode = 1774400000", encoding="utf-8")
+    gradle_file.write_text("versionCode = ciVersionCode ?: 11", encoding="utf-8")
     service_account = tmp_path / "play.json"
     service_account.write_text("{}", encoding="utf-8")
     json_output = tmp_path / "result.json"
@@ -127,6 +149,7 @@ def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.Cap
         "_fetch_existing_track_codes",
         lambda _service, _package, _tracks: {"production": [1774400002], "beta": []},
     )
+    monkeypatch.setattr(calc.time, "time", lambda: 1774400002)
     monkeypatch.setattr(
         calc,
         "_parse_args",


### PR DESCRIPTION
## Summary
- let the Android release version-code helper tolerate dynamic Gradle definitions like `ciVersionCode ?: 11`
- compute the next release code from existing Play track codes plus a time floor
- extend calculator tests for dynamic Gradle input

## Verification
- `python3 -m pytest -q scripts/tests/test_compute_android_release_version_code.py scripts/tests/test_play_publish.py`
