### PR TITLE
feat: add optional InsForge runtime config

### DIFF
--- a/.ai/changelog/2026-03.md
+++ b/.ai/changelog/2026-03.md
@@ -1,0 +1,9 @@
+# 2026-03 Changelog
+
+## [2026-03-16] feat: add optional InsForge runtime config
+
+- **What**: Adds Android and iOS runtime configuration services, analytics runtime context, local experiment assignment, and tracked InsForge sample payload/manifests for remote defaults.
+- **Why**: Enables high-ROI remote defaults and experiment control without forcing a backend dependency or overriding persisted user settings.
+- **Impact**: Timer config loading now supports optional remote defaults, analytics events can carry runtime config metadata, and both mobile apps safely fall back to bundled behavior if InsForge is unavailable.
+- **Gotchas**: The live InsForge project still needs the `training_assets/runtime/mobile-runtime-config.json` object provisioned before the app can fetch remote config outside local fallback mode.
+- **Related**: `feat/insforge-remote-config`, `7198d74c`

--- a/insforge/README.md
+++ b/insforge/README.md
@@ -1,0 +1,44 @@
+# InsForge Runtime Config
+
+This project uses InsForge as an optional runtime-config backend.
+
+The app does not require InsForge to run. If the backend is unreachable, the
+mobile clients fall back to bundled defaults and no experiments are assigned.
+
+## Contract
+
+- Project URL: `https://9gz9qqaz.us-east.insforge.app`
+- Storage bucket: `training_assets`
+- Object path: `runtime/mobile-runtime-config.json`
+
+## Payload shape
+
+The mobile apps expect the storage object to contain JSON like:
+
+```json
+{
+  "configVersion": "2026-03-16",
+  "defaultTimerConfig": {
+    "minSeconds": 0,
+    "maxSeconds": 300,
+    "alarmDuration": 10,
+    "hiddenMode": false,
+    "repeatEnabled": false,
+    "soundType": "intense",
+    "volume": 0.5,
+    "vibrationEnabled": false
+  },
+  "experiments": [
+    {
+      "key": "paywall_copy",
+      "variants": [
+        { "key": "control", "rolloutPercent": 50 },
+        { "key": "drill_sergeant", "rolloutPercent": 50 }
+      ]
+    }
+  ]
+}
+```
+
+The app performs deterministic local assignment from the PostHog distinct ID, so
+the backend only needs to ship experiment definitions and default values.

--- a/insforge/insforge.toml
+++ b/insforge/insforge.toml
@@ -1,0 +1,7 @@
+[project]
+name = "random-tactical-timer"
+id = "133db63a-7067-4d39-8c12-2404a60b0aac"
+region = "us-east"
+
+[storage]
+buckets = ["training_assets"]

