### PR TITLE
fix: repair release metadata drift and Pro sound arsenal UX

### DIFF
--- a/.ai/changelog/2026-03.md
+++ b/.ai/changelog/2026-03.md
@@ -9,3 +9,13 @@
 - fixed local Python 3.9 compatibility for script tests that used modern annotation syntax without postponed evaluation
 - corrected stale monetization claims in the public README and Android store description so docs match the shipped subscription model
 - added regression coverage for version parsing and degraded analytics handling
+## 2026-03-17 — Fix persisted Pro voice-callout toggle on mobile
+
+- replaced the fake Pro `ON` label with a real persisted `voiceCalloutsEnabled` toggle on iOS and Android
+- stored the voice-callout preference in each platform's timer config persistence path so it survives app restarts
+- updated active timer/runtime gating so Pro voice callouts only fire when the user explicitly leaves the toggle enabled
+- preserved the voice-callout preference when loop/config updates rebuild timer state during an active session
+- normalized premium UI copy so `Sound Arsenal` is the user-facing label instead of `TACTICAL EXPANSION (PRO)`
+- made the free Sound Arsenal preview expanded by default and auto-expanded it when Pro becomes active
+- removed hardcoded Android/iOS UI purchase wiring that surfaced the legacy `elite` product name above the billing layer
+- added regression coverage for mobile parity, config defaults, iOS config encoding, and Android repository persistence

--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -91,7 +91,8 @@ jobs:
           if [ -n "$VERSION_INPUT" ]; then
             VERSION="$VERSION_INPUT"
           else
-            VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | grep -oE '[0-9]+(\.[0-9]+){1,2}')
+            eval "$(python scripts/source_versions.py --repo-root . --format shell)"
+            VERSION="$IOS_VERSION_NAME"
           fi
           if [ -z "$VERSION" ]; then
             echo "Failed to resolve iOS version" >&2

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -94,11 +94,10 @@ jobs:
             echo "ios_version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Info.plist commonly contains build-setting placeholders like $(MARKETING_VERSION).
-          # Read MARKETING_VERSION directly from the Xcode project for a stable X.Y.Z value.
-          IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | sed -n 's/.*= *\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' || true)
+          eval "$(python scripts/source_versions.py --repo-root . --format shell)"
+          IOS_VERSION="${IOS_VERSION_NAME:-}"
           if [ -z "$IOS_VERSION" ]; then
-            echo "❌ Could not determine iOS version (MARKETING_VERSION) from Xcode project"
+            echo "❌ Could not determine iOS version from source metadata"
             exit 1
           fi
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -510,9 +510,10 @@ jobs:
         if: steps.gate.outputs.enabled == 'true'
         id: versions
         run: |
-          IOS_VERSION=$(grep -m1 'MARKETING_VERSION' native-ios/RandomTimer.xcodeproj/project.pbxproj | grep -oP '[\\d.]+' || echo "")
+          eval "$(python scripts/source_versions.py --repo-root . --format shell)"
+          IOS_VERSION="${IOS_VERSION_NAME:-}"
           if [ -z "$IOS_VERSION" ]; then
-            echo "❌ Could not read iOS version from native-ios/RandomTimer.xcodeproj/project.pbxproj"
+            echo "❌ Could not read iOS version from source metadata"
             exit 1
           fi
           echo "ios_version=$IOS_VERSION" >> "$GITHUB_OUTPUT"

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 11
-        versionName = "1.2.2"
+        versionCode = ciVersionCode ?: 1773900000
+        versionName = "1.3.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -46,6 +46,7 @@ class ProManager
         companion object {
             const val BASE_PRODUCT_ID = "pro_base"
             const val ELITE_PRODUCT_ID = "elite_tactical"
+            const val PRO_PRODUCT_ID = ELITE_PRODUCT_ID
 
             internal fun canUseDebugUnlock(
                 @Suppress("UNUSED_PARAMETER") isDebugBuild: Boolean = true,
@@ -298,6 +299,13 @@ class ProManager
                 details?.oneTimePurchaseOfferDetails?.formattedPrice ?: "$7.99"
             }
         }
+
+        suspend fun getFormattedProPrice(): String = getFormattedPrice(PRO_PRODUCT_ID)
+
+        suspend fun launchProPurchase(
+            activity: Activity,
+            entryPoint: String,
+        ): Boolean = launchPurchase(activity, PRO_PRODUCT_ID, entryPoint)
 
         override fun onPurchasesUpdated(
             result: BillingResult,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
@@ -65,6 +65,7 @@ class TimerRepositoryImpl
                         } ?: SoundType.INTENSE,
                     volume = preferences[KEY_VOLUME] ?: 0.5f,
                     vibrationEnabled = preferences[KEY_VIBRATION_ENABLED] ?: false,
+                    voiceCalloutsEnabled = preferences[KEY_VOICE_CALLOUTS_ENABLED] ?: false,
                 ).clampedForPro()
             }
 
@@ -78,6 +79,7 @@ class TimerRepositoryImpl
                 preferences[KEY_SOUND_TYPE] = config.soundType.name
                 preferences[KEY_VOLUME] = config.volume
                 preferences[KEY_VIBRATION_ENABLED] = config.vibrationEnabled
+                preferences[KEY_VOICE_CALLOUTS_ENABLED] = config.voiceCalloutsEnabled
             }
         }
 
@@ -105,6 +107,7 @@ class TimerRepositoryImpl
                             } ?: SoundType.INTENSE,
                         volume = preferences[KEY_VOLUME] ?: 0.5f,
                         vibrationEnabled = preferences[KEY_VIBRATION_ENABLED] ?: false,
