### PR TITLE
fix(release): restore ios version lineage guardrails

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -150,6 +150,13 @@ jobs:
           printf '%s' "$APPSTORE_PRIVATE_KEY" > "$KEY_PATH"
           python scripts/normalize_pem.py "$KEY_PATH"
 
+      - name: Guard iOS version lineage against ASC
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY_PATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
+        run: python scripts/check_ios_version_lineage.py --repo-root .
+
       - name: Configure git credentials for match
         env:
           GIT_AUTH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
@@ -177,9 +184,9 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          TESTFLIGHT_GROUPS: ${{ secrets.TESTFLIGHT_GROUPS }}
-          TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL }}
-          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ secrets.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS }}
+          TESTFLIGHT_GROUPS: ${{ secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
+          TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ secrets.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS || 'false' }}
         run: fastlane beta
         working-directory: native-ios
 

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -81,6 +81,13 @@ jobs:
           echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
           echo "$APPSTORE_PRIVATE_KEY" > /tmp/appstore_key.p8
 
+      - name: Guard iOS version lineage against ASC
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY_PATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
+        run: python scripts/check_ios_version_lineage.py --repo-root .
+
       - name: Resolve iOS version
         id: version
         env:

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1773779000
-        versionName = "1.2.6"
+        versionCode = ciVersionCode ?: 1773900000
+        versionName = "1.3.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CURRENT_PROJECT_VERSION = 172;
+				CURRENT_PROJECT_VERSION = 409;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -613,7 +613,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.9;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -626,7 +626,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 172;
+				CURRENT_PROJECT_VERSION = 409;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -635,7 +635,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -715,7 +715,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 172;
+				CURRENT_PROJECT_VERSION = 409;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.9;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 172;
+				CURRENT_PROJECT_VERSION = 409;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -745,7 +745,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/scripts/check_ios_version_lineage.py
+++ b/scripts/check_ios_version_lineage.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Prevent iOS TestFlight uploads from regressing behind live ASC pre-release versions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+try:
+    from scripts.asc_client import ASCClient, AscClientError
+    from scripts.source_versions import VersionParseError, read_source_versions
+except ModuleNotFoundError:
+    from asc_client import ASCClient, AscClientError
+    from source_versions import VersionParseError, read_source_versions
+
+
+SEMVER_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)\s*$")
+
+
+class LineageError(RuntimeError):
+    """Raised when local iOS versioning regresses behind App Store Connect."""
+
+
+@dataclass
+class LineageReport:
+    bundle_id: str
+    local_version: str
+    local_build: int
+    highest_remote_version: Optional[str]
+    highest_remote_build_for_highest_version: Optional[int]
+    highest_remote_build_for_local_version: Optional[int]
+    passed: bool
+    reason: str
+
+
+def _parse_semver(value: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(value or "")
+    if not match:
+        raise ValueError(f"Invalid semantic version: {value!r} (expected X.Y.Z)")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _semver_or_none(value: str) -> Optional[tuple[int, int, int]]:
+    try:
+        return _parse_semver(value)
+    except ValueError:
+        return None
+
+
+def _highest_semver(versions: list[str]) -> Optional[str]:
+    ranked: list[tuple[tuple[int, int, int], str]] = []
+    for version in versions:
+        parsed = _semver_or_none(version)
+        if parsed is None:
+            continue
+        ranked.append((parsed, version.strip()))
+    if not ranked:
+        return None
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return ranked[0][1]
+
+
+def _build_int_or_none(value: object) -> Optional[int]:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _highest_build(build_numbers: list[int]) -> Optional[int]:
+    return max(build_numbers) if build_numbers else None
+
+
+def _get_app_id(client: ASCClient, bundle_id: str) -> str:
+    data = client.get("/apps", params={"filter[bundleId]": bundle_id})
+    apps = data.get("data", [])
+    if not apps:
+        raise LineageError(f"No App Store Connect app found for bundleId={bundle_id}")
+    return str(apps[0].get("id") or "")
+
+
+def _list_remote_pre_release_versions(client: ASCClient, app_id: str) -> list[str]:
+    items = client.get_all(
+        "/preReleaseVersions",
+        params={
+            "filter[app]": app_id,
+            "limit": 200,
+            "fields[preReleaseVersions]": "version,platform",
+        },
+    )
+    versions: list[str] = []
+    for item in items:
+        attrs = item.get("attributes") or {}
+        if str(attrs.get("platform") or "").upper() != "IOS":
+            continue
+        version = str(attrs.get("version") or "").strip()
+        if version:
+            versions.append(version)
+    return versions
+
+
+def _list_remote_builds_by_marketing_version(client: ASCClient, app_id: str) -> dict[str, list[int]]:
+    data = client.get(
+        "/builds",
+        params={
+            "filter[app]": app_id,
+            "include": "preReleaseVersion",
+            "sort": "-uploadedDate",
+            "limit": 200,
+            "fields[builds]": "version,preReleaseVersion",
+            "fields[preReleaseVersions]": "version",
+        },
+    )
+
+    pre_release_versions: dict[str, str] = {}
+    for item in data.get("included", []):
+        if item.get("type") != "preReleaseVersions":
+            continue
+        version = str((item.get("attributes") or {}).get("version") or "").strip()
+        if version:
+            pre_release_versions[str(item.get("id") or "")] = version
+
+    builds_by_version: dict[str, list[int]] = {}
+    for build in data.get("data", []):
+        rel = (
+            (build.get("relationships") or {})
+            .get("preReleaseVersion", {})
+            .get("data")
+            or {}
+        )
+        marketing_version = pre_release_versions.get(str(rel.get("id") or ""))
+        build_number = _build_int_or_none((build.get("attributes") or {}).get("version"))
+        if marketing_version is None or build_number is None:
+            continue
+        builds_by_version.setdefault(marketing_version, []).append(build_number)
+    return builds_by_version
+
+
+def evaluate_lineage(
+    *,
+    bundle_id: str,
+    local_version: str,
+    local_build: int,
+    remote_versions: list[str],
+    remote_builds_by_version: dict[str, list[int]],
+) -> LineageReport:
+    highest_remote_version = _highest_semver(remote_versions)
+    highest_remote_build_for_local_version = _highest_build(remote_builds_by_version.get(local_version, []))
+    highest_remote_build_for_highest_version = (
+        _highest_build(remote_builds_by_version.get(highest_remote_version, []))
+        if highest_remote_version is not None
+        else None
+    )
+
+    if highest_remote_version is None:
+        return LineageReport(
+            bundle_id=bundle_id,
+            local_version=local_version,
+            local_build=local_build,
+            highest_remote_version=None,
+            highest_remote_build_for_highest_version=None,
+            highest_remote_build_for_local_version=highest_remote_build_for_local_version,
+            passed=True,
+            reason="no_remote_ios_pre_release_versions_found",
+        )
+
+    if _parse_semver(local_version) < _parse_semver(highest_remote_version):
+        return LineageReport(
+            bundle_id=bundle_id,
+            local_version=local_version,
+            local_build=local_build,
+            highest_remote_version=highest_remote_version,
+            highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
+            highest_remote_build_for_local_version=highest_remote_build_for_local_version,
+            passed=False,
+            reason=(
+                f"Local iOS marketing version {local_version} regresses behind "
+                f"App Store Connect pre-release version {highest_remote_version}"
+            ),
+        )
+
+    if highest_remote_build_for_local_version is not None and local_build < highest_remote_build_for_local_version:
+        reason = (
+            f"Local iOS build {local_build} trails ASC build {highest_remote_build_for_local_version} "
+            f"for version {local_version}; next TestFlight upload will auto-increment."
+        )
+    else:
+        reason = "local_ios_version_lineage_is_current"
+
+    return LineageReport(
+        bundle_id=bundle_id,
+        local_version=local_version,
+        local_build=local_build,
+        highest_remote_version=highest_remote_version,
+        highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
+        highest_remote_build_for_local_version=highest_remote_build_for_local_version,
+        passed=True,
+        reason=reason,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate local iOS source version against live App Store Connect pre-release versions."
+    )
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument("--bundle-id", default="com.igorganapolsky.randomtimer")
+    parser.add_argument("--json-out", default="", help="Optional JSON report output path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    repo_root = Path(args.repo_root).resolve()
+
+    try:
+        versions = read_source_versions(repo_root)
+    except (OSError, VersionParseError) as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        client = ASCClient.from_env(timeout=30)
+        app_id = _get_app_id(client, args.bundle_id)
+        remote_versions = _list_remote_pre_release_versions(client, app_id)
+        remote_builds_by_version = _list_remote_builds_by_marketing_version(client, app_id)
+    except (AscClientError, LineageError) as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+
+    report = evaluate_lineage(
+        bundle_id=args.bundle_id,
+        local_version=str(versions["ios"]["version_name"]),
+        local_build=int(versions["ios"]["build_number"]),
+        remote_versions=remote_versions,
+        remote_builds_by_version=remote_builds_by_version,
+    )
+
+    print(f"Local iOS source version: {report.local_version} ({report.local_build})")
+    print(f"ASC highest pre-release version: {report.highest_remote_version or 'none'}")
+    if report.highest_remote_build_for_highest_version is not None:
+        print(
+            "ASC highest build for highest version: "
+            f"{report.highest_remote_build_for_highest_version}"
+        )
+    if report.highest_remote_build_for_local_version is not None:
+        print(
+            f"ASC highest build for local version {report.local_version}: "
+            f"{report.highest_remote_build_for_local_version}"
+        )
+    print(report.reason)
+
+    if args.json_out:
+        output_path = Path(args.json_out)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(asdict(report), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_ios_version_lineage.py
+++ b/scripts/tests/test_check_ios_version_lineage.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from scripts.check_ios_version_lineage import evaluate_lineage
+
+
+def test_evaluate_lineage_rejects_local_marketing_version_behind_remote():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.2.6",
+        local_build=172,
+        remote_versions=["1.0", "1.2.6", "1.3.9"],
+        remote_builds_by_version={"1.2.6": [194], "1.3.9": [409]},
+    )
+
+    assert report.passed is False
+    assert report.highest_remote_version == "1.3.9"
+    assert report.highest_remote_build_for_highest_version == 409
+    assert "regresses behind" in report.reason
+
+
+def test_evaluate_lineage_allows_current_marketing_version_with_lower_local_build():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.9",
+        local_build=409,
+        remote_versions=["1.0", "1.2.6", "1.3.9"],
+        remote_builds_by_version={"1.2.6": [194], "1.3.9": [409]},
+    )
+
+    assert report.passed is True
+    assert report.highest_remote_version == "1.3.9"
+    assert report.highest_remote_build_for_local_version == 409
+    assert "lineage_is_current" in report.reason or "auto-increment" in report.reason
+
+
+def test_evaluate_lineage_ignores_non_semver_remote_versions_when_choosing_highest():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.9",
+        local_build=409,
+        remote_versions=["1.0", "1.3.9", "not-a-version"],
+        remote_builds_by_version={"1.3.9": [409]},
+    )
+
+    assert report.passed is True
+    assert report.highest_remote_version == "1.3.9"

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 INTERNAL_DISTRIBUTION_WORKFLOW = ROOT / ".github/workflows/internal-distribution.yml"
 IOS_INTERNAL_RETRY_WORKFLOW = ROOT / ".github/workflows/ios-internal-retry.yml"