--- a/insforge/runtime/mobile-runtime-config.json
+++ b/insforge/runtime/mobile-runtime-config.json
@@ -1,0 +1,22 @@
+{
+  "configVersion": "2026-03-16",
+  "defaultTimerConfig": {
+    "minSeconds": 0,
+    "maxSeconds": 300,
+    "alarmDuration": 10,
+    "hiddenMode": false,
+    "repeatEnabled": false,
+    "soundType": "intense",
+    "volume": 0.5,
+    "vibrationEnabled": false
+  },
+  "experiments": [
+    {
+      "key": "paywall_copy",
+      "variants": [
+        { "key": "control", "rolloutPercent": 50 },
+        { "key": "drill_sergeant", "rolloutPercent": 50 }
+      ]
+    }
+  ]
+}

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -52,6 +52,8 @@ android {
 
         // PostHog Analytics - from gradle.properties or CI secret
         buildConfigField("String", "POSTHOG_API_KEY", "\"${System.getenv("POSTHOG_API_KEY") ?: project.findProperty("POSTHOG_API_KEY") ?: ""}\"")
+        buildConfigField("String", "INSFORGE_API_BASE_URL", "\"${System.getenv("INSFORGE_API_BASE_URL") ?: project.findProperty("INSFORGE_API_BASE_URL") ?: ""}\"")
+        buildConfigField("String", "INSFORGE_API_KEY", "\"${System.getenv("INSFORGE_API_KEY") ?: project.findProperty("INSFORGE_API_KEY") ?: ""}\"")
     }
 
     signingConfigs {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/RandomTimerApp.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/RandomTimerApp.kt
@@ -1,15 +1,21 @@
 package com.iganapolsky.randomtimer
 
 import android.app.Application
-import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
+import com.iganapolsky.randomtimer.runtime.RuntimeConfigurationService
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltAndroidApp
 class RandomTimerApp : Application() {
-
     @Inject lateinit var analyticsService: AnalyticsService
+
+    @Inject lateinit var runtimeConfigurationService: RuntimeConfigurationService
+
+    @Inject lateinit var appScope: CoroutineScope
 
     override fun onCreate() {
         super.onCreate()
@@ -21,5 +27,14 @@ class RandomTimerApp : Application() {
         }
 
         analyticsService.initialize(this)
+
+        appScope.launch {
+            runtimeConfigurationService.snapshot.collect { snapshot ->
+                analyticsService.updateRuntimeContext(snapshot.analyticsProperties())
+            }
+        }
+        appScope.launch {
+            runtimeConfigurationService.refresh(analyticsService.currentDistinctId())
+        }
     }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -19,6 +19,8 @@ class AnalyticsService
         private var initialized = false
         private var prefs: SharedPreferences? = null
         private var analyticsContextProperties: Map<String, Any> = emptyMap()
+        private var runtimeContextProperties: Map<String, Any> = emptyMap()
+        private var currentDistinctId: String? = null
 
         fun initialize(application: Application) {
             if (initialized) return
@@ -52,8 +54,9 @@ class AnalyticsService
                     AnalyticsProperties.RUNTIME_TARGET to if (isEmulator()) "emulator" else "device",
                 )
             initialized = true
+            currentDistinctId = getOrCreateDistinctId(application)
             identify(
-                userId = getOrCreateDistinctId(application),
+                userId = currentDistinctId.orEmpty(),
                 properties = analyticsContextProperties,
             )
             trackApplicationLifecycleEvents()
@@ -93,6 +96,14 @@ class AnalyticsService
         fun flush() {
             if (!initialized) return
             PostHog.flush()
+        }
+
+        fun currentDistinctId(): String? = currentDistinctId
+
+        fun updateRuntimeContext(properties: Map<String, Any>) {
+            runtimeContextProperties = properties
+            val distinctId = currentDistinctId ?: return
+            identify(distinctId)
         }
 
         // --- UTM Attribution ---
@@ -190,9 +201,9 @@ class AnalyticsService
 
         private fun mergeProperties(properties: Map<String, Any>?): Map<String, Any> =
             if (properties.isNullOrEmpty()) {
-                analyticsContextProperties
+                analyticsContextProperties + runtimeContextProperties
             } else {
-                analyticsContextProperties + properties
+                properties + analyticsContextProperties + runtimeContextProperties
             }
 
         private fun buildAudience(): String {
@@ -287,6 +298,8 @@ object AnalyticsProperties {
     const val BUILD_AUDIENCE = "build_audience"
     const val BUILD_TYPE = "build_type"
     const val RUNTIME_TARGET = "runtime_target"
+    const val RUNTIME_CONFIG_SOURCE = "runtime_config_source"
+    const val RUNTIME_CONFIG_VERSION = "runtime_config_version"
 }
 
 object AnalyticsScreens {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
@@ -15,8 +15,9 @@ import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
+import com.iganapolsky.randomtimer.runtime.RuntimeConfigurationService
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.milliseconds
@@ -27,6 +28,7 @@ class TimerRepositoryImpl
     constructor(
         private val dataStore: DataStore<Preferences>,
         private val proManager: ProManager,
+        private val runtimeConfigurationService: RuntimeConfigurationService,
     ) : TimerRepository {
         /**
          * Clamps a deserialized config to the current Pro entitlement.
@@ -48,24 +50,8 @@ class TimerRepositoryImpl
         }
 
         override fun getTimerConfig(): Flow<TimerConfig> =
-            dataStore.data.map { preferences ->
-                TimerConfig(
-                    minSeconds = preferences[KEY_MIN_SECONDS] ?: 0,
-                    maxSeconds = preferences[KEY_MAX_SECONDS] ?: 30,
-                    alarmDuration = preferences[KEY_ALARM_DURATION] ?: 10,
-                    hiddenMode = preferences[KEY_HIDDEN_MODE] ?: false,
-                    repeatEnabled = preferences[KEY_REPEAT_ENABLED] ?: false,
-                    soundType =
-                        preferences[KEY_SOUND_TYPE]?.let {
-                            try {
-                                SoundType.valueOf(it)
-                            } catch (_: Exception) {
-                                SoundType.INTENSE
-                            }
-                        } ?: SoundType.INTENSE,
-                    volume = preferences[KEY_VOLUME] ?: 0.5f,
-                    vibrationEnabled = preferences[KEY_VIBRATION_ENABLED] ?: false,
-                ).clampedForPro()
+            combine(dataStore.data, runtimeConfigurationService.snapshot) { preferences, snapshot ->
+                (readStoredConfig(preferences) ?: snapshot.defaultConfig).clampedForPro()
             }
 
         override suspend fun saveTimerConfig(config: TimerConfig) {
@@ -81,31 +67,14 @@ class TimerRepositoryImpl
             }
         }
 
-        override fun getActiveTimer(): Flow<TimerState?> {
-            return dataStore.data.map { preferences ->
-                val targetMs = preferences[KEY_ACTIVE_TARGET] ?: return@map null
-                val remainingMs = preferences[KEY_ACTIVE_REMAINING] ?: return@map null
-                val statusStr = preferences[KEY_ACTIVE_STATUS] ?: return@map null
-                val startedAt = preferences[KEY_ACTIVE_STARTED_AT] ?: return@map null
+        override fun getActiveTimer(): Flow<TimerState?> =
+            combine(dataStore.data, runtimeConfigurationService.snapshot) { preferences, snapshot ->
+                val targetMs = preferences[KEY_ACTIVE_TARGET] ?: return@combine null
+                val remainingMs = preferences[KEY_ACTIVE_REMAINING] ?: return@combine null
+                val statusStr = preferences[KEY_ACTIVE_STATUS] ?: return@combine null
+                val startedAt = preferences[KEY_ACTIVE_STARTED_AT] ?: return@combine null
 
-                val config =
-                    TimerConfig(
-                        minSeconds = preferences[KEY_MIN_SECONDS] ?: 0,
-                        maxSeconds = preferences[KEY_MAX_SECONDS] ?: 30,
-                        alarmDuration = preferences[KEY_ALARM_DURATION] ?: 10,
-                        hiddenMode = preferences[KEY_HIDDEN_MODE] ?: false,
-                        repeatEnabled = preferences[KEY_REPEAT_ENABLED] ?: false,
-                        soundType =
-                            preferences[KEY_SOUND_TYPE]?.let {
-                                try {
-                                    SoundType.valueOf(it)
-                                } catch (_: Exception) {
-                                    SoundType.INTENSE
-                                }
-                            } ?: SoundType.INTENSE,
-                        volume = preferences[KEY_VOLUME] ?: 0.5f,
-                        vibrationEnabled = preferences[KEY_VIBRATION_ENABLED] ?: false,
-                    ).clampedForPro()
+                val config = (readStoredConfig(preferences) ?: snapshot.defaultConfig).clampedForPro()
 
                 TimerState(
                     config = config,
@@ -115,7 +84,6 @@ class TimerRepositoryImpl
                     startedAt = startedAt,
                 )
             }
-        }
 
         override suspend fun saveActiveTimer(state: TimerState) {
             dataStore.edit { preferences ->
@@ -151,5 +119,32 @@ class TimerRepositoryImpl
             private val KEY_ACTIVE_REMAINING = longPreferencesKey("active_remaining_ms")
             private val KEY_ACTIVE_STATUS = stringPreferencesKey("active_status")
             private val KEY_ACTIVE_STARTED_AT = longPreferencesKey("active_started_at")
+        }
+
+        private fun readStoredConfig(preferences: Preferences): TimerConfig? {
+            val hasStoredConfig =
+                preferences[KEY_MIN_SECONDS] != null ||
+                    preferences[KEY_MAX_SECONDS] != null ||
+                    preferences[KEY_ALARM_DURATION] != null ||
+                    preferences[KEY_HIDDEN_MODE] != null ||
+                    preferences[KEY_REPEAT_ENABLED] != null ||
+                    preferences[KEY_SOUND_TYPE] != null ||
+                    preferences[KEY_VOLUME] != null ||
+                    preferences[KEY_VIBRATION_ENABLED] != null
+            if (!hasStoredConfig) return null
+
+            return TimerConfig(
+                minSeconds = preferences[KEY_MIN_SECONDS] ?: TimerConfig.DEFAULT.minSeconds,
+                maxSeconds = preferences[KEY_MAX_SECONDS] ?: TimerConfig.DEFAULT.maxSeconds,
+                alarmDuration = preferences[KEY_ALARM_DURATION] ?: TimerConfig.DEFAULT.alarmDuration,
+                hiddenMode = preferences[KEY_HIDDEN_MODE] ?: TimerConfig.DEFAULT.hiddenMode,
+                repeatEnabled = preferences[KEY_REPEAT_ENABLED] ?: TimerConfig.DEFAULT.repeatEnabled,
+                soundType =
+                    preferences[KEY_SOUND_TYPE]?.let {
+                        runCatching { SoundType.valueOf(it) }.getOrDefault(TimerConfig.DEFAULT.soundType)
+                    } ?: TimerConfig.DEFAULT.soundType,
+                volume = preferences[KEY_VOLUME] ?: TimerConfig.DEFAULT.volume,
+                vibrationEnabled = preferences[KEY_VIBRATION_ENABLED] ?: TimerConfig.DEFAULT.vibrationEnabled,
+            )
         }
     }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/runtime/RuntimeConfigurationService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/runtime/RuntimeConfigurationService.kt
@@ -1,0 +1,206 @@
+package com.iganapolsky.randomtimer.runtime
+
+import com.iganapolsky.randomtimer.BuildConfig
+import com.iganapolsky.randomtimer.domain.model.SoundType
+import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.absoluteValue
+
+data class RuntimeConfigurationSnapshot(
+    val defaultConfig: TimerConfig = TimerConfig.DEFAULT,
+    val configSource: String = "bundled",
+    val configVersion: String = "bundled",
+    val experiments: Map<String, String> = emptyMap(),
+) {
+    fun analyticsProperties(): Map<String, Any> =
+        buildMap {
+            put("runtime_config_source", configSource)
+            put("runtime_config_version", configVersion)
+            experiments.forEach { (key, value) ->
+                put("experiment_$key", value)
+            }
+        }
+}
+
+data class RuntimeConfigurationPayload(
+    val configVersion: String,
+    val defaultTimerConfig: TimerConfig,
+    val experiments: List<RuntimeExperimentDefinition>,
+) {
+    fun toSnapshot(distinctId: String): RuntimeConfigurationSnapshot =
+        RuntimeConfigurationSnapshot(
+            defaultConfig = defaultTimerConfig,
+            configSource = "insforge_storage",
+            configVersion = configVersion,
+            experiments = RuntimeExperimentAssigner.assign(distinctId, experiments),
+        )
+}
+
+data class RuntimeExperimentDefinition(
+    val key: String,
+    val variants: List<RuntimeExperimentVariant>,
+)
+
+data class RuntimeExperimentVariant(
+    val key: String,
+    val rolloutPercent: Int,
+)
+
+internal object RuntimeExperimentAssigner {
+    fun assign(
+        distinctId: String,
+        experiments: List<RuntimeExperimentDefinition>,
+    ): Map<String, String> =
+        experiments
+            .mapNotNull { definition ->
+                chooseVariant(distinctId, definition)?.let { definition.key to it }
+            }.toMap()
+
+    private fun chooseVariant(
+        distinctId: String,
+        definition: RuntimeExperimentDefinition,
+    ): String? {
+        if (definition.variants.isEmpty()) return null
+
+        val bucket = bucketFor("${definition.key}:$distinctId")
+        var cumulative = 0
+        definition.variants.forEach { variant ->
+            val rollout = variant.rolloutPercent.coerceIn(0, 100)
+            cumulative += rollout
+            if (bucket < cumulative) {
+                return variant.key
+            }
+        }
+        return null
+    }
+
+    private fun bucketFor(seed: String): Int {
+        val digest = MessageDigest.getInstance("SHA-256").digest(seed.toByteArray())
+        val raw =
+            digest.take(8).fold(0L) { acc, byte ->
+                (acc shl 8) or (byte.toLong() and 0xff)
+            }
+        return (raw.absoluteValue % 100).toInt()
+    }
+}
+
+@Singleton
+class RuntimeConfigurationService
+    @Inject
+    constructor() {
+        private val _snapshot = MutableStateFlow(RuntimeConfigurationSnapshot())
+        val snapshot: StateFlow<RuntimeConfigurationSnapshot> = _snapshot.asStateFlow()
+
+        suspend fun refresh(distinctId: String?) {
+            val baseUrl = BuildConfig.INSFORGE_API_BASE_URL.trim().removeSuffix("/")
+            val apiKey = BuildConfig.INSFORGE_API_KEY.trim()
+            if (distinctId.isNullOrBlank() || baseUrl.isBlank() || apiKey.isBlank()) {
+                return
+            }
+
+            val payload =
+                runCatching {
+                    fetchPayload(
+                        objectUrl = "$baseUrl/api/storage/buckets/training_assets/objects/runtime/mobile-runtime-config.json",
+                        apiKey = apiKey,
+                    )
+                }.getOrNull() ?: return
+
+            _snapshot.value = payload.toSnapshot(distinctId)
+        }
+
+        internal fun applyPayloadForTesting(
+            payload: RuntimeConfigurationPayload,
+            distinctId: String,
+        ) {
+            _snapshot.value = payload.toSnapshot(distinctId)
+        }
+
+        private suspend fun fetchPayload(
+            objectUrl: String,
+            apiKey: String,
+        ): RuntimeConfigurationPayload =
+            withContext(Dispatchers.IO) {
+                val connection =
+                    (URL(objectUrl).openConnection() as HttpURLConnection).apply {
+                        requestMethod = "GET"
+                        setRequestProperty("x-api-key", apiKey)
+                        setRequestProperty("accept", "application/json")
+                        connectTimeout = 5000
+                        readTimeout = 5000
+                        instanceFollowRedirects = true
+                    }
+                try {
+                    val code = connection.responseCode
+                    require(code in 200..299) { "Runtime config fetch failed with HTTP $code" }
+                    val body = connection.inputStream.bufferedReader().use { it.readText() }
+                    parsePayload(body)
+                } finally {
+                    connection.disconnect()
+                }
+            }
+
+        companion object {
+            internal fun parsePayload(json: String): RuntimeConfigurationPayload {
+                val root = JSONObject(json)
+                val configVersion = root.optString("configVersion").ifBlank { "unknown" }
+                val timer = root.optJSONObject("defaultTimerConfig") ?: JSONObject()
+                val experiments = root.optJSONArray("experiments") ?: JSONArray()
+
+                return RuntimeConfigurationPayload(
+                    configVersion = configVersion,
+                    defaultTimerConfig =
+                        TimerConfig(
+                            minSeconds = timer.optInt("minSeconds", TimerConfig.DEFAULT.minSeconds),
+                            maxSeconds = timer.optInt("maxSeconds", TimerConfig.DEFAULT.maxSeconds),
+                            alarmDuration = timer.optInt("alarmDuration", TimerConfig.DEFAULT.alarmDuration),
+                            hiddenMode = timer.optBoolean("hiddenMode", TimerConfig.DEFAULT.hiddenMode),
+                            repeatEnabled = timer.optBoolean("repeatEnabled", TimerConfig.DEFAULT.repeatEnabled),
+                            soundType = parseSoundType(timer.optString("soundType")),
+                            volume = timer.optDouble("volume", TimerConfig.DEFAULT.volume.toDouble()).toFloat(),
+                            vibrationEnabled = timer.optBoolean("vibrationEnabled", TimerConfig.DEFAULT.vibrationEnabled),
+                        ),
+                    experiments =
+                        buildList {
+                            for (index in 0 until experiments.length()) {
+                                val experiment = experiments.optJSONObject(index) ?: continue
+                                val key = experiment.optString("key")
+                                if (key.isBlank()) continue
+                                val variantsJson = experiment.optJSONArray("variants") ?: JSONArray()
+                                val variants =
+                                    buildList {
+                                        for (variantIndex in 0 until variantsJson.length()) {
+                                            val variant = variantsJson.optJSONObject(variantIndex) ?: continue
+                                            val variantKey = variant.optString("key")
+                                            if (variantKey.isBlank()) continue
+                                            add(
+                                                RuntimeExperimentVariant(
+                                                    key = variantKey,
+                                                    rolloutPercent = variant.optInt("rolloutPercent", 0),
+                                                ),
+                                            )
+                                        }
+                                    }
+                                add(RuntimeExperimentDefinition(key = key, variants = variants))
+                            }
+                        },
+                )
+            }
+
+            private fun parseSoundType(raw: String?): SoundType =
+                runCatching {
+                    SoundType.valueOf(raw.orEmpty().trim().uppercase())
+                }.getOrDefault(TimerConfig.DEFAULT.soundType)
+        }
+    }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplTest.kt
@@ -8,6 +8,8 @@ import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
+import com.iganapolsky.randomtimer.runtime.RuntimeConfigurationPayload
+import com.iganapolsky.randomtimer.runtime.RuntimeConfigurationService
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -50,6 +52,55 @@ class TimerRepositoryImplTest {
         }
 
     @Test
+    fun getTimerConfig_uses_runtime_defaults_when_preferences_are_empty() =
+        runTest {
+            val runtimeConfigurationService = RuntimeConfigurationService()
+            runtimeConfigurationService.applyPayloadForTesting(
+                payload =
+                    RuntimeConfigurationPayload(
+                        configVersion = "2026-03-16",
+                        defaultTimerConfig =
+                            TimerConfig.DEFAULT.copy(
+                                minSeconds = 0,
+                                maxSeconds = 300,
+                                alarmDuration = 15,
+                            ),
+                        experiments = emptyList(),
+                    ),
+                distinctId = "device-1",
+            )
+
+            val repo = createRepository(this, runtimeConfigurationService = runtimeConfigurationService)
+            val config = repo.getTimerConfig().first()
+
+            assertThat(config.minSeconds).isEqualTo(0)
+            assertThat(config.maxSeconds).isEqualTo(300)
+            assertThat(config.alarmDuration).isEqualTo(15)
+        }
+
+    @Test
+    fun getTimerConfig_prefers_saved_config_over_runtime_defaults() =
+        runTest {
+            val runtimeConfigurationService = RuntimeConfigurationService()
+            runtimeConfigurationService.applyPayloadForTesting(
+                payload =
+                    RuntimeConfigurationPayload(
+                        configVersion = "2026-03-16",
+                        defaultTimerConfig = TimerConfig.DEFAULT.copy(maxSeconds = 300),
+                        experiments = emptyList(),
+                    ),
+                distinctId = "device-1",
+            )
+
+            val repo = createRepository(this, runtimeConfigurationService = runtimeConfigurationService)
+            val savedConfig = TimerConfig.DEFAULT.copy(minSeconds = 12, maxSeconds = 42)
+            repo.saveTimerConfig(savedConfig)
+
+            val config = repo.getTimerConfig().first()
+            assertThat(config).isEqualTo(savedConfig)
+        }
+
+    @Test
     fun getActiveTimer_returns_null_when_active_timer_is_not_stored() =
         runTest {
             val repo = createRepository(this)
@@ -75,7 +126,10 @@ class TimerRepositoryImplTest {
             assertThat(restored).isEqualTo(state)
         }
 
-    private fun createRepository(testScope: TestScope): TimerRepositoryImpl {
+    private fun createRepository(
+        testScope: TestScope,
+        runtimeConfigurationService: RuntimeConfigurationService = RuntimeConfigurationService(),
+    ): TimerRepositoryImpl {
         val dataStore =
             PreferenceDataStoreFactory.create(
                 scope = testScope.backgroundScope,
@@ -99,6 +153,6 @@ class TimerRepositoryImplTest {
             if (level.isPro) SoundType.entries.toList() else SoundType.FREE
         }
 
-        return TimerRepositoryImpl(dataStore, proManager)
+        return TimerRepositoryImpl(dataStore, proManager, runtimeConfigurationService)
     }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/runtime/RuntimeConfigurationServiceTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/runtime/RuntimeConfigurationServiceTest.kt
@@ -1,0 +1,65 @@
+package com.iganapolsky.randomtimer.runtime
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RuntimeConfigurationServiceTest {
+    @Test
+    fun parsePayload_reads_default_config_and_experiments() {
+        val payload =
+            RuntimeConfigurationService.parsePayload(
+                """
+                {
+                  "configVersion": "2026-03-16",
+                  "defaultTimerConfig": {
+                    "minSeconds": 0,
+                    "maxSeconds": 300,
+                    "alarmDuration": 15,
+                    "hiddenMode": false,
+                    "repeatEnabled": false,
+                    "soundType": "gentle",
+                    "volume": 0.7,
+                    "vibrationEnabled": true
+                  },
+                  "experiments": [
+                    {
+                      "key": "paywall_copy",
+                      "variants": [
+                        {"key": "control", "rolloutPercent": 50},
+                        {"key": "drill_sergeant", "rolloutPercent": 50}
+                      ]
+                    }
+                  ]
+                }
+                """.trimIndent(),
+            )
+
+        assertThat(payload.configVersion).isEqualTo("2026-03-16")
+        assertThat(payload.defaultTimerConfig.maxSeconds).isEqualTo(300)
+        assertThat(payload.defaultTimerConfig.alarmDuration).isEqualTo(15)
+        assertThat(payload.defaultTimerConfig.vibrationEnabled).isTrue()
+        assertThat(payload.experiments).hasSize(1)
+        assertThat(payload.experiments.single().variants).hasSize(2)
+    }
+
+    @Test
+    fun experimentAssignment_is_deterministic_for_same_device() {
+        val experiments =
+            listOf(
+                RuntimeExperimentDefinition(
+                    key = "paywall_copy",
+                    variants =
+                        listOf(
+                            RuntimeExperimentVariant("control", 50),
+                            RuntimeExperimentVariant("drill_sergeant", 50),
+                        ),
+                ),
+            )
+
+        val first = RuntimeExperimentAssigner.assign("device-123", experiments)
+        val second = RuntimeExperimentAssigner.assign("device-123", experiments)
+
+        assertThat(first).isEqualTo(second)
+        assertThat(first["paywall_copy"]).isNotNull()
+    }
+}

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		840C3EEAD4E35D7D202C1C68 /* TimerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B55AFED96FE157EA7D0BF85 /* TimerModelsTests.swift */; };
 		A1C100112233445566778899 /* Audio in Resources */ = {isa = PBXBuildFile; fileRef = A1C1001122334455667788BB /* Audio */; };
 		A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */; };
+		E7F0A1112233445566778899 /* RuntimeConfigurationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F0A1112233445566778898 /* RuntimeConfigurationService.swift */; };
 		PRVT001122334455AABB0002 /* ProValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRVT001122334455AABB0001 /* ProValidationTests.swift */; };
 		85ABA1B34E3D14E790434638 /* ProManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A3DD46F85A68522E1B0902 /* ProManager.swift */; };
 		AIVC00112233445566778899 /* AIVoiceCalloutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AIVC00112233445566778800 /* AIVoiceCalloutService.swift */; };
