### PR TITLE
fix(ci): run release branch checks automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, 'release/**', 'hotfix/**']
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
   merge_group:
     types: [checks_requested]
-    branches: [develop, main]
+    branches: [develop, main, 'release/**', 'hotfix/**']
   push:
-    branches: [develop, main]
+    branches: [develop, main, 'release/**', 'hotfix/**']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -21,6 +21,12 @@ def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():
     assert "No tests/python directory found; skipping legacy pytest suite." not in source
 
 
+def test_ci_workflow_covers_release_and_hotfix_branches():
+    source = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "branches: [develop, main, 'release/**', 'hotfix/**']" in source
+
+
 def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evidence():
     source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary\n- trigger the main CI workflow for release and hotfix pull requests\n- trigger CI on direct pushes to release and hotfix branches\n- add a workflow contract test that locks those branch filters in place\n\n## Verification\n- python3.11 inline import execution of scripts/tests/test_growth_workflow_contracts.py (17 contract tests passed)\n\n## Why\nRelease-targeting PRs were left with pending  statuses because the required CI jobs never auto-ran on those branch targets.