### PR TITLE
fix(ios): harden voice preview catalog mapping

### DIFF
--- a/.ai/changelog/2026-03.md
+++ b/.ai/changelog/2026-03.md
@@ -1,5 +1,12 @@
 # 2026-03
 
+## 2026-03-20 — Harden iOS voice preview against duplicate runtime catalog entries
+
+- replaced crash-prone duplicate-key dictionary construction in the iOS voice catalog runtime with first-entry-wins mapping so malformed or stale remote packs cannot terminate the app
+- added an iOS unit regression that proves duplicate elapsed milestones and duplicate cue texts no longer trigger a fatal error
+- added an iOS UI smoke test that taps `PREVIEW` on the setup screen and requires the app to remain alive on the same screen afterward
+- confirmed the likely production failure mode: runtime-downloaded Pro voice catalogs can be cached locally, so preview must degrade safely even when pack metadata is imperfect
+
 ## 2026-03-20 — Restore sticky iOS Start Timer action on setup
 
 - moved the iOS `Start Timer` CTA out of the scroll content and back into a bottom safe-area inset so it stays visible on smaller devices

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -21,7 +21,11 @@ internal struct VoiceCueCatalog: Codable {
     let commandCues: [Cue]
 
     var elapsedCueBySecond: [Int: ElapsedCue] {
-        Dictionary(uniqueKeysWithValues: elapsedCues.map { ($0.second, $0) })
+        var mapping = [Int: ElapsedCue]()
+        for cue in elapsedCues where mapping[cue.second] == nil {
+            mapping[cue.second] = cue
+        }
+        return mapping
     }
 
     var fallbackCommandCue: Cue {
@@ -29,9 +33,20 @@ internal struct VoiceCueCatalog: Codable {
     }
 
     var filenameByText: [String: String] {
-        var mapping = [previewElapsed.text: previewElapsed.filename]
-        elapsedCues.forEach { mapping[$0.text] = $0.filename }
-        commandCues.forEach { mapping[$0.text] = $0.filename }
+        var mapping = [String: String]()
+
+        if mapping[previewElapsed.text] == nil {
+            mapping[previewElapsed.text] = previewElapsed.filename
+        }
+
+        for cue in elapsedCues where mapping[cue.text] == nil {
+            mapping[cue.text] = cue.filename
+        }
+
+        for cue in commandCues where mapping[cue.text] == nil {
+            mapping[cue.text] = cue.filename
+        }
+
         return mapping
     }
 

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -80,6 +80,24 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertNotNil(bundledVoiceAudioURL(for: fallback, bundle: .main))
     }
 
+    func testVoiceCatalogRuntimeMapsIgnoreDuplicateKeys() {
+        let catalog = VoiceCueCatalog(
+            previewElapsed: .init(filename: "preview_elapsed", text: "Repeat me."),
+            fallbackCommandFilename: "cmd_primary",
+            elapsedCues: [
+                .init(second: 30, filename: "elapsed_primary", text: "Thirty elapsed."),
+                .init(second: 30, filename: "elapsed_duplicate", text: "Thirty elapsed duplicate."),
+            ],
+            commandCues: [
+                .init(filename: "cmd_primary", text: "Repeat me."),
+                .init(filename: "cmd_duplicate", text: "Repeat me."),
+            ]
+        )
+
+        XCTAssertEqual(catalog.elapsedCueBySecond[30]?.filename, "elapsed_primary")
+        XCTAssertEqual(catalog.filenameByText["Repeat me."], "preview_elapsed")
+    }
+
     func testNextCommandCueAvoidsImmediateRepeatWhenPossible() {
         let cues = [
             VoiceCueCatalog.Cue(filename: "cue_a", text: "Cue A"),
@@ -97,7 +115,35 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
 
         let voicePayload = Data("voice-remote".utf8)
         let soundPayload = Data("sound-remote".utf8)
-        let manifest = RemoteProAudioManifest(
+        let manifest = makeRemoteManifest(voicePayload: voicePayload, soundPayload: soundPayload)
+
+        let store = ProAudioPackStore(bundle: .main, manifestURL: nil, cacheRoot: cacheRoot)
+        try store.installForTesting(
+            manifest: manifest,
+            payloadsByKey: [
+                "voice:preview_elapsed": voicePayload,
+                "sound:alarm": soundPayload,
+            ]
+        )
+
+        XCTAssertEqual(store.voiceCatalog().previewElapsed.text, "Fifteen seconds elapsed. Move.")
+        XCTAssertEqual(store.soundCatalog().packId, "2026-04_field")
+        XCTAssertEqual(
+            try Data(contentsOf: XCTUnwrap(store.voiceAudioURL(for: "preview_elapsed", bundle: .main))),
+            voicePayload
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: XCTUnwrap(store.soundAudioURL(for: .intense, bundle: .main))),
+            soundPayload
+        )
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func makeRemoteManifest(voicePayload: Data, soundPayload: Data) -> RemoteProAudioManifest {
+        RemoteProAudioManifest(
             schemaVersion: 1,
             packId: "2026-04_field",
             releaseMonth: "2026-04",
@@ -134,23 +180,5 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
                 ),
             ]
         )
-
-        let store = ProAudioPackStore(bundle: .main, manifestURL: nil, cacheRoot: cacheRoot)
-        try store.installForTesting(
-            manifest: manifest,
-            payloadsByKey: [
-                "voice:preview_elapsed": voicePayload,
-                "sound:alarm": soundPayload,
-            ]
-        )
-
-        XCTAssertEqual(store.voiceCatalog().previewElapsed.text, "Fifteen seconds elapsed. Move.")
-        XCTAssertEqual(store.soundCatalog().packId, "2026-04_field")
-        XCTAssertEqual(try Data(contentsOf: XCTUnwrap(store.voiceAudioURL(for: "preview_elapsed", bundle: .main))), voicePayload)
-        XCTAssertEqual(try Data(contentsOf: XCTUnwrap(store.soundAudioURL(for: .intense, bundle: .main))), soundPayload)
-    }
-
-    private func sha256Hex(_ data: Data) -> String {
-        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/native-ios/RandomTimerUITests/RandomTimerUITests.swift
+++ b/native-ios/RandomTimerUITests/RandomTimerUITests.swift
@@ -39,6 +39,11 @@ final class RandomTimerUITests: XCTestCase {
         XCTAssertTrue(startButton.waitForExistence(timeout: timeout))
     }
 
+    private func saveScreenshot(_ screenshot: XCUIScreenshot, named name: String, outputDir: String) {
+        let path = "\(outputDir)/\(name)"
+        FileManager.default.createFile(atPath: path, contents: screenshot.pngRepresentation)
+    }
+
     func testSetupStateShowsStartTimer() {
         let app = launchApp()
         ensureSetupScreen(app)
@@ -51,6 +56,21 @@ final class RandomTimerUITests: XCTestCase {
         let startButton = app.buttons["Start Timer"]
         XCTAssertTrue(startButton.waitForExistence(timeout: 3.0))
         XCTAssertTrue(startButton.isHittable)
+    }
+
+    func testPreviewVoiceCueDoesNotCrashSetupScreen() {
+        let app = launchApp()
+        ensureSetupScreen(app)
+
+        let previewButton = app.buttons["PREVIEW"]
+        XCTAssertTrue(previewButton.waitForExistence(timeout: 3.0))
+        previewButton.tap()
+
+        let startButton = app.buttons["Start Timer"]
+        XCTAssertTrue(
+            startButton.waitForExistence(timeout: 3.0),
+            "Preview must not crash the app or navigate away from setup."
+        )
     }
 
     func testRunningStateShowsRunningLabelAndPauseAction() {
@@ -121,7 +141,7 @@ final class RandomTimerUITests: XCTestCase {
         let app = XCUIApplication()
         // The script expects raw screenshots in /tmp/appstore_screenshots
         let outputDir = "/tmp/appstore_screenshots"
-        
+
         // Force Pro/Elite state for screenshots
         app.launchArguments += ["-ui-test-elite", "true"]
 
@@ -139,8 +159,7 @@ final class RandomTimerUITests: XCTestCase {
             loopToggle.tap()
         }
         sleep(2)
-        let setupScreenshot = app.windows.firstMatch.screenshot()
-        FileManager.default.createFile(atPath: "\(outputDir)/1_setup.png", contents: setupScreenshot.pngRepresentation)
+        saveScreenshot(app.windows.firstMatch.screenshot(), named: "1_setup.png", outputDir: outputDir)
 
         // 2. Active timer (running state)
         let startButton = app.buttons["Start Timer"]
@@ -150,24 +169,21 @@ final class RandomTimerUITests: XCTestCase {
         // Dismiss notification permission if it appears
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
         sleep(2)
-        let activeScreenshot = app.windows.firstMatch.screenshot()
-        FileManager.default.createFile(atPath: "\(outputDir)/2_active.png", contents: activeScreenshot.pngRepresentation)
+        saveScreenshot(app.windows.firstMatch.screenshot(), named: "2_active.png", outputDir: outputDir)
 
         // 3. Alarm state (timer just went off)
         app.terminate()
         app.launchArguments = ["-ui-test-state", "alarm", "-ui-test-pro", "true"]
         app.launch()
         sleep(2)
-        let alarmScreenshot = app.windows.firstMatch.screenshot()
-        FileManager.default.createFile(atPath: "\(outputDir)/3_alarm.png", contents: alarmScreenshot.pngRepresentation)
+        saveScreenshot(app.windows.firstMatch.screenshot(), named: "3_alarm.png", outputDir: outputDir)
 
         // 4. Running timer (different view/state if needed)
         app.terminate()
         app.launchArguments = ["-ui-test-state", "running", "-ui-test-pro", "true"]
         app.launch()
         sleep(2)
-        let runningScreenshot = app.windows.firstMatch.screenshot()
-        FileManager.default.createFile(atPath: "\(outputDir)/4_running.png", contents: runningScreenshot.pngRepresentation)
+        saveScreenshot(app.windows.firstMatch.screenshot(), named: "4_running.png", outputDir: outputDir)
     }
 
     func testLandscapeShowsActionButtons() {


### PR DESCRIPTION
## Summary
- harden iOS voice catalog lookups so duplicate runtime entries no longer crash preview playback
- add a regression unit test for duplicate elapsed seconds and duplicate cue texts
- add a UI smoke test that taps PREVIEW and proves setup stays alive

## Verification
- DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer xcodebuild test -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=RandomTimer AppStore iPhone 16 Pro Max,OS=18.6' -only-testing:RandomTimerTests/AIVoiceCalloutServiceTests -only-testing:RandomTimerUITests/RandomTimerUITests/testPreviewVoiceCueDoesNotCrashSetupScreen\n- python3 -m pytest -q scripts/tests/test_mobile_feature_parity.py\n- DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer swiftlint lint --strict native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift\n- DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer swiftlint lint --strict native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift\n- DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer swiftlint lint --strict native-ios/RandomTimerUITests/RandomTimerUITests.swift\n- git diff --check