### PR TITLE
hotfix: unblock iOS metadata publish for v1.3.11

### DIFF
--- a/native-ios/fastlane/metadata/en-US/keywords.txt
+++ b/native-ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-dry fire timer,reaction timer,mma training,tactical timer,random interval timer,boxing round timer,bjj training,hiit clock,response training,ooda loop,shot timer,combat sports,sparring timer,martial arts,shooting timer,agility drills,random start
+dry fire,boxing,mma,bjj,hiit,sparring,shooting,agility,drills,range,interval,beep

--- a/scripts/refresh_ios_screenshot_creatives.py
+++ b/scripts/refresh_ios_screenshot_creatives.py
@@ -18,14 +18,14 @@ try:
 except ImportError:
     sys.exit("Pillow is required: pip install Pillow")
 
-SCREENSHOT_SPECS: dict[str, tuple[int, int]] = {
-    "1_setup.png": (1290, 2796),
-    "2_active.png": (1290, 2796),
-    "3_alarm.png": (1290, 2796),
-    "4_running.png": (1290, 2796),
-    "5_ipad_setup.png": (2048, 2732),
-    "6_ipad_running.png": (2048, 2732),
-    "7_ipad_stopped.png": (2048, 2732),
+SCREENSHOT_SPECS: dict[str, set[tuple[int, int]]] = {
+    "1_setup.png": {(1290, 2796)},
+    "2_active.png": {(1290, 2796)},
+    "3_alarm.png": {(1290, 2796)},
+    "4_running.png": {(1290, 2796)},
+    "5_ipad_setup.png": {(2048, 2732), (2064, 2752)},
+    "6_ipad_running.png": {(2048, 2732), (2064, 2752)},
+    "7_ipad_stopped.png": {(2048, 2732), (2064, 2752)},
 }
 
 METADATA_LIMITS: dict[str, tuple[int, int]] = {
@@ -46,14 +46,15 @@ def validate(root: Path) -> list[str]:
     screenshots_dir = root / "native-ios" / "fastlane" / "screenshots" / "en-US"
     metadata_dir = root / "native-ios" / "fastlane" / "metadata" / "en-US"
 
-    for name, (exp_w, exp_h) in SCREENSHOT_SPECS.items():
+    for name, allowed_sizes in SCREENSHOT_SPECS.items():
         path = screenshots_dir / name
         if not path.is_file():
             errors.append(f"missing screenshot: {name}")
             continue
         img = Image.open(path)
-        if img.size != (exp_w, exp_h):
-            errors.append(f"{name}: {img.size[0]}x{img.size[1]}, expected {exp_w}x{exp_h}")
+        if img.size not in allowed_sizes:
+            expected = " or ".join(f"{w}x{h}" for (w, h) in sorted(allowed_sizes))
+            errors.append(f"{name}: {img.size[0]}x{img.size[1]}, expected {expected}")
 
     for name, (min_len, max_len) in METADATA_LIMITS.items():
         path = metadata_dir / name

--- a/scripts/tests/test_refresh_ios_screenshot_creatives.py
+++ b/scripts/tests/test_refresh_ios_screenshot_creatives.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from PIL import Image
+
+from scripts import refresh_ios_screenshot_creatives as refresh
+
+
+def _write_png(path: Path, size: tuple[int, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image = Image.new("RGB", size, color=(20, 20, 30))
+    image.save(path)
+
+
+def _write_metadata(root: Path) -> None:
+    metadata_dir = root / "native-ios" / "fastlane" / "metadata" / "en-US"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    values = {
+        "name.txt": "Random Tactical Timer",
+        "subtitle.txt": "Reaction Training",
+        "description.txt": "A tactical reaction timer for pressure drills and interval focus.",
+        "keywords.txt": "dry fire,boxing,mma,bjj,hiit,sparring,shooting,agility,drills,range,interval,beep",
+        "promotional_text.txt": "Build speed and discipline with randomized drills.",
+        "release_notes.txt": "App Store creative overhaul.",
+        "privacy_url.txt": "https://igorganapolsky.com/privacy",
+        "support_url.txt": "https://igorganapolsky.com/support",
+        "marketing_url.txt": "https://igorganapolsky.com/random-tactical-timer",
+    }
+    for name, content in values.items():
+        (metadata_dir / name).write_text(content, encoding="utf-8")
+
+
+def _write_required_assets(root: Path, ipad_size: tuple[int, int]) -> None:
+    screenshots_dir = root / "native-ios" / "fastlane" / "screenshots" / "en-US"
+    for filename in ("1_setup.png", "2_active.png", "3_alarm.png", "4_running.png"):
+        _write_png(screenshots_dir / filename, (1290, 2796))
+    for filename in ("5_ipad_setup.png", "6_ipad_running.png", "7_ipad_stopped.png"):
+        _write_png(screenshots_dir / filename, ipad_size)
+    (root / "PRIVACY_POLICY.md").write_text("Privacy policy", encoding="utf-8")
+    _write_metadata(root)
+
+
+def test_accepts_current_13_inch_ipad_size(tmp_path: Path) -> None:
+    _write_required_assets(tmp_path, (2064, 2752))
+
+    assert refresh.validate(tmp_path) == []
+
+
+def test_accepts_legacy_13_inch_ipad_size(tmp_path: Path) -> None:
+    _write_required_assets(tmp_path, (2048, 2732))
+
+    assert refresh.validate(tmp_path) == []

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -460,7 +460,7 @@ def print_results(results: list[dict]):
 # Polling
 # ---------------------------------------------------------------------------
 
-def poll_until_done(verify_fn, poll_interval: int, timeout: int, terminal_statuses: set[str] | None = None) -> dict:
+def poll_until_done(verify_fn, poll_interval: int, timeout: int, terminal_statuses: Optional[set[str]] = None) -> dict:
     """Call verify_fn repeatedly until it passes or times out."""
     deadline = time.time() + timeout
     attempt = 0


### PR DESCRIPTION
## Summary\n- shorten App Store keywords to stay within Apple's 100-character limit\n- accept both current and legacy 13-inch iPad screenshot dimensions in the local validator\n- restore local Python 3.9 compatibility for scripts/verify_release.py\n- add validator coverage for both supported iPad screenshot sizes\n\n## Verification\n- python3 scripts/refresh_ios_screenshot_creatives.py\n- python3 -m pytest -q scripts/tests/test_refresh_ios_screenshot_creatives.py scripts/tests/test_verify_release.py\n- python3 -m pytest scripts/tests/ -q --cov=scripts --cov-report=term --cov-report=xml:coverage-python.xml\n- git diff --check