### PR TITLE
hotfix: fix ios submit age rating verification

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -674,11 +674,71 @@ def verify_review_detail(client: ASCClient, version_id: str) -> None:
         die("App Review contactPhone is missing.")
 
 
-def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = None) -> None:
-    # Current ASC API exposes a unified AgeRatingDeclaration relationship on the App Store Version:
-    #   GET /v1/appStoreVersions/{id}/ageRatingDeclaration
-    # Some older code paths used app/appInfo relationships which may not exist on newer APIs.
+def _list_app_infos(client: ASCClient, app_id: str) -> list[dict[str, Any]]:
+    params = {
+        "limit": 200,
+        "fields[appInfos]": "appStoreState",
+    }
+    if hasattr(client, "get_all"):
+        infos = client.get_all(f"/apps/{app_id}/appInfos", params=params)
+    else:
+        payload = client.request("GET", f"/apps/{app_id}/appInfos", params=params)
+        infos = payload.get("data") or []
+    return [it for it in infos if isinstance(it, dict)]
+
+
+def _ordered_app_infos_for_version(
+    client: ASCClient, app_id: str, version_id: str | None = None
+) -> tuple[list[dict[str, Any]], list[str]]:
     errors: list[str] = []
+    version_state: str | None = None
+    if version_id:
+        try:
+            version_state = get_version_state(client, version_id)
+        except Exception as e:
+            errors.append(f"version /appStoreVersions/{version_id}: {e}")
+
+    infos: list[dict[str, Any]] = []
+    try:
+        infos = _list_app_infos(client, app_id)
+    except Exception as e:
+        errors.append(f"app /apps/{app_id}/appInfos: {e}")
+        return [], errors
+
+    if not version_state:
+        return infos, errors
+
+    matching: list[dict[str, Any]] = []
+    other: list[dict[str, Any]] = []
+    for info_obj in infos:
+        state = (info_obj.get("attributes") or {}).get("appStoreState")
+        if state == version_state:
+            matching.append(info_obj)
+        else:
+            other.append(info_obj)
+    return matching + other, errors
+
+
+def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = None) -> None:
+    # Apple currently exposes AgeRatingDeclaration from App Info:
+    #   GET /v1/appInfos/{id}/ageRatingDeclaration
+    # The older App Store Version relationship is deprecated and now returns PATH_ERROR
+    # for this app, so prefer the App Info path and only use the version path as a fallback.
+    errors: list[str] = []
+    app_infos, info_errors = _ordered_app_infos_for_version(client, app_id, version_id)
+    errors.extend(info_errors)
+
+    for info_obj in app_infos:
+        app_info_id = info_obj.get("id")
+        if not isinstance(app_info_id, str) or not app_info_id:
+            continue
+        try:
+            data = client.request("GET", f"/appInfos/{app_info_id}/ageRatingDeclaration")
+            if data.get("data"):
+                return
+        except Exception as e:
+            errors.append(f"appInfo /appInfos/{app_info_id}/ageRatingDeclaration: {e}")
+
     if version_id:
         try:
             data = client.request("GET", f"/appStoreVersions/{version_id}/ageRatingDeclaration")
@@ -686,8 +746,6 @@ def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = N
                 return
         except Exception as e:
             errors.append(f"version /appStoreVersions/{version_id}/ageRatingDeclaration: {e}")
-    else:
-        errors.append("version_id missing (cannot verify ageRatingDeclaration).")
 
     detail = "\n  ".join(errors)
     die("Age Rating declaration not found. Complete Age Rating in App Store Connect.\n  " + detail)

