### PR TITLE
fix(voice): elapsed cues only, no command cues

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -274,12 +274,7 @@ class AIVoiceCalloutManager
                 return
             }
 
-            if (shouldFireCommandCue(elapsedSeconds)) {
-                val cue = randomCommandCue()
-                speak(cue.text)
-                lastCommandCueFilename = cue.filename
-                nextCommandCueAt = elapsedSeconds + 30
-            }
+            // Command cues disabled — only elapsed cues fire at 30s intervals
         }
 
         private fun shouldFireCommandCue(elapsedSeconds: Int): Boolean {

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -234,12 +234,7 @@ final class AIVoiceCalloutService {
             return
         }
 
-        if shouldFireCommandCue(elapsedSeconds: elapsedSeconds) {
-            let cue = randomCommandCue()
-            speak(cue.text)
-            lastCommandCueFilename = cue.filename
-            nextCommandCueAt = elapsedSeconds + 30
-        }
+        // Command cues disabled — only elapsed cues fire at 30s intervals
     }
 
     private func elapsedMilestone(for elapsed: Int) -> VoiceCueCatalog.ElapsedCue? {


### PR DESCRIPTION
## Summary
Command cues ("Move with a purpose") were firing alongside elapsed cues, causing
repetitive callouts. Disabled command cues entirely. Now ONLY elapsed time
announcements fire at 30s intervals:

- 30s: "Thirty seconds elapsed. Stay locked in."
- 60s: "One minute elapsed. Keep pressure on."
- 90s: "One minute thirty elapsed. Stay disciplined."
- etc.

One callout every 30 seconds. No repeats. No "move with a purpose" spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)