### PR TITLE
fix: clarify active loop badge copy

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
@@ -392,14 +392,14 @@ internal fun loopBadgeText(
     roundCount: Int,
 ): String {
     if (!enabled) {
-        return "LOOP OFF"
+        return "Loop Off"
     }
     if (repeatRounds == 0) {
-        return "LOOP"
+        return "Infinite Loop"
     }
 
     val clampedRound = roundCount.coerceIn(1, repeatRounds)
-    return "ROUND $clampedRound/$repeatRounds"
+    return "Round $clampedRound/$repeatRounds"
 }
 
 private fun formatDurationReadable(duration: kotlin.time.Duration): String {

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenBadgeTextTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenBadgeTextTest.kt
@@ -6,21 +6,21 @@ import org.junit.Test
 class ActiveTimerScreenBadgeTextTest {
     @Test
     fun loopBadgeShowsOffStateWhenDisabled() {
-        assertThat(loopBadgeText(enabled = false, repeatRounds = 4, roundCount = 2)).isEqualTo("LOOP OFF")
+        assertThat(loopBadgeText(enabled = false, repeatRounds = 4, roundCount = 2)).isEqualTo("Loop Off")
     }
 
     @Test
     fun loopBadgeShowsInfiniteLabelWhenEnabledWithoutRoundCap() {
-        assertThat(loopBadgeText(enabled = true, repeatRounds = 0, roundCount = 3)).isEqualTo("LOOP")
+        assertThat(loopBadgeText(enabled = true, repeatRounds = 0, roundCount = 3)).isEqualTo("Infinite Loop")
     }
 
     @Test
     fun loopBadgeShowsFiniteRoundProgressWhenRoundCapIsSet() {
-        assertThat(loopBadgeText(enabled = true, repeatRounds = 5, roundCount = 2)).isEqualTo("ROUND 2/5")
+        assertThat(loopBadgeText(enabled = true, repeatRounds = 5, roundCount = 2)).isEqualTo("Round 2/5")
     }
 
     @Test
     fun loopBadgeClampsVisibleRoundToConfiguredLimit() {
-        assertThat(loopBadgeText(enabled = true, repeatRounds = 3, roundCount = 7)).isEqualTo("ROUND 3/3")
+        assertThat(loopBadgeText(enabled = true, repeatRounds = 3, roundCount = 7)).isEqualTo("Round 3/3")
     }
 }

--- a/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
@@ -42,11 +42,11 @@ struct ActiveTimerScreen: View {
     }
 
     static func loopBadgeText(enabled: Bool, repeatRounds: Int, roundCount: Int) -> String {
-        guard enabled else { return "LOOP OFF" }
-        guard repeatRounds > 0 else { return "LOOP" }
+        guard enabled else { return "Loop Off" }
+        guard repeatRounds > 0 else { return "Infinite Loop" }
 
         let clampedRound = Swift.max(1, Swift.min(roundCount, repeatRounds))
-        return "ROUND \(clampedRound)/\(repeatRounds)"
+        return "Round \(clampedRound)/\(repeatRounds)"
     }
 
     static func loopBadgeAccessibilityLabel(enabled: Bool, repeatRounds: Int, roundCount: Int) -> String {

--- a/native-ios/RandomTimerTests/CircularTimerViewTests.swift
+++ b/native-ios/RandomTimerTests/CircularTimerViewTests.swift
@@ -110,21 +110,21 @@ final class CircularTimerViewTests: XCTestCase {
 
     func testLoopBadgeTextShowsOffStateWhenDisabled() {
         let result = ActiveTimerScreen.loopBadgeText(enabled: false, repeatRounds: 4, roundCount: 2)
-        XCTAssertEqual(result, "LOOP OFF")
+        XCTAssertEqual(result, "Loop Off")
     }
 
     func testLoopBadgeTextShowsInfiniteLoopWhenNoRoundCapIsSet() {
         let result = ActiveTimerScreen.loopBadgeText(enabled: true, repeatRounds: 0, roundCount: 3)
-        XCTAssertEqual(result, "LOOP")
+        XCTAssertEqual(result, "Infinite Loop")
     }
 
     func testLoopBadgeTextShowsFiniteRoundProgress() {
         let result = ActiveTimerScreen.loopBadgeText(enabled: true, repeatRounds: 5, roundCount: 2)
-        XCTAssertEqual(result, "ROUND 2/5")
+        XCTAssertEqual(result, "Round 2/5")
     }
 
     func testLoopBadgeTextClampsVisibleRoundToConfiguredLimit() {
         let result = ActiveTimerScreen.loopBadgeText(enabled: true, repeatRounds: 3, roundCount: 8)
-        XCTAssertEqual(result, "ROUND 3/3")
+        XCTAssertEqual(result, "Round 3/3")
     }
 }

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -145,11 +145,14 @@ def test_active_timer_loop_badge_shows_round_progress_on_both_platforms():
 
     assert "repeatRounds" in android_active
     assert "roundCount" in android_active
-    assert '"ROUND $clampedRound/$repeatRounds"' in android_active
+    assert 'return "Infinite Loop"' in android_active
+    assert 'return "Round $clampedRound/$repeatRounds"' in android_active
 
     assert "repeatRounds" in ios_active
     assert "roundCount" in ios_active
-    assert 'return "ROUND \\(clampedRound)/\\(repeatRounds)"' in ios_active
+    assert 'guard enabled else { return "Loop Off" }' in ios_active
+    assert 'guard repeatRounds > 0 else { return "Infinite Loop" }' in ios_active
+    assert 'return "Round \\(clampedRound)/\\(repeatRounds)"' in ios_active
 
 
 def test_android_setup_screen_has_single_start_timer_cta_and_clear_free_loop_copy():


### PR DESCRIPTION
## Summary
- clarify active timer loop badge copy on iOS and Android
- show Infinite Loop for uncapped looping and Round x/y for finite looping
- update parity and platform tests to lock the behavior in place

## Verification
- python3 -m pytest -q scripts/tests/test_mobile_feature_parity.py
- git diff --check

## Notes
- local Android Gradle verification is blocked by a reproducible Gradle daemon/KSP crash before the targeted unit test task executes; GitHub CI is the final Android proof source for this PR
- local xcodebuild targeted run is slow in this environment; GitHub CI is the final iOS proof source for this PR