### PR TITLE
docs(readme): tighten PR bot evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ No ads. Privacy-first. Free core timer with an optional Pro subscription for adv
 
 ## PR Automation Stack
 
-This repository uses multiple PR review and analysis agents. The table below reflects the **live March 26, 2026 state** of the repo, not aspirational tooling.
+This repository uses multiple PR review and analysis agents. The table below reflects the **live March 27, 2026 state** of the repo, not aspirational tooling.
 
 | Bot / service | Status | What it does | Repo evidence |
 | --- | --- | --- | --- |
-| **Seer by Sentry** | **Active** | Posts PR review comments focused on safety, error handling, and risk. | [`.github/seer.app.yml`](.github/seer.app.yml) and recent `sentry[bot]` reviews on merged PRs such as `#904` and `#903` |
+| **Seer by Sentry** | **Active** | Posts PR review comments focused on safety, error handling, and risk. | [`.github/seer.app.yml`](.github/seer.app.yml), historical `seer-by-sentry` review records on merged PRs, and recent `Seer Code Review` check runs from the `sentry` app on PR heads such as `#914` |
 | **Claude Review** | **Active** | Runs PR review and `@claude` assist flows through GitHub Actions. | [`.github/workflows/claude-review.yml`](.github/workflows/claude-review.yml) |
 | **GitHub Copilot code review** | **Enabled on `develop` and `main`** | Automatically reviews pull requests, including new pushes and drafts on protected branches. | Protected branch rulesets now include `copilot_code_review` with `review_on_push=true` and `review_draft_pull_requests=true` |
 | **SonarQube Cloud** | **Active** | Decorates PRs and enforces a quality gate on analyzed code. | Recent `sonarqubecloud[bot]` PR comments and the live `SonarCloud Code Analysis` check |
 | **Cursor BugBot / `@cursor` agent** | **Repo-ready, app install still required** | BugBot reviews PRs; `@cursor ...` can trigger cloud-agent fixes on PRs and issues. | [`BUGBOT.md`](BUGBOT.md) plus Cursor docs for [Bugbot](https://cursor.com/docs/bugbot) and [GitHub integration](https://cursor.com/docs/integrations/github) |
 
-Current note: SonarQube Cloud is green on the long-lived branch currently analyzed by SonarCloud. Cursor remains repo-ready until its external GitHub app install is enabled.
+Current note: SonarQube Cloud is green on the long-lived branch currently analyzed by SonarCloud. Cursor remains repo-ready until its external GitHub app install is enabled; Cursor's GitHub docs still require installing `github.com/apps/cursor` with repository access and pull-request write permissions.
 
 ## North Star (Defined February 23, 2026)
 


### PR DESCRIPTION
## Summary
- refresh the PR automation status date in README
- cite live Seer check-run evidence instead of overstated recent review examples
- clarify that Cursor still needs the external GitHub app install and PR write access

## Verification
- PYTHONPATH=/tmp/random-timer-pydeps python3 -m pytest scripts/tests/test_pr_automation_docs.py scripts/tests/test_repo_hygiene_contracts.py -q
- bash scripts/hygiene-check.sh