### PR TITLE
fix(release): verify public Play listing after production publish

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -31,7 +31,7 @@ on:
           - 'false'
           - 'true'
         required: false
-        default: 'false'
+        default: 'true'
 
 concurrency:
   group: mobile-release-pipeline-${{ github.ref_name }}-${{ inputs.platform || 'both' }}
@@ -474,6 +474,15 @@ jobs:
             ARGS="$ARGS --version ${{ steps.versions.outputs.ios_version }}"
           fi
           python scripts/verify_release.py $ARGS
+
+      - name: Verify public Google Play listing (production only)
+        if: needs.android-release.result == 'success' && steps.android_track.outputs.track == 'production'
+        run: |
+          python scripts/verify_play_public_listing.py \
+            --package com.iganapolsky.randomtimer \
+            --country US \
+            --timeout 900 \
+            --poll-interval 60
 
       - name: Cleanup secrets
         if: always()

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -99,6 +99,20 @@ def test_native_release_workflow_disables_hidden_play_fallback_and_verifies_requ
     assert "(inputs.platform == 'android' && needs.android-release.result == 'success')" in source
 
 
+def test_native_release_workflow_submits_ios_for_review_by_default():
+    source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    submit_review_block = source.split("submit_review:", 1)[1].split("concurrency:", 1)[0]
+    assert "default: 'true'" in submit_review_block
+
+
+def test_native_release_workflow_verifies_public_play_listing_for_production():
+    source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Verify public Google Play listing (production only)" in source
+    assert "python scripts/verify_play_public_listing.py" in source
+
+
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():
     source = NORTH_STAR_GUARDRAIL_WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_verify_play_public_listing.py
+++ b/scripts/tests/test_verify_play_public_listing.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import verify_play_public_listing as vpl
+
+
+class _Resp:
+    def __init__(self, status_code: int, headers: dict[str, str] | None = None):
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+def test_verify_public_listing_returns_pass_on_http_200(monkeypatch):
+    monkeypatch.setattr(
+        vpl.requests,
+        "get",
+        lambda *_args, **_kwargs: _Resp(200, {"date": "Fri, 27 Mar 2026 17:31:57 GMT"}),
+    )
+
+    result = vpl.verify_public_listing("https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer")
+
+    assert result.passed is True
+    assert result.status == "PUBLIC"
+    assert "HTTP 200" in result.details
+
+
+def test_verify_public_listing_reports_http_404(monkeypatch):
+    monkeypatch.setattr(
+        vpl.requests,
+        "get",
+        lambda *_args, **_kwargs: _Resp(404, {"date": "Fri, 27 Mar 2026 17:31:57 GMT"}),
+    )
+
+    result = vpl.verify_public_listing("https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer")
+
+    assert result.passed is False
+    assert result.status == "HTTP_404"
+    assert "Fri, 27 Mar 2026 17:31:57 GMT" in result.details
+
+
+def test_poll_until_visible_returns_first_success(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_verify(_url: str):
+        calls["count"] += 1
+        if calls["count"] == 3:
+            return vpl.PublicListingResult(True, "PUBLIC", "HTTP 200")
+        return vpl.PublicListingResult(False, "HTTP_404", "HTTP 404")
+
+    monkeypatch.setattr(vpl, "verify_public_listing", fake_verify)
+    monkeypatch.setattr(vpl.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = vpl.poll_until_visible("https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer", timeout=5, poll_interval=1)
+
+    assert result.passed is True
+    assert calls["count"] == 3
+
+
+def test_poll_until_visible_times_out(monkeypatch):
+    monkeypatch.setattr(
+        vpl,
+        "verify_public_listing",
+        lambda _url: vpl.PublicListingResult(False, "HTTP_404", "HTTP 404"),
+    )
+    monkeypatch.setattr(vpl.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = vpl.poll_until_visible(
+        "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
+        timeout=0,
+        poll_interval=1,
+    )
+
+    assert result.passed is False
+    assert result.status == "TIMEOUT"
+    assert "timed out" in result.details
+
+
+def test_parse_args_defaults_to_us_store_url(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "verify_play_public_listing.py",
+            "--package",
+            "com.iganapolsky.randomtimer",
+        ],
+    )
+
+    args = vpl.parse_args()
+
+    assert args.package == "com.iganapolsky.randomtimer"
+    assert args.country == "US"

--- a/scripts/verify_play_public_listing.py
+++ b/scripts/verify_play_public_listing.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Verify that a Google Play app listing is publicly visible."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+
+import requests
+
+
+DEFAULT_TIMEOUT = 900
+DEFAULT_POLL_INTERVAL = 60
+
+
+@dataclass
+class PublicListingResult:
+    passed: bool
+    status: str
+    details: str
+
+
+def build_store_url(package: str, country: str) -> str:
+    normalized = (country or "US").strip().upper()
+    return f"https://play.google.com/store/apps/details?id={package}&hl=en_{normalized}&gl={normalized}"
+
+
+def verify_public_listing(url: str) -> PublicListingResult:
+    try:
+        response = requests.get(
+            url,
+            allow_redirects=True,
+            timeout=30,
+            headers={"User-Agent": "Random-Timer-Release-Verification/1.0"},
+        )
+    except requests.RequestException as exc:
+        return PublicListingResult(False, "ERROR", f"Play public listing request failed: {exc}")
+
+    status = response.status_code
+    date_header = response.headers.get("date", "unknown")
+    if status == 200:
+        return PublicListingResult(True, "PUBLIC", f"HTTP 200 on {date_header}")
+    return PublicListingResult(False, f"HTTP_{status}", f"HTTP {status} on {date_header}")
+
+
+def poll_until_visible(url: str, timeout: int, poll_interval: int) -> PublicListingResult:
+    deadline = time.time() + timeout
+
+    while True:
+        result = verify_public_listing(url)
+        if result.passed:
+            return result
+
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            return PublicListingResult(
+                False,
+                "TIMEOUT",
+                f"{result.details} (timed out after {timeout}s)",
+            )
+
+        time.sleep(min(poll_interval, max(0, remaining)))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that the Google Play public listing is visible."
+    )
+    parser.add_argument("--package", required=True, help="Android package name")
+    parser.add_argument("--country", default="US", help="Two-letter storefront country code")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument(
+        "--url",
+        help="Explicit store URL. If omitted, generated from --package and --country.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    url = args.url or build_store_url(args.package, args.country)
+    result = poll_until_visible(url, timeout=args.timeout, poll_interval=args.poll_interval)
+
+    print()
+    print("══ Play Public Listing Verification ═════════════════")
+    print(f"URL:    {url}")
+    print(f"Status: {result.status}")
+    print(f"Detail: {result.details}")
+    print("══════════════════════════════════════════════════════")
+    print()
+
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds an explicit post-publish verification step for Google Play production that polls the public storefront URL. This prevents the release workflow from reporting success when the production backend upload succeeded but the public listing is still unavailable.
