### PR TITLE
fix(ci): skip pilot group assignment for internal testflight

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -21,15 +21,15 @@ platform :ios do
       api_key: api_key
     }
 
+    distribute_external = ENV.fetch("TESTFLIGHT_DISTRIBUTE_EXTERNAL", "false") == "true"
+    return options unless distribute_external
+
     group_names = ENV.fetch("TESTFLIGHT_GROUPS", "").split(",").map(&:strip).reject(&:empty?)
-    return options if group_names.empty?
+    UI.user_error!("TESTFLIGHT_GROUPS required when TESTFLIGHT_DISTRIBUTE_EXTERNAL=true") if group_names.empty?
 
     options[:groups] = group_names
-    distribute_external = ENV.fetch("TESTFLIGHT_DISTRIBUTE_EXTERNAL", "false") == "true"
-    options[:distribute_external] = distribute_external
-    if distribute_external
-      options[:notify_external_testers] = ENV.fetch("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS", "false") == "true"
-    end
+    options[:distribute_external] = true
+    options[:notify_external_testers] = ENV.fetch("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS", "false") == "true"
     options
   end
 

--- a/scripts/tests/test_ios_fastlane_contracts.py
+++ b/scripts/tests/test_ios_fastlane_contracts.py
@@ -5,12 +5,14 @@ ROOT = Path(__file__).resolve().parents[2]
 FASTFILE = ROOT / "native-ios/fastlane/Fastfile"
 
 
-def test_ios_beta_lane_supports_explicit_testflight_groups():
+def test_ios_beta_lane_only_assigns_testflight_groups_for_external_distribution():
     source = FASTFILE.read_text(encoding="utf-8")
 
     assert "TESTFLIGHT_GROUPS" in source
+    assert 'return options unless distribute_external' in source
     assert "options[:groups]" in source
-    assert "distribute_external" in source
+    assert "options[:distribute_external] = true" in source
+    assert 'TESTFLIGHT_GROUPS required when TESTFLIGHT_DISTRIBUTE_EXTERNAL=true' in source
 
 
 def test_ios_beta_lane_handles_duplicate_build_numbers_with_retry_logic():


### PR DESCRIPTION
## Summary
- stop passing TestFlight groups to Fastlane upload for internal-only uploads
- require TESTFLIGHT_GROUPS only when external distribution is explicitly enabled
- lock the behavior with a Fastlane contract test

## Verification
- python3 -m pytest -q scripts/tests/test_ios_fastlane_contracts.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_check_ios_version_lineage.py scripts/tests/test_source_versions.py
- git diff --check

## Runtime evidence
- Internal Distribution run 23314745636 uploaded and processed 1.3.9 (410) successfully
- the same run failed afterward inside pilot with Access Unavailable while assigning groups
- live ASC read-back already shows GROUP_BUILD 410 in Internal Testers
