### PR TITLE
fix(marketing): tighten store positioning copy

### DIFF
--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,18 +1,20 @@
 TRAIN FOR CHAOS. NOT RHYTHM.
 
-Most timers teach your brain to anticipate the bell. That's comfort training — and it makes you slower when it counts. Random Tactical Timer fires at an unpredictable moment inside your chosen time window, forcing genuine reaction under stress. This is pattern-interrupt training for serious fighters and operators.
+Most timers teach anticipation. Random Tactical Timer trains reaction.
+
+Instead of firing on a predictable beat, it triggers at an unpredictable moment inside your chosen time window, forcing real response under pressure. This is pattern-interrupt training built for dry fire, sparring, drills, and reaction work.
 
 BUILT FOR:
+- Dry fire and draw-to-first-shot drills
 - Boxing pad rounds, bag intervals, and shadowboxing flurries
 - BJJ scramble and positional transition drills
-- MMA, Muay Thai, and Combatives pattern-interrupt work
-- Law enforcement and Military defensive tactics training
+- MMA, Muay Thai, and combatives reaction work
 - HIIT and CrossFit sessions that punish predictability
 
-WHY UNPREDICTABILITY WORKS:
-- Pattern Interrupt: Force your nervous system to stay present, not wait for a buzzer.
-- Stress Inoculation: Build composure by training against uncertain triggers—the same method used in tactical and military stress-conditioning.
-- Eliminate Anticipation: Stop "cruising" through rounds. React when the stimulus hits, not when you expect it.
+WHY IT WORKS:
+- Stop anticipation: react to the cue, not the countdown.
+- Stay present: uncertainty keeps your nervous system engaged.
+- Train under pressure: build composure when the trigger is not on your schedule.
 
 KEY FEATURES:
 - True random trigger within your selected min/max range

--- a/native-android/fastlane/metadata/android/en-US/short_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Combat reaction timer. Train under pressure — boxing, BJJ, tactical drills.
+Most timers train anticipation. This one trains reaction under pressure.

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -1,22 +1,23 @@
-ELIMINATE PREDICTABILITY. MASTER THE OODA LOOP.
+TRAIN FOR CHAOS. NOT RHYTHM.
 
-Random Tactical Timer is a professional-grade response training tool designed to punish lazy rhythm and build explosive reaction speed. Built for dry fire, MMA, HIIT, and tactical training, it removes the "cheat" of a standard countdown by using unpredictable start intervals.
+Most timers teach anticipation. Random Tactical Timer trains reaction.
 
-### TRAIN LIKE YOU FIGHT
-Standard timers teach you to anticipate the beep. Random Tactical Timer forces you to react to it. Whether you're working draw speed on the range or defensive entries on the mat, our randomized engine ensures every rep is a fresh challenge.
+Instead of firing on a predictable beat, it triggers at an unpredictable moment inside your chosen time window, forcing real response under pressure.
 
-### TACTICAL FEATURES
-- **LOUD & CLEAR:** Aggressive alarms and voice callouts that cut through range noise and gym chaos.
-- **PRO SOUND ARSENAL:** 10 distinct tactical cues including Klaxon, Airhorn, and Siren.
-- **ELAPSED VOICE CALLOUTS:** Keep your eyes on the threat—the app tells you exactly how much time has passed.
-- **EXTENDED RANGE:** Configure intervals from 5 seconds to 60 minutes.
-- **LOOP & ROUND LIMITS:** Automated drill cycles with Pro-level round selection.
+Built for dry fire, sparring, drills, and reaction training.
 
-### BUILT FOR UTILITY
-- **STAY HONEST:** No visual countdown. No cheating the start.
-- **DISTANCE READY:** High-contrast tactical UI designed to be readable across the mat or down the range.
-- **ADAPTIVE:** Perfectly tuned for dry fire, boxing, wrestling, and high-intensity interval work.
+FEATURES
+- Random trigger timing inside your selected range
+- Hidden countdown mode to stop timer watching
+- Loud alarms, haptics, and Pro voice callouts
+- Loop mode with optional round limits
+- Extended session range up to 60 minutes
 
-Stop timing your drills. Start training your response. 
+TRAINING USES
+- Dry fire and draw-to-first-shot drills
+- Boxing pad rounds, bag work, and shadowboxing flurries
+- BJJ scrambles and positional transition drills
+- MMA, Muay Thai, and combatives reaction work
+- HIIT and conditioning sessions that punish predictability
 
-GET TACTICAL.
+Stop timing your drills. Start training your response.

--- a/native-ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/native-ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-ELIMINATE PREDICTABILITY. TRAIN REACTION TIME UNDER STRESS.
+Most timers train anticipation. This one trains reaction under pressure.

--- a/native-ios/fastlane/metadata/en-US/subtitle.txt
+++ b/native-ios/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Reaction Training, Randomized
+Train Reaction Under Pressure

--- a/scripts/tests/test_store_metadata_copy.py
+++ b/scripts/tests/test_store_metadata_copy.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_android_store_copy_uses_reaction_positioning() -> None:
+    full_description = (
+        REPO_ROOT / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "full_description.txt"
+    ).read_text(encoding="utf-8")
+    short_description = (
+        REPO_ROOT / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "short_description.txt"
+    ).read_text(encoding="utf-8")
+
+    assert "TRAIN FOR CHAOS. NOT RHYTHM." in full_description
+    assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in full_description
+    assert "serious fighters and operators" not in full_description
+    assert "trains reaction under pressure" in short_description
+
+
+def test_ios_store_copy_matches_reaction_positioning() -> None:
+    description = (
+        REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "description.txt"
+    ).read_text(encoding="utf-8")
+    promotional_text = (
+        REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "promotional_text.txt"
+    ).read_text(encoding="utf-8")
+    subtitle = (
+        REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "subtitle.txt"
+    ).read_text(encoding="utf-8").strip()
+
+    assert "TRAIN FOR CHAOS. NOT RHYTHM." in description
+    assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in description
+    assert "Built for dry fire, sparring, drills, and reaction training." in description
+    assert "trains reaction under pressure" in promotional_text
+    assert subtitle == "Train Reaction Under Pressure"


### PR DESCRIPTION
## Summary\n- tighten the Android and iOS store copy around reaction training\n- remove the narrower "serious fighters and operators" positioning\n- add a regression test for the updated store metadata messaging\n\n## Verification\n- PYTHONPATH=/tmp/random-timer-pydeps:/private/tmp/random-timer-store-copy python3 -m pytest scripts/tests/test_store_metadata_copy.py scripts/tests/test_refresh_ios_screenshot_creatives.py -q\n