### PR TITLE
fix(release): keep ios review submission opt-in

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -31,7 +31,7 @@ on:
           - 'false'
           - 'true'
         required: false
-        default: 'true'
+        default: 'false'
 
 concurrency:
   group: mobile-release-pipeline-${{ github.ref_name }}-${{ inputs.platform || 'both' }}

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -99,11 +99,11 @@ def test_native_release_workflow_disables_hidden_play_fallback_and_verifies_requ
     assert "(inputs.platform == 'android' && needs.android-release.result == 'success')" in source
 
 
-def test_native_release_workflow_submits_ios_for_review_by_default():
+def test_native_release_workflow_keeps_ios_review_submission_opt_in():
     source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
     submit_review_block = source.split("submit_review:", 1)[1].split("concurrency:", 1)[0]
-    assert "default: 'true'" in submit_review_block
+    assert "default: 'false'" in submit_review_block
 
 
 def test_native_release_workflow_verifies_public_play_listing_for_production():


### PR DESCRIPTION
## Summary\n- restore the safer submit_review default to false in native-release\n- keep the new public Play listing verification intact\n- update the workflow contract test to match the opt-in behavior\n\n## Verification\n- PYTHONPATH=/tmp/random-timer-pydeps:/private/tmp/random-timer-store-hardening python3 -m pytest scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_verify_play_public_listing.py -q\n