### PR TITLE
chore: upgrade GitHub Actions workflow runtimes

### DIFF
--- a/.github/workflows/add-testflight-tester.yml
+++ b/.github/workflows/add-testflight-tester.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/android-metadata-sync.yml
+++ b/.github/workflows/android-metadata-sync.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/android17-canary.yml
+++ b/.github/workflows/android17-canary.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         working-directory: native-android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload canary test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android17-canary-artifacts
           path: |

--- a/.github/workflows/asc-ground-truth.yml
+++ b/.github/workflows/asc-ground-truth.yml
@@ -4,9 +4,9 @@ jobs:
   check:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/branch-protection-sync.yml
+++ b/.github/workflows/branch-protection-sync.yml
@@ -15,7 +15,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate branch protection token
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Architecture Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Architecture ban checks (Kotlin)
         run: |
@@ -81,10 +81,10 @@ jobs:
     name: Legacy Python Compile Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -111,7 +111,7 @@ jobs:
       run:
         working-directory: native-android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-java@v4
         with:
@@ -139,14 +139,14 @@ jobs:
         run: ./gradlew assembleDebug --no-daemon
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug
           path: native-android/app/build/outputs/apk/debug/app-debug.apk
 
       - name: Upload Android coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-unit-coverage
           path: |
@@ -161,7 +161,7 @@ jobs:
       run:
         working-directory: native-ios
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select Xcode
         run: |
@@ -227,7 +227,7 @@ jobs:
 
       - name: Upload iOS xcresult
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-test-results-xcresult
           path: native-ios/build/TestResults.xcresult
@@ -240,10 +240,10 @@ jobs:
       run:
         working-directory: tests/playwright
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-local-artifacts
           path: |
@@ -268,10 +268,10 @@ jobs:
     name: Python Script Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -283,7 +283,7 @@ jobs:
 
       - name: Upload Python coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-coverage-xml
           path: coverage-python.xml
@@ -312,7 +312,7 @@ jobs:
 
       - name: Upload release readiness artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-readiness-local
           path: |
@@ -325,10 +325,10 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -369,7 +369,7 @@ jobs:
 
       - name: Upload north star artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: north-star-guardrail
           path: marketing/data/north_star.json
@@ -383,7 +383,7 @@ jobs:
       pull-requests: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -450,7 +450,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Enforce AI review thread resolution
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -523,10 +523,10 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -560,7 +560,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const androidResult = '${{ needs.android.result }}';

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,7 +35,7 @@ jobs:
       statuses: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Claude Code Review
         id: claude_review
@@ -119,7 +119,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Claude Code Assist
         if: ${{ env.ANTHROPIC_API_KEY != '' }}

--- a/.github/workflows/daily-growth-publishing.yml
+++ b/.github/workflows/daily-growth-publishing.yml
@@ -23,12 +23,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -104,7 +104,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
       - name: Upload growth artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: growth-daily-artifacts
           path: |

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/enforce-develop-to-main.yml
+++ b/.github/workflows/enforce-develop-to-main.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 1

--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-26
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.gate.outputs.ref }}
 
@@ -107,7 +107,7 @@ jobs:
         run: bash scripts/preflight-release.sh --platform ios --layer 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -204,7 +204,7 @@ jobs:
           python scripts/verify_release.py --platform ios --version "$VERSION" --wait --timeout 900 --poll-interval 60
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ios-ipa-internal
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.gate.outputs.ref }}
 
@@ -347,7 +347,7 @@ jobs:
             --version "${{ steps.versions.outputs.android_version_name }}"
 
       - name: Upload Android AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: android-aab-internal
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.gate.outputs.ref }}
 
@@ -453,7 +453,7 @@ jobs:
           echo "::warning::Firebase App Distribution failed (e.g. 404). Check vars.FIREBASE_INTERNAL_GROUPS matches a valid group alias in Firebase Console, or vars.FIREBASE_INTERNAL_TESTERS has valid emails."
 
       - name: Upload Android APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: android-apk-firebase-internal

--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -37,7 +37,7 @@ jobs:
       IOS_METADATA_ONLY: ${{ inputs.metadata_only }}
       IOS_STRICT_RETRY_ON_EDITABLE: ${{ inputs.strict_retry_on_editable }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fail fast on required App Store secrets
         env:
@@ -70,7 +70,7 @@ jobs:
           fastlane --version
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload readiness report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: asc-ready-report
           path: |
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload version resolution report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: asc-version-resolution
           path: /tmp/asc_version.json

--- a/.github/workflows/ios-release-context.yml
+++ b/.github/workflows/ios-release-context.yml
@@ -27,10 +27,10 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload release context artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-release-context
           path: /tmp/release-context.json

--- a/.github/workflows/ios-reviews-ops.yml
+++ b/.github/workflows/ios-reviews-ops.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload reviews ops artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: asc-reviews-ops
           path: |

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fail fast on required App Store secrets
         env:
@@ -54,7 +54,7 @@ jobs:
         run: bash scripts/preflight-release.sh --platform ios --layer 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -230,14 +230,14 @@ jobs:
 
       - name: Upload version resolution report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: asc-version-resolution
           path: /tmp/asc_version.json
 
       - name: Upload submission readiness artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-submit-readiness
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
       PROJECTS_V2_OWNER: IgorGanapolsky
       PROJECTS_V2_NUMBER: 1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/github-script@v7
+      - uses: actions/checkout@v6
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PROJECT_PAT }}
           script: |

