### PR TITLE
fix: skip android internal changelog uploads

### DIFF
--- a/native-android/fastlane/Fastfile
+++ b/native-android/fastlane/Fastfile
@@ -26,6 +26,7 @@ platform :android do
       track: "internal",
       aab: "app/build/outputs/bundle/release/app-release.aab",
       skip_upload_metadata: true,
+      skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: true
     )

--- a/scripts/tests/test_android_fastlane_contracts.py
+++ b/scripts/tests/test_android_fastlane_contracts.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FASTFILE = ROOT / "native-android" / "fastlane" / "Fastfile"
+
+
+def test_internal_lane_skips_play_changelog_uploads():
+    source = FASTFILE.read_text(encoding="utf-8")
+
+    assert "lane :internal do" in source
+    assert 'track: "internal"' in source
+    assert "skip_upload_metadata: true" in source
+    assert "skip_upload_changelogs: true" in source


### PR DESCRIPTION
## Summary
- skip Play changelog uploads on the Android internal lane so internal releases do not touch unsupported localized listing endpoints
- add a Fastlane contract test that locks this behavior in place

## Verification
- python3 -m pytest -q scripts/tests/test_android_fastlane_contracts.py scripts/tests/test_growth_workflow_contracts.py