### PR TITLE
fix(store): unblock metadata sync workflows

### DIFF
--- a/scripts/listing_snapshot.py
+++ b/scripts/listing_snapshot.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Write a store-listing snapshot artifact for Android or iOS."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.source_versions import read_source_versions
+except ModuleNotFoundError:
+    from source_versions import read_source_versions  # type: ignore
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _png_inventory(directory: Path) -> list[dict[str, str]]:
+    files = sorted(directory.glob("*.png")) if directory.is_dir() else []
+    return [{"file": path.name, "sha256": _sha256(path)} for path in files]
+
+
+def build_android_snapshot(
+    repo_root: Path,
+    *,
+    source_run_id: str,
+    source_run_url: str,
+    track: str,
+    version_code: str,
+) -> dict[str, Any]:
+    versions = read_source_versions(repo_root)
+    images_root = repo_root / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "images"
+    icon_path = images_root / "icon.png"
+    feature_graphic_path = images_root / "featureGraphic" / "feature-graphic.png"
+    screenshots_dir = images_root / "phoneScreenshots"
+    return {
+        "generated_at": _now_iso(),
+        "platform": "android",
+        "source_run": {"id": source_run_id, "url": source_run_url},
+        "app_name": (repo_root / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "title.txt")
+        .read_text(encoding="utf-8")
+        .strip(),
+        "version_name": str(versions["android"]["version_name"]),
+        "version_code": version_code or str(versions["android"]["version_code"]),
+        "track": track,
+        "icon_sha256": _sha256(icon_path),
+        "feature_graphic_sha256": _sha256(feature_graphic_path),
+        "screenshots": _png_inventory(screenshots_dir),
+    }
+
+
+def build_ios_snapshot(
+    repo_root: Path,
+    *,
+    source_run_id: str,
+    source_run_url: str,
+    locale: str,
+    app_store_version: str,
+) -> dict[str, Any]:
+    versions = read_source_versions(repo_root)
+    screenshots_dir = repo_root / "native-ios" / "fastlane" / "screenshots" / locale
+    icon_path = (
+        repo_root
+        / "native-ios"
+        / "RandomTimer"
+        / "Resources"
+        / "Assets.xcassets"
+        / "AppIcon.appiconset"
+        / "icon-1024.png"
+    )
+    return {
+        "generated_at": _now_iso(),
+        "platform": "ios",
+        "source_run": {"id": source_run_id, "url": source_run_url},
+        "app_name": (repo_root / "native-ios" / "fastlane" / "metadata" / locale / "name.txt")
+        .read_text(encoding="utf-8")
+        .strip(),
+        "version_name": str(versions["ios"]["version_name"]),
+        "build_number": str(versions["ios"]["build_number"]),
+        "app_store_version": app_store_version or str(versions["ios"]["version_name"]),
+        "locale": locale,
+        "icon_sha256": _sha256(icon_path),
+        "screenshots": _png_inventory(screenshots_dir),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Write a store-listing snapshot artifact.")
+    parser.add_argument("--platform", choices=("android", "ios"), required=True)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--source-run-id", default="")
+    parser.add_argument("--source-run-url", default="")
+    parser.add_argument("--track", default="")
+    parser.add_argument("--version-code", default="")
+    parser.add_argument("--locale", default="en-US")
+    parser.add_argument("--app-store-version", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    if args.platform == "android":
+        payload = build_android_snapshot(
+            repo_root,
+            source_run_id=args.source_run_id,
+            source_run_url=args.source_run_url,
+            track=args.track,
+            version_code=args.version_code,
+        )
+    else:
+        payload = build_ios_snapshot(
+            repo_root,
+            source_run_id=args.source_run_id,
+            source_run_url=args.source_run_url,
+            locale=args.locale,
+            app_store_version=args.app_store_version,
+        )
+
+    output_path = Path(args.output).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_android_metadata.py
+++ b/scripts/sync_android_metadata.py
@@ -18,9 +18,6 @@ import os
 import sys
 from pathlib import Path
 
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
-
 PACKAGE_NAME = "com.iganapolsky.randomtimer"
 METADATA_ROOT = Path(__file__).resolve().parent.parent / "native-android" / "fastlane" / "metadata" / "android"
 
@@ -42,18 +39,46 @@ def read_metadata(lang_dir: str, filename: str) -> str:
     return ""
 
 
-def main():
-    key_path = os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH", os.path.join(os.environ.get("RUNNER_TEMP", os.getcwd()), "play-service-account.json"))
-    if not os.path.exists(key_path):
-        print(f"Service account key not found at {key_path}", file=sys.stderr)
-        sys.exit(1)
+def build_edits_service(key_path: str):
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
 
     credentials = service_account.Credentials.from_service_account_file(
         key_path,
         scopes=["https://www.googleapis.com/auth/androidpublisher"],
     )
     service = build("androidpublisher", "v3", credentials=credentials)
-    edits = service.edits()
+    return service.edits()
+
+
+def commit_edit(edits, *, edit_id: str):
+    try:
+        return edits.commit(
+            packageName=PACKAGE_NAME,
+            editId=edit_id,
+            changesNotSentForReview=True,
+        ).execute()
+    except Exception as exc:
+        message = str(exc).lower()
+        if "changes are sent for review automatically" in message and "changesnotsentforreview" in message:
+            print(
+                "Play rejected changesNotSentForReview; retrying commit without that flag for auto-review apps.",
+                file=sys.stderr,
+            )
+            return edits.commit(
+                packageName=PACKAGE_NAME,
+                editId=edit_id,
+            ).execute()
+        raise
+
+
+def main():
+    key_path = os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH", os.path.join(os.environ.get("RUNNER_TEMP", os.getcwd()), "play-service-account.json"))
+    if not os.path.exists(key_path):
+        print(f"Service account key not found at {key_path}", file=sys.stderr)
+        sys.exit(1)
+
+    edits = build_edits_service(key_path)
 
     # Create edit
     edit = edits.insert(packageName=PACKAGE_NAME, body={}).execute()
@@ -103,12 +128,7 @@ def main():
     if skipped:
         print(f"Skipped {len(skipped)} locales (enable in Play Console if needed): {', '.join(skipped)}", file=sys.stderr)
 
-    # Commit edit with changesNotSentForReview=true since we can't auto-send for review
-    edits.commit(
-        packageName=PACKAGE_NAME,
-        editId=edit_id,
-        changesNotSentForReview=True
-    ).execute()
+    commit_edit(edits, edit_id=edit_id)
     print(f"Committed edit. Updated {len(updated)} languages: {', '.join(updated)}")
 
 

--- a/scripts/tests/test_listing_snapshot.py
+++ b/scripts/tests/test_listing_snapshot.py
@@ -1,0 +1,121 @@
+import json
+from pathlib import Path
+
+from PIL import Image
+
+from scripts import listing_snapshot
+
+
+def _write_png(path: Path, size: tuple[int, int], color: tuple[int, int, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color=color).save(path, format="PNG")
+
+
+def _seed_versions(repo: Path) -> None:
+    (repo / "native-android/app").mkdir(parents=True, exist_ok=True)
+    (repo / "native-android/app/build.gradle.kts").write_text(
+        'versionName = "1.3.14"\nversionCode = 1773900042\n',
+        encoding="utf-8",
+    )
+    (repo / "native-ios/RandomTimer.xcodeproj").mkdir(parents=True, exist_ok=True)
+    (repo / "native-ios/RandomTimer.xcodeproj/project.pbxproj").write_text(
+        "MARKETING_VERSION = 1.3.14;\nCURRENT_PROJECT_VERSION = 42;\n",
+        encoding="utf-8",
+    )
+
+
+def test_build_android_snapshot_includes_expected_inventory(tmp_path: Path) -> None:
+    _seed_versions(tmp_path)
+    (tmp_path / "native-android/fastlane/metadata/android/en-US").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "native-android/fastlane/metadata/android/en-US/title.txt").write_text(
+        "Random Tactical Timer",
+        encoding="utf-8",
+    )
+    _write_png(tmp_path / "native-android/fastlane/metadata/android/en-US/images/icon.png", (1024, 1024), (1, 2, 3))
+    _write_png(
+        tmp_path / "native-android/fastlane/metadata/android/en-US/images/featureGraphic/feature-graphic.png",
+        (1024, 500),
+        (4, 5, 6),
+    )
+    _write_png(
+        tmp_path / "native-android/fastlane/metadata/android/en-US/images/phoneScreenshots/1_setup.png",
+        (1344, 2992),
+        (7, 8, 9),
+    )
+
+    payload = listing_snapshot.build_android_snapshot(
+        tmp_path,
+        source_run_id="123",
+        source_run_url="https://example.com/run/123",
+        track="internal",
+        version_code="1773900042",
+    )
+
+    assert payload["platform"] == "android"
+    assert payload["track"] == "internal"
+    assert payload["version_code"] == "1773900042"
+    assert payload["screenshots"][0]["file"] == "1_setup.png"
+
+
+def test_build_ios_snapshot_includes_expected_inventory(tmp_path: Path) -> None:
+    _seed_versions(tmp_path)
+    (tmp_path / "native-ios/fastlane/metadata/en-US").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "native-ios/fastlane/metadata/en-US/name.txt").write_text(
+        "Random Tactical Timer",
+        encoding="utf-8",
+    )
+    _write_png(
+        tmp_path / "native-ios/RandomTimer/Resources/Assets.xcassets/AppIcon.appiconset/icon-1024.png",
+        (1024, 1024),
+        (12, 13, 14),
+    )
+    _write_png(tmp_path / "native-ios/fastlane/screenshots/en-US/1_setup.png", (1290, 2796), (15, 16, 17))
+
+    payload = listing_snapshot.build_ios_snapshot(
+        tmp_path,
+        source_run_id="987",
+        source_run_url="https://example.com/run/987",
+        locale="en-US",
+        app_store_version="1.3.14",
+    )
+
+    assert payload["platform"] == "ios"
+    assert payload["app_store_version"] == "1.3.14"
+    assert payload["screenshots"][0]["file"] == "1_setup.png"
+
+
+def test_listing_snapshot_main_writes_json_output(tmp_path: Path, monkeypatch) -> None:
+    _seed_versions(tmp_path)
+    (tmp_path / "native-android/fastlane/metadata/android/en-US").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "native-android/fastlane/metadata/android/en-US/title.txt").write_text(
+        "Random Tactical Timer",
+        encoding="utf-8",
+    )
+    _write_png(tmp_path / "native-android/fastlane/metadata/android/en-US/images/icon.png", (1024, 1024), (1, 1, 1))
+    _write_png(
+        tmp_path / "native-android/fastlane/metadata/android/en-US/images/featureGraphic/feature-graphic.png",
+        (1024, 500),
+        (2, 2, 2),
+    )
+    _write_png(
+        tmp_path / "native-android/fastlane/metadata/android/en-US/images/phoneScreenshots/1_setup.png",
+        (1344, 2992),
+        (3, 3, 3),
+    )
+    output = tmp_path / "snapshot.json"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "listing_snapshot.py",
+            "--platform",
+            "android",
+            "--repo-root",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+    )
+    assert listing_snapshot.main() == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["platform"] == "android"