@@ -139,6 +140,7 @@
 		CCFBE5D59081407DA7F38ED6 /* RandomTimerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomTimerUITests.swift; sourceTree = "<group>"; };
 		CE62A2F6E881E0CCA7DF2361 /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		D4045FE32D7D1E2F9D4C423C /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
+		E7F0A1112233445566778898 /* RuntimeConfigurationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeConfigurationService.swift; sourceTree = "<group>"; };
 		ECD7E2987345EA2F0A52A882 /* SharedTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTypes.swift; sourceTree = "<group>"; };
 		F29061814BF691DA7F9CD649 /* airhorn.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = airhorn.mp3; sourceTree = "<group>"; };
 		F5F3E399050BD30295736FEA /* drum_roll.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = drum_roll.mp3; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				A1B2C3D400000002DEADBEEF /* Logger.swift */,
 				3BE6975376BF7C7C6B14F8BF /* NotificationService.swift */,
 				8EEB9F4FF4ED4C88A5232642 /* LiveActivityService.swift */,
+				E7F0A1112233445566778898 /* RuntimeConfigurationService.swift */,
 				D4045FE32D7D1E2F9D4C423C /* StorageService.swift */,
 				CE62A2F6E881E0CCA7DF2361 /* TimerManager.swift */,
 				4EB219B60074D5E0130A3D15 /* ServiceProtocols.swift */,
