### PR TITLE
fix: restore android internal distribution delivery

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -271,4 +271,112 @@ jobs:
         if: always()
         run: |
           rm -f /tmp/release.keystore native-android/play-store-key.json
+
+  android-firebase-internal:
+    name: Android Firebase App Distribution (Internal)
+    needs: [gate]
+    if: needs.gate.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.ref }}
+
+      - name: Fail fast on Firebase distribution inputs
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_INTERNAL_TESTERS: ${{ secrets.FIREBASE_INTERNAL_TESTERS }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          for name in GOOGLE_SERVICES_JSON ANDROID_KEYSTORE_BASE64 FIREBASE_ANDROID_APP_ID FIREBASE_INTERNAL_TESTERS; do
+            if [ -z "${!name:-}" ]; then
+              echo "❌ Missing required secret: $name"
+              exit 1
+            fi
+          done
+          if [ -z "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ] && [ -z "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
+            echo "❌ Missing required secret: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_PLAY_JSON_KEY"
+            exit 1
+          fi
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Create google-services.json
+        working-directory: native-android
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Decode keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > /tmp/release.keystore
+
+      - name: Build release APK
+        working-directory: native-android
+        env:
+          KEYSTORE_PATH: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+        run: |
+          set -euo pipefail
+          ./gradlew assembleRelease --no-daemon
+
+      - name: Write Firebase service account key
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > /tmp/firebase-service-account.json
+          else
+            echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/firebase-service-account.json
+          fi
+
+      - name: Distribute APK to Firebase App Distribution
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-service-account.json
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_INTERNAL_TESTERS: ${{ secrets.FIREBASE_INTERNAL_TESTERS }}
+        run: |
+          set -euo pipefail
+          npx --yes firebase-tools appdistribution:distribute \
+            native-android/app/build/outputs/apk/release/app-release.apk \
+            --app "$FIREBASE_ANDROID_APP_ID" \
+            --testers "$FIREBASE_INTERNAL_TESTERS" \
+            --release-notes "Internal CI build ${GITHUB_SHA}"
+
+      - name: Upload Android APK artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-apk-firebase-internal
+          path: native-android/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: warn
+
+      - name: Cleanup Firebase secrets
+        if: always()
+        run: |
+          rm -f /tmp/release.keystore /tmp/firebase-service-account.json
 # Triggering fresh check

--- a/native-android/fastlane/Fastfile
+++ b/native-android/fastlane/Fastfile
@@ -26,6 +26,7 @@ platform :android do
       track: "internal",
       aab: "app/build/outputs/bundle/release/app-release.aab",
       skip_upload_metadata: true,
+      skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: true
     )

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773762924.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773762924.txt
@@ -1,0 +1,3 @@
+- Fixed iOS Pro range validation and release build path regressions.
+- Improved internal distribution reliability for TestFlight and Google Play.
+- Polished premium setup flow labels and Sound Arsenal behavior.

--- a/scripts/tests/test_android_fastlane_contracts.py
+++ b/scripts/tests/test_android_fastlane_contracts.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FASTFILE = ROOT / "native-android" / "fastlane" / "Fastfile"
+
+
+def test_internal_lane_skips_play_changelog_uploads():
+    source = FASTFILE.read_text(encoding="utf-8")
+
+    assert "lane :internal do" in source
+    assert 'track: "internal"' in source
+    assert "skip_upload_metadata: true" in source
+    assert "skip_upload_changelogs: true" in source

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -23,6 +23,7 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
 
     assert "preflight-release" in source or "Preflight release" in source
     assert "ios-testflight-internal" in source or "android-internal" in source
+    assert "android-firebase-internal" in source
 
 
 def test_internal_distribution_workflow_emits_platform_specific_release_artifacts():
@@ -30,6 +31,7 @@ def test_internal_distribution_workflow_emits_platform_specific_release_artifact
 
     assert "ios-ipa-internal" in source or "ios-ipa" in source
     assert "android-aab-internal" in source or "android-aab" in source
+    assert "android-apk-firebase-internal" in source
 
 
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():

--- a/scripts/tests/test_source_versions.py
+++ b/scripts/tests/test_source_versions.py
@@ -71,3 +71,21 @@ def test_cli_json_output_matches_reader(tmp_path: Path):
     payload = json.loads(result.stdout)
     assert payload["android"]["version_code"] == 11
     assert payload["ios"]["build_number"] == 14
+
+
+def test_repository_android_version_code_has_nonempty_changelog():
+    repo_root = Path(__file__).resolve().parents[2]
+    versions = source_versions.read_source_versions(repo_root)
+    changelog_file = (
+        repo_root
+        / "native-android"
+        / "fastlane"
+        / "metadata"
+        / "android"
+        / "en-US"
+        / "changelogs"
+        / f"{versions['android']['version_code']}.txt"
+    )
+
+    assert changelog_file.is_file()
+    assert changelog_file.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary
- restore the Android Firebase App Distribution internal job to the internal distribution workflow
- restore the Android internal changelog coverage and guard it with source-version tests
- keep Play internal uploads off changelog endpoints in the Android internal Fastlane lane

## Verification
- python3 -m pytest -q scripts/tests/test_android_fastlane_contracts.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_source_versions.py
- bash scripts/preflight-release.sh --platform android --layer 1