### PR TITLE
fix(android): sticky Start Timer button via Scaffold bottomBar

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -195,6 +195,20 @@ fun TimerSetupScreen(
                     )
                 }
             },
+            bottomBar = {
+                PrimaryButton(
+                    text = "Start Timer",
+                    onClick = onStartTimer,
+                    modifier =
+                        Modifier
+                            .padding(horizontal = spacing.outerHorizontal)
+                            .padding(bottom = 16.dp, top = 8.dp)
+                            .graphicsLayer {
+                                scaleX = 1.02f
+                                scaleY = 1.02f
+                            },
+                )
+            },
             containerColor = TimerColors.BackgroundDark,
             modifier = Modifier.fillMaxSize(),
         ) { paddingValues ->
@@ -623,19 +637,6 @@ fun TimerSetupScreen(
                             }
                         }
                     }
-                }
-
-                // Start Button
-                item {
-                    PrimaryButton(
-                        text = "Start Timer",
-                        onClick = onStartTimer,
-                        modifier =
-                            Modifier.padding(top = spacing.startButtonTop).graphicsLayer {
-                                scaleX = 1.02f
-                                scaleY = 1.02f
-                            },
-                    )
                 }
 
                 // 3. Sound Arsenal


### PR DESCRIPTION
Move Start button from LazyColumn to Scaffold bottomBar. iOS already done. BUILD SUCCESSFUL locally.