+                        voiceCalloutsEnabled = preferences[KEY_VOICE_CALLOUTS_ENABLED] ?: false,
                     ).clampedForPro()
 
                 TimerState(
@@ -145,6 +148,7 @@ class TimerRepositoryImpl
             private val KEY_SOUND_TYPE = stringPreferencesKey("sound_type")
             private val KEY_VOLUME = floatPreferencesKey("volume")
             private val KEY_VIBRATION_ENABLED = booleanPreferencesKey("vibration_enabled")
+            private val KEY_VOICE_CALLOUTS_ENABLED = booleanPreferencesKey("voice_callouts_enabled")
 
             // Active timer keys
             private val KEY_ACTIVE_TARGET = longPreferencesKey("active_target_ms")

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -50,6 +50,8 @@ data class TimerConfig(
     val volume: Float,
     /** Whether vibration is enabled */
     val vibrationEnabled: Boolean = false,
+    /** Whether timed voice callouts should play during training */
+    val voiceCalloutsEnabled: Boolean = false,
 ) {
     init {
         require(minSeconds >= 0) { "Minimum seconds cannot be negative" }
@@ -82,6 +84,7 @@ data class TimerConfig(
                 soundType = SoundType.INTENSE,
                 volume = 0.5f,
                 vibrationEnabled = false,
+                voiceCalloutsEnabled = false,
             )
 
         val ALARM_DURATION_OPTIONS = listOf(5, 10, 15, 30, 60)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
@@ -152,6 +152,7 @@ class TimerForegroundService : Service() {
                 val soundType = intent.getStringExtra(EXTRA_SOUND_TYPE) ?: "INTENSE"
                 val volume = intent.getFloatExtra(EXTRA_VOLUME, 1.0f)
                 val vibrationEnabled = intent.getBooleanExtra(EXTRA_VIBRATION_ENABLED, true)
+                val voiceCalloutsEnabled = intent.getBooleanExtra(EXTRA_VOICE_CALLOUTS_ENABLED, false)
 
                 if (targetMs > 0) {
                     startTimerFromExtras(
@@ -165,6 +166,7 @@ class TimerForegroundService : Service() {
                         soundType = soundType,
                         volume = volume,
                         vibrationEnabled = vibrationEnabled,
+                        voiceCalloutsEnabled = voiceCalloutsEnabled,
                     )
                 }
             }
@@ -228,6 +230,7 @@ class TimerForegroundService : Service() {
         soundType: String,
         volume: Float,
         vibrationEnabled: Boolean,
+        voiceCalloutsEnabled: Boolean,
     ) {
         val config =
             TimerConfig(
@@ -244,6 +247,7 @@ class TimerForegroundService : Service() {
                     },
                 volume = volume,
                 vibrationEnabled = vibrationEnabled,
+                voiceCalloutsEnabled = voiceCalloutsEnabled,
             )
 
         val initialState =
@@ -293,7 +297,7 @@ class TimerForegroundService : Service() {
                     _timerState.value = state
                     updateNotification(state)
 
-                    if (proManager.entitlementLevel.value.isPro) {
+                    if (proManager.entitlementLevel.value.isPro && state.config.voiceCalloutsEnabled) {
                         val elapsedSec = (state.targetDuration - newRemaining).inWholeSeconds.toInt()
                         voiceCalloutManager.triggerCallout(elapsedSec)
                     }
@@ -1018,6 +1022,7 @@ class TimerForegroundService : Service() {
         const val EXTRA_SOUND_TYPE = "sound_type"
         const val EXTRA_VOLUME = "volume"
         const val EXTRA_VIBRATION_ENABLED = "vibration_enabled"
+        const val EXTRA_VOICE_CALLOUTS_ENABLED = "voice_callouts_enabled"
         const val EXTRA_FROM_ALARM_NOTIFICATION = "from_alarm_notification"
 
         private const val STOP_SOURCE_APP = "app"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerServiceControllerImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerServiceControllerImpl.kt
@@ -9,76 +9,81 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class TimerServiceControllerImpl @Inject constructor(
-    @ApplicationContext private val context: Context
-) : TimerServiceController {
-
-    override fun bindService(connection: ServiceConnection) {
-        val intent = Intent(context, TimerForegroundService::class.java)
-        context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
-    }
-
-    override fun unbindService(connection: ServiceConnection) {
-        context.unbindService(connection)
-    }
-
-    override fun startTimer(state: TimerState) {
-        val intent = Intent(context, TimerForegroundService::class.java).apply {
-            action = TimerForegroundService.ACTION_START
-            putExtra(TimerForegroundService.EXTRA_APP_IN_FOREGROUND, true)
-            putExtra(TimerForegroundService.EXTRA_TARGET_DURATION_MS, state.targetDuration.inWholeMilliseconds)
-            putExtra(TimerForegroundService.EXTRA_REMAINING_DURATION_MS, state.remainingDuration.inWholeMilliseconds)
-            putExtra(TimerForegroundService.EXTRA_MIN_SECONDS, state.config.minSeconds)
-            putExtra(TimerForegroundService.EXTRA_MAX_SECONDS, state.config.maxSeconds)
-            putExtra(TimerForegroundService.EXTRA_ALARM_DURATION, state.config.alarmDuration)
-            putExtra(TimerForegroundService.EXTRA_HIDDEN_MODE, state.config.hiddenMode)
-            putExtra(TimerForegroundService.EXTRA_REPEAT_ENABLED, state.config.repeatEnabled)
-            putExtra(TimerForegroundService.EXTRA_SOUND_TYPE, state.config.soundType.name)
-            putExtra(TimerForegroundService.EXTRA_VOLUME, state.config.volume)
-            putExtra(TimerForegroundService.EXTRA_VIBRATION_ENABLED, state.config.vibrationEnabled)
+class TimerServiceControllerImpl
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) : TimerServiceController {
+        override fun bindService(connection: ServiceConnection) {
+            val intent = Intent(context, TimerForegroundService::class.java)
+            context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
         }
-        // Timer starts from the foreground UI, so a regular service start avoids forcing
-        // an immediate foreground notification while the app is visible.
-        context.startService(intent)
-    }
 
-    override fun stopTimer() {
-        sendAction(TimerForegroundService.ACTION_STOP)
-    }
-
-    override fun dismissAlarm() {
-        sendAction(TimerForegroundService.ACTION_DISMISS_ALARM)
-    }
-
-    override fun silenceAlarm() {
-        sendAction(TimerForegroundService.ACTION_SILENCE_ALARM)
-    }
-
-    override fun pauseTimer() {
-        sendAction(TimerForegroundService.ACTION_PAUSE)
-    }
-
-    override fun resumeTimer() {
-        sendAction(TimerForegroundService.ACTION_RESUME)
-    }
-
-    override fun resetTimer() {
-        sendAction(TimerForegroundService.ACTION_RESET)
-    }
-
-    override fun updateLoop(enabled: Boolean) {
-        val intent = Intent(context, TimerForegroundService::class.java).apply {
-            action = TimerForegroundService.ACTION_UPDATE_LOOP
-            putExtra(TimerForegroundService.EXTRA_REPEAT_ENABLED, enabled)
+        override fun unbindService(connection: ServiceConnection) {
+            context.unbindService(connection)
         }
-        context.startService(intent)
-    }
 
-    private fun sendAction(action: String) {
-        val intent = Intent(context, TimerForegroundService::class.java).apply {
-            this.action = action
-            putExtra(TimerForegroundService.EXTRA_APP_IN_FOREGROUND, true)
+        override fun startTimer(state: TimerState) {
+            val intent =
+                Intent(context, TimerForegroundService::class.java).apply {
+                    action = TimerForegroundService.ACTION_START
+                    putExtra(TimerForegroundService.EXTRA_APP_IN_FOREGROUND, true)
+                    putExtra(TimerForegroundService.EXTRA_TARGET_DURATION_MS, state.targetDuration.inWholeMilliseconds)
+                    putExtra(TimerForegroundService.EXTRA_REMAINING_DURATION_MS, state.remainingDuration.inWholeMilliseconds)
+                    putExtra(TimerForegroundService.EXTRA_MIN_SECONDS, state.config.minSeconds)
+                    putExtra(TimerForegroundService.EXTRA_MAX_SECONDS, state.config.maxSeconds)
+                    putExtra(TimerForegroundService.EXTRA_ALARM_DURATION, state.config.alarmDuration)
+                    putExtra(TimerForegroundService.EXTRA_HIDDEN_MODE, state.config.hiddenMode)
+                    putExtra(TimerForegroundService.EXTRA_REPEAT_ENABLED, state.config.repeatEnabled)
+                    putExtra(TimerForegroundService.EXTRA_SOUND_TYPE, state.config.soundType.name)
+                    putExtra(TimerForegroundService.EXTRA_VOLUME, state.config.volume)
+                    putExtra(TimerForegroundService.EXTRA_VIBRATION_ENABLED, state.config.vibrationEnabled)
+                    putExtra(TimerForegroundService.EXTRA_VOICE_CALLOUTS_ENABLED, state.config.voiceCalloutsEnabled)
+                }
+            // Timer starts from the foreground UI, so a regular service start avoids forcing
+            // an immediate foreground notification while the app is visible.
+            context.startService(intent)
         }
-        context.startService(intent)
+
+        override fun stopTimer() {
+            sendAction(TimerForegroundService.ACTION_STOP)
+        }
+
+        override fun dismissAlarm() {
+            sendAction(TimerForegroundService.ACTION_DISMISS_ALARM)
+        }
+
+        override fun silenceAlarm() {
+            sendAction(TimerForegroundService.ACTION_SILENCE_ALARM)
+        }
+
+        override fun pauseTimer() {
+            sendAction(TimerForegroundService.ACTION_PAUSE)
+        }
+
+        override fun resumeTimer() {
+            sendAction(TimerForegroundService.ACTION_RESUME)
+        }
+
+        override fun resetTimer() {
+            sendAction(TimerForegroundService.ACTION_RESET)
+        }
+
+        override fun updateLoop(enabled: Boolean) {
+            val intent =
+                Intent(context, TimerForegroundService::class.java).apply {
+                    action = TimerForegroundService.ACTION_UPDATE_LOOP
+                    putExtra(TimerForegroundService.EXTRA_REPEAT_ENABLED, enabled)
+                }
+            context.startService(intent)
+        }
+
+        private fun sendAction(action: String) {
+            val intent =
+                Intent(context, TimerForegroundService::class.java).apply {
+                    this.action = action
+                    putExtra(TimerForegroundService.EXTRA_APP_IN_FOREGROUND, true)
+                }
+            context.startService(intent)
+        }
     }
-}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -113,7 +113,7 @@ fun RandomTimerNavHost(
                 isPro = isPro,
                 onUpgradeTap = {
                     scope.launch {
-                        proPrice = viewModel.proManager.getFormattedPrice(ProManager.ELITE_PRODUCT_ID)
+                        proPrice = viewModel.proManager.getFormattedProPrice()
                         paywallEntryPoint = "setup_upgrade_cta"
                         showPaywall = true
                     }
@@ -181,9 +181,9 @@ fun RandomTimerNavHost(
     if (showPaywall) {
         PaywallSheet(
             proPrice = proPrice,
-            onPurchase = { productID ->
+            onPurchase = {
                 scope.launch {
-                    activity?.let { viewModel.proManager.launchPurchase(it, productID, paywallEntryPoint) }
+                    activity?.let { viewModel.proManager.launchProPurchase(it, paywallEntryPoint) }
                     showPaywall = false
                 }
             },

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -47,7 +47,7 @@ private fun Modifier.holdForHiddenUnlock(
 @Composable
 fun PaywallSheet(
     proPrice: String,
-    onPurchase: (String) -> Unit,
+    onPurchase: () -> Unit,
     onRestore: () -> Unit,
     onDismiss: () -> Unit,
     onDebugUnlock: (() -> Unit)? = null,
@@ -101,14 +101,15 @@ fun PaywallSheet(
 
             ProFeatureRow(text = "10 alarm sounds (vs 2 free)")
             ProFeatureRow(text = "Extended range up to 60 minutes")
-            ProFeatureRow(text = "Spoken countdown cues + command callouts")
+            ProFeatureRow(text = "Sound Arsenal with 10 alarm sounds")
+            ProFeatureRow(text = "Timed voice callouts during training")
             ProFeatureRow(text = "Support independent development")
 
             Spacer(modifier = Modifier.height(24.dp))
 
             PrimaryButton(
                 text = "Unlock Pro \u2022 $proPrice",
-                onClick = { onPurchase("elite_tactical") },
+                onClick = onPurchase,
             )
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -165,7 +166,11 @@ fun TimerSetupScreen(
     modifier: Modifier = Modifier,
 ) {
     val haptic = LocalHapticFeedback.current
-    var showArsenal by remember { mutableStateOf(isPro) }
+    var showArsenal by remember { mutableStateOf(!isPro) }
+
+    LaunchedEffect(isPro) {
+        showArsenal = true
+    }
 
     fun updateConfig(
         minSeconds: Int = config.minSeconds,
@@ -175,6 +180,7 @@ fun TimerSetupScreen(
         soundType: SoundType = config.soundType,
         volume: Float = config.volume,
         vibrationEnabled: Boolean = config.vibrationEnabled,
+        voiceCalloutsEnabled: Boolean = config.voiceCalloutsEnabled,
     ) {
         onConfigChange(
             config.copy(
@@ -186,6 +192,7 @@ fun TimerSetupScreen(
                 soundType = soundType,
                 volume = volume,
                 vibrationEnabled = vibrationEnabled,
+                voiceCalloutsEnabled = voiceCalloutsEnabled,
             ),
         )
     }
@@ -439,11 +446,19 @@ fun TimerSetupScreen(
                                     Spacer(modifier = Modifier.width(8.dp))
 
                                     if (isPro) {
-                                        Text(
-                                            text = "ON",
-                                            style = MaterialTheme.typography.labelSmall,
-                                            fontWeight = FontWeight.Bold,
-                                            color = TimerColors.AccentPrimary,
+                                        Switch(
+                                            checked = config.voiceCalloutsEnabled,
+                                            onCheckedChange = { enabled ->
+                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                updateConfig(voiceCalloutsEnabled = enabled)
+                                            },
+                                            colors =
+                                                SwitchDefaults.colors(
+                                                    checkedThumbColor = TimerColors.AccentPrimary,
+                                                    checkedTrackColor = TimerColors.AccentPrimary.copy(alpha = 0.5f),
+                                                    uncheckedThumbColor = TimerColors.TextMuted,
+                                                    uncheckedTrackColor = TimerColors.SliderTrack,
+                                                ),
                                         )
                                     } else {
                                         Surface(
@@ -560,7 +575,7 @@ fun TimerSetupScreen(
                     )
                 }
 
-                // Zone 2: Tactical Expansion (PRO)
+                // 3. Sound Arsenal
                 item {
                     Spacer(modifier = Modifier.height(if (isCompactHeight) 8.dp else 16.dp))
                     Row(
@@ -569,22 +584,19 @@ fun TimerSetupScreen(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = if (isPro) "TACTICAL EXPANSION (PRO) \uD83D\uDD13" else "TACTICAL EXPANSION (PRO) \uD83D\uDD12",
+                            text = "Sound Arsenal",
                             style = MaterialTheme.typography.labelSmall,
-                            color = if (isPro) TimerColors.AccentPrimary else TimerColors.TextMuted,
+                            fontWeight = FontWeight.Bold,
+                            color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
                             modifier =
                                 Modifier.pointerInput(Unit) {
                                     detectTapGestures(
                                         onTap = {
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            if (isPro) {
-                                                if (isCompactHeight) {
-                                                    showArsenalSheet = true
-                                                } else {
-                                                    showArsenal = !showArsenal
-                                                }
+                                            if (isCompactHeight) {
+                                                showArsenalSheet = true
                                             } else {
-                                                onUpgradeTap()
+                                                showArsenal = !showArsenal
                                             }
                                         },
                                         onPress = {
@@ -600,9 +612,11 @@ fun TimerSetupScreen(
 
                         val actionLabel =
                             when {
-                                isCompactHeight -> "Open Sound Arsenal"
-                                !isPro -> if (showArsenal) "Hide Sound Arsenal" else "View Sound Arsenal"
-                                else -> "View Sound Arsenal"
+                                isCompactHeight && isPro -> "Open Sound Arsenal"
+                                isCompactHeight -> "Preview Sounds"
+                                showArsenal -> "Hide Sound Arsenal"
+                                isPro -> "View Sound Arsenal"
+                                else -> "Preview Sounds"
                             }
                         Text(
                             text = actionLabel,
@@ -622,7 +636,7 @@ fun TimerSetupScreen(
                     }
                 }
 
-                // Pro Sound Arsenal
+                // Sound Arsenal
                 item {
                     if (!isCompactHeight) {
                         AnimatedVisibility(

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplTest.kt
@@ -42,6 +42,7 @@ class TimerRepositoryImplTest {
                     soundType = SoundType.GENTLE,
                     volume = 0.8f,
                     vibrationEnabled = true,
+                    voiceCalloutsEnabled = true,
                 )
 
             repo.saveTimerConfig(newConfig)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
@@ -14,6 +14,7 @@ class TimerConfigTest {
         assertThat(config.maxSeconds).isEqualTo(30)
         assertThat(config.volume).isEqualTo(0.5f)
         assertThat(config.vibrationEnabled).isFalse()
+        assertThat(config.voiceCalloutsEnabled).isFalse()
     }
 
     @Test
@@ -131,6 +132,24 @@ class TimerConfigTest {
             )
 
         assertThat(config.vibrationEnabled).isTrue()
+    }
+
+    @Test
+    fun `config can enable voice callouts`() {
+        val config =
+            TimerConfig(
+                minSeconds = 30,
+                maxSeconds = 120,
+                alarmDuration = 10,
+                hiddenMode = false,
+                repeatEnabled = false,
+                soundType = SoundType.INTENSE,
+                volume = 0.5f,
+                vibrationEnabled = false,
+                voiceCalloutsEnabled = true,
+            )
+
+        assertThat(config.voiceCalloutsEnabled).isTrue()
     }
 
     @Test

--- a/native-android/fastlane/Fastfile
+++ b/native-android/fastlane/Fastfile
@@ -47,7 +47,7 @@ platform :android do
   desc "Verify release landed on the expected track"
   lane :verify do |options|
     track = options[:track] || "alpha"
-    version_code = options[:version_code] || ENV["ANDROID_VERSION_CODE"] || sh("sed -n 's/.*versionCode *= *//p' ../app/build.gradle.kts").strip
+    version_code = options[:version_code] || ENV["ANDROID_VERSION_CODE"] || sh("python3 #{File.expand_path('../../scripts/source_versions.py', __dir__)} --repo-root #{File.expand_path('../..', __dir__)} --format value --key ANDROID_VERSION_CODE").strip
     sh("python3 #{File.expand_path('../../scripts/verify_release.py', __dir__)} " \
        "--platform android --track #{track} --version-code #{version_code}")
   end

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773900000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773900000.txt
@@ -1,0 +1,1 @@
+Random Tactical Timer 1.3.7 baseline production release metadata.

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 151;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -613,7 +613,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.3.7;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -626,7 +626,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 151;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -635,7 +635,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -715,7 +715,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 151;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.3.7;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 151;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -745,7 +745,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -96,6 +96,7 @@ final class TimerManager: ObservableObject {
             "max_duration": newConfig.maxDuration,
             "sound_type": String(describing: newConfig.soundType),
             "repeat_enabled": newConfig.repeatEnabled,
+            "voice_callouts_enabled": newConfig.voiceCalloutsEnabled,
         ])
 
         Task {
@@ -550,7 +551,7 @@ final class TimerManager: ObservableObject {
         Logger.timer.debug("tick: remaining = \(state.remainingDuration)")
 
         // Trigger voice callouts for Pro users
-        if ProManager.shared.isPro {
+        if ProManager.shared.isPro && state.config.voiceCalloutsEnabled {
             let elapsed = Int(state.targetDuration - state.remainingDuration)
             AIVoiceCalloutService.shared.triggerCallout(elapsedSeconds: elapsed)
         }

--- a/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ActiveTimerScreen: View {
     @EnvironmentObject var timerManager: TimerManager
     @Environment(\.verticalSizeClass) private var verticalSizeClass
-    
+
     @State private var loopEnabled: Bool = false
     @State private var showResetFeedback: Bool = false
     @State private var resetFeedbackTask: Task<Void, Never>?
@@ -195,7 +195,7 @@ struct ActiveTimerScreen: View {
         Button(action: {
             loopEnabled.toggle()
             updateConfigLoop()
-        }) {
+        }, label: {
             HStack(spacing: 6) {
                 Text("🔁")
                     .font(.body)
@@ -212,7 +212,7 @@ struct ActiveTimerScreen: View {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(loopEnabled ? Color.accentPrimary : Color.glassBorder, lineWidth: 1)
             )
-        }
+        })
         .buttonStyle(.plain)
     }
 
@@ -225,7 +225,9 @@ struct ActiveTimerScreen: View {
             hiddenMode: config.hiddenMode,
             repeatEnabled: loopEnabled,
             soundType: config.soundType,
-            volume: config.volume
+            volume: config.volume,
+            vibrationEnabled: config.vibrationEnabled,
+            voiceCalloutsEnabled: config.voiceCalloutsEnabled
         )
         timerManager.updateConfig(newConfig)
     }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -6,7 +6,7 @@ struct TimerSetupScreen: View {
     @EnvironmentObject var proManager: ProManager
     @State private var showPaywall = false
     @State private var paywallEntryPoint: PaywallEntryPoint = .unknown
-    @State private var showArsenal = false
+    @State private var showArsenal = true
     @AppStorage("hasCompletedFirstTimer") private var hasCompletedFirstTimer = false
 
     // Read directly from timerManager.config to avoid animation issues
@@ -130,10 +130,17 @@ struct TimerSetupScreen: View {
                             }
 
                             if proManager.isPro {
-                                Text("ON")
-                                    .font(.caption2)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(.accentPrimary)
+                                Toggle(
+                                    "",
+                                    isOn: Binding(
+                                        get: { config.voiceCalloutsEnabled },
+                                        set: { enabled in
+                                            updateConfig(voiceCalloutsEnabled: enabled)
+                                        }
+                                    )
+                                )
+                                .labelsHidden()
+                                .tint(.accentPrimary)
                             } else {
                                 Button {
                                     presentPaywall(entryPoint: .soundGate)
@@ -223,35 +230,29 @@ struct TimerSetupScreen: View {
                 .scaleEffect(1.02)
                 .padding(.vertical, 8)
 
-                // Zone 2: Tactical Expansion (PRO)
+                // 3. Sound Arsenal
                 HStack {
-                    Text("TACTICAL EXPANSION (PRO)")
+                    Text("Sound Arsenal")
                         .font(.caption2)
                         .fontWeight(.bold)
-                        .foregroundColor(proManager.isPro ? .accentPrimary : .textMuted)
+                        .foregroundColor(proManager.isPro ? .textPrimary : .textMuted)
                         .onTapGesture {
-                            if !proManager.isPro {
-                                presentPaywall(entryPoint: .soundGate)
-                            }
-                        }
-
-                    if !proManager.isPro {
-                        Image(systemName: "lock.fill")
-                            .font(.caption2)
-                            .foregroundColor(.textMuted)
-
-                        Spacer()
-
-                        Button {
                             withAnimation(.spring()) {
                                 showArsenal.toggle()
                             }
-                        } label: {
-                            Text(showArsenal ? "Hide Sound Arsenal" : "View Sound Arsenal")
-                                .font(.caption2)
-                                .fontWeight(.bold)
-                                .foregroundColor(.accentPrimary)
                         }
+
+                    Spacer()
+
+                    Button {
+                        withAnimation(.spring()) {
+                            showArsenal.toggle()
+                        }
+                    } label: {
+                        Text(showArsenal ? "Hide Sound Arsenal" : (proManager.isPro ? "View Sound Arsenal" : "Preview Sounds"))
+                            .font(.caption2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.accentPrimary)
                     }
                 }
                 .padding(.top, 8)
@@ -340,9 +341,13 @@ struct TimerSetupScreen: View {
         }
         .onAppear {
             AnalyticsService.shared.screen(AnalyticsScreens.timerSetup)
-            // Ensure Arsenal state matches Pro status on load
-            if proManager.isPro {
-                showArsenal = true
+            showArsenal = true
+        }
+        .onChange(of: proManager.isPro) { _, isPro in
+            if isPro {
+                withAnimation(.spring()) {
+                    showArsenal = true
+                }
             }
         }
     }
@@ -354,7 +359,8 @@ struct TimerSetupScreen: View {
         alarmDuration: Int? = nil,
         soundType: SoundType? = nil,
         volume: Float? = nil,
-        vibrationEnabled: Bool? = nil
+        vibrationEnabled: Bool? = nil,
+        voiceCalloutsEnabled: Bool? = nil
     ) {
         let newConfig = TimerConfig(
             minSeconds: minSeconds ?? config.minSeconds,
@@ -364,7 +370,8 @@ struct TimerSetupScreen: View {
             repeatEnabled: config.repeatEnabled,
             soundType: soundType ?? config.soundType,
             volume: volume ?? config.volume,
-            vibrationEnabled: vibrationEnabled ?? config.vibrationEnabled
+            vibrationEnabled: vibrationEnabled ?? config.vibrationEnabled,
+            voiceCalloutsEnabled: voiceCalloutsEnabled ?? config.voiceCalloutsEnabled
         )
         timerManager.updateConfig(newConfig)
     }

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -10,12 +10,13 @@ final class TimerConfigTests: XCTestCase {
         XCTAssertEqual(config.minSeconds, 0)
         XCTAssertEqual(config.maxSeconds, 30)
         XCTAssertEqual(config.alarmDuration, 10)
+        XCTAssertFalse(config.voiceCalloutsEnabled)
     }
 
     func testConfigInitEnforcesPreconditions() {
         // minSeconds cannot be negative
         // XCTest expect crash is hard, so we just check it doesn't throw if we use valid values
-        let _ = TimerConfig(minSeconds: 0, maxSeconds: 10)
+        _ = TimerConfig(minSeconds: 0, maxSeconds: 10)
     }
 
     func testConfigClampingForFreeUser() {
@@ -37,7 +38,7 @@ final class TimerConfigTests: XCTestCase {
     }
 
     func testConfigDecodingSupportsLegacyKeysAndLooseSoundNames() throws {
-        let payload = """
+        let payload = Data("""
         {
           "min_time": -5,
           "max_time": 9000,
@@ -48,7 +49,7 @@ final class TimerConfigTests: XCTestCase {
           "soundVolume": "1.5",
           "vibration": "yes"
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(TimerConfig.self, from: payload)
 
@@ -60,6 +61,26 @@ final class TimerConfigTests: XCTestCase {
         XCTAssertEqual(decoded.soundType, .drumRoll)
         XCTAssertEqual(decoded.volume, 1.0, accuracy: 0.0001)
         XCTAssertTrue(decoded.vibrationEnabled)
+        XCTAssertFalse(decoded.voiceCalloutsEnabled)
+    }
+
+    func testConfigEncodingRoundTripsVoiceCalloutsFlag() throws {
+        let config = TimerConfig(
+            minSeconds: 15,
+            maxSeconds: 45,
+            alarmDuration: 10,
+            hiddenMode: false,
+            repeatEnabled: true,
+            soundType: .gentle,
+            volume: 0.7,
+            vibrationEnabled: true,
+            voiceCalloutsEnabled: true
+        )
+
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(TimerConfig.self, from: encoded)
+
+        XCTAssertEqual(decoded, config)
     }
 }
 
@@ -447,7 +468,7 @@ final class TimerStateTests: XCTestCase {
     }
 
     func testStateDecodingSupportsLegacyKeysAndStatusNormalization() throws {
-        let payload = """
+        let payload = Data("""
         {
           "config": {},
           "target_duration": 120,
@@ -455,7 +476,7 @@ final class TimerStateTests: XCTestCase {
           "remaining_duration": 60,
           "timerStatus": "PAUSED"
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(TimerState.self, from: payload)
 

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ActivityKit
-
 // MARK: - Sound Type
 
 public enum SoundType: String, Codable, Sendable, CaseIterable {
@@ -105,6 +104,8 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     public let volume: Float
     /// Whether vibration is enabled
     public let vibrationEnabled: Bool
+    /// Whether timed voice callouts should play during training
+    public let voiceCalloutsEnabled: Bool
 
     public init(
         minSeconds: Int = 0,
@@ -114,7 +115,8 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         repeatEnabled: Bool = false, // Default to LOOP OFF
         soundType: SoundType = .intense,
         volume: Float = 0.5, // Default to 50%
-        vibrationEnabled: Bool = false
+        vibrationEnabled: Bool = false,
+        voiceCalloutsEnabled: Bool = false
     ) {
         precondition(minSeconds >= 0, "Minimum seconds cannot be negative")
         precondition(maxSeconds >= minSeconds, "Maximum seconds must be >= minimum seconds")
@@ -130,6 +132,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         self.soundType = soundType
         self.volume = volume
         self.vibrationEnabled = vibrationEnabled
+        self.voiceCalloutsEnabled = voiceCalloutsEnabled
     }
 
     /// Minimum as TimeInterval
@@ -157,6 +160,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         case soundType
         case volume
         case vibrationEnabled
+        case voiceCalloutsEnabled
 
         // Legacy / compatibility keys
         case minDuration
@@ -173,6 +177,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         case soundVolume
         case vibration
         case vibration_enabled
+        case voice_callouts_enabled
     }
 
     private enum EncodingKeys: String, CodingKey {
@@ -184,6 +189,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         case soundType
         case volume
         case vibrationEnabled
+        case voiceCalloutsEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -217,6 +223,10 @@ public struct TimerConfig: Codable, Sendable, Equatable {
             forKeys: [.vibrationEnabled, .vibration_enabled, .vibration],
             defaultValue: false
         )
+        let voiceCalloutsEnabled = container.decodeFirstBool(
+            forKeys: [.voiceCalloutsEnabled, .voice_callouts_enabled],
+            defaultValue: false
+        )
 
         let soundType = container.decodeFirstSoundType(
             forKeys: [.soundType, .sound_type, .alarmSound, .sound],
@@ -237,7 +247,8 @@ public struct TimerConfig: Codable, Sendable, Equatable {
             repeatEnabled: repeatEnabled,
             soundType: soundType,
             volume: clampedVolume,
-            vibrationEnabled: vibrationEnabled
+            vibrationEnabled: vibrationEnabled,
+            voiceCalloutsEnabled: voiceCalloutsEnabled
         )
     }
 
@@ -251,6 +262,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         try container.encode(soundType, forKey: .soundType)
         try container.encode(volume, forKey: .volume)
         try container.encode(vibrationEnabled, forKey: .vibrationEnabled)
+        try container.encode(voiceCalloutsEnabled, forKey: .voiceCalloutsEnabled)
     }
 
     /// Returns a copy of this config with values clamped to the caller's Pro entitlement.
@@ -269,7 +281,8 @@ public struct TimerConfig: Codable, Sendable, Equatable {
             repeatEnabled: repeatEnabled,
             soundType: clampedSound,
             volume: volume,
-            vibrationEnabled: vibrationEnabled
+            vibrationEnabled: vibrationEnabled,
+            voiceCalloutsEnabled: voiceCalloutsEnabled
         )
     }
 }

--- a/scripts/release_context.py
+++ b/scripts/release_context.py
@@ -22,6 +22,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+try:
+    from scripts.source_versions import VersionParseError, read_source_versions
+except ModuleNotFoundError:
+    from source_versions import VersionParseError, read_source_versions
+
 IPHONE_LARGE_DIMENSIONS = {
     "1320x2868",
     "2868x1320",
@@ -99,15 +104,10 @@ def _safe_output_path(raw_path: str, repo_root: Path) -> Path:
 
 
 def detect_ios_version(repo_root: Path) -> str:
-    pbxproj = repo_root / "native-ios" / "RandomTimer.xcodeproj" / "project.pbxproj"
-    if not pbxproj.is_file():
-        raise ContextError(f"Missing Xcode project file: {pbxproj}")
-
-    text = pbxproj.read_text(encoding="utf-8", errors="replace")
-    match = re.search(r"MARKETING_VERSION\s*=\s*([0-9]+(?:\.[0-9]+){1,2})\s*;", text)
-    if not match:
-        raise ContextError("Could not detect MARKETING_VERSION in project.pbxproj")
-    return match.group(1)
+    try:
+        return str(read_source_versions(repo_root)["ios"]["version_name"])
+    except VersionParseError as exc:
+        raise ContextError(str(exc)) from exc
 
 
 def _classify_dimension(size: str) -> str:

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -51,6 +51,17 @@ def test_ios_metadata_sync_can_remove_locked_waiting_for_review_version_and_uplo
     assert "remove_from_review_if_locked" in source
     assert "python scripts/asc_remove_from_review.py" in source
     assert "asc-remove-from-review" in source
+    assert "python scripts/source_versions.py --repo-root . --format shell" in source
+    assert "grep -m1 'MARKETING_VERSION'" not in source
+
+
+def test_ios_submit_and_native_release_workflows_use_shared_source_version_parser():
+    submit_source = (ROOT / ".github/workflows/ios-submit-review.yml").read_text(encoding="utf-8")
+    native_release_source = (ROOT / ".github/workflows/native-release.yml").read_text(encoding="utf-8")
+
+    assert "python scripts/source_versions.py --repo-root . --format shell" in submit_source
+    assert "grep -m1 'MARKETING_VERSION'" not in submit_source
+    assert "python scripts/source_versions.py --repo-root . --format shell" in native_release_source
 
 
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -13,6 +13,7 @@ ANDROID_VIEWMODEL = ROOT / "native-android/app/src/main/java/com/iganapolsky/ran
 ANDROID_SOUND_PREVIEW = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/SoundPreviewManager.kt"
 ANDROID_SOUND_PREVIEW_IMPL = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/data/SoundPreviewManagerImpl.kt"
 ANDROID_NAV = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt"
+ANDROID_PRO_MANAGER = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt"
 
 IOS_TIMER_MODELS = ROOT / "native-ios/SharedModels/TimerModels.swift"
 IOS_PRO_MANAGER = ROOT / "native-ios/RandomTimer/Sources/Services/ProManager.swift"
@@ -76,9 +77,31 @@ def test_paywall_hidden_unlock_is_on_title_and_unlocks_pro_not_elite():
 def test_voice_callouts_present_on_both_platforms():
     android_setup = _read(ANDROID_SETUP)
     ios_setup = _read(IOS_SETUP)
+    android_timer_config = _read(ANDROID_TIMER_CONFIG)
+    ios_timer_models = _read(IOS_TIMER_MODELS)
 
     for source in (android_setup, ios_setup):
         assert "Voice Callouts" in source
+        assert "Countdown" in source
+        assert "Focus" in source
+
+    assert "voiceCalloutsEnabled" in android_timer_config
+    assert "voiceCalloutsEnabled" in ios_timer_models
+
+
+def test_voice_callouts_use_toggle_when_pro_and_runtime_respects_setting():
+    android_setup = _read(ANDROID_SETUP)
+    android_service = _read(ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt")
+    ios_setup = _read(IOS_SETUP)
+    ios_timer_manager = _read(IOS_TIMER_MANAGER)
+
+    assert "checked = config.voiceCalloutsEnabled" in android_setup
+    assert "updateConfig(voiceCalloutsEnabled = enabled)" in android_setup
+    assert "proManager.entitlementLevel.value.isPro && state.config.voiceCalloutsEnabled" in android_service
+
+    assert "config.voiceCalloutsEnabled" in ios_setup
+    assert "updateConfig(voiceCalloutsEnabled: enabled)" in ios_setup
+    assert "ProManager.shared.isPro && state.config.voiceCalloutsEnabled" in ios_timer_manager
 
 
 def test_voice_preview_supports_command_cues_on_both_platforms():
@@ -97,3 +120,23 @@ def test_voice_preview_supports_command_cues_on_both_platforms():
     assert "func previewCommandCue()" in ios_timer_manager
     assert "func previewCommandCue()" in ios_voice_service
     assert "func previewCountdownCue()" in ios_voice_service
+
+
+def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
+    android_setup = _read(ANDROID_SETUP)
+    android_paywall = _read(ANDROID_PAYWALL)
+    android_nav = _read(ANDROID_NAV)
+    android_pro_manager = _read(ANDROID_PRO_MANAGER)
+    ios_setup = _read(IOS_SETUP)
+
+    assert "TACTICAL EXPANSION" not in android_setup
+    assert "TACTICAL EXPANSION" not in ios_setup
+    assert "Preview Sounds" in android_setup
+    assert "Preview Sounds" in ios_setup
+    assert "Sound Arsenal with 10 alarm sounds" in android_paywall
+
+    assert "const val PRO_PRODUCT_ID = ELITE_PRODUCT_ID" in android_pro_manager
+    assert "suspend fun getFormattedProPrice()" in android_pro_manager
+    assert "suspend fun launchProPurchase(" in android_pro_manager
+    assert "getFormattedProPrice()" in android_nav
+    assert "launchProPurchase(it, paywallEntryPoint)" in android_nav

--- a/scripts/tests/test_release_context.py
+++ b/scripts/tests/test_release_context.py
@@ -11,6 +11,7 @@ from scripts.release_context import (
     build_summary,
     collect_local_context,
     collect_remote_context,
+    detect_ios_version,
 )
 
 
@@ -31,6 +32,24 @@ def _write_png(path: Path, width: int, height: int, rgb: tuple[int, int, int] = 
 
 
 class ReleaseContextLocalTests(unittest.TestCase):
+    def test_detect_ios_version_reads_shared_source_metadata(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            ios_project = repo / "native-ios" / "RandomTimer.xcodeproj"
+            android_app = repo / "native-android" / "app"
+            ios_project.mkdir(parents=True)
+            android_app.mkdir(parents=True)
+            (ios_project / "project.pbxproj").write_text(
+                "MARKETING_VERSION = 1.3.7;\nCURRENT_PROJECT_VERSION = 151;\n",
+                encoding="utf-8",
+            )
+            (android_app / "build.gradle.kts").write_text(
+                'android {\n  defaultConfig {\n    versionCode = ciVersionCode ?: 1773900000\n    versionName = "1.3.7"\n  }\n}\n',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(detect_ios_version(repo), "1.3.7")
+
     def test_collect_local_context_marks_ready_when_assets_are_complete(self):
         with tempfile.TemporaryDirectory() as td:
             repo = Path(td)

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -95,10 +95,16 @@ def test_voice_callouts_are_gated_as_pro_on_both_platforms():
     android_setup = ANDROID_SETUP_SCREEN.read_text(encoding="utf-8")
     android_service = ANDROID_FOREGROUND_SERVICE.read_text(encoding="utf-8")
     ios_setup = IOS_SETUP_SCREEN.read_text(encoding="utf-8")
+    ios_timer_manager = (ROOT / "native-ios/RandomTimer/Sources/Services/TimerManager.swift").read_text(encoding="utf-8")
+    android_config = ANDROID_CONFIG.read_text(encoding="utf-8")
+    ios_models = IOS_MODELS.read_text(encoding="utf-8")
 
-    assert "if (isPro) {" in android_setup
-    assert "proManager.entitlementLevel.value.isPro" in android_service
-    assert "if proManager.isPro {" in ios_setup
+    assert "voiceCalloutsEnabled" in android_config
+    assert "public let voiceCalloutsEnabled: Bool" in ios_models
+    assert "checked = config.voiceCalloutsEnabled" in android_setup
+    assert "config.voiceCalloutsEnabled" in ios_setup
+    assert "proManager.entitlementLevel.value.isPro && state.config.voiceCalloutsEnabled" in android_service
+    assert "ProManager.shared.isPro && state.config.voiceCalloutsEnabled" in ios_timer_manager
 
 
 def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():
@@ -134,6 +140,20 @@ def test_voice_preview_actions_and_copy_match_across_mobile_platforms():
     ]:
         assert snippet in android_setup, f"Missing '{snippet}' in Android setup screen"
         assert snippet in ios_setup, f"Missing '{snippet}' in iOS setup screen"
+
+    assert "timed callouts during training" in android_setup.lower()
+    assert "timed callouts during training" in ios_setup.lower()
+
+
+def test_sound_arsenal_is_expanded_by_default_for_free_users():
+    android_setup = ANDROID_SETUP_SCREEN.read_text(encoding="utf-8")
+    ios_setup = IOS_SETUP_SCREEN.read_text(encoding="utf-8")
+
+    assert "var showArsenal by remember { mutableStateOf(!isPro) }" in android_setup
+    assert "@State private var showArsenal = true" in ios_setup
+    assert "showArsenal = true" in android_setup
+    assert 'Text("Sound Arsenal")' in ios_setup
+    assert 'text = "Sound Arsenal"' in android_setup
 
 
 def test_voice_runtime_callouts_are_elapsed_only_on_both_platforms():


### PR DESCRIPTION
## Summary
- align source release metadata with the real store candidate version (1.3.7 / Android base code 1773900000 / iOS build 151)
- replace the remaining brittle iOS workflow version extraction with `scripts/source_versions.py`
- include the Android/iOS Pro Sound Arsenal and voice-toggle persistence fix from the pending product branch
- add regression coverage for release-context/workflow parsing and mobile parity

## Verification
- python3 -m pytest -q scripts/tests/test_source_versions.py scripts/tests/test_compute_android_release_version_code.py scripts/tests/test_release_context.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_mobile_feature_parity.py scripts/tests/test_timer_defaults_parity.py
- bash scripts/preflight-release.sh --platform both --layer 1
- python3 scripts/source_versions.py --repo-root . --format json
- python3 scripts/release_context.py --repo-root . --locale en-US --json-out .tmp-release-context.json --no-remote
- cd native-android && ./gradlew assembleDebug testDebugUnitTest --tests com.iganapolsky.randomtimer.domain.model.TimerConfigTest --tests com.iganapolsky.randomtimer.data.repository.TimerRepositoryImplTest --tests com.iganapolsky.randomtimer.billing.MonetizationAnalyticsPayloadTest
- cd native-ios && xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,id=FB1D04C9-33DF-40E5-9F56-466FE9D1495B' -only-testing:RandomTimerTests/TimerConfigTests test

## Notes
- This supersedes the open product-only PR that fixed the Sound Arsenal and voice-toggle state but did not fix release-version drift.
