### PR TITLE
fix(hygiene): ignore local artifact buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ temp/
 # Python virtual environments
 .venv/
 venv/
+.venv-chatterbox/
+native-android/.venv-chatterbox/
 
 # Python bytecode
 __pycache__/
@@ -116,6 +118,8 @@ apple_status.json
 .aider*
 
 # RLHF local feedback data
+.rlhf/feedback.jsonl
+.rlhf/rejection-ledger.jsonl
 .rlhf/feedback-log.jsonl
 .rlhf/memory-log.jsonl
 .rlhf/feedback-sequences.jsonl
@@ -130,3 +134,6 @@ apple_status.json
 .rlhf/.watcher-offset
 .rlhf/chatgpt-openapi.yaml
 .rlhf/contextfs/
+
+# Local evidence captures
+evidence/

--- a/scripts/tests/test_repo_hygiene_contracts.py
+++ b/scripts/tests/test_repo_hygiene_contracts.py
@@ -65,3 +65,16 @@ def test_hygiene_check_matches_current_repo_policy() -> None:
     assert '"GEMINI.md"' in contents
     assert '"BUGBOT.md"' in contents
     assert "Possible secret or temp-path leak" not in contents
+
+
+def test_gitignore_covers_known_local_artifact_buckets() -> None:
+    contents = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+    expected_entries = (
+        ".venv-chatterbox/",
+        "native-android/.venv-chatterbox/",
+        ".rlhf/feedback.jsonl",
+        ".rlhf/rejection-ledger.jsonl",
+        "evidence/",
+    )
+    for entry in expected_entries:
+        assert entry in contents, f".gitignore must ignore {entry}"


### PR DESCRIPTION
## Summary\n- ignore disposable local chatterbox virtualenv mirrors\n- ignore local RLHF scratch logs not covered by the current policy\n- ignore local evidence capture output\n- add a regression test for the new ignore contract\n\n## Verification\n- PYTHONPATH=/tmp/random-timer-pydeps python3 -m pytest scripts/tests/test_repo_hygiene_contracts.py -q\n- bash scripts/hygiene-check.sh\n- python3 inline untracked-count check -> 0 untracked files in the isolated worktree\n