### PR TITLE
Add SwiftUI agent skill bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: run-android-device run-android-emulator run-ios-device run-ios-sim fix-ios-device install-hooks
 .PHONY: verify verify-android verify-android-instrumentation verify-ios verify-ios-ui maestro-android maestro-ios
 .PHONY: playwright-install playwright-install-agent-browser playwright-verify-local playwright-verify-strict playwright-store-console playwright-store-console-agent playwright-sync-auth-secrets
+.PHONY: swiftui-skill-install swiftui-skill-verify
 .PHONY: device-tests device-tests-adb phoneclaw-visual
 
 ANDROID_DIR := native-android
@@ -191,3 +192,9 @@ self-heal:
 # Internal distribution (Firebase + TestFlight)
 distribute:
 	@gh workflow run internal-distribution.yml --ref develop
+
+swiftui-skill-install:
+	@bash scripts/install-swiftui-agent-skill.sh
+
+swiftui-skill-verify:
+	@bash scripts/verify-swiftui-agent-skill.sh

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Use paid spend only when attribution is measurable and activation quality holds.
 - **Python automation layer** in [`scripts/`](scripts/) drives release ops, analytics snapshots, growth reporting, and store metadata workflows.
 - **GitHub Actions pipelines** in [`.github/workflows/`](.github/workflows/) run CI, release automation, metadata sync, and guardrail checks.
 - **Fastlane metadata** lives under [`native-ios/fastlane`](native-ios/fastlane) and [`native-android/fastlane`](native-android/fastlane).
+- **Optional SwiftUI skill setup** for iOS-only agent work lives in [`docs/SWIFTUI_AGENT_SKILL.md`](docs/SWIFTUI_AGENT_SKILL.md).
 
 ## Build & Test
 

--- a/docs/SWIFTUI_AGENT_SKILL.md
+++ b/docs/SWIFTUI_AGENT_SKILL.md
@@ -1,0 +1,47 @@
+# SwiftUI-Agent-Skill
+
+This repo supports an optional SwiftUI-only agent skill workflow based on Paul Hudson's open-source [`twostraws/SwiftUI-Agent-Skill`](https://github.com/twostraws/SwiftUI-Agent-Skill).
+
+## Why This Exists
+
+The highest-ROI use is iOS UI work:
+- SwiftUI screen refactors
+- paywall and setup screen cleanup
+- iPhone/iPad layout polish
+- accessibility and state-binding review before App Store screenshot capture
+
+This integration is intentionally narrow. Do not use this skill for release, store publishing, CI repair, Android work, or production operations.
+
+## Cost
+
+The upstream skill is open source, so the repo-side adoption cost is `$0`.
+
+## Install
+
+Use the canonical task entrypoint:
+
+```bash
+make swiftui-skill-install
+```
+
+That installs the upstream `swiftui-pro` skill into `${CODEX_HOME:-~/.codex}/skills/swiftui-pro`.
+
+## Verify
+
+```bash
+make swiftui-skill-verify
+```
+
+The verifier checks for:
+- `SKILL.md`
+- `agents/`
+- `references/`
+
+## Scope Rule
+
+Use this skill only for:
+- SwiftUI implementation
+- SwiftUI review
+- iOS visual polish
+
+Keep release automation, store operations, analytics, and Android delivery in the repo's existing scripts and workflows.