--- a/.github/workflows/north-star-guardrail.yml
+++ b/.github/workflows/north-star-guardrail.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload north star snapshot
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: north-star-snapshot
           path: marketing/data/north_star.json

--- a/.github/workflows/north-star-ops.yml
+++ b/.github/workflows/north-star-ops.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload North Star ops report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: north-star-ops-report
           path: |

--- a/.github/workflows/pause-paid-campaigns.yml
+++ b/.github/workflows/pause-paid-campaigns.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -80,7 +80,7 @@ jobs:
           CREATE_PR_OPERATION: ${{ steps.create_pr.outputs.pull-request-operation }}
           CREATE_PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}
           INPUT_REASON: ${{ inputs.reason }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paid-pause-artifacts
           path: |

--- a/.github/workflows/play-production-countries.yml
+++ b/.github/workflows/play-production-countries.yml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: tests/playwright
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload Play Console artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: play-production-countries-artifacts
           path: tests/playwright/test-results/play-production-countries

--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   check_suite:
-    types: [requested, rerequested, completed]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -27,7 +27,7 @@ jobs:
       issues: write
     steps:
       - name: Reconcile labels, commit status, and incidents
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           REQUIRED_CHECKS_FROM_VAR: ${{ vars.PR_REQUIRED_CHECKS || '' }}
         with:

--- a/.github/workflows/projects-perms-check.yml
+++ b/.github/workflows/projects-perms-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Projects v2 token access
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PROJECTS_V2_OWNER: IgorGanapolsky
           PROJECTS_V2_NUMBER: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -36,13 +36,13 @@ jobs:
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate version
         env:
           VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "Invalid version format: $VERSION"
             exit 1
           fi
@@ -55,10 +55,10 @@ jobs:
       id-token: write
     environment: ${{ github.event.inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -132,14 +132,14 @@ jobs:
           previous_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           if [ -n "$previous_tag" ]; then
             echo "# Changes since $previous_tag" > RELEASE_NOTES.md
-            git log --pretty=format:"* %s" $previous_tag..HEAD >> RELEASE_NOTES.md
+            git log --pretty=format:"* %s" "${previous_tag}"..HEAD >> RELEASE_NOTES.md
           else
             echo "# Initial release" > RELEASE_NOTES.md
             git log --pretty=format:"* %s" >> RELEASE_NOTES.md
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.6.1
         if: ${{ github.event.inputs.environment == 'production' }}
         with:
           tag_name: ${{ needs.prepare.outputs.version }}
@@ -151,7 +151,7 @@ jobs:
             sbom.cdx.json
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom
           path: sbom.cdx.json

--- a/.github/workflows/resolve-bot-comments.yml
+++ b/.github/workflows/resolve-bot-comments.yml
@@ -15,10 +15,10 @@ jobs:
   resolve:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,13 +28,13 @@ jobs:
       matrix:
         scan-type: [dependencies, code, mobile]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
         if: matrix.scan-type == 'dependencies'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload Security Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-results-${{ matrix.scan-type }}
           path: |

--- a/.github/workflows/store-console-verification.yml
+++ b/.github/workflows/store-console-verification.yml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: tests/playwright
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: store-console-verification-artifacts
           path: |

--- a/.github/workflows/weekly-aso-rotation.yml
+++ b/.github/workflows/weekly-aso-rotation.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload rotation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: aso-rotation-report
           path: marketing/data/aso_rotation_report.md

--- a/.github/workflows/weekly-attribution-feedback.yml
+++ b/.github/workflows/weekly-attribution-feedback.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload attribution report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: attribution-report
           path: marketing/data/attribution-report.md

--- a/.github/workflows/weekly-cro-optimization.yml
+++ b/.github/workflows/weekly-cro-optimization.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload CRO report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cro-report
           path: |

--- a/.github/workflows/weekly-north-star-experiment.yml
+++ b/.github/workflows/weekly-north-star-experiment.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload experiment artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-north-star-experiment
           path: |

--- a/.github/workflows/weekly-paid-acquisition.yml
+++ b/.github/workflows/weekly-paid-acquisition.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload acquisition report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paid-acquisition-report
           path: |

--- a/.github/workflows/weekly-referral-content.yml
+++ b/.github/workflows/weekly-referral-content.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload referral report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: referral-report
           path: |

--- a/.github/workflows/weekly-review-velocity.yml
+++ b/.github/workflows/weekly-review-velocity.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload velocity report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: review-velocity-report
           path: |

--- a/.github/workflows/weekly-shared.yml
+++ b/.github/workflows/weekly-shared.yml
@@ -95,12 +95,12 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: ${{ fromJSON(inputs.fetch_depth) }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload artifact
         if: always() && inputs.artifact_name != '' && inputs.artifact_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_path }}

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload dashboard snapshot
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wiki-dashboard
           path: |


### PR DESCRIPTION
## Summary
- upgrade stale GitHub Actions runtime-dependent actions to current releases across workflow files
- fix invalid `check_suite` activity types in the PR state machine workflow
- upgrade `softprops/action-gh-release` and clean the remaining quote issues in `release.yml`

## Verification
- `rg -n "actions/(checkout@v4|setup-python@v5|setup-node@v4|upload-artifact@v4|github-script@v7)" .github/workflows -g "*.yml"`
- `actionlint .github/workflows/pr-state-machine.yml .github/workflows/release.yml`
- `actionlint -ignore "SC2044|SC2012|SC2129|SC2155|SC2086" .github/workflows/*.yml`
- `git diff --check`