### PR TITLE
fix(ios): clamp config when Pro range is toggled off

### DIFF
--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -457,7 +457,7 @@ struct TimerSetupScreen: View {
             voiceEnabled: voiceEnabled ?? config.voiceEnabled,
             repeatRounds: repeatRounds ?? config.repeatRounds
         )
-        timerManager.updateConfig(newConfig)
+        timerManager.updateConfig(newConfig.clamped(isPro: proManager.isPro))
     }
 
     private func repeatLoopDetailTitle(isPro: Bool) -> String {

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -206,5 +206,6 @@ def test_setup_screen_pro_range_toggle_and_voice_gating_are_present_on_both_plat
 
     assert 'Text(config.useExtendedRange ? "1H" : "5m")' in ios_setup
     assert "config.useExtendedRange ? proManager.maxSecondsLimit : 300" in ios_setup
+    assert "timerManager.updateConfig(newConfig.clamped(isPro: proManager.isPro))" in ios_setup
     assert 'Text("PRO: 1H' in ios_setup
     assert 'Text("PREVIEW")' in ios_setup


### PR DESCRIPTION
## Summary
- clamp the updated iOS timer config when Pro users toggle extended range off
- keep the mobile feature parity test aligned with the expected clamp path

## Verification
- `pytest -q scripts/tests/test_mobile_feature_parity.py`
- `DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,name=RandomTimer AppStore iPhone 16 Pro Max,OS=18.6' -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`