--- a/scripts/tests/test_sync_android_metadata.py
+++ b/scripts/tests/test_sync_android_metadata.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import sync_android_metadata
+
+
+class _FakeRequest:
+    def __init__(self, exc: Exception | None = None):
+        self._exc = exc
+
+    def execute(self):
+        if self._exc is not None:
+            raise self._exc
+        return {"ok": True}
+
+
+class _FakeEdits:
+    def __init__(self, first_error: Exception | None = None):
+        self.first_error = first_error
+        self.calls: list[dict[str, object]] = []
+
+    def commit(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) == 1 and self.first_error is not None:
+            return _FakeRequest(self.first_error)
+        return _FakeRequest()
+
+
+def test_commit_edit_retries_without_changes_not_sent_for_review_flag() -> None:
+    edits = _FakeEdits(
+        Exception(
+            'HttpError 400: "Changes are sent for review automatically. The query parameter '
+            'changesNotSentForReview must not be set."'
+        )
+    )
+
+    sync_android_metadata.commit_edit(edits, edit_id="123")
+
+    assert edits.calls == [
+        {
+            "packageName": sync_android_metadata.PACKAGE_NAME,
+            "editId": "123",
+            "changesNotSentForReview": True,
+        },
+        {
+            "packageName": sync_android_metadata.PACKAGE_NAME,
+            "editId": "123",
+        },
+    ]
+
+
+def test_commit_edit_uses_changes_not_sent_for_review_when_supported() -> None:
+    edits = _FakeEdits()
+
+    sync_android_metadata.commit_edit(edits, edit_id="123")
+
+    assert edits.calls == [
+        {
+            "packageName": sync_android_metadata.PACKAGE_NAME,
+            "editId": "123",
+            "changesNotSentForReview": True,
+        }
+    ]
+
+
+def test_commit_edit_does_not_swallow_unrelated_failures() -> None:
+    edits = _FakeEdits(Exception("some other commit failure"))
+
+    with pytest.raises(Exception, match="some other commit failure"):
+        sync_android_metadata.commit_edit(edits, edit_id="123")


### PR DESCRIPTION
## Summary
- retry Android Play edit commits without changesNotSentForReview when the app auto-sends changes for review
- track the iOS listing snapshot helper and its regression tests so the metadata workflow can upload artifacts in CI
- cover both workflow blockers with focused Python tests

## Testing
- PYTHONPATH=/tmp/random-timer-pydeps:/private/tmp/random-timer-android-metadata-fix python3 -m pytest scripts/tests/test_sync_android_metadata.py scripts/tests/test_listing_snapshot.py -q
- python3 scripts/listing_snapshot.py --platform ios --repo-root . --locale en-US --app-store-version 1.3.13 --source-run-id local --source-run-url https://example.com/local --output /tmp/ios-listing-snapshot-local.json