@@ -517,6 +520,7 @@
 				E479E3D609A46B2F93C1BD2C /* RangeSliderView.swift in Sources */,
 				A1B2C3D400000004SHARE01 /* ShareSheet.swift in Sources */,
 				D8BFD3BC04A1001EE7329508 /* StorageService.swift in Sources */,
+				E7F0A1112233445566778899 /* RuntimeConfigurationService.swift in Sources */,
 				1EF5792885AFE606EACC05F9 /* TimerManager.swift in Sources */,
 				17E69C010FAA04EFC0076358 /* TimerModels.swift in Sources */,
 				4C7AAC0D5B84BD7DFA0ACEAB /* TimerSetupScreen.swift in Sources */,
@@ -606,6 +610,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.2.2;
+				INSFORGE_API_BASE_URL = "$(INSFORGE_API_BASE_URL)";
+				INSFORGE_API_KEY = "$(INSFORGE_API_KEY)";
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -716,6 +722,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.2.2;
+				INSFORGE_API_BASE_URL = "$(INSFORGE_API_BASE_URL)";
+				INSFORGE_API_KEY = "$(INSFORGE_API_KEY)";
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;

--- a/native-ios/RandomTimer/Info.plist
+++ b/native-ios/RandomTimer/Info.plist
@@ -28,6 +28,10 @@
 	<true/>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>INSFORGE_API_BASE_URL</key>
