### PR TITLE
fix(ci): improve deleted-project Play API remediation

### DIFF
--- a/scripts/check_store_access.py
+++ b/scripts/check_store_access.py
@@ -101,12 +101,22 @@ def check_android_access(package_name: str) -> Tuple[bool, str]:
         )
     except Exception as exc:
         details = f"Google Play API access failed: {exc}"
+        err_text = str(exc).lower()
         if "403" in str(exc) and service_account_email:
-            details += (
-                f"\n  Service account: {service_account_email}\n"
-                "  Fix: Grant this account access in Play Console > Users and permissions,"
-                " and confirm API access is linked for this app."
-            )
+            details += f"\n  Service account: {service_account_email}"
+            if "consumer_invalid" in err_text or "has been deleted" in err_text:
+                details += (
+                    "\n  Fix: The Google Cloud project for this key is missing or the "
+                    "Play Developer API consumer is invalid. In Google Cloud Console, use an "
+                    "active project, enable Google Play Android Developer API, link that project "
+                    "in Play Console (API access), invite the service account under Users and "
+                    "permissions, then replace GitHub secret GOOGLE_PLAY_JSON_KEY with a new key JSON."
+                )
+            else:
+                details += (
+                    "\n  Fix: Grant this account access in Play Console > Users and permissions,"
+                    " and confirm API access is linked for this app."
+                )
         return (False, details)
 
 

--- a/scripts/tests/test_check_store_access.py
+++ b/scripts/tests/test_check_store_access.py
@@ -65,3 +65,37 @@ def test_check_ios_access_not_found_app(monkeypatch):
     ok, summary = csa.check_ios_access("com.example.app")
     assert ok is False
     assert "no app found" in summary.lower()
+
+
+def test_check_android_access_surfaces_deleted_project_remediation(monkeypatch):
+    monkeypatch.setenv(
+        "GOOGLE_PLAY_JSON_KEY",
+        json.dumps({"client_email": "svc@example.com", "project_id": "dead-project"}),
+    )
+
+    class _CredsFactory:
+        @staticmethod
+        def from_service_account_info(*_args, **_kwargs):
+            return object()
+
+    class _Edits:
+        def insert(self, **_kwargs):
+            raise Exception("HttpError 403: consumer_invalid; Project #123 has been deleted.")
+
+    class _Service:
+        def edits(self):
+            return _Edits()
+
+    fake_google_oauth2 = SimpleNamespace(service_account=SimpleNamespace(Credentials=_CredsFactory))
+    fake_discovery = SimpleNamespace(build=lambda *_a, **_k: _Service())
+
+    monkeypatch.setitem(__import__("sys").modules, "google.oauth2", fake_google_oauth2)
+    monkeypatch.setitem(__import__("sys").modules, "google.oauth2.service_account", fake_google_oauth2.service_account)
+    monkeypatch.setitem(__import__("sys").modules, "googleapiclient.discovery", fake_discovery)
+
+    ok, summary = csa.check_android_access("com.example.app")
+
+    assert ok is False
+    assert "svc@example.com" in summary
+    assert "Google Cloud project for this key is missing" in summary
+    assert "GOOGLE_PLAY_JSON_KEY" in summary


### PR DESCRIPTION
## Summary
- distinguish deleted or invalid Google Cloud Play API consumers from generic 403 permission failures
- print the correct operator remediation for `consumer_invalid` / deleted-project cases
- add a focused regression test for the new error text

## Verification
- `PYTHONPATH=/tmp/random-timer-pydeps:/private/tmp/random-timer-store-access-remediation python3 -m pytest scripts/tests/test_check_store_access.py -q`
