### PR TITLE
hotfix: use review submission api for ios resubmits

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -78,7 +78,7 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+          echo "$APPSTORE_PRIVATE_KEY" > "$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8"
           echo "$APPSTORE_PRIVATE_KEY" > /tmp/appstore_key.p8
 
       - name: Guard iOS version lineage against ASC
@@ -215,18 +215,11 @@ jobs:
           if [[ "$STATE" == "WAITING_FOR_REVIEW" || "$STATE" == "IN_REVIEW" || "$STATE" == "PENDING_DEVELOPER_RELEASE" || "$STATE" == "READY_FOR_SALE" ]]; then
             echo "Already submitted ($STATE); skipping submit_review."
           else
-            # Use our ASC preflight script for hard validation, then submit via Fastlane deliver.
-            python scripts/asc_submit_for_review.py --version "$IOS_VERSION" --locale "$LOCALE" --dry-run
-
-            cd native-ios
-            fastlane submit_review version:"$IOS_VERSION"
-            cd ..
-          fi
-
-          if [[ "$WAIT_FOR_STATE" == "true" ]]; then
-            python scripts/asc_poll_version_state.py --version "$IOS_VERSION" --wait --timeout 1800 --poll-interval 20
-          else
-            python scripts/asc_poll_version_state.py --version "$IOS_VERSION"
+            SUBMIT_ARGS=(--version "$IOS_VERSION" --locale "$LOCALE")
+            if [[ "$WAIT_FOR_STATE" == "true" ]]; then
+              SUBMIT_ARGS+=(--wait)
+            fi
+            python scripts/asc_submit_for_review.py "${SUBMIT_ARGS[@]}"
           fi
 
       - name: Upload version resolution report