+	<string>$(INSFORGE_API_BASE_URL)</string>
+	<key>INSFORGE_API_KEY</key>
+	<string>$(INSFORGE_API_KEY)</string>
 	<key>POSTHOG_API_KEY</key>
 	<string>$(POSTHOG_API_KEY)</string>
 	<key>UIApplicationSceneManifest</key>

--- a/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
+++ b/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct RandomTimerApp: App {
     @StateObject private var timerManager = TimerManager()
+    @State private var runtimeConfigurationService = RuntimeConfigurationService()
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
@@ -11,12 +12,18 @@ struct RandomTimerApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(timerManager: timerManager)
                 .environmentObject(timerManager)
                 .environmentObject(ProManager.shared)
                 .preferredColorScheme(.dark)
                 .onOpenURL { url in
                     AnalyticsService.shared.trackDeepLink(url)
+                }
+                .task {
+                    AnalyticsService.shared.updateRuntimeContext(runtimeConfigurationService.snapshot.analyticsProperties)
+                    await runtimeConfigurationService.refreshIfNeeded(distinctId: AnalyticsService.shared.currentDistinctId())
+                    AnalyticsService.shared.updateRuntimeContext(runtimeConfigurationService.snapshot.analyticsProperties)
+                    await timerManager.applyRemoteDefaultsIfNeeded(runtimeConfigurationService.snapshot.defaultConfig)
                 }
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -39,7 +46,7 @@ struct ContentView: View {
         case activeTimer
     }
 
-    @EnvironmentObject var timerManager: TimerManager
+    @ObservedObject var timerManager: TimerManager
     @State private var didApplyUITestSeed: Bool = false
     @State private var navigationPath: [Route] = []
     @State private var hadActiveTimer = false
@@ -64,7 +71,7 @@ struct ContentView: View {
             Task {
                 // Short delay to ensure environment is fully ready
                 try? await Task.sleep(for: .seconds(0.5))
-                
+
                 let args = ProcessInfo.processInfo.arguments
                 guard let index = args.firstIndex(of: "-ui-test-state"),
                       args.indices.contains(index + 1) else { return }
@@ -151,7 +158,7 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+    ContentView(timerManager: TimerManager())
         .environmentObject(TimerManager())
         .environmentObject(ProManager.shared)
 }

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -22,6 +22,8 @@ final class AnalyticsService {
     private let hasTrackedApplicationInstalledKey = "has_tracked_application_installed"
     private let utmKeys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]
     private let appleAdsAttributionFetchedKey = "apple_ads_attribution_fetched"
+    private var runtimeContextProperties: [String: Any] = [:]
+    private var currentDistinctIdValue: String?
 
     // API key loaded from Info.plist (set POSTHOG_API_KEY in build settings)
     private var apiKey: String {
@@ -82,8 +84,16 @@ final class AnalyticsService {
     }
 
     private func mergedProperties(_ properties: [String: Any]?) -> [String: Any] {
-        guard var props = properties else { return analyticsContextProperties }
+        guard var props = properties else {
+            return analyticsContextProperties.merging(
+                runtimeContextProperties,
+                uniquingKeysWith: { _, latest in latest }
+            )
+        }
         for (key, value) in analyticsContextProperties {
+            props[key] = value
+        }
+        for (key, value) in runtimeContextProperties {
             props[key] = value
         }
         return props
@@ -105,6 +115,7 @@ final class AnalyticsService {
 #endif
         initialized = true
         let distinctId = getOrCreateDistinctId()
+        currentDistinctIdValue = distinctId
         identify(userId: distinctId, properties: analyticsContextProperties)
         trackApplicationLifecycleEvents()
         logger.info("PostHog initialized")
@@ -150,6 +161,16 @@ final class AnalyticsService {
 #if canImport(PostHog)
         PostHogSDK.shared.flush()
 #endif
+    }
+
+    func currentDistinctId() -> String? {
+        currentDistinctIdValue
+    }
+
+    func updateRuntimeContext(_ properties: [String: Any]) {
+        runtimeContextProperties = properties
+        guard let distinctId = currentDistinctIdValue else { return }
+        identify(userId: distinctId)
     }
 
     // MARK: - UTM Attribution
@@ -205,12 +226,15 @@ final class AnalyticsService {
                 return
             }
 
-            var request = URLRequest(url: URL(string: "https://api-adservices.apple.com/api/v1/")!)
+            guard let attributionURL = URL(string: "https://api-adservices.apple.com/api/v1/") else {
+                return
+            }
+            var request = URLRequest(url: attributionURL)
             request.httpMethod = "POST"
             request.setValue("text/plain", forHTTPHeaderField: "Content-Type")
             request.httpBody = Data(token.utf8)
 
-            URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
                 guard let data = data, error == nil else {
                     self?.logger.error("Apple Ads attribution request failed: \(error?.localizedDescription ?? "unknown")")
                     return
@@ -369,6 +393,8 @@ enum AnalyticsProperties {
     static let buildAudience = "build_audience"
     static let buildType = "build_type"
     static let runtimeTarget = "runtime_target"
+    static let runtimeConfigSource = "runtime_config_source"
+    static let runtimeConfigVersion = "runtime_config_version"
 }
 
 enum AnalyticsValues {

--- a/native-ios/RandomTimer/Sources/Services/RuntimeConfigurationService.swift
+++ b/native-ios/RandomTimer/Sources/Services/RuntimeConfigurationService.swift
@@ -1,0 +1,158 @@
+import CryptoKit
+import Foundation
+
+struct RuntimeConfigurationSnapshot: Equatable {
+    let defaultConfig: TimerConfig
+    let configSource: String
+    let configVersion: String
+    let experiments: [String: String]
+
+    static let bundled = RuntimeConfigurationSnapshot(
+        defaultConfig: .default,
+        configSource: "bundled",
+        configVersion: "bundled",
+        experiments: [:]
+    )
+
+    var analyticsProperties: [String: Any] {
+        var properties: [String: Any] = [
+            AnalyticsProperties.runtimeConfigSource: configSource,
+            AnalyticsProperties.runtimeConfigVersion: configVersion,
+        ]
+        experiments.forEach { key, value in
+            properties["experiment_\(key)"] = value
+        }
+        return properties
+    }
+}
+
+struct RuntimeConfigurationPayload: Decodable, Equatable {
+    let configVersion: String
+    let defaultTimerConfig: TimerConfig
+    let experiments: [RuntimeExperimentDefinition]
+
+    func toSnapshot(distinctId: String) -> RuntimeConfigurationSnapshot {
+        RuntimeConfigurationSnapshot(
+            defaultConfig: defaultTimerConfig,
+            configSource: "insforge_storage",
+            configVersion: configVersion,
+            experiments: RuntimeExperimentAssigner.assign(distinctId: distinctId, experiments: experiments)
+        )
+    }
+}
+
+struct RuntimeExperimentDefinition: Decodable, Equatable {
+    let key: String
+    let variants: [RuntimeExperimentVariant]
+}
+
+struct RuntimeExperimentVariant: Decodable, Equatable {
+    let key: String
+    let rolloutPercent: Int
+}
+
+enum RuntimeExperimentAssigner {
+    static func assign(
+        distinctId: String,
+        experiments: [RuntimeExperimentDefinition]
+    ) -> [String: String] {
+        Dictionary(
+            uniqueKeysWithValues: experiments.compactMap { definition in
+                guard let variant = chooseVariant(distinctId: distinctId, definition: definition) else {
+                    return nil
+                }
+                return (definition.key, variant)
+            }
+        )
+    }
+
+    private static func chooseVariant(
+        distinctId: String,
+        definition: RuntimeExperimentDefinition
+    ) -> String? {
+        guard definition.variants.isEmpty == false else { return nil }
+
+        let bucket = bucketFor(seed: "\(definition.key):\(distinctId)")
+        var cumulative = 0
+        for variant in definition.variants {
+            cumulative += max(0, min(100, variant.rolloutPercent))
+            if bucket < cumulative {
+                return variant.key
+            }
+        }
+        return nil
+    }
+
+    private static func bucketFor(seed: String) -> Int {
+        let digest = SHA256.hash(data: Data(seed.utf8))
+        let value = digest.prefix(8).reduce(UInt64(0)) { partial, byte in
+            (partial << 8) | UInt64(byte)
+        }
+        return Int(value % 100)
+    }
+}
+
+@MainActor
+final class RuntimeConfigurationService {
+    private(set) var snapshot: RuntimeConfigurationSnapshot = .bundled
+
+    private let session: URLSession
+    private var didRefresh = false
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func refreshIfNeeded(distinctId: String?) async {
+        guard didRefresh == false else { return }
+        didRefresh = true
+        guard
+            let distinctId,
+            distinctId.isEmpty == false,
+            let objectURL,
+            apiKey.isEmpty == false
+        else {
+            return
+        }
+
+        do {
+            let payload = try await fetchPayload(from: objectURL, apiKey: apiKey)
+            snapshot = payload.toSnapshot(distinctId: distinctId)
+        } catch {
+            // Optional runtime config. Fall back silently to bundled defaults.
+        }
+    }
+
+    func applyPayloadForTesting(_ payload: RuntimeConfigurationPayload, distinctId: String) {
+        snapshot = payload.toSnapshot(distinctId: distinctId)
+    }
+
+    private var objectURL: URL? {
+        guard
+            let raw = Bundle.main.object(forInfoDictionaryKey: "INSFORGE_API_BASE_URL") as? String,
+            raw.isEmpty == false
+        else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return URL(string: "\(trimmed)/api/storage/buckets/training_assets/objects/runtime/mobile-runtime-config.json")
+    }
+
+    private var apiKey: String {
+        Bundle.main.object(forInfoDictionaryKey: "INSFORGE_API_KEY") as? String ?? ""
+    }
+
+    private func fetchPayload(from objectURL: URL, apiKey: String) async throws -> RuntimeConfigurationPayload {
+        var request = URLRequest(url: objectURL)
+        request.httpMethod = "GET"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 5
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(RuntimeConfigurationPayload.self, from: data)
+    }
+}

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -18,6 +18,8 @@ final class TimerManager: ObservableObject {
     nonisolated private let storageService: TimerStorage
     private let notificationService: TimerNotificationHandling
     private let liveActivityService: TimerLiveActivityHandling
+    private let loadedConfigFromStorageAtLaunch: Bool
+    private var userModifiedConfigSinceLaunch = false
 
     // MARK: - Initialization
 
@@ -32,7 +34,9 @@ final class TimerManager: ObservableObject {
 
         // Load config synchronously from storage to avoid UI flicker.
         // Clamp to current Pro entitlement so expired Pro users don't retain Pro-only values.
-        let rawConfig = storageService.loadConfigSync() ?? .default
+        let storedConfig = storageService.loadConfigSync()
+        self.loadedConfigFromStorageAtLaunch = storedConfig != nil
+        let rawConfig = storedConfig ?? .default
         self.config = rawConfig.clamped(isPro: ProManager.shared.isPro)
 
         // Wire Bluetooth/CarPlay media button and notification action callbacks.
@@ -83,6 +87,7 @@ final class TimerManager: ObservableObject {
     // MARK: - Public Methods
 
     func updateConfig(_ newConfig: TimerConfig) {
+        userModifiedConfigSinceLaunch = true
         config = newConfig
 
         // Sync config into running timer state so alarmTick sees the change
@@ -101,6 +106,18 @@ final class TimerManager: ObservableObject {
         Task {
             await storageService.saveConfig(newConfig)
         }
+    }
+
+    func applyRemoteDefaultsIfNeeded(_ newConfig: TimerConfig) async {
+        guard loadedConfigFromStorageAtLaunch == false else { return }
+        guard userModifiedConfigSinceLaunch == false else { return }
+        guard timerState == nil else { return }
+
+        let clamped = newConfig.clamped(isPro: ProManager.shared.isPro)
+        guard config != clamped else { return }
+
+        config = clamped
+        await storageService.saveConfig(clamped)
     }
 
     func startTimer() async {

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -15,7 +15,7 @@ final class TimerConfigTests: XCTestCase {
     func testConfigInitEnforcesPreconditions() {
         // minSeconds cannot be negative
         // XCTest expect crash is hard, so we just check it doesn't throw if we use valid values
-        let _ = TimerConfig(minSeconds: 0, maxSeconds: 10)
+        _ = TimerConfig(minSeconds: 0, maxSeconds: 10)
     }
 
     func testConfigClampingForFreeUser() {
@@ -37,7 +37,7 @@ final class TimerConfigTests: XCTestCase {
     }
 
     func testConfigDecodingSupportsLegacyKeysAndLooseSoundNames() throws {
-        let payload = """
+        let payload = Data("""
         {
           "min_time": -5,
           "max_time": 9000,
@@ -48,7 +48,7 @@ final class TimerConfigTests: XCTestCase {
           "soundVolume": "1.5",
           "vibration": "yes"
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(TimerConfig.self, from: payload)
 
@@ -262,13 +262,19 @@ final class TimerManagerSilenceTests: XCTestCase {
 
 // MARK: - Mocks
 
-final class MockStorageService: TimerStorage {
-    func saveConfig(_ config: TimerConfig) async {}
-    func loadConfig() async -> TimerConfig? { return nil }
+final class MockStorageService: @unchecked Sendable, TimerStorage {
+    var storedConfig: TimerConfig?
+
+    init(initialConfig: TimerConfig? = nil) {
+        self.storedConfig = initialConfig
+    }
+
+    func saveConfig(_ config: TimerConfig) async { storedConfig = config }
+    func loadConfig() async -> TimerConfig? { return storedConfig }
     func saveTimerState(_ state: TimerState) async {}
     func loadTimerState() async -> TimerState? { return nil }
     func clearTimerState() async {}
-    nonisolated func loadConfigSync() -> TimerConfig? { return nil }
+    nonisolated func loadConfigSync() -> TimerConfig? { return storedConfig }
     nonisolated func loadTimerStateSync() -> TimerState? { return nil }
     nonisolated func clearTimerStateSync() {}
 }
@@ -360,6 +366,56 @@ final class TimerManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testApplyRemoteDefaultsPersistsWhenNoStoredConfigExists() async {
+        let storage = MockStorageService()
+        let manager = TimerManager(
+            storageService: storage,
+            notificationService: MockNotificationService(),
+            liveActivityService: MockLiveActivityService()
+        )
+
+        let remoteConfig = TimerConfig(minSeconds: 0, maxSeconds: 300, alarmDuration: 15)
+        await manager.applyRemoteDefaultsIfNeeded(remoteConfig)
+
+        XCTAssertEqual(manager.config, remoteConfig)
+        XCTAssertEqual(storage.storedConfig, remoteConfig)
+    }
+
+    @MainActor
+    func testApplyRemoteDefaultsDoesNotOverrideStoredConfig() async {
+        let stored = TimerConfig(minSeconds: 12, maxSeconds: 42)
+        let storage = MockStorageService(initialConfig: stored)
+        let manager = TimerManager(
+            storageService: storage,
+            notificationService: MockNotificationService(),
+            liveActivityService: MockLiveActivityService()
+        )
+
+        await manager.applyRemoteDefaultsIfNeeded(TimerConfig(minSeconds: 0, maxSeconds: 300))
+
+        XCTAssertEqual(manager.config, stored)
+        XCTAssertEqual(storage.storedConfig, stored)
+    }
+
+    @MainActor
+    func testApplyRemoteDefaultsDoesNotOverrideUserMutation() async {
+        let storage = MockStorageService()
+        let manager = TimerManager(
+            storageService: storage,
+            notificationService: MockNotificationService(),
+            liveActivityService: MockLiveActivityService()
+        )
+        let userConfig = TimerConfig(minSeconds: 5, maxSeconds: 25)
+        manager.updateConfig(userConfig)
+        await Task.yield()
+
+        await manager.applyRemoteDefaultsIfNeeded(TimerConfig(minSeconds: 0, maxSeconds: 300))
+
+        XCTAssertEqual(manager.config, userConfig)
+        XCTAssertEqual(storage.storedConfig, userConfig)
+    }
+
+    @MainActor
     func testResetTimerRerollsDurationWithinConfiguredRange() async {
         let manager = TimerManager(
             storageService: MockStorageService(),
@@ -447,7 +503,7 @@ final class TimerStateTests: XCTestCase {
     }
 
     func testStateDecodingSupportsLegacyKeysAndStatusNormalization() throws {
-        let payload = """
+        let payload = Data("""
         {
           "config": {},
           "target_duration": 120,
@@ -455,7 +511,7 @@ final class TimerStateTests: XCTestCase {
           "remaining_duration": 60,
           "timerStatus": "PAUSED"
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(TimerState.self, from: payload)
 
@@ -463,6 +519,45 @@ final class TimerStateTests: XCTestCase {
         XCTAssertEqual(decoded.startedAt.timeIntervalSince1970, 1600000000)
         XCTAssertEqual(decoded.remainingDuration, 60)
         XCTAssertEqual(decoded.status, .paused)
+    }
+}
+
+final class RuntimeConfigurationServiceTests: XCTestCase {
+    func testRuntimePayloadDecodesAndAssignsDeterministically() throws {
+        let data = Data("""
+        {
+          "configVersion": "2026-03-16",
+          "defaultTimerConfig": {
+            "minSeconds": 0,
+            "maxSeconds": 300,
+            "alarmDuration": 15,
+            "hiddenMode": false,
+            "repeatEnabled": false,
+            "soundType": "gentle",
+            "volume": 0.7,
+            "vibrationEnabled": true
+          },
+          "experiments": [
+            {
+              "key": "paywall_copy",
+              "variants": [
+                { "key": "control", "rolloutPercent": 50 },
+                { "key": "drill_sergeant", "rolloutPercent": 50 }
+              ]
+            }
+          ]
+        }
+        """.utf8)
+
+        let payload = try JSONDecoder().decode(RuntimeConfigurationPayload.self, from: data)
+        let first = payload.toSnapshot(distinctId: "device-123")
+        let second = payload.toSnapshot(distinctId: "device-123")
+
+        XCTAssertEqual(payload.defaultTimerConfig.maxSeconds, 300)
+        XCTAssertEqual(payload.defaultTimerConfig.alarmDuration, 15)
+        XCTAssertTrue(payload.defaultTimerConfig.vibrationEnabled)
+        XCTAssertEqual(first, second)
+        XCTAssertNotNil(first.experiments["paywall_copy"])
     }
 }
 


### PR DESCRIPTION
## Summary
- add optional InsForge-backed runtime defaults and experiment assignment for Android and iOS
- enrich analytics with runtime config source/version and experiment properties
- keep persisted user settings authoritative and fall back cleanly when InsForge is unavailable

## Verification
- `cd native-android && ./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.runtime.RuntimeConfigurationServiceTest --tests com.iganapolsky.randomtimer.data.repository.TimerRepositoryImplTest assembleDebug`
- `cd native-ios && xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,id=FB1D04C9-33DF-40E5-9F56-466FE9D1495B' -only-testing:RandomTimerTests/TimerManagerTests -only-testing:RandomTimerTests/RuntimeConfigurationServiceTests -only-testing:RandomTimerTests/TimerConfigTests test`

## Notes
- InsForge credentials were wired into local `.env` and GitHub Actions secrets and verified with authenticated API calls before implementation.
- The live project still needs the `training_assets/runtime/mobile-runtime-config.json` object provisioned for remote values to serve outside local fallback mode.