### PR TITLE
fix: restore iOS pro refresh copy parity

### DIFF
--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -70,7 +70,7 @@ struct PaywallSheet: View {
                         ProFeatureRow(text: "Extended range up to 60 minutes")
                         ProFeatureRow(text: "Elapsed-time voice callouts")
                         ProFeatureRow(text: "Loop with optional round limits")
-                        ProFeatureRow(text: "Monthly voice and sound refreshes")
+                        ProFeatureRow(text: "Monthly voice callout and sound arsenal refreshes")
                         ProFeatureRow(text: "Support independent development")
                     }
                 }


### PR DESCRIPTION
## Summary\n- restore the iOS paywall Pro feature copy to match the Android wording and the parity contract\n- fix the red Python Script Tests lane introduced by PR #839\n\n## Verification\n- uv run --python 3.11 --with pytest==8.4.2 --with pytest-cov==7.0.0 --with pillow==11.3.0 python -m pytest scripts/tests/ -q --cov=scripts --cov-report=term --cov-report=xml:coverage-python.xml\n- DEVELOPER_DIR=/Applications/Xcode-26.1.1.app/Contents/Developer xcodebuild -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=RandomTimer AppStore iPhone 16 Pro Max,OS=18.6' build\n- git diff --check