### PR TITLE
fix(ci): install asc deps before ios lineage guard

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -150,6 +150,9 @@ jobs:
           printf '%s' "$APPSTORE_PRIVATE_KEY" > "$KEY_PATH"
           python scripts/normalize_pem.py "$KEY_PATH"
 
+      - name: Install App Store Connect Python dependencies
+        run: python -m pip install pyjwt==2.11.0 cryptography==46.0.5 requests==2.32.5
+
       - name: Guard iOS version lineage against ASC
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -197,7 +200,6 @@ jobs:
           APPSTORE_PRIVATE_KEY_PATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
         run: |
           set -euo pipefail
-          python -m pip install pyjwt==2.11.0 cryptography==46.0.5 requests==2.32.5
           VERSION="$(python scripts/source_versions.py --repo-root . --format json | python -c 'import json,sys; print(json.load(sys.stdin)["ios"]["version_name"])')"
           python scripts/verify_release.py --platform ios --version "$VERSION" --wait --timeout 900 --poll-interval 60
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -26,6 +26,10 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
     assert "preflight-release" in source or "Preflight release" in source
     assert "ios-testflight-internal" in source or "android-internal" in source
     assert "check_ios_version_lineage.py" in source
+    assert "Install App Store Connect Python dependencies" in source
+    assert source.index("Install App Store Connect Python dependencies") < source.index(
+        "Guard iOS version lineage against ASC"
+    )
     assert "Internal Testers" in source
     assert "TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}" in source
 


### PR DESCRIPTION
## Summary
- install App Store Connect Python dependencies before the iOS lineage guard in Internal Distribution
- reuse that install for the later TestFlight read-back step
- lock the workflow contract test to require dependency install before the guard

## Evidence
- `python3 -m pytest -q scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_check_ios_version_lineage.py scripts/tests/test_source_versions.py`
- `git diff --check`
- clean-venv reproduction: guard failed with `Missing requests` before install, then passed after installing `pyjwt`, `cryptography`, and `requests`