--- a/scripts/asc_verify_ready.py
+++ b/scripts/asc_verify_ready.py
@@ -206,14 +206,51 @@ def _get_app_price_schedules(client: AscClient, app_id: str) -> List[Dict[str, A
     return payload.get("data", []) or []
 
 
-def _get_age_rating_declaration(client: AscClient, app_id: str) -> Optional[Dict[str, Any]]:
-    # Relationship is singular on apps: appStoreAgeRatingDeclaration
+def _get_age_rating_declaration(
+    client: AscClient, app_id: str, *, version_state: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
     payload = client.get(
-        f"/apps/{app_id}/appStoreAgeRatingDeclaration",
-        params={"fields[appStoreAgeRatingDeclarations]": "alcoholTobaccoOrDrugUseOrReferences,gamblingAndContests,violenceCartoonOrFantasy,violenceRealistic,profanityOrCrudeHumor"},
+        f"/apps/{app_id}/appInfos",
+        params={
+            "limit": "200",
+            "fields[appInfos]": "appStoreState",
+        },
     )
-    data = payload.get("data")
-    return data if isinstance(data, dict) else None
+    app_infos = [item for item in (payload.get("data") or []) if isinstance(item, dict)]
+    if version_state:
+        matching = [item for item in app_infos if (item.get("attributes") or {}).get("appStoreState") == version_state]
+        if matching:
+            app_infos = matching + [item for item in app_infos if item not in matching]
+
+    last_error: Exception | None = None
+    for app_info in app_infos:
+        app_info_id = app_info.get("id")
+        if not isinstance(app_info_id, str) or not app_info_id:
+            continue
+        try:
+            payload = client.get(
+                f"/appInfos/{app_info_id}/ageRatingDeclaration",
+                params={
+                    "fields[ageRatingDeclarations]": (
+                        "advertising,alcoholTobaccoOrDrugUseOrReferences,contests,gambling,"
+                        "gamblingSimulated,gunsOrOtherWeapons,healthOrWellnessTopics,lootBox,"
+                        "medicalOrTreatmentInformation,messagingAndChat,parentalControls,"
+                        "profanityOrCrudeHumor,sexualContentGraphicAndNudity,sexualContentOrNudity,"
+                        "horrorOrFearThemes,matureOrSuggestiveThemes,unrestrictedWebAccess,"
+                        "userGeneratedContent,violenceCartoonOrFantasy,violenceRealistic,"
+                        "violenceRealisticProlongedGraphicOrSadistic"
+                    )
+                },
+            )
+            data = payload.get("data")
+            if isinstance(data, dict):
+                return data
+        except Exception as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    return None
 
 
 def verify_ready(
@@ -437,21 +474,16 @@ def verify_ready(
 
     # Age rating declaration exists
     try:
-        decl = _get_age_rating_declaration(client, app_id)
+        decl = _get_age_rating_declaration(
+            client,
+            app_id,
+            version_state=str((app_store_version.get("attributes") or {}).get("appStoreState") or ""),
+        )
         checks.append(
             Check(
                 name="Age Rating Completed",
                 passed=decl is not None,
-                details="OK" if decl else "Missing appStoreAgeRatingDeclaration",
-            )
-        )
-    except AscClientError as exc:
-        checks.append(
-            Check(
-                name="Age Rating Completed",
-                passed=True,
-                details=f"Skipped check (endpoint/API unavailable): {exc}",
-                evidence={"skipped": True},
+                details="OK" if decl else "Missing ageRatingDeclaration on App Info",
             )
         )
     except Exception as exc:

--- a/scripts/tests/test_asc_submit_for_review_age_rating.py
+++ b/scripts/tests/test_asc_submit_for_review_age_rating.py
@@ -4,12 +4,21 @@ from scripts.tests.router_client import RouterClient
 
 
 class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
-    def test_verify_age_rating_reads_age_rating_declaration_from_version(self):
+    def test_verify_age_rating_reads_age_rating_declaration_from_state_matched_app_info(self):
         from scripts.asc_submit_for_review import verify_age_rating
 
         client = RouterClient(
             {
-                ("GET", "/appStoreVersions/ver1/ageRatingDeclaration"): {
+                ("GET", "/appStoreVersions/ver1"): {
+                    "data": {"id": "ver1", "type": "appStoreVersions", "attributes": {"appStoreState": "REJECTED"}}
+                },
+                ("GET", "/apps/app1/appInfos"): {
+                    "data": [
+                        {"id": "info-ready", "type": "appInfos", "attributes": {"appStoreState": "READY_FOR_SALE"}},
+                        {"id": "info-rejected", "type": "appInfos", "attributes": {"appStoreState": "REJECTED"}},
+                    ]
+                },
+                ("GET", "/appInfos/info-rejected/ageRatingDeclaration"): {
                     "data": {"id": "decl1", "type": "ageRatingDeclarations", "attributes": {}}
                 }
             }
@@ -21,6 +30,13 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
         client = RouterClient(
             {
+                ("GET", "/appStoreVersions/ver1"): {
+                    "data": {"id": "ver1", "type": "appStoreVersions", "attributes": {"appStoreState": "REJECTED"}}
+                },
+                ("GET", "/apps/app1/appInfos"): {
+                    "data": [{"id": "info-rejected", "type": "appInfos", "attributes": {"appStoreState": "REJECTED"}}]
+                },
+                ("GET", "/appInfos/info-rejected/ageRatingDeclaration"): RuntimeError("404"),
                 ("GET", "/appStoreVersions/ver1/ageRatingDeclaration"): RuntimeError("404"),
             }
         )
@@ -30,4 +46,3 @@ class AscSubmitForReviewVerifyAgeRatingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/scripts/tests/test_asc_verify_ready.py
+++ b/scripts/tests/test_asc_verify_ready.py
@@ -56,7 +56,7 @@ class _FakeAscClient:
 
         if path == "/apps/app1/appInfos":
             return {
-                "data": [{"id": "info1", "type": "appInfos"}],
+                "data": [{"id": "info1", "type": "appInfos", "attributes": {"appStoreState": "READY_FOR_SALE"}}],
                 "included": [
                     {
                         "id": "infoLoc1",
@@ -83,7 +83,7 @@ class _FakeAscClient:
         if path == "/apps/app1/appPriceSchedules":
             return {"data": [{"id": "price1", "type": "appPriceSchedules"}]}
 
-        if path == "/apps/app1/appStoreAgeRatingDeclaration":
+        if path == "/appInfos/info1/ageRatingDeclaration":
             return {"data": {"id": "age1", "type": "appStoreAgeRatingDeclarations"}}
 
         if path == "/appStoreVersionLocalizations/loc1/appScreenshotSets":


### PR DESCRIPTION
## Summary
- switch ASC age rating checks from deprecated App Store version paths to live App Info relationships
- make the hard readiness gate verify age rating truthfully instead of skipping on PATH_ERROR
- cover the new App Info lookup path in submit and readiness tests

## Verification
- python3 -m pytest -q scripts/tests/test_asc_submit_for_review_age_rating.py scripts/tests/test_asc_verify_ready.py scripts/tests/test_asc_submit_for_review.py scripts/tests/test_asc_submit_for_review_pricing.py scripts/tests/test_asc_submit_for_review_review_detail.py scripts/tests/test_asc_submit_for_review_version_localization.py
- APPSTORE_KEY_ID=*** APPSTORE_ISSUER_ID=*** APPSTORE_PRIVATE_KEY=... python3 scripts/asc_submit_for_review.py --version 1.3.11 --locale en-US --dry-run
- APPSTORE_KEY_ID=*** APPSTORE_ISSUER_ID=*** APPSTORE_PRIVATE_KEY=... python3 scripts/asc_verify_ready.py --version 1.3.11 --locale en-US
- git diff --check