### PR TITLE
fix(ci): correct preflight-release.sh path in internal distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -104,7 +104,7 @@ jobs:
           done
 
       - name: Preflight release checks (iOS)
-        run: bash scripts/ci/preflight-release.sh --platform ios --layer 1
+        run: bash scripts/preflight-release.sh --platform ios --layer 1
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -228,7 +228,7 @@ jobs:
           done
 
       - name: Preflight release checks (Android)
-        run: bash scripts/ci/preflight-release.sh --platform android --layer 1
+        run: bash scripts/preflight-release.sh --platform android --layer 1
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -389,7 +389,7 @@ jobs:
           fi
 
       - name: Preflight release checks (Android)
-        run: bash scripts/ci/preflight-release.sh --platform android --layer 1
+        run: bash scripts/preflight-release.sh --platform android --layer 1
 
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- All three internal distribution jobs (TestFlight, Play, Firebase) fail immediately because the workflow references `scripts/ci/preflight-release.sh` but the script lives at `scripts/preflight-release.sh`
- One-line path fix across 3 occurrences

## Test plan
- [ ] Re-run internal distribution after merge — all 3 jobs should pass the preflight step

🤖 Generated with [Claude Code](https://claude.com/claude-code)