### PR TITLE
fix(ci): default internal Android delivery to Play while Play Protect appeal is pending

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -10,16 +10,17 @@ on:
       target:
         description: "Platform target to distribute"
         required: false
-        default: all
+        default: all_safe
         type: choice
         options:
+          - all_safe
           - all
           - ios
           - android_play
           - android_firebase
 
 concurrency:
-  group: internal-distribution-${{ github.event_name }}-${{ inputs.ref || github.ref_name }}-${{ inputs.target || 'all' }}
+  group: internal-distribution-${{ github.event_name }}-${{ inputs.ref || github.ref_name }}-${{ inputs.target || 'all_safe' }}
   cancel-in-progress: true
 
 jobs:
@@ -47,7 +48,7 @@ jobs:
           REF=""
           SHA=""
           REASON="not_eligible"
-          TARGET="${INPUT_TARGET:-all}"
+          TARGET="${INPUT_TARGET:-all_safe}"
 
           if [[ "$EVENT_NAME" != "workflow_dispatch" ]]; then
             echo "Only workflow_dispatch is supported for budget-safe internal distribution."
@@ -66,8 +67,10 @@ jobs:
           # Budget ack check removed — REQUIRED_BUDGET_ACK was never defined,
           # causing unbound variable crash with set -u.
 
-          TARGET="${INPUT_TARGET:-all}"
+          TARGET="${INPUT_TARGET:-all_safe}"
           case "$TARGET" in
+            all_safe)
+              ;;
             all)
               ;;
             ios)
@@ -111,7 +114,7 @@ jobs:
   ios-testflight-internal:
     name: iOS TestFlight (Internal)
     needs: [gate]
-    if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
+    if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
     runs-on: macos-26
     environment: production
     steps:
@@ -249,7 +252,7 @@ jobs:
   android-play-internal:
     name: Android Google Play (Internal)
     needs: [gate]
-    if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'android_play')
+    if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'android_play')
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -404,6 +407,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Note Play Protect mitigation
+        run: |
+          echo "Android Firebase internal APK delivery is explicit opt-in only."
+          echo "Reason: Play Protect classified a recent Firebase-distributed APK as harmful during tester install."
+          echo "Use target=all_safe or target=android_play unless Firebase APK delivery is required for debugging."
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.gate.outputs.ref }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -177,6 +177,12 @@ CI/workflows persist contract artifacts (`/tmp/delegation_contract*.json`) so ev
 
 Android Firebase App Distribution is documented separately in [FIREBASE_ANDROID_INFRASTRUCTURE.md](FIREBASE_ANDROID_INFRASTRUCTURE.md).
 
+As of March 26, 2026, Android Firebase APK delivery is not the default internal-distribution path. A Firebase-distributed APK was flagged by Google Play Protect on tester install with a harmful-app warning, so the default `Internal Distribution` workflow target is now `all_safe`:
+- iOS TestFlight
+- Android Google Play internal
+
+Use `target=android_firebase` only when Firebase APK delivery is explicitly required for debugging or appeal evidence collection.
+
 Important: Android runtime Firebase and Android App Distribution do not currently use the same Firebase project. Check that document before rotating any Firebase secret.
 
 ### Android (Google Play)


### PR DESCRIPTION
## Summary

- default Internal Distribution to a safe path (`all_safe`) that runs iOS TestFlight + Android Play internal
- require explicit opt-in for Android Firebase APK delivery while Play Protect appeal is pending
- document the mitigation in release docs

## Why

A Firebase-distributed Android APK was flagged by Google Play Protect during tester install with a harmful-app warning. Google Play internal distribution remains the safer default path while that classification is appealed.

## Evidence

- blocked APK SHA-256: `91c148376f968b33e7f4c16fb8a6bfcf1f709cdd3135a35bd212ff0c053bbed9`
- package: `com.iganapolsky.randomtimer`
- version: `1.3.11 (1773900000)`
- local manifest/code audit found no installer-bypass or privilege-escalation APIs
