### PR TITLE
fix(ios): reactivate voice audio session before cues

### DIFF
--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -143,30 +143,42 @@ final class AIVoiceCalloutService {
         let lastCommandCueFilename: String?
     }
 
+    typealias AudioSessionActivator = @MainActor () -> Void
+
     static let shared = AIVoiceCalloutService()
 
     private static let log = Logger(subsystem: "com.iganapolsky.randomtimer", category: "voice")
+    private static func activateVoiceAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, options: [.duckOthers])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            log.error("Audio session setup failed: \(error.localizedDescription)")
+        }
+    }
 
     private let bundle: Bundle
     private let packStore: ProAudioPackStore
+    private let activateAudioSession: AudioSessionActivator
     private var audioPlayer: AVAudioPlayer?
     private var lastElapsedMilestone = 0
     private var nextCommandCueAt = 0
     private var lastCommandCueFilename: String?
 
-    init(bundle: Bundle = .main, packStore: ProAudioPackStore = .shared) {
+    init(
+        bundle: Bundle = .main,
+        packStore: ProAudioPackStore = .shared,
+        activateAudioSession: @escaping AudioSessionActivator = AIVoiceCalloutService.activateVoiceAudioSession
+    ) {
         self.bundle = bundle
         self.packStore = packStore
-
-        do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, options: [.duckOthers])
-            try AVAudioSession.sharedInstance().setActive(true)
-        } catch {
-            Self.log.error("Audio session setup failed: \(error.localizedDescription)")
-        }
+        self.activateAudioSession = activateAudioSession
+        self.activateAudioSession()
     }
 
     func speak(_ text: String) {
+        activateAudioSession()
+
         let catalog = packStore.voiceCatalog(bundle: bundle)
         let mappedFilename = catalog.filenameByText[text]
         let filename = mappedFilename ?? catalog.fallbackCommandCue.filename

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -4,12 +4,25 @@ import CryptoKit
 
 @MainActor
 final class AIVoiceCalloutServiceTests: XCTestCase {
+    private final class CounterBox {
+        var value = 0
+    }
+
     private func makeUnusedTestAssetURL(filename: String) -> URL {
         URL(filePath: NSTemporaryDirectory()).appendingPathComponent(filename)
     }
 
     private func makeSut() -> AIVoiceCalloutService {
         let service = AIVoiceCalloutService(bundle: .main)
+        service.resetSession()
+        return service
+    }
+
+    private func makeSut(counter: CounterBox) -> AIVoiceCalloutService {
+        let service = AIVoiceCalloutService(
+            bundle: .main,
+            activateAudioSession: { counter.value += 1 }
+        )
         service.resetSession()
         return service
     }
@@ -112,6 +125,19 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 12), .max)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 20), .max)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 40), 30)
+    }
+
+    func testBeginSessionReactivatesAudioSessionBeforePlayback() {
+        let counter = CounterBox()
+        let sut = makeSut(counter: counter)
+
+        sut.beginSession(totalDurationSeconds: 60)
+
+        XCTAssertGreaterThanOrEqual(
+            counter.value,
+            2,
+            "Voice playback must reactivate AVAudioSession after preview teardown deactivates it."
+        )
     }
 
     func testRemotePackStoreInstallsAndServesRemoteVoiceAndSoundAssets() throws {


### PR DESCRIPTION
## Summary
- reactivate the shared AVAudioSession immediately before every voice cue playback
- preserve the existing shared service API while making audio-session activation injectable for tests
- add a focused regression test proving beginSession reactivates audio before playback

## Verification
- xcodebuild -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4" test -only-testing:RandomTimerTests/AIVoiceCalloutServiceTests