+IOS_SUBMIT_REVIEW_WORKFLOW = ROOT / ".github/workflows/ios-submit-review.yml"
 NORTH_STAR_GUARDRAIL_WORKFLOW = ROOT / ".github/workflows/north-star-guardrail.yml"
 NORTH_STAR_OPS_WORKFLOW = ROOT / ".github/workflows/north-star-ops.yml"
 WEEKLY_EXPERIMENT_WORKFLOW = ROOT / ".github/workflows/weekly-north-star-experiment.yml"
@@ -24,6 +25,9 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
 
     assert "preflight-release" in source or "Preflight release" in source
     assert "ios-testflight-internal" in source or "android-internal" in source
+    assert "check_ios_version_lineage.py" in source
+    assert "Internal Testers" in source
+    assert "TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}" in source
 
 
 def test_internal_distribution_workflow_emits_platform_specific_release_artifacts():
@@ -48,6 +52,12 @@ def test_ios_internal_retry_dispatch_targets_ios_only():
     source = IOS_INTERNAL_RETRY_WORKFLOW.read_text(encoding="utf-8")
 
     assert "-f target=ios" in source
+
+
+def test_ios_submit_review_workflow_guards_ios_version_lineage():
+    source = IOS_SUBMIT_REVIEW_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "check_ios_version_lineage.py" in source
 
 
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():