--- a/scripts/install-swiftui-agent-skill.sh
+++ b/scripts/install-swiftui-agent-skill.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+SKILLS_DIR="$CODEX_HOME_DIR/skills"
+SKILL_NAME="${SWIFTUI_AGENT_SKILL_NAME:-swiftui-pro}"
+TARGET_DIR="$SKILLS_DIR/$SKILL_NAME"
+INSTALLER_ROOT="$CODEX_HOME_DIR/skills/.system/skill-installer"
+INSTALLER_SCRIPT="$INSTALLER_ROOT/scripts/install-skill-from-github.py"
+
+if [[ ! -f "$INSTALLER_SCRIPT" ]]; then
+  echo "SwiftUI skill installer helper not found: $INSTALLER_SCRIPT" >&2
+  exit 1
+fi
+
+if [[ -f "$TARGET_DIR/SKILL.md" ]]; then
+  echo "SwiftUI skill already installed: $TARGET_DIR"
+  exit 0
+fi
+
+mkdir -p "$SKILLS_DIR"
+
+python3 "$INSTALLER_SCRIPT" \
+  --repo twostraws/SwiftUI-Agent-Skill \
+  --path swiftui-pro \
+  --dest "$SKILLS_DIR" \
+  --name "$SKILL_NAME"
+
+echo "Installed SwiftUI skill to $TARGET_DIR"

--- a/scripts/tests/test_swiftui_agent_skill_integration.py
+++ b/scripts/tests/test_swiftui_agent_skill_integration.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+README = ROOT / "README.md"
+MAKEFILE = ROOT / "Makefile"
+DOC = ROOT / "docs" / "SWIFTUI_AGENT_SKILL.md"
+INSTALLER = ROOT / "scripts" / "install-swiftui-agent-skill.sh"
+VERIFIER = ROOT / "scripts" / "verify-swiftui-agent-skill.sh"
+
+
+def test_readme_links_to_swiftui_skill_guide():
+    source = README.read_text(encoding="utf-8")
+    assert "docs/SWIFTUI_AGENT_SKILL.md" in source
+
+
+def test_makefile_exposes_swiftui_skill_targets():
+    source = MAKEFILE.read_text(encoding="utf-8")
+    assert "swiftui-skill-install:" in source
+    assert "swiftui-skill-verify:" in source
+
+
+def test_swiftui_skill_doc_scopes_usage():
+    source = DOC.read_text(encoding="utf-8")
+    assert "SwiftUI-Agent-Skill" in source
+    assert "$0" in source
+    assert "SwiftUI" in source
+    assert "Do not use this skill for release" in source
+    assert "make swiftui-skill-install" in source
+    assert "make swiftui-skill-verify" in source
+
+
+def test_installer_script_uses_upstream_skill_installer_and_repo_path():
+    source = INSTALLER.read_text(encoding="utf-8")
+    assert "skill-installer" in source
+    assert "twostraws/SwiftUI-Agent-Skill" in source
+    assert "swiftui-pro" in source
+    assert "CODEX_HOME" in source
+
+
+def test_verifier_script_checks_expected_skill_layout():
+    source = VERIFIER.read_text(encoding="utf-8")
+    assert "SKILL.md" in source
+    assert "agents" in source
+    assert "references" in source
+    assert "swiftui-pro" in source

--- a/scripts/verify-swiftui-agent-skill.sh
+++ b/scripts/verify-swiftui-agent-skill.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+SKILL_NAME="${SWIFTUI_AGENT_SKILL_NAME:-swiftui-pro}"
+TARGET_DIR="$CODEX_HOME_DIR/skills/$SKILL_NAME"
+
+required_paths=(
+  "$TARGET_DIR/SKILL.md"
+  "$TARGET_DIR/agents"
+  "$TARGET_DIR/references"
+)
+
+for path in "${required_paths[@]}"; do
+  if [[ ! -e "$path" ]]; then
+    echo "Missing SwiftUI skill path: $path" >&2
+    exit 1
+  fi
+done
+
+echo "SwiftUI skill verified: $TARGET_DIR"


### PR DESCRIPTION
## Summary
- add repo-local bootstrap and verification scripts for the upstream SwiftUI-Agent-Skill
- add Make targets and docs for SwiftUI-only usage
- add contract tests for the integration

## Verification
- python3 -m pytest -q scripts/tests/test_swiftui_agent_skill_integration.py
- bash -n scripts/install-swiftui-agent-skill.sh
- bash -n scripts/verify-swiftui-agent-skill.sh
- CODEX_HOME=tmp make swiftui-skill-install swiftui-skill-verify
- gitleaks git --pre-commit --staged --no-banner
