### PR TITLE
fix(ios): restore sticky setup start timer button

### DIFF
--- a/.ai/changelog/2026-03.md
+++ b/.ai/changelog/2026-03.md
@@ -1,5 +1,13 @@
 # 2026-03
 
+## 2026-03-20 — Restore sticky iOS Start Timer action on setup
+
+- moved the iOS `Start Timer` CTA out of the scroll content and back into a bottom safe-area inset so it stays visible on smaller devices
+- added enough trailing spacer in the setup scroll view so the lower cards no longer slide underneath the sticky footer
+- added a parity guard that fails if the iOS setup screen loses its sticky bottom action bar again
+- added an iOS UI test that requires the `Start Timer` button to be hittable on launch, not merely present somewhere in the hierarchy
+- confirmed the regression source: `release/v1.3.9` already had the sticky footer, but `develop` was still shipping the older in-scroll layout to TestFlight
+
 ## 2026-03-17 — Technical debt audit: analytics truth + release parsing cleanup
 
 - preserved last-known-good analytics outputs when PostHog data is degraded or missing, instead of publishing fake zeroes

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -264,15 +264,6 @@ struct TimerSetupScreen: View {
                     }
                 }
 
-                // Start Button
-                PrimaryButton(title: "Start Timer") {
-                    Task {
-                        await timerManager.startTimer()
-                    }
-                }
-                .scaleEffect(1.02)
-                .padding(.vertical, 8)
-
                 // 4. Sound Arsenal
                 HStack {
                     Text("SOUND ARSENAL")
@@ -368,9 +359,20 @@ struct TimerSetupScreen: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
                 }
 
-                Spacer(minLength: 32)
+                Spacer(minLength: 140)
             }
             .padding(.horizontal, 24)
+        }
+        .safeAreaInset(edge: .bottom) {
+            PrimaryButton(title: "Start Timer") {
+                Task {
+                    await timerManager.startTimer()
+                }
+            }
+            .scaleEffect(1.02)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 8)
+            .background(Color.backgroundDark)
         }
         .background(Color.backgroundDark.ignoresSafeArea())
         .navigationTitle("Random Tactical Timer")

--- a/native-ios/RandomTimerUITests/RandomTimerUITests.swift
+++ b/native-ios/RandomTimerUITests/RandomTimerUITests.swift
@@ -44,6 +44,15 @@ final class RandomTimerUITests: XCTestCase {
         ensureSetupScreen(app)
     }
 
+    func testSetupStateKeepsStartTimerHittable() {
+        let app = launchApp()
+        ensureSetupScreen(app)
+
+        let startButton = app.buttons["Start Timer"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(startButton.isHittable)
+    }
+
     func testRunningStateShowsRunningLabelAndPauseAction() {
         let app = launchApp(withState: "running")
         XCTAssertTrue(app.staticTexts["Timer running..."].waitForExistence(timeout: 2.0))

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -160,3 +160,11 @@ def test_android_setup_screen_has_single_start_timer_cta_and_clear_free_loop_cop
     assert 'repeatLoopDetailTitle(isPro = isPro)' in android_setup
     assert 'repeatLoopDetailSummary(' in android_setup
     assert 'Infinite Loop - Pro unlocks round limits' in android_setup
+
+
+def test_ios_setup_screen_keeps_start_timer_in_sticky_bottom_inset():
+    ios_setup = _read(IOS_SETUP)
+
+    assert ".safeAreaInset(edge: .bottom)" in ios_setup
+    assert 'PrimaryButton(title: "Start Timer")' in ios_setup
+    assert "Spacer(minLength: 140)" in ios_setup


### PR DESCRIPTION
## Summary
- move the iOS setup-screen Start Timer CTA into a bottom safe-area inset so it stays visible on device
- add bottom spacer room so the lower setup cards do not render underneath the sticky button
- add regression guards for sticky-footer structure and Start Timer hittability on launch

## Root cause
- `release/v1.3.9` already had the sticky Start Timer footer
- `develop` still shipped the older in-scroll button layout
- Internal Distribution ships from `develop`, so the latest TestFlight build regressed to the non-sticky setup screen

## Verification
- python3 -m pytest -q scripts/tests/test_mobile_feature_parity.py
- DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer xcodebuild test -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=RandomTimer AppStore iPhone 16 Pro Max,OS=18.6' -only-testing:RandomTimerUITests/RandomTimerUITests/testSetupStateKeepsStartTimerHittable