### PR TITLE
chore: update codecov action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload Python coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:
           files: coverage-python.xml
           flags: python-scripts


### PR DESCRIPTION
## Summary
- update the pinned Codecov action from the old v5 commit to upstream `v5.5.3`
- remove the remaining Node 20 deprecation source seen in merged `develop` CI

## Verification
- `rg -n "codecov/codecov-action@" .github/workflows -g "*.yml"`
- `actionlint -ignore "SC2044|SC2012|SC2129|SC2155|SC2086" .github/workflows/ci.yml`
- `gh api 'repos/codecov/codecov-action/contents/action.yml?ref=1af58845a975a7985b0beb0cbe6fbbb71a41dbad' --jq .content | tr -d "\\n" | base64 --decode`\n- `git diff --check`