### PR TITLE
fix(android): use USAGE_MEDIA for voice callouts

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -209,7 +209,7 @@ class AIVoiceCalloutManager
                         setAudioAttributes(
                             AudioAttributes
                                 .Builder()
-                                .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+                                .setUsage(AudioAttributes.USAGE_MEDIA)
                                 .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                                 .build(),
                         )


### PR DESCRIPTION
## Summary
Voice callouts on Android were using `USAGE_ASSISTANCE_SONIFICATION` which follows the notification volume stream. This is often muted. Changed to `USAGE_MEDIA` so callouts play on the media volume, matching user expectations and the in-app volume slider.

## Test plan
- [ ] Start timer with voice callouts on, verify audio plays on media volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)