### PR TITLE
chore: reduce technical debt in release automation and analytics

### DIFF
--- a/.ai/changelog/2026-03.md
+++ b/.ai/changelog/2026-03.md
@@ -1,0 +1,11 @@
+# 2026-03
+
+## 2026-03-17 — Technical debt audit: analytics truth + release parsing cleanup
+
+- preserved last-known-good analytics outputs when PostHog data is degraded or missing, instead of publishing fake zeroes
+- added `scripts/source_versions.py` as the shared source-of-truth parser for Android/iOS release metadata
+- rewired release tooling and workflow steps to use the shared parser instead of brittle regex scraping
+- hardened `scripts/hygiene-check.sh` to warn on `/tmp/` leaks in tracked files
+- fixed local Python 3.9 compatibility for script tests that used modern annotation syntax without postponed evaluation
+- corrected stale monetization claims in the public README and Android store description so docs match the shipped subscription model
+- added regression coverage for version parsing and degraded analytics handling

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -384,13 +384,9 @@ jobs:
       - name: Extract version info
         id: versions
         run: |
-          # Android versionCode from build.gradle.kts
-          VERSION_CODE=$(grep -oP 'versionCode\s*=\s*\K\d+' native-android/app/build.gradle.kts || echo "")
-          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
-
-          # iOS version from project.pbxproj
-          IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | grep -oP '[\d.]+' || echo "")
-          echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"
+          eval "$(python scripts/source_versions.py --repo-root . --format shell)"
+          echo "version_code=$ANDROID_VERSION_CODE" >> "$GITHUB_OUTPUT"
+          echo "ios_version=$IOS_VERSION_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Debug workflow inputs (no secrets)
         run: |
@@ -658,8 +654,9 @@ jobs:
       - name: Extract version from source
         id: version
         run: |
-          VERSION_NAME=$(sed -n 's/.*versionName *= *"\([^"]*\)".*/\1/p' native-android/app/build.gradle.kts | head -1)
-          VERSION_CODE=$(sed -n 's/.*versionCode *= *\([0-9]*\).*/\1/p' native-android/app/build.gradle.kts | head -1)
+          eval "$(python scripts/source_versions.py --repo-root . --format shell)"
+          VERSION_NAME="$ANDROID_VERSION_NAME"
+          VERSION_CODE="$ANDROID_VERSION_CODE"
           TAG="v${VERSION_NAME}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ play-console-service-account.json
 
 # coverage reports
 coverage/
+.coverage
+.coverage.*
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Built for fighters, operators, and serious athletes.**
 
-No ads. No subscriptions. Purpose-built performance training.
+No ads. Privacy-first. Free core timer with an optional Pro subscription for advanced training features.
 
 ---
 

--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -29,4 +29,4 @@ HOW IT WORKS:
 4. React with explosive intensity when the cue hits
 5. Loop for continuous stress rounds
 
-Zero ads. No subscriptions. No tracking. Just a tool for those who train for reality.
+Zero ads. No tracking. Free core timer with an optional Pro upgrade for advanced training features.

--- a/scripts/attribution_feedback.py
+++ b/scripts/attribution_feedback.py
@@ -40,6 +40,26 @@ def _requests_module():
         return None
 
 
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _data_quality(*, generated_at: str, preserved_previous_metrics: bool) -> Dict[str, Any]:
+    return {
+        "is_stale": bool(QUERY_ERRORS) and preserved_previous_metrics,
+        "preserved_previous_metrics": preserved_previous_metrics,
+        "last_attempt_generated_at": generated_at,
+        "last_good_generated_at": "",
+        "reason": QUERY_ERRORS[-1] if QUERY_ERRORS else "",
+    }
+
+
 def posthog_query(query: str, api_key: str, project_id: str) -> Optional[Dict[str, Any]]:
     """Execute a PostHog HogQL query via the API."""
     requests = _requests_module()
