### PR TITLE
revert: restore debug unlock for production use

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -2,7 +2,6 @@ package com.iganapolsky.randomtimer.billing
 
 import android.app.Activity
 import android.content.Context
-import com.iganapolsky.randomtimer.BuildConfig
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
@@ -51,7 +50,9 @@ class ProManager
             const val ELITE_PRODUCT_ID = "elite_tactical"
             const val PRO_PRODUCT_ID = ELITE_PRODUCT_ID
 
-            internal fun canUseDebugUnlock(): Boolean = BuildConfig.DEBUG
+            internal fun canUseDebugUnlock(
+                @Suppress("UNUSED_PARAMETER") isDebugBuild: Boolean = true,
+            ): Boolean = true
         }
 
         private val _entitlementLevel = MutableStateFlow(EntitlementLevel.NONE)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerDebugUnlockGuardTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerDebugUnlockGuardTest.kt
@@ -1,12 +1,16 @@
 package com.iganapolsky.randomtimer.billing
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ProManagerDebugUnlockGuardTest {
     @Test
-    fun `canUseDebugUnlock matches BuildConfig DEBUG`() {
-        // In unit tests, BuildConfig.DEBUG is true
-        assertEquals(com.iganapolsky.randomtimer.BuildConfig.DEBUG, ProManager.canUseDebugUnlock())
+    fun `canUseDebugUnlock returns true in debug builds`() {
+        assertTrue(ProManager.canUseDebugUnlock(isDebugBuild = true))
+    }
+
+    @Test
+    fun `canUseDebugUnlock returns true in release builds`() {
+        assertTrue(ProManager.canUseDebugUnlock(isDebugBuild = false))
     }
 }


### PR DESCRIPTION
## Summary
- Reverts the `BuildConfig.DEBUG` guard on `canUseDebugUnlock()` — intentionally available in production for the developer
- Restores the original test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)