--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -751,18 +751,150 @@ def verify_age_rating(client: ASCClient, app_id: str, version_id: str | None = N
     die("Age Rating declaration not found. Complete Age Rating in App Store Connect.\n  " + detail)
 
 
-def submit_for_review(client: ASCClient, version_id: str) -> None:
-    # Apple’s public App Store Connect OpenAPI currently exposes:
-    # - GET /v1/appStoreVersions/{id}/appStoreVersionSubmission
-    # - DELETE /v1/appStoreVersionSubmissions/{id}
-    # but does not expose a CREATE operation for submissions.
-    #
-    # Attempting to POST will fail with FORBIDDEN_ERROR ("does not allow CREATE").
-    # Use Fastlane `deliver` (see native-ios/fastlane/Fastfile lane `submit_review`)
-    # or submit via the App Store Connect UI.
-    die(
-        "App Store Connect API does not support creating an appStoreVersionSubmission via POST. "
-        "Use fastlane `submit_review` (deliver submit_for_review) or submit in App Store Connect UI."
+def _list_review_submissions(client: ASCClient, app_id: str) -> list[dict[str, Any]]:
+    params = {"limit": 200, "fields[reviewSubmissions]": "platform,state,submittedDate"}
+    if hasattr(client, "get_all"):
+        return client.get_all(f"/apps/{app_id}/reviewSubmissions", params=params)
+    payload = client.request("GET", f"/apps/{app_id}/reviewSubmissions", params=params)
+    return payload.get("data") or []
+
+
+def _list_review_submission_items(client: ASCClient, submission_id: str) -> list[dict[str, Any]]:
+    data = client.request(
+        "GET",
+        f"/reviewSubmissions/{submission_id}/items",
+        params={
+            "limit": 200,
+            "include": "appStoreVersion,appCustomProductPageVersion",
+            "fields[reviewSubmissionItems]": "state",
+        },
+    )
+    return data.get("data") or []
+
+
+def _find_submission_for_version(
+    client: ASCClient, *, app_id: str, version_id: str
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    for submission in _list_review_submissions(client, app_id):
+        submission_id = submission.get("id")
+        if not isinstance(submission_id, str) or not submission_id:
+            continue
+        for item in _list_review_submission_items(client, submission_id):
+            rel_version = ((item.get("relationships") or {}).get("appStoreVersion") or {}).get("data") or {}
+            if rel_version.get("id") == version_id:
+                return submission, item
+    return None, None
+
+
+def _create_review_submission(client: ASCClient, *, app_id: str) -> dict[str, Any]:
+    payload = {
+        "data": {
+            "type": "reviewSubmissions",
+            "attributes": {"platform": "IOS"},
+            "relationships": {"app": {"data": {"type": "apps", "id": app_id}}},
+        }
+    }
+    return client.request("POST", "/reviewSubmissions", payload=payload).get("data") or {}
+
+
+def _create_review_submission_item(client: ASCClient, *, submission_id: str, version_id: str) -> dict[str, Any]:
+    payload = {
+        "data": {
+            "type": "reviewSubmissionItems",
+            "relationships": {
+                "reviewSubmission": {"data": {"type": "reviewSubmissions", "id": submission_id}},
+                "appStoreVersion": {"data": {"type": "appStoreVersions", "id": version_id}},
+            },
+        }
+    }
+    return client.request("POST", "/reviewSubmissionItems", payload=payload).get("data") or {}
+
+
+def _mark_review_submission_item_resolved(client: ASCClient, *, item_id: str) -> dict[str, Any]:
+    payload = {
+        "data": {
+            "type": "reviewSubmissionItems",
+            "id": item_id,
+            "attributes": {"resolved": True},
+        }
+    }
+    return client.request("PATCH", f"/reviewSubmissionItems/{item_id}", payload=payload).get("data") or {}
+
+
+def _submit_review_submission(
+    client: ASCClient,
+    *,
+    submission_id: str,
+    retries: int = 6,
+    retry_delay: int = 10,
+) -> dict[str, Any]:
+    payload = {
+        "data": {
+            "type": "reviewSubmissions",
+            "id": submission_id,
+            "attributes": {"submitted": True},
+        }
+    }
+    last_error: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            return client.request("PATCH", f"/reviewSubmissions/{submission_id}", payload=payload).get("data") or {}
+        except Exception as exc:
+            last_error = exc
+            msg = str(exc)
+            if "already in progress" in msg.lower():
+                info(f"Review submission {submission_id} is already in progress.")
+                return client.request("GET", f"/reviewSubmissions/{submission_id}").get("data") or {}
+            if "not ready to be submitted yet" not in msg.lower() or attempt == retries:
+                raise
+            info(
+                f"Review submission {submission_id} not ready yet; retrying in {retry_delay}s "
+                f"({attempt}/{retries})…"
+            )
+            time.sleep(retry_delay)
+    if last_error:
+        raise last_error
+    raise AssertionError("unreachable")
+
+
+def submit_for_review(client: ASCClient, app_id: str, version_id: str) -> None:
+    submission, item = _find_submission_for_version(client, app_id=app_id, version_id=version_id)
+    if submission:
+        info(
+            "Found existing review submission "
+            f"{submission.get('id')} (state={(submission.get('attributes') or {}).get('state', 'UNKNOWN')})."
+        )
+    else:
+        info("No existing review submission found for this version; creating one.")
+
+    if not submission:
+        submission = _create_review_submission(client, app_id=app_id)
+        submission_id = str(submission.get("id") or "")
+        if not submission_id:
+            die("Failed to create review submission (missing submission id in response).")
+        item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
+    else:
+        submission_id = str(submission.get("id") or "")
+        if not submission_id:
+            die("Existing review submission is missing an id.")
+        if not item:
+            item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
+
+    item_id = str((item or {}).get("id") or "")
+    item_state = ((item or {}).get("attributes") or {}).get("state", "UNKNOWN")
+    if not item_id:
+        die("Review submission item is missing an id.")
+
+    if item_state == "REJECTED":
+        info(f"Resolving rejected review submission item {item_id} for resubmission…")
+        item = _mark_review_submission_item_resolved(client, item_id=item_id)
+        item_state = ((item or {}).get("attributes") or {}).get("state", item_state)
+        info(f"Review submission item {item_id} state: {item_state}")
+
+    submission = _submit_review_submission(client, submission_id=submission_id)
+    info(
+        "Review submission "
+        f"{submission_id} state: {((submission or {}).get('attributes') or {}).get('state', 'UNKNOWN')}"
     )
 
 
@@ -851,7 +983,7 @@ def main() -> int:
 
     build_id = select_valid_build_id(client, app_id, args.version)
     attach_build(client, version_id, build_id)
-    submit_for_review(client, version_id)
+    submit_for_review(client, app_id, version_id)
 
     if args.wait:
         wait_for_state(client, version_id, timeout=args.timeout, poll_interval=args.poll_interval)

--- a/scripts/tests/test_asc_submit_for_review_submission_flow.py
+++ b/scripts/tests/test_asc_submit_for_review_submission_flow.py
@@ -1,0 +1,143 @@
+import unittest
+
+from scripts.tests.router_client import RouterClient
+
+
+class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
+    def test_submit_for_review_resolves_rejected_item_and_resubmits_existing_submission(self):
+        from scripts.asc_submit_for_review import submit_for_review
+
+        item_id = "item-1"
+        submission_id = "sub-1"
+        version_id = "ver-1"
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/reviewSubmissions"): {
+                    "data": [
+                        {
+                            "id": submission_id,
+                            "type": "reviewSubmissions",
+                            "attributes": {"state": "UNRESOLVED_ISSUES"},
+                        }
+                    ]
+                },
+                ("GET", f"/reviewSubmissions/{submission_id}/items"): {
+                    "data": [
+                        {
+                            "id": item_id,
+                            "type": "reviewSubmissionItems",
+                            "attributes": {"state": "REJECTED"},
+                            "relationships": {
+                                "appStoreVersion": {"data": {"type": "appStoreVersions", "id": version_id}}
+                            },
+                        }
+                    ]
+                },
+                ("PATCH", f"/reviewSubmissionItems/{item_id}"): {
+                    "data": {
+                        "id": item_id,
+                        "type": "reviewSubmissionItems",
+                        "attributes": {"state": "READY_FOR_REVIEW"},
+                    }
+                },
+                ("PATCH", f"/reviewSubmissions/{submission_id}"): {
+                    "data": {
+                        "id": submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "WAITING_FOR_REVIEW"},
+                    }
+                },
+            }
+        )
+
+        submit_for_review(client, "app-1", version_id)
+
+        self.assertEqual(client.calls[0]["path"], "/apps/app-1/reviewSubmissions")
+        self.assertEqual(client.calls[1]["path"], f"/reviewSubmissions/{submission_id}/items")
+        self.assertEqual(client.calls[2]["path"], f"/reviewSubmissionItems/{item_id}")
+        self.assertEqual(
+            client.calls[2]["payload"],
+            {
+                "data": {
+                    "type": "reviewSubmissionItems",
+                    "id": item_id,
+                    "attributes": {"resolved": True},
+                }
+            },
+        )
+        self.assertEqual(client.calls[3]["path"], f"/reviewSubmissions/{submission_id}")
+        self.assertEqual(
+            client.calls[3]["payload"],
+            {
+                "data": {
+                    "type": "reviewSubmissions",
+                    "id": submission_id,
+                    "attributes": {"submitted": True},
+                }
+            },
+        )
+
+    def test_submit_for_review_creates_submission_and_item_when_missing(self):
+        from scripts.asc_submit_for_review import submit_for_review
+
+        submission_id = "sub-new"
+        version_id = "ver-1"
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/reviewSubmissions"): {"data": []},
+                ("POST", "/reviewSubmissions"): {
+                    "data": {
+                        "id": submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
+                    }
+                },
+                ("POST", "/reviewSubmissionItems"): {
+                    "data": {
+                        "id": "item-new",
+                        "type": "reviewSubmissionItems",
+                        "attributes": {"state": "READY_FOR_REVIEW"},
+                    }
+                },
+                ("PATCH", f"/reviewSubmissions/{submission_id}"): {
+                    "data": {
+                        "id": submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "WAITING_FOR_REVIEW"},
+                    }
+                },
+            }
+        )
+
+        submit_for_review(client, "app-1", version_id)
+
+        self.assertEqual(client.calls[1]["path"], "/reviewSubmissions")
+        self.assertEqual(
+            client.calls[1]["payload"],
+            {
+                "data": {
+                    "type": "reviewSubmissions",
+                    "attributes": {"platform": "IOS"},
+                    "relationships": {"app": {"data": {"type": "apps", "id": "app-1"}}},
+                }
+            },
+        )
+        self.assertEqual(client.calls[2]["path"], "/reviewSubmissionItems")
+        self.assertEqual(
+            client.calls[2]["payload"],
+            {
+                "data": {
+                    "type": "reviewSubmissionItems",
+                    "relationships": {
+                        "reviewSubmission": {"data": {"type": "reviewSubmissions", "id": submission_id}},
+                        "appStoreVersion": {"data": {"type": "appStoreVersions", "id": version_id}},
+                    },
+                }
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -85,6 +85,8 @@ def test_ios_submit_review_workflow_guards_ios_version_lineage():
     source = IOS_SUBMIT_REVIEW_WORKFLOW.read_text(encoding="utf-8")
 
     assert "check_ios_version_lineage.py" in source
+    assert 'python scripts/asc_submit_for_review.py "${SUBMIT_ARGS[@]}"' in source
+    assert 'fastlane submit_review' not in source
 
 
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():


### PR DESCRIPTION
## Summary
- replace the stale Fastlane-only review submit path with App Store Connect reviewSubmissions API handling
- resolve rejected review submission items before resubmitting the existing submission
- add workflow and unit-test coverage for the resubmit flow

## Verification
- python3 -m pytest -q scripts/tests/test_asc_submit_for_review_submission_flow.py scripts/tests/test_asc_submit_for_review.py scripts/tests/test_asc_submit_for_review_age_rating.py scripts/tests/test_asc_submit_for_review_review_detail.py scripts/tests/test_asc_verify_ready.py scripts/tests/test_growth_workflow_contracts.py
- APPSTORE_KEY_ID=*** APPSTORE_ISSUER_ID=*** APPSTORE_PRIVATE_KEY=*** python3 scripts/asc_submit_for_review.py --version 1.3.11 --locale en-US --wait --timeout 60 --poll-interval 10
- git diff --check
- actionlint .github/workflows/ios-submit-review.yml