### PR TITLE
fix(ios): correct pilot parameter names for tester invite

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -209,9 +209,9 @@ platform :ios do
     pilot(
       api_key: api_key,
       app_identifier: "com.igorganapolsky.randomtimer",
-      tester_email: email,
-      tester_first_name: first,
-      tester_last_name: last,
+      email: email,
+      first_name: first,
+      last_name: last,
       groups: [group],
       distribute_only: true,
       notify_external_testers: true,


### PR DESCRIPTION
One-line fix: pilot uses email/first_name/last_name, not tester_email/tester_first_name/tester_last_name.