### PR DESCRIPTION
## Summary
- restore source version lineage to the live iOS/TestFlight line (`1.3.9` / build `409`) so the next internal build supersedes the currently installed `1.3.9 (409)` build instead of downgrading to `1.2.6 (194)`
- add a live App Store Connect lineage guard that blocks internal distribution and review submission when the repo marketing version trails the highest ASC pre-release version
- make internal distribution deterministic for the current setup by defaulting TestFlight delivery to `Internal Testers` and explicit external flags of `false`

## Verification
- `python3 scripts/source_versions.py --repo-root . --format json`
- `python3 -m pytest -q scripts/tests/test_check_ios_version_lineage.py scripts/tests/test_source_versions.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_validate_release_branch.py scripts/tests/test_compute_android_release_version_code.py`
- `git diff --check`
- `python3 -m py_compile scripts/check_ios_version_lineage.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/internal-distribution.yml"); YAML.load_file(".github/workflows/ios-submit-review.yml"); puts "yaml:ok"'`
- `bash scripts/preflight-release.sh --platform both --layer 1`
- `python3 scripts/check_ios_version_lineage.py --repo-root .` with live ASC credentials
- `gh secret set TESTFLIGHT_GROUPS --body "Internal Testers"`
- `gh secret set TESTFLIGHT_DISTRIBUTE_EXTERNAL --body "false"`
- `gh secret set TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS --body "false"`

## Live ASC evidence
- Local iOS source version: `1.3.9 (409)`
- ASC highest pre-release version: `1.3.9`
- ASC highest build for `1.3.9`: `409`
- Internal Distribution run `23311249170` successfully uploaded and distributed `1.2.6 (194)`, which explains the missing update: the device was already on newer build `1.3.9 (409)`.