@@ -324,14 +344,24 @@ def build_keyword_performance(
 def write_aso_feedback(
     repo_root: Path,
     keyword_performance: Dict[str, int],
+    *,
+    preserved_from: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """Write keyword performance data for the ASO rotation script to consume."""
     feedback_path = repo_root / "marketing" / "keywords" / "posthog_feedback.json"
     feedback_path.parent.mkdir(parents=True, exist_ok=True)
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
     payload = {
-        "generated_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "generated_at": generated_at,
+        "status": "ok" if not QUERY_ERRORS else "degraded",
         "keyword_installs": keyword_performance,
+        "data_quality": _data_quality(
+            generated_at=generated_at,
+            preserved_previous_metrics=bool(preserved_from),
+        ),
     }
+    if preserved_from:
+        payload["data_quality"]["last_good_generated_at"] = str(preserved_from.get("generated_at", ""))
     feedback_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return feedback_path
 
@@ -340,6 +370,8 @@ def write_content_feedback(
     repo_root: Path,
     campaign_installs: List[Dict[str, Any]],
     funnel: Dict[str, Any],
+    *,
+    preserved_from: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """Write content performance data for the content pipeline to consume."""
     feedback_path = repo_root / "marketing" / "data" / "content_feedback.json"
@@ -351,11 +383,19 @@ def write_content_feedback(
         key=lambda r: -(r.get("activation_rate") or 0),
     )[:20]
 
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
     payload = {
-        "generated_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "generated_at": generated_at,
+        "status": "ok" if not QUERY_ERRORS else "degraded",
         "onboarding_funnel": funnel,
         "top_campaigns_by_activation": top_campaigns,
+        "data_quality": _data_quality(
+            generated_at=generated_at,
+            preserved_previous_metrics=bool(preserved_from),
+        ),
     }
+    if preserved_from:
+        payload["data_quality"]["last_good_generated_at"] = str(preserved_from.get("generated_at", ""))
     feedback_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return feedback_path
 
@@ -439,16 +479,23 @@ def run(
     project_id = os.getenv("POSTHOG_PROJECT_ID", "").strip()
     report_path = repo_root / "marketing" / "data" / "attribution-report.md"
     report_path.parent.mkdir(parents=True, exist_ok=True)
+    aso_existing_path = repo_root / "marketing" / "keywords" / "posthog_feedback.json"
+    content_existing_path = repo_root / "marketing" / "data" / "content_feedback.json"
+    aso_existing = _load_json(aso_existing_path)
+    content_existing = _load_json(content_existing_path)
 
     if not api_key or not project_id:
         # Generate empty feedback files so downstream scripts don't break
-        empty_kw: Dict[str, int] = {}
-        write_aso_feedback(repo_root, empty_kw)
-        write_content_feedback(repo_root, [], {"window_days": days})
-        report_path.write_text(
-            "# Attribution Feedback Report\n\nNo PostHog query data available: missing API key and/or project id.\n",
-            encoding="utf-8",
-        )
+        keyword_installs = aso_existing.get("keyword_installs", {}) if aso_existing else {}
+        content_funnel = content_existing.get("onboarding_funnel", {"window_days": days}) if content_existing else {"window_days": days}
+        campaigns = content_existing.get("top_campaigns_by_activation", []) if content_existing else []
+        write_aso_feedback(repo_root, keyword_installs, preserved_from=aso_existing or None)
+        write_content_feedback(repo_root, campaigns, content_funnel, preserved_from=content_existing or None)
+        if not report_path.exists():
+            report_path.write_text(
+                "# Attribution Feedback Report\n\nNo PostHog query data available: missing API key and/or project id.\n",
+                encoding="utf-8",
+            )
         return {
             "status": "skipped",
             "reason": "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID",
@@ -460,16 +507,32 @@ def run(
     campaign_installs = fetch_campaign_installs(api_key, project_id, days)
     keyword_performance = build_keyword_performance(attribution, campaign_installs)
 
+    preserved_previous_metrics = bool(QUERY_ERRORS) and (bool(aso_existing) or bool(content_existing))
+    if preserved_previous_metrics:
+        keyword_performance = aso_existing.get("keyword_installs", keyword_performance) if aso_existing else keyword_performance
+        if content_existing:
+            funnel = content_existing.get("onboarding_funnel", funnel)
+            campaign_installs = content_existing.get("top_campaigns_by_activation", campaign_installs)
+
     if not dry_run:
-        aso_path = write_aso_feedback(repo_root, keyword_performance)
-        content_path = write_content_feedback(repo_root, campaign_installs, funnel)
+        aso_path = write_aso_feedback(
+            repo_root,
+            keyword_performance,
+            preserved_from=aso_existing if preserved_previous_metrics else None,
+        )
+        content_path = write_content_feedback(
+            repo_root,
+            campaign_installs,
+            funnel,
+            preserved_from=content_existing if preserved_previous_metrics else None,
+        )
     else:
         aso_path = Path("(dry-run)")
         content_path = Path("(dry-run)")
 
     report = build_report(attribution, funnel, campaign_installs, keyword_performance)
-
-    report_path.write_text(report, encoding="utf-8")
+    if not (preserved_previous_metrics and report_path.exists()):
+        report_path.write_text(report, encoding="utf-8")
 
     # Write to GitHub Actions step summary if available
     summary_file = os.getenv("GITHUB_STEP_SUMMARY", "").strip()
@@ -488,6 +551,7 @@ def run(
         "report": str(report_path),
         "query_errors_count": len(QUERY_ERRORS),
         "last_query_error": QUERY_ERRORS[-1] if QUERY_ERRORS else "",
+        "preserved_previous_metrics": preserved_previous_metrics,
     }
 
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -81,16 +81,21 @@ if [[ ! -f "$GRADLE_FILE" ]]; then
   exit 1
 fi
 
-CURRENT_VERSION_NAME=$(sed -n 's/.*versionName *= *"\([^"]*\)".*/\1/p' "$GRADLE_FILE" | head -1)
-CURRENT_VERSION_CODE=$(sed -n 's/.*versionCode *= *\([0-9]*\).*/\1/p' "$GRADLE_FILE" | head -1)
-NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
-
 if [[ ! -f "$PBXPROJ" ]]; then
   echo -e "${RED}Error: $PBXPROJ not found${RESET}" >&2
   exit 1
 fi
 
-IOS_CURRENT_VERSION=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -n 's/.*= *\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
+if ! VERSION_EXPORTS=$(python3 "$PROJECT_ROOT/scripts/source_versions.py" --repo-root "$PROJECT_ROOT" --format shell); then
+  echo -e "${RED}Error: could not resolve current source versions${RESET}" >&2
+  exit 1
+fi
+eval "$VERSION_EXPORTS"
+
+CURRENT_VERSION_NAME="${ANDROID_VERSION_NAME:-}"
+CURRENT_VERSION_CODE="${ANDROID_VERSION_CODE:-}"
+IOS_CURRENT_VERSION="${IOS_VERSION_NAME:-}"
+NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
 
 echo -e "${CYAN}Current state:${RESET}"
 echo "  Android: v${CURRENT_VERSION_NAME} (code ${CURRENT_VERSION_CODE})"
@@ -120,8 +125,44 @@ sed_inplace() {
 
 # ── Android: update build.gradle.kts ─────────────────────────────────────────
 
-sed_inplace "s/versionCode *= *[0-9]*/versionCode = ${NEW_VERSION_CODE}/" "$GRADLE_FILE"
-sed_inplace "s/versionName *= *\"[^\"]*\"/versionName = \"${NEW_VERSION}\"/" "$GRADLE_FILE"
+python3 - "$GRADLE_FILE" "$NEW_VERSION" "$NEW_VERSION_CODE" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+gradle_file = Path(sys.argv[1])
+new_version = sys.argv[2]
+new_version_code = sys.argv[3]
+text = gradle_file.read_text(encoding="utf-8")
+
+text, version_name_count = re.subn(
+    r'versionName\s*=\s*"[^"]*"',
+    f'versionName = "{new_version}"',
+    text,
+    count=1,
+)
+if version_name_count != 1:
+    raise SystemExit("Could not update versionName in build.gradle.kts")
+
+text, version_code_count = re.subn(
+    r'(versionCode\s*=\s*[^\n]*?\?:\s*)\d+',
+    rf'\g<1>{new_version_code}',
+    text,
+    count=1,
+)
+if version_code_count == 0:
+    text, version_code_count = re.subn(
+        r'versionCode\s*=\s*\d+',
+        f'versionCode = {new_version_code}',
+        text,
+        count=1,
+    )
+if version_code_count != 1:
+    raise SystemExit("Could not update versionCode in build.gradle.kts")
+
+gradle_file.write_text(text, encoding="utf-8")
+PY
+
 echo -e "${GREEN}✓${RESET} Android build.gradle.kts updated"
 
 # ── iOS: update project.pbxproj (all build configurations) ──────────────────

--- a/scripts/compute_android_release_version_code.py
+++ b/scripts/compute_android_release_version_code.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 from typing import Any
+
+try:
+    from scripts.source_versions import VersionParseError, extract_android_version_code
+except ModuleNotFoundError:
+    from source_versions import VersionParseError, extract_android_version_code
 
 
 ANDROID_PACKAGE_DEFAULT = "com.iganapolsky.randomtimer"
@@ -16,11 +20,10 @@ DEFAULT_TRACKS = ("production", "beta", "alpha", "internal")
 
 
 def _read_gradle_version_code(gradle_file: Path) -> int:
-    content = gradle_file.read_text(encoding="utf-8")
-    match = re.search(r"versionCode\s*=\s*(\d+)", content)
-    if not match:
-        raise ValueError(f"Unable to find versionCode in {gradle_file}")
-    return int(match.group(1))
+    try:
+        return extract_android_version_code(gradle_file.read_text(encoding="utf-8"))
+    except VersionParseError as exc:
+        raise ValueError(f"Unable to find versionCode in {gradle_file}") from exc
 
 
 def _load_play_service(service_account_json: Path):

--- a/scripts/hygiene-check.sh
+++ b/scripts/hygiene-check.sh
@@ -53,10 +53,10 @@ fi
 # ── 3. No secrets or temp paths ─────────────────────────────────────
 echo "3. No secrets or temp paths"
 
-secret_hits=$(git grep -l 'PRIVATE_KEY\|SECRET_KEY\|password.*=\|/private/tmp/' -- '*.md' '*.sh' '*.yml' '*.yaml' '*.json' '*.kt' '*.swift' 2>/dev/null | grep -v '.gitleaks.toml' | grep -v 'pre-push' | grep -v 'hygiene-check' || true)
+secret_hits=$(git grep -l 'PRIVATE_KEY\|SECRET_KEY\|password.*=\|/private/tmp/\|/tmp/' -- '*.md' '*.sh' '*.yml' '*.yaml' '*.json' '*.kt' '*.swift' 2>/dev/null | grep -v '.gitleaks.toml' | grep -v 'pre-push' | grep -v 'hygiene-check' || true)
 if [ -n "$secret_hits" ]; then
   while IFS= read -r hit; do
-    warn "Possible secret/temp path in: $hit"
+    warn "Possible secret or temp-path leak in: $hit"
   done <<< "$secret_hits"
 fi
 

--- a/scripts/north_star_guardrail.py
+++ b/scripts/north_star_guardrail.py
@@ -48,6 +48,33 @@ def _load_paid_campaigns(path: Path) -> Dict[str, Any]:
     return payload
 
 
+def _load_existing_payload(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _data_quality(
+    *,
+    generated_at: str,
+    status: str,
+    errors: List[str],
+    preserved_previous_metrics: bool,
+    last_good_generated_at: str = "",
+) -> Dict[str, Any]:
+    return {
+        "is_stale": status in {"degraded", "skipped"} and preserved_previous_metrics,
+        "preserved_previous_metrics": preserved_previous_metrics,
+        "last_attempt_generated_at": generated_at,
+        "last_good_generated_at": last_good_generated_at,
+        "reason": errors[-1] if errors else "",
+    }
+
+
 def _active_campaigns(campaigns: Sequence[Dict[str, Any]], active_statuses: Set[str]) -> List[Dict[str, Any]]:
     active: List[Dict[str, Any]] = []
     for campaign in campaigns:
@@ -152,6 +179,13 @@ def _empty_payload(lookback_days: int, wqtu_window_days: int, reason: str = "") 
                 "enforceable_status": "not_applicable",
             },
         },
+        "data_quality": {
+            "is_stale": False,
+            "preserved_previous_metrics": False,
+            "last_attempt_generated_at": "",
+            "last_good_generated_at": "",
+            "reason": "",
+        },
         "query_diagnostics": {"errors": []},
         "snapshots": [],
     }
@@ -168,6 +202,8 @@ def run(
 ) -> Dict[str, Any]:
     output_path = repo_root / "marketing" / "data" / "north_star.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _load_existing_payload(output_path)
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
 
     key = (
         os.getenv("POSTHOG_PERSONAL_API_KEY", "").strip()
@@ -194,6 +230,7 @@ def run(
     """
     errors: List[str] = []
     payload = _empty_payload(lookback_days, wqtu_window_days)
+    payload["generated_at"] = generated_at
     payload["north_star"]["targets"] = {
         "checkpoint_2026_03_31": checkpoint_target,
         "quarter_2026_06_30": quarter_target,
@@ -212,6 +249,28 @@ def run(
     if not key or not project_id:
         payload["status"] = "skipped"
         payload["status_reason"] = "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID"
+        previous_north_star = existing.get("north_star", {}) if isinstance(existing.get("north_star"), dict) else {}
+        previous_paid = existing.get("paid", {}) if isinstance(existing.get("paid"), dict) else {}
+        if previous_north_star:
+            payload["north_star"]["wqtu_7d"] = int(previous_north_star.get("wqtu_7d", 0) or 0)
+            payload["north_star"]["timer_completed_7d"] = int(previous_north_star.get("timer_completed_7d", 0) or 0)
+            payload["north_star"]["completed_users_7d"] = int(previous_north_star.get("completed_users_7d", 0) or 0)
+            payload["north_star"]["sessions_per_completed_user_7d"] = float(
+                previous_north_star.get("sessions_per_completed_user_7d", 0.0) or 0.0
+            )
+            payload["north_star"]["on_track_checkpoint"] = bool(previous_north_star.get("on_track_checkpoint"))
+            payload["north_star"]["on_track_quarter"] = bool(previous_north_star.get("on_track_quarter"))
+        if previous_paid:
+            payload["paid"]["paid_distinct_users_30d"] = int(previous_paid.get("paid_distinct_users_30d", 0) or 0)
+            payload["paid"]["paid_events_by_source_30d"] = previous_paid.get("paid_events_by_source_30d", [])
+        payload["snapshots"] = existing.get("snapshots", []) if isinstance(existing.get("snapshots"), list) else []
+        payload["data_quality"] = _data_quality(
+            generated_at=generated_at,
+            status="skipped",
+            errors=[],
+            preserved_previous_metrics=bool(previous_north_star or previous_paid),
+            last_good_generated_at=str(existing.get("generated_at", "")),
+        )
         lock_active = len(active) > 0
         lock_reasons = ["active campaigns exist but PostHog credentials are missing"] if lock_active else []
         lock_status = "enforceable" if lock_active else "not_applicable"
@@ -304,9 +363,24 @@ def run(
         errors,
     )
 
-    sessions_per_user = 0.0
-    if completed_users_7d > 0:
-        sessions_per_user = round(completions_7d / completed_users_7d, 2)
+    previous_north_star = existing.get("north_star", {}) if isinstance(existing.get("north_star"), dict) else {}
+    previous_paid = existing.get("paid", {}) if isinstance(existing.get("paid"), dict) else {}
+    preserved_previous_metrics = False
+    if errors and (previous_north_star or previous_paid):
+        preserved_previous_metrics = True
+        wqtu = int(previous_north_star.get("wqtu_7d", 0) or 0)
+        completions_7d = int(previous_north_star.get("timer_completed_7d", 0) or 0)
+        completed_users_7d = int(previous_north_star.get("completed_users_7d", 0) or 0)
+        sessions_per_user = float(previous_north_star.get("sessions_per_completed_user_7d", 0.0) or 0.0)
+        paid_distinct_users_30d = int(previous_paid.get("paid_distinct_users_30d", 0) or 0)
+        paid_events_by_source_30d = previous_paid.get("paid_events_by_source_30d", [])
+    else:
+        sessions_per_user = 0.0
+        if completed_users_7d > 0:
+            sessions_per_user = round(completions_7d / completed_users_7d, 2)
+        paid_events_by_source_30d = [
+            {"source": str(row[0]), "events": int(row[1] or 0), "users": int(row[2] or 0)} for row in paid_events_rows
+        ]
 
     payload["status"] = "ok" if not errors else "degraded"
     payload["north_star"]["wqtu_7d"] = wqtu
@@ -317,9 +391,7 @@ def run(
     payload["north_star"]["on_track_quarter"] = wqtu >= quarter_target
 
     payload["paid"]["paid_distinct_users_30d"] = paid_distinct_users_30d
-    payload["paid"]["paid_events_by_source_30d"] = [
-        {"source": str(row[0]), "events": int(row[1] or 0), "users": int(row[2] or 0)} for row in paid_events_rows
-    ]
+    payload["paid"]["paid_events_by_source_30d"] = paid_events_by_source_30d
     now = dt.datetime.now(dt.timezone.utc)
     outside_grace = [c for c in active if _campaign_outside_grace(c, now, campaign_grace_days)]
     payload["paid"]["active_campaigns_outside_grace_count"] = len(outside_grace)
@@ -363,28 +435,31 @@ def run(
     payload["paid"]["guardrail_violated"] = lock_active
     payload["paid"]["guardrail_reason"] = "; ".join(lock_reasons)
 
+    payload["data_quality"] = _data_quality(
+        generated_at=generated_at,
+        status=payload["status"],
+        errors=errors,
+        preserved_previous_metrics=preserved_previous_metrics,
+        last_good_generated_at=str(existing.get("generated_at", "")) if preserved_previous_metrics else "",
+    )
     payload["query_diagnostics"]["errors"] = errors
 
-    if output_path.exists():
-        try:
-            existing = json.loads(output_path.read_text(encoding="utf-8"))
-            snapshots = existing.get("snapshots", [])
-            if isinstance(snapshots, list):
-                payload["snapshots"] = snapshots
-        except (json.JSONDecodeError, OSError):
-            payload["snapshots"] = []
+    snapshots = existing.get("snapshots", [])
+    if isinstance(snapshots, list):
+        payload["snapshots"] = snapshots
 
-    payload["snapshots"].append(
-        {
-            "timestamp": payload["generated_at"],
-            "wqtu_7d": wqtu,
-            "timer_completed_7d": completions_7d,
-            "completed_users_7d": completed_users_7d,
-            "paid_distinct_users_30d": paid_distinct_users_30d,
-            "active_campaign_count": len(active),
-            "guardrail_violated": payload["paid"]["guardrail_violated"],
-        }
-    )
+    if not preserved_previous_metrics:
+        payload["snapshots"].append(
+            {
+                "timestamp": payload["generated_at"],
+                "wqtu_7d": wqtu,
+                "timer_completed_7d": completions_7d,
+                "completed_users_7d": completed_users_7d,
+                "paid_distinct_users_30d": paid_distinct_users_30d,
+                "active_campaign_count": len(active),
+                "guardrail_violated": payload["paid"]["guardrail_violated"],
+            }
+        )
     payload["snapshots"] = payload["snapshots"][-120:]
 
     output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
@@ -401,6 +476,7 @@ def run(
         "no_scale_lock_reasons": payload["paid"]["no_scale_lock"]["reasons"],
         "no_scale_lock_enforceable_status": payload["paid"]["no_scale_lock"]["enforceable_status"],
         "query_errors_count": len(errors),
+        "preserved_previous_metrics": preserved_previous_metrics,
     }
 
 

--- a/scripts/north_star_ops.py
+++ b/scripts/north_star_ops.py
@@ -37,6 +37,19 @@ def _append_staleness_warning(path: Path, warnings: list[str]) -> None:
         )
 
 
+def _append_quality_warning(path: Path, payload: dict[str, Any], warnings: list[str]) -> None:
+    status = str(payload.get("status", "")).strip().lower()
+    quality = payload.get("data_quality", {})
+    if not isinstance(quality, dict):
+        quality = {}
+    if status in {"degraded", "skipped"} or quality.get("is_stale"):
+        last_good = str(quality.get("last_good_generated_at") or "").strip()
+        detail = f"stale metrics in {path.name}"
+        if last_good:
+            detail += f" (last good `{last_good}`)"
+        warnings.append(detail)
+
+
 def _relative(path: Path, repo_root: Path) -> str:
     return str(path.resolve().relative_to(repo_root.resolve()))
 
@@ -91,6 +104,8 @@ def build_ops_payload(repo_root: Path) -> dict[str, Any]:
     warnings: list[str] = []
     for path in (north_star_path, feedback_path, cro_path, paid_path, apple_ads_path):
         _append_staleness_warning(path, warnings)
+    _append_quality_warning(north_star_path, north_star_payload, warnings)
+    _append_quality_warning(feedback_path, feedback_payload, warnings)
 
     if paid.get("no_scale_lock", {}).get("active"):
         warnings.append("paid no-scale lock is active")

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -114,18 +114,16 @@ ANDROID_VERSION_CODE=""
 IOS_VERSION_NAME=""
 IOS_BUILD_NUMBER=""
 
-GRADLE_FILE="$PROJECT_ROOT/native-android/app/build.gradle.kts"
-if [[ -f "$GRADLE_FILE" ]]; then
-  ANDROID_VERSION_NAME=$(sed -n 's/.*versionName *= *"\([^"]*\)".*/\1/p' "$GRADLE_FILE" | head -1)
-  ANDROID_VERSION_CODE=$(sed -n 's/.*versionCode *= *\([0-9]*\).*/\1/p' "$GRADLE_FILE" | head -1)
+if VERSION_EXPORTS=$(python3 "$PROJECT_ROOT/scripts/source_versions.py" --repo-root "$PROJECT_ROOT" --format shell 2>/dev/null); then
+  eval "$VERSION_EXPORTS"
+  ANDROID_VERSION_NAME="${ANDROID_VERSION_NAME:-}"
+  ANDROID_VERSION_CODE="${ANDROID_VERSION_CODE:-}"
+  IOS_VERSION_NAME="${IOS_VERSION_NAME:-}"
+  IOS_BUILD_NUMBER="${IOS_BUILD_NUMBER:-}"
   info "Android: v${ANDROID_VERSION_NAME:-?} (code ${ANDROID_VERSION_CODE:-?})"
-fi
-
-PBXPROJ="$PROJECT_ROOT/native-ios/RandomTimer.xcodeproj/project.pbxproj"
-if [[ -f "$PBXPROJ" ]]; then
-  IOS_VERSION_NAME=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -n 's/.*= *\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' || true)
-  IOS_BUILD_NUMBER=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -n 's/.*= *\([0-9]*\).*/\1/p' || true)
   info "iOS:     v${IOS_VERSION_NAME:-?} (build ${IOS_BUILD_NUMBER:-?})"
+else
+  warn "Could not resolve source versions from scripts/source_versions.py"
 fi
 
 # Cross-platform version parity warning

--- a/scripts/source_versions.py
+++ b/scripts/source_versions.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Read release version metadata from Android and iOS source files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class VersionParseError(RuntimeError):
+    """Raised when source version metadata cannot be parsed."""
+
+
+ANDROID_VERSION_NAME_RE = re.compile(r'versionName\s*=\s*"([^"]+)"')
+ANDROID_VERSION_CODE_RE = re.compile(r"versionCode\s*=\s*(\d+)")
+ANDROID_VERSION_CODE_FALLBACK_RE = re.compile(r"versionCode\s*=\s*[^\n]*?\?:\s*(\d+)")
+IOS_MARKETING_VERSION_RE = re.compile(r"MARKETING_VERSION\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)\s*;")
+IOS_BUILD_NUMBER_RE = re.compile(r"CURRENT_PROJECT_VERSION\s*=\s*(\d+)\s*;")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        raise VersionParseError(f"Missing required file: {path}")
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def extract_android_version_name(text: str) -> str:
+    match = ANDROID_VERSION_NAME_RE.search(text)
+    if not match:
+        raise VersionParseError("Could not parse Android versionName")
+    return match.group(1)
+
+
+def extract_android_version_code(text: str) -> int:
+    match = ANDROID_VERSION_CODE_RE.search(text)
+    if match:
+        return int(match.group(1))
+
+    fallback_match = ANDROID_VERSION_CODE_FALLBACK_RE.search(text)
+    if fallback_match:
+        return int(fallback_match.group(1))
+
+    raise VersionParseError("Could not parse Android versionCode")
+
+
+def extract_ios_version_name(text: str) -> str:
+    match = IOS_MARKETING_VERSION_RE.search(text)
+    if not match:
+        raise VersionParseError("Could not parse iOS MARKETING_VERSION")
+    return match.group(1)
+
+
+def extract_ios_build_number(text: str) -> int:
+    match = IOS_BUILD_NUMBER_RE.search(text)
+    if not match:
+        raise VersionParseError("Could not parse iOS CURRENT_PROJECT_VERSION")
+    return int(match.group(1))
+
+
+def read_source_versions(repo_root: Path) -> dict[str, dict[str, Any]]:
+    android_file = repo_root / "native-android" / "app" / "build.gradle.kts"
+    ios_file = repo_root / "native-ios" / "RandomTimer.xcodeproj" / "project.pbxproj"
+
+    android_text = _read_text(android_file)
+    ios_text = _read_text(ios_file)
+
+    return {
+        "android": {
+            "version_name": extract_android_version_name(android_text),
+            "version_code": extract_android_version_code(android_text),
+        },
+        "ios": {
+            "version_name": extract_ios_version_name(ios_text),
+            "build_number": extract_ios_build_number(ios_text),
+        },
+    }
+
+
+def _flatten_versions(payload: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "ANDROID_VERSION_NAME": payload["android"]["version_name"],
+        "ANDROID_VERSION_CODE": payload["android"]["version_code"],
+        "IOS_VERSION_NAME": payload["ios"]["version_name"],
+        "IOS_BUILD_NUMBER": payload["ios"]["build_number"],
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read release version metadata from source files.")
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument("--format", choices=("json", "shell", "value"), default="json")
+    parser.add_argument("--key", default="", help="Required when --format=value")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    try:
+        payload = read_source_versions(Path(args.repo_root).resolve())
+    except VersionParseError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    flat = _flatten_versions(payload)
+    if args.format == "shell":
+        for key, value in flat.items():
+            print(f"{key}={shlex.quote(str(value))}")
+        return 0
+
+    if args.key not in flat:
+        print(f"❌ Unknown key '{args.key}'", file=sys.stderr)
+        return 2
+
+    print(flat[args.key])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/store_downloads_snapshot.py
+++ b/scripts/store_downloads_snapshot.py
@@ -90,6 +90,74 @@ def query_rows(query: str, api_key: str, project_id: str, errors: List[str]) -> 
     return rows
 
 
+def _load_existing_payload(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _metric_definitions() -> Dict[str, Any]:
+    return {
+        "downloads_30d": {
+            "display_name": "Distinct install users (30d)",
+            "source": "posthog",
+            "semantic_type": "proxy",
+            "description": (
+                "Distinct live-device users with an 'Application Installed' event over the trailing window. "
+                "This is a PostHog proxy metric, not store download truth."
+            ),
+        }
+    }
+
+
+def _data_quality(
+    *,
+    generated_at: str,
+    status: str,
+    errors: List[str],
+    preserved_previous_metrics: bool,
+    last_good_generated_at: str = "",
+) -> Dict[str, Any]:
+    is_stale = status in {"degraded", "skipped"} and preserved_previous_metrics
+    return {
+        "is_stale": is_stale,
+        "preserved_previous_metrics": preserved_previous_metrics,
+        "last_attempt_generated_at": generated_at,
+        "last_good_generated_at": last_good_generated_at,
+        "reason": errors[-1] if errors else "",
+    }
+
+
+def _preserve_previous_metrics(
+    existing: Dict[str, Any],
+    *,
+    generated_at: str,
+    status: str,
+    reason: str,
+    errors: List[str],
+) -> Optional[Dict[str, Any]]:
+    if not existing:
+        return None
+    payload = dict(existing)
+    payload["generated_at"] = generated_at
+    payload["status"] = status
+    payload["status_reason"] = reason
+    payload["metric_definitions"] = _metric_definitions()
+    payload["query_diagnostics"] = {"errors": errors}
+    payload["data_quality"] = _data_quality(
+        generated_at=generated_at,
+        status=status,
+        errors=errors,
+        preserved_previous_metrics=True,
+        last_good_generated_at=str(existing.get("generated_at", "")),
+    )
+    return payload
+
+
 def _empty_snapshot(window_days: int, reason: str = "") -> Dict[str, Any]:
     return {
         "generated_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
@@ -101,6 +169,14 @@ def _empty_snapshot(window_days: int, reason: str = "") -> Dict[str, Any]:
         "android": {"downloads_30d": 0, "active_installs": 0},
         "combined": {"downloads_30d": 0},
         "active_users": {"dau": 0, "wau": 0, "mau": 0},
+        "metric_definitions": _metric_definitions(),
+        "data_quality": {
+            "is_stale": False,
+            "preserved_previous_metrics": False,
+            "last_attempt_generated_at": "",
+            "last_good_generated_at": "",
+            "reason": "",
+        },
         "query_diagnostics": {"errors": []},
         "snapshots": [],
     }
@@ -109,6 +185,8 @@ def _empty_snapshot(window_days: int, reason: str = "") -> Dict[str, Any]:
 def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
     output_path = repo_root / "marketing" / "data" / "store_downloads.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _load_existing_payload(output_path)
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
 
     key = (
         os.getenv("POSTHOG_PERSONAL_API_KEY", "").strip()
@@ -121,8 +199,30 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
     payload = _empty_snapshot(days)
 
     if not key or not project_id:
+        payload["generated_at"] = generated_at
         payload["status"] = "skipped"
         payload["status_reason"] = "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID"
+        preserved = _preserve_previous_metrics(
+            existing,
+            generated_at=generated_at,
+            status="skipped",
+            reason=payload["status_reason"],
+            errors=[],
+        )
+        if preserved is not None:
+            output_path.write_text(json.dumps(preserved, indent=2) + "\n", encoding="utf-8")
+            return {
+                "status": "skipped",
+                "output": str(output_path),
+                "reason": payload["status_reason"],
+                "preserved_previous_metrics": True,
+            }
+        payload["data_quality"] = _data_quality(
+            generated_at=generated_at,
+            status="skipped",
+            errors=[],
+            preserved_previous_metrics=False,
+        )
         output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         return {"status": "skipped", "output": str(output_path), "reason": payload["status_reason"]}
 
@@ -202,8 +302,31 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         errors,
     )
 
+    if errors:
+        preserved = _preserve_previous_metrics(
+            existing,
+            generated_at=generated_at,
+            status="degraded",
+            reason="preserved last good metrics after degraded PostHog query",
+            errors=errors,
+        )
+        if preserved is not None:
+            output_path.write_text(json.dumps(preserved, indent=2) + "\n", encoding="utf-8")
+            return {
+                "status": "degraded",
+                "output": str(output_path),
+                "ios_downloads_30d": int(preserved.get("ios", {}).get("downloads_30d", 0) or 0),
+                "android_downloads_30d": int(preserved.get("android", {}).get("downloads_30d", 0) or 0),
+                "combined_downloads_30d": int(preserved.get("combined", {}).get("downloads_30d", 0) or 0),
+                "dau": int(preserved.get("active_users", {}).get("dau", 0) or 0),
+                "wau": int(preserved.get("active_users", {}).get("wau", 0) or 0),
+                "mau": int(preserved.get("active_users", {}).get("mau", 0) or 0),
+                "query_errors_count": len(errors),
+                "preserved_previous_metrics": True,
+            }
+
     payload = {
-        "generated_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "generated_at": generated_at,
         "window_days": days,
         "source": "posthog",
         "status": "ok" if not errors else "degraded",
@@ -215,18 +338,20 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         },
         "combined": {"downloads_30d": ios_downloads + android_downloads},
         "active_users": {"dau": dau, "wau": wau, "mau": mau},
+        "metric_definitions": _metric_definitions(),
+        "data_quality": _data_quality(
+            generated_at=generated_at,
+            status="ok" if not errors else "degraded",
+            errors=errors,
+            preserved_previous_metrics=False,
+        ),
         "query_diagnostics": {"errors": errors},
         "snapshots": [],
     }
 
-    if output_path.exists():
-        try:
-            existing = json.loads(output_path.read_text(encoding="utf-8"))
-            snapshots = existing.get("snapshots", [])
-            if isinstance(snapshots, list):
-                payload["snapshots"] = snapshots
-        except (json.JSONDecodeError, OSError):
-            pass
+    snapshots = existing.get("snapshots", [])
+    if isinstance(snapshots, list):
+        payload["snapshots"] = snapshots
 
     snapshot = {
         "timestamp": payload["generated_at"],
@@ -238,7 +363,8 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         "wau": wau,
         "mau": mau,
     }
-    payload["snapshots"].append(snapshot)
+    if not errors:
+        payload["snapshots"].append(snapshot)
     payload["snapshots"] = payload["snapshots"][-90:]
 
     output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/scripts/tests/test_attribution_feedback.py
+++ b/scripts/tests/test_attribution_feedback.py
@@ -1,4 +1,5 @@
 import tempfile
+import json
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -46,6 +47,60 @@ class AttributionFeedbackTests(unittest.TestCase):
             self.assertTrue(report.exists())
             text = report.read_text(encoding="utf-8")
             self.assertIn("No PostHog query data available", text)
+
+    def test_run_preserves_previous_content_feedback_when_queries_degrade(self):
+        from scripts import attribution_feedback as af
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            content_path = root / "marketing" / "data" / "content_feedback.json"
+            content_path.parent.mkdir(parents=True, exist_ok=True)
+            content_path.write_text(
+                json.dumps(
+                    {
+                        "generated_at": "2026-03-15T10:00:00+00:00",
+                        "status": "ok",
+                        "onboarding_funnel": {
+                            "first_open": 20,
+                            "first_timer_configured": 10,
+                            "first_timer_completed": 5,
+                            "open_to_completed_rate": 0.25,
+                        },
+                        "top_campaigns_by_activation": [{"campaign": "asa_brand", "activation_rate": 0.5}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            keyword_path = root / "marketing" / "keywords" / "posthog_feedback.json"
+            keyword_path.parent.mkdir(parents=True, exist_ok=True)
+            keyword_path.write_text(
+                json.dumps({"generated_at": "2026-03-15T10:00:00+00:00", "keyword_installs": {"hiit": 3}}),
+                encoding="utf-8",
+            )
+            report = root / "marketing" / "data" / "attribution-report.md"
+            report.write_text("# Attribution Feedback Report\n\nold\n", encoding="utf-8")
+
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "POSTHOG_PERSONAL_API_KEY": "phx_test",
+                    "POSTHOG_PROJECT_ID": "299775",
+                },
+                clear=True,
+            ), mock.patch.object(af, "fetch_utm_attribution", side_effect=lambda *_args, **_kwargs: af.QUERY_ERRORS.append("http_504") or []), mock.patch.object(
+                af, "fetch_onboarding_funnel", return_value={"first_open": 0, "first_timer_configured": 0, "first_timer_completed": 0}
+            ), mock.patch.object(
+                af, "fetch_campaign_installs", return_value=[]
+            ):
+                result = af.run(root, days=30, dry_run=False)
+
+            self.assertEqual(result["status"], "degraded")
+            self.assertTrue(result["preserved_previous_metrics"])
+            payload = json.loads(content_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["onboarding_funnel"]["first_open"], 20)
+            self.assertTrue(payload["data_quality"]["is_stale"])
+            self.assertEqual(payload["data_quality"]["last_good_generated_at"], "2026-03-15T10:00:00+00:00")
+            self.assertEqual(report.read_text(encoding="utf-8"), "# Attribution Feedback Report\n\nold\n")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_compute_android_release_version_code.py
+++ b/scripts/tests/test_compute_android_release_version_code.py
@@ -23,6 +23,22 @@ def test_read_gradle_version_code_extracts_integer(tmp_path: Path):
     assert calc._read_gradle_version_code(gradle_file) == 1774400000
 
 
+def test_read_gradle_version_code_extracts_elvis_fallback_integer(tmp_path: Path):
+    gradle_file = tmp_path / "build.gradle.kts"
+    gradle_file.write_text(
+        """
+        android {
+            defaultConfig {
+                versionCode = ciVersionCode ?: 1774400000
+            }
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    assert calc._read_gradle_version_code(gradle_file) == 1774400000
+
+
 def test_extract_release_codes_skips_invalid_values():
     payload = {
         "releases": [

--- a/scripts/tests/test_growth_content_pipeline.py
+++ b/scripts/tests/test_growth_content_pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 import unittest
 from pathlib import Path

--- a/scripts/tests/test_north_star_guardrail.py
+++ b/scripts/tests/test_north_star_guardrail.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import sys
 import tempfile
@@ -349,6 +351,67 @@ class NorthStarGuardrailTests(unittest.TestCase):
                 exit_code = nsg.main()
 
             self.assertEqual(exit_code, 1)
+
+    def test_run_preserves_previous_query_metrics_when_posthog_degrades(self):
+        from scripts import north_star_guardrail as nsg
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            data_dir = root / "marketing" / "data"
+            data_dir.mkdir(parents=True, exist_ok=True)
+            self._write_paid_campaigns(root, ["draft"])
+            (data_dir / "north_star.json").write_text(
+                json.dumps(
+                    {
+                        "generated_at": "2026-03-15T10:00:00+00:00",
+                        "status": "ok",
+                        "north_star": {
+                            "wqtu_7d": 5,
+                            "timer_completed_7d": 18,
+                            "completed_users_7d": 6,
+                            "sessions_per_completed_user_7d": 3.0,
+                            "targets": {"checkpoint_2026_03_31": 8, "quarter_2026_06_30": 25},
+                            "on_track_checkpoint": False,
+                            "on_track_quarter": False,
+                        },
+                        "paid": {
+                            "paid_distinct_users_30d": 4,
+                            "paid_events_by_source_30d": [{"source": "apple_ads", "events": 7, "users": 4}],
+                        },
+                        "snapshots": [{"timestamp": "2026-03-15T10:00:00+00:00", "wqtu_7d": 5}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def degraded_scalar(_sql, _key, _project_id, errors):
+                errors.append("http_504")
+                return 0
+
+            def degraded_rows(_sql, _key, _project_id, errors):
+                errors.append("http_504")
+                return []
+
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "POSTHOG_PERSONAL_API_KEY": "phx_test",
+                    "POSTHOG_PROJECT_ID": "299775",
+                },
+                clear=True,
+            ), mock.patch.object(nsg, "query_scalar", side_effect=degraded_scalar), mock.patch.object(
+                nsg, "query_rows", side_effect=degraded_rows
+            ):
+                result = nsg.run(root)
+
+            self.assertEqual(result["status"], "degraded")
+            self.assertTrue(result["preserved_previous_metrics"])
+            payload = json.loads((data_dir / "north_star.json").read_text(encoding="utf-8"))
+            self.assertEqual(payload["north_star"]["wqtu_7d"], 5)
+            self.assertEqual(payload["paid"]["paid_distinct_users_30d"], 4)
+            self.assertTrue(payload["data_quality"]["is_stale"])
+            self.assertEqual(payload["data_quality"]["last_good_generated_at"], "2026-03-15T10:00:00+00:00")
+            self.assertEqual(len(payload["snapshots"]), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_north_star_ops.py
+++ b/scripts/tests/test_north_star_ops.py
@@ -121,3 +121,41 @@ def test_run_writes_json_and_markdown_reports(tmp_path: Path):
     assert json_path.exists()
     assert md_path.exists()
     assert "Next Experiment" in md_path.read_text(encoding="utf-8")
+
+
+def test_build_ops_payload_warns_on_stale_metric_inputs(tmp_path: Path):
+    repo_root = tmp_path
+    _write_json(
+        repo_root / "marketing/data/north_star.json",
+        {
+            "status": "degraded",
+            "north_star": {
+                "wqtu_7d": 1,
+                "targets": {"checkpoint_2026_03_31": 8, "quarter_2026_06_30": 25},
+            },
+            "paid": {"paid_distinct_users_30d": 0, "no_scale_lock": {"active": False, "reasons": []}},
+            "data_quality": {"is_stale": True, "last_good_generated_at": "2026-03-15T10:00:00+00:00"},
+        },
+    )
+    _write_json(
+        repo_root / "marketing/data/content_feedback.json",
+        {
+            "status": "degraded",
+            "onboarding_funnel": {
+                "first_open": 100,
+                "first_timer_configured": 80,
+                "first_timer_completed": 30,
+                "open_to_configured_rate": 0.8,
+                "configured_to_completed_rate": 0.375,
+                "open_to_completed_rate": 0.3,
+                "window_days": 30,
+            },
+            "top_campaigns_by_activation": [],
+            "data_quality": {"is_stale": True, "last_good_generated_at": "2026-03-15T10:00:00+00:00"},
+        },
+    )
+
+    payload = nso.build_ops_payload(repo_root)
+
+    assert any("stale metrics in north_star.json" in warning for warning in payload["warnings"])
+    assert any("stale metrics in content_feedback.json" in warning for warning in payload["warnings"])

--- a/scripts/tests/test_source_versions.py
+++ b/scripts/tests/test_source_versions.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import source_versions
+
+
+def _write_repo_version_files(repo_root: Path, android_line: str = "versionCode = 11") -> None:
+    android_file = repo_root / "native-android" / "app" / "build.gradle.kts"
+    ios_file = repo_root / "native-ios" / "RandomTimer.xcodeproj" / "project.pbxproj"
+    android_file.parent.mkdir(parents=True, exist_ok=True)
+    ios_file.parent.mkdir(parents=True, exist_ok=True)
+
+    android_file.write_text(
+        f'android {{\n  defaultConfig {{\n    {android_line}\n    versionName = "1.2.2"\n  }}\n}}\n',
+        encoding="utf-8",
+    )
+    ios_file.write_text(
+        "MARKETING_VERSION = 1.2.2;\nCURRENT_PROJECT_VERSION = 14;\n",
+        encoding="utf-8",
+    )
+
+
+def test_extract_android_version_code_handles_elvis_fallback():
+    text = 'versionCode = ciVersionCode ?: 11\nversionName = "1.2.2"\n'
+    assert source_versions.extract_android_version_code(text) == 11
+
+
+def test_read_source_versions_returns_all_expected_values(tmp_path: Path):
+    _write_repo_version_files(tmp_path, android_line="versionCode = ciVersionCode ?: 11")
+    versions = source_versions.read_source_versions(tmp_path)
+
+    assert versions == {
+        "android": {"version_name": "1.2.2", "version_code": 11},
+        "ios": {"version_name": "1.2.2", "build_number": 14},
+    }
+
+
+def test_cli_shell_output_is_sourceable(tmp_path: Path):
+    _write_repo_version_files(tmp_path)
+    script = Path(__file__).resolve().parents[1] / "source_versions.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--repo-root", str(tmp_path), "--format", "shell"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    lines = dict(line.split("=", 1) for line in result.stdout.strip().splitlines())
+    assert lines["ANDROID_VERSION_NAME"] == "1.2.2"
+    assert lines["ANDROID_VERSION_CODE"] == "11"
+    assert lines["IOS_VERSION_NAME"] == "1.2.2"
+    assert lines["IOS_BUILD_NUMBER"] == "14"
+
+
+def test_cli_json_output_matches_reader(tmp_path: Path):
+    _write_repo_version_files(tmp_path)
+    script = Path(__file__).resolve().parents[1] / "source_versions.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--repo-root", str(tmp_path), "--format", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["android"]["version_code"] == 11
+    assert payload["ios"]["build_number"] == 14

--- a/scripts/tests/test_store_downloads_snapshot.py
+++ b/scripts/tests/test_store_downloads_snapshot.py
@@ -67,6 +67,56 @@ class StoreDownloadsSnapshotTests(unittest.TestCase):
             self.assertEqual(payload["android"]["active_installs"], 11)
             self.assertEqual(len(payload["snapshots"]), 1)
 
+    def test_run_preserves_previous_metrics_when_query_degrades(self):
+        from scripts import store_downloads_snapshot as sds
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            out = root / "marketing" / "data" / "store_downloads.json"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(
+                json.dumps(
+                    {
+                        "generated_at": "2026-03-15T10:00:00+00:00",
+                        "status": "ok",
+                        "ios": {"downloads_30d": 4},
+                        "android": {"downloads_30d": 10, "active_installs": 9},
+                        "combined": {"downloads_30d": 14},
+                        "active_users": {"dau": 2, "wau": 6, "mau": 15},
+                        "snapshots": [{"timestamp": "2026-03-15T10:00:00+00:00", "combined_downloads_30d": 14}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def degraded_rows(_sql, _key, _project_id, errors):
+                errors.append("http_504")
+                return []
+
+            def degraded_scalar(_sql, _key, _project_id, errors):
+                errors.append("http_504")
+                return 0
+
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "POSTHOG_PERSONAL_API_KEY": "phx_test",
+                    "POSTHOG_PROJECT_ID": "299775",
+                },
+                clear=True,
+            ), mock.patch.object(sds, "query_rows", side_effect=degraded_rows), mock.patch.object(
+                sds, "query_scalar", side_effect=degraded_scalar
+            ):
+                result = sds.run(root, days=30)
+
+            self.assertEqual(result["status"], "degraded")
+            self.assertTrue(result["preserved_previous_metrics"])
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(payload["combined"]["downloads_30d"], 14)
+            self.assertTrue(payload["data_quality"]["is_stale"])
+            self.assertEqual(payload["data_quality"]["last_good_generated_at"], "2026-03-15T10:00:00+00:00")
+            self.assertEqual(len(payload["snapshots"]), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_wiki_sync.py
+++ b/scripts/tests/test_wiki_sync.py
@@ -271,3 +271,107 @@ def test_inject_paid_uses_apple_live_metrics(data_dir: Path, paid_template: str)
     assert "API reports 1 campaign(s), 1 active" in result
     assert "Apple Ads Taps (30d snapshot trend)" in result
     assert "Platform | Config Status | Live Status | Daily Budget" in result
+
+
+def test_inject_dashboard_marks_stale_download_proxy_metrics(data_dir: Path) -> None:
+    template = textwrap.dedent("""\
+        # Dashboard
+
+        <!-- DOWNLOADS_START -->
+        old
+        <!-- DOWNLOADS_END -->
+    """)
+    (data_dir / "store_downloads.json").write_text(json.dumps({
+        "status": "degraded",
+        "generated_at": "2026-03-16T00:00:00+00:00",
+        "ios": {"downloads_30d": 4},
+        "android": {"downloads_30d": 7, "active_installs": 9},
+        "combined": {"downloads_30d": 11},
+        "active_users": {"dau": 2, "wau": 5, "mau": 12},
+        "metric_definitions": {
+            "downloads_30d": {"display_name": "Distinct install users (30d)"}
+        },
+        "data_quality": {
+            "is_stale": True,
+            "last_good_generated_at": "2026-03-15T10:00:00+00:00",
+            "reason": "http_504",
+        },
+    }))
+
+    result = inject_dashboard_data(template, data_dir)
+    assert "Distinct install users (30d)" in result
+    assert "showing last good metrics from `2026-03-15T10:00:00+00:00`" in result
+    assert "http_504" in result
+
+
+def test_inject_dashboard_marks_stale_north_star_and_funnel(data_dir: Path) -> None:
+    template = textwrap.dedent("""\
+        # Dashboard
+
+        <!-- NORTH_STAR_START -->
+        old
+        <!-- NORTH_STAR_END -->
+
+        <!-- FUNNEL_START -->
+        old
+        <!-- FUNNEL_END -->
+    """)
+    (data_dir / "north_star.json").write_text(json.dumps({
+        "status": "degraded",
+        "north_star": {
+            "wqtu_7d": 9,
+            "timer_completed_7d": 27,
+            "completed_users_7d": 9,
+            "sessions_per_completed_user_7d": 3.0,
+            "targets": {"checkpoint_2026_03_31": 8, "quarter_2026_06_30": 25},
+        },
+        "paid": {"paid_distinct_users_30d": 2, "active_campaign_count": 1, "guardrail_violated": False},
+        "data_quality": {
+            "is_stale": True,
+            "last_good_generated_at": "2026-03-15T10:00:00+00:00",
+            "reason": "http_504",
+        },
+    }))
+    (data_dir / "content_feedback.json").write_text(json.dumps({
+        "status": "degraded",
+        "onboarding_funnel": {
+            "first_open": 100,
+            "first_timer_configured": 75,
+            "first_timer_completed": 30,
+            "open_to_configured_rate": 0.75,
+            "open_to_completed_rate": 0.30,
+        },
+        "data_quality": {
+            "is_stale": True,
+            "last_good_generated_at": "2026-03-15T10:00:00+00:00",
+            "reason": "query timeout",
+        },
+    }))
+
+    result = inject_dashboard_data(template, data_dir)
+    assert result.count("_Data quality: stale") == 2
+    assert "query timeout" in result
+
+
+def test_inject_paid_acquisition_marks_stale_sources(data_dir: Path, paid_template: str) -> None:
+    (data_dir / "north_star.json").write_text(json.dumps({
+        "status": "degraded",
+        "north_star": {"wqtu_7d": 1, "targets": {"checkpoint_2026_03_31": 8, "quarter_2026_06_30": 25}},
+        "paid": {"paid_distinct_users_30d": 0, "paid_events_by_source_30d": [], "active_campaign_count": 1, "guardrail_violated": False},
+        "data_quality": {"is_stale": True, "last_good_generated_at": "2026-03-15T10:00:00+00:00", "reason": "http_504"},
+    }))
+    (data_dir / "store_downloads.json").write_text(json.dumps({
+        "status": "degraded",
+        "combined": {"downloads_30d": 9},
+        "metric_definitions": {"downloads_30d": {"display_name": "Distinct install users (30d)"}},
+        "data_quality": {"is_stale": True, "last_good_generated_at": "2026-03-15T10:00:00+00:00", "reason": "http_504"},
+    }))
+    (data_dir / "content_feedback.json").write_text(json.dumps({
+        "status": "degraded",
+        "onboarding_funnel": {"open_to_completed_rate": 0.242},
+        "data_quality": {"is_stale": True, "last_good_generated_at": "2026-03-15T10:00:00+00:00", "reason": "query timeout"},
+    }))
+
+    result = inject_paid_acquisition_data(paid_template, data_dir)
+    assert "Distinct install users (30d)" in result
+    assert "showing last good metrics from `2026-03-15T10:00:00+00:00`" in result

--- a/scripts/validate_release_branch.py
+++ b/scripts/validate_release_branch.py
@@ -14,40 +14,21 @@ import re
 import sys
 from pathlib import Path
 
+try:
+    from scripts.source_versions import (
+        VersionParseError,
+        extract_android_version_name,
+        extract_ios_version_name,
+    )
+except ModuleNotFoundError:
+    from source_versions import VersionParseError, extract_android_version_name, extract_ios_version_name
+
 
 class ValidationError(RuntimeError):
     """Raised when release branch validation fails."""
 
 
 RELEASE_BRANCH_RE = re.compile(r"^(?:release|hotfix)/v(?P<version>\d+\.\d+\.\d+)$")
-ANDROID_VERSION_RE = re.compile(r'versionName\s*=\s*"([^"]+)"')
-IOS_VERSION_RE = re.compile(r"MARKETING_VERSION\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)\s*;")
-
-
-def _read_text(path: Path) -> str:
-    if not path.is_file():
-        raise ValidationError(f"Missing required file: {path}")
-    return path.read_text(encoding="utf-8", errors="replace")
-
-
-def _extract_android_version(repo_root: Path) -> str:
-    gradle_file = repo_root / "native-android" / "app" / "build.gradle.kts"
-    text = _read_text(gradle_file)
-    match = ANDROID_VERSION_RE.search(text)
-    if not match:
-        raise ValidationError(f"Could not parse Android versionName in {gradle_file}")
-    return match.group(1)
-
-
-def _extract_ios_version(repo_root: Path) -> str:
-    pbxproj_file = repo_root / "native-ios" / "RandomTimer.xcodeproj" / "project.pbxproj"
-    text = _read_text(pbxproj_file)
-    match = IOS_VERSION_RE.search(text)
-    if not match:
-        raise ValidationError(f"Could not parse iOS MARKETING_VERSION in {pbxproj_file}")
-    return match.group(1)
-
-
 def validate_release_branch(repo_root: Path, head_ref: str) -> dict:
     branch_match = RELEASE_BRANCH_RE.match(head_ref.strip())
     if not branch_match:
@@ -56,8 +37,19 @@ def validate_release_branch(repo_root: Path, head_ref: str) -> dict:
         )
 
     expected_version = branch_match.group("version")
-    android_version = _extract_android_version(repo_root)
-    ios_version = _extract_ios_version(repo_root)
+    try:
+        android_text = (repo_root / "native-android" / "app" / "build.gradle.kts").read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        ios_text = (repo_root / "native-ios" / "RandomTimer.xcodeproj" / "project.pbxproj").read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        android_version = extract_android_version_name(android_text)
+        ios_version = extract_ios_version_name(ios_text)
+    except (OSError, VersionParseError) as exc:
+        raise ValidationError(str(exc)) from exc
 
     if android_version != ios_version:
         raise ValidationError(

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -70,6 +70,39 @@ def _fmt_num_allow_zero(val: Any) -> str:
     return str(val)
 
 
+def _data_quality_note(payload: Optional[Dict[str, Any]], *, fallback_source: str = "") -> str:
+    if not payload:
+        return ""
+    quality = payload.get("data_quality", {})
+    if not isinstance(quality, dict):
+        quality = {}
+    status = str(payload.get("status", "")).strip().lower()
+    is_stale = bool(quality.get("is_stale"))
+    if status not in {"degraded", "skipped"} and not is_stale:
+        return ""
+    last_good = str(quality.get("last_good_generated_at") or "").strip()
+    reason = str(quality.get("reason") or payload.get("status_reason") or fallback_source).strip()
+    note = "_Data quality: stale"
+    if last_good:
+        note += f"; showing last good metrics from `{last_good}`"
+    if reason:
+        note += f"; latest read issue: `{reason}`"
+    note += "._"
+    return note
+
+
+def _metric_display_name(payload: Optional[Dict[str, Any]], metric_key: str, default: str) -> str:
+    if not payload:
+        return default
+    definitions = payload.get("metric_definitions", {})
+    if not isinstance(definitions, dict):
+        return default
+    definition = definitions.get(metric_key, {})
+    if not isinstance(definition, dict):
+        return default
+    return str(definition.get("display_name") or default)
+
+
 def _extract_budget_allocation(pc: Optional[Dict[str, Any]]) -> Dict[str, float]:
     if not pc:
         return {}
@@ -353,6 +386,8 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
         android = dl.get("android", {})
         combined = dl.get("combined", {})
         users = dl.get("active_users", {})
+        downloads_label = _metric_display_name(dl, "downloads_30d", "Downloads (30d)")
+        quality_note = _data_quality_note(dl, fallback_source="store downloads snapshot degraded")
         ios_30 = _fmt_num(ios.get("downloads_30d"))
         and_30 = _fmt_num(android.get("downloads_30d"))
         comb_30 = _fmt_num(combined.get("downloads_30d"))
@@ -360,7 +395,7 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
         downloads_block = (
             "| Metric | iOS | Android | Combined |\n"
             "|--------|:---:|:-------:|:--------:|\n"
-            f"| Downloads (30d) | {ios_30} | {and_30} | {comb_30} |\n"
+            f"| {downloads_label} | {ios_30} | {and_30} | {comb_30} |\n"
             f"| Active Installs | — | {and_active} | — |\n\n"
             "| Active Users | Count |\n"
             "|-------------|:-----:|\n"
@@ -368,6 +403,8 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
             f"| WAU | {_fmt_num(users.get('wau'))} |\n"
             f"| MAU | {_fmt_num(users.get('mau'))} |"
         )
+        if quality_note:
+            downloads_block += f"\n\n{quality_note}"
         dashboard = re.sub(
             r"<!-- DOWNLOADS_START -->.*?<!-- DOWNLOADS_END -->",
             f"<!-- DOWNLOADS_START -->\n{downloads_block}\n<!-- DOWNLOADS_END -->",
@@ -381,6 +418,7 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
         nsm = ns.get("north_star", {})
         paid = ns.get("paid", {})
         targets = nsm.get("targets", {})
+        quality_note = _data_quality_note(ns, fallback_source="north star snapshot degraded")
         north_star_block = (
             "| Metric | Value |\n"
             "|--------|-------|\n"
@@ -394,6 +432,8 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
             f"| Active Campaign Count | {_fmt_num_allow_zero(paid.get('active_campaign_count'))} |\n"
             f"| Guardrail Violated | {'YES' if paid.get('guardrail_violated') else 'NO'} |"
         )
+        if quality_note:
+            north_star_block += f"\n\n{quality_note}"
         dashboard = re.sub(
             r"<!-- NORTH_STAR_START -->.*?<!-- NORTH_STAR_END -->",
             f"<!-- NORTH_STAR_START -->\n{north_star_block}\n<!-- NORTH_STAR_END -->",
@@ -552,6 +592,7 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
     cf = load_json(data_dir / "content_feedback.json")
     if cf:
         funnel = cf.get("onboarding_funnel", {})
+        quality_note = _data_quality_note(cf, fallback_source="attribution feedback degraded")
         fo = funnel.get("first_open", 0)
         fc = funnel.get("first_timer_configured", 0)
         ft = funnel.get("first_timer_completed", 0)
@@ -564,6 +605,8 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
             f"| First Timer Configured | {_fmt_num(fc)} | {_fmt(oc_rate)} of opens |\n"
             f"| First Timer Completed | {_fmt_num(ft)} | {_fmt(ot_rate)} of opens |"
         )
+        if quality_note:
+            funnel_block += f"\n\n{quality_note}"
         dashboard = re.sub(
             r"<!-- FUNNEL_START -->.*?<!-- FUNNEL_END -->",
             f"<!-- FUNNEL_START -->\n{funnel_block}\n<!-- FUNNEL_END -->",
@@ -669,6 +712,12 @@ def inject_paid_acquisition_data(page: str, data_dir: Path) -> str:
         )
 
     downloads_30d = dl.get("combined", {}).get("downloads_30d")
+    downloads_label = _metric_display_name(dl, "downloads_30d", "Downloads (30d)")
+    quality_notes = [note for note in (
+        _data_quality_note(ns, fallback_source="north star snapshot degraded"),
+        _data_quality_note(dl, fallback_source="store downloads snapshot degraded"),
+        _data_quality_note(cf, fallback_source="attribution feedback degraded"),
+    ) if note]
     kpi_block = (
         "| Metric | Value |\n"
         "|--------|-------|\n"
@@ -682,7 +731,7 @@ def inject_paid_acquisition_data(page: str, data_dir: Path) -> str:
         f"| WQTU (7d) | {_fmt_num_allow_zero(nsm.get('wqtu_7d'))} |\n"
         f"| WQTU Checkpoint Target (2026-03-31) | {_fmt_num_allow_zero(targets.get('checkpoint_2026_03_31'))} |\n"
         f"| WQTU Quarter Target (2026-06-30) | {_fmt_num_allow_zero(targets.get('quarter_2026_06_30'))} |\n"
-        f"| Downloads (30d) | {_fmt_num_allow_zero(downloads_30d)} |\n"
+        f"| {downloads_label} | {_fmt_num_allow_zero(downloads_30d)} |\n"
         f"| Apple Ads Campaigns (API) | {_fmt_num_allow_zero(apple.get('campaign_count', 0))} |\n"
         f"| Apple Ads Active Campaigns (API) | {_fmt_num_allow_zero(apple.get('active_campaign_count', 0))} |\n"
         f"| Apple Ads Impressions (30d) | {_fmt_num_allow_zero(apple_metrics.get('impressions', 0))} |\n"
@@ -692,6 +741,8 @@ def inject_paid_acquisition_data(page: str, data_dir: Path) -> str:
         f"| Apple Ads Live Finding | {apple_finding} |\n"
         f"| Guardrail Violated | {'YES' if paid.get('guardrail_violated') else 'NO'} |"
     )
+    if quality_notes:
+        kpi_block += "\n\n" + "\n".join(quality_notes)
 
     paid_rows = paid.get("paid_events_by_source_30d", [])
     if isinstance(paid_rows, list) and paid_rows:


### PR DESCRIPTION
## Summary
- harden the analytics truth layer so degraded PostHog reads preserve last-known-good data instead of publishing fake zeroes
- centralize Android/iOS source version parsing and reuse it across release scripts and workflows
- align hygiene/docs with shipped behavior by catching `/tmp/` leaks and removing false `No subscriptions` claims

## Verification
- `python3 -m pytest -q scripts/tests/test_source_versions.py scripts/tests/test_compute_android_release_version_code.py scripts/tests/test_validate_release_branch.py scripts/tests/test_store_downloads_snapshot.py scripts/tests/test_attribution_feedback.py scripts/tests/test_north_star_guardrail.py scripts/tests/test_north_star_ops.py scripts/tests/test_wiki_sync.py`
- `python3 -m pytest scripts/tests -q --cov=scripts --cov-report=term --cov-report=json:/tmp/random-timer-audit-python-coverage-after.json`
- `bash scripts/hygiene-check.sh`
- `./scripts/preflight-release.sh --platform both --layer 1`
- `./scripts/bump-version.sh 1.2.3 --dry-run`
- `python3 scripts/source_versions.py --repo-root . --format json`
