### PR TITLE
fix(distribution): explicit group targeting

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -431,7 +431,7 @@ jobs:
         with:
           appId: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-          groups: ${{ vars.FIREBASE_INTERNAL_GROUPS || env.FIREBASE_INTERNAL_GROUPS }}
+          groups: "internal-testers"
           testers: ${{ vars.FIREBASE_INTERNAL_TESTERS }}
           file: native-android/app/build/outputs/apk/release/app-release.apk
           releaseNotes: |

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -132,7 +132,11 @@ platform :ios do
     testflight_api_key = defined?(api_key) ? api_key : nil
     upload_attempts = 0
     begin
-      upload_to_testflight(**testflight_upload_options(testflight_api_key))
+      upload_to_testflight(
+        api_key: testflight_api_key,
+        groups: ["Internal"],
+        skip_waiting_for_build_processing: false
+      )
     rescue => e
       raise unless duplicate_testflight_build_error?(e)
       raise if upload_attempts >= 1 || !defined?(api_key)


### PR DESCRIPTION
Restores explicit group targeting for Firebase (internal-testers) and TestFlight (Internal) to ensure notifications are triggered.