### PR TITLE
fix(asc): fail app-only submit when subscription review is pending

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -17,6 +17,10 @@ from typing import Any, Dict, Iterable, Optional
 from scripts.asc_client import APP_STORE_CONNECT_API, ASCClient, AscClientError
 
 FASTLANE_METADATA_DIR = os.path.join("native-ios", "fastlane", "metadata")
+SUBSCRIPTION_REVIEW_DOC_URL = (
+    "https://developer.apple.com/documentation/appstoreconnectapi/"
+    "submitting-subscriptions-and-subscription-groups-for-app-review"
+)
 
 
 def die(msg: str, code: int = 1) -> "None":
@@ -857,8 +861,16 @@ def _submit_review_submission(
     raise AssertionError("unreachable")
 
 
-def _attach_subscriptions_to_submission(client: ASCClient, app_id: str, submission_id: str) -> None:
-    """Attach any 'Ready to Submit' subscription groups to the review submission."""
+def _guard_pending_subscription_review(client: ASCClient, app_id: str) -> None:
+    """Fail fast when subscriptions require manual App Store Connect review handling.
+
+    Apple does not support attaching the first subscription to an app review submission
+    through the App Store Connect API. Submitting the app version alone produces a false
+    green in CI and gets rejected by App Review, so stop before creating/submitting a
+    review submission when any subscription is still pending review work.
+    """
+    blockers: list[tuple[str, str]] = []
+
     try:
         resp = client.request(
             "GET",
@@ -884,30 +896,32 @@ def _attach_subscriptions_to_submission(client: ASCClient, app_id: str, submissi
             for sub in subs:
                 if not sub:
                     continue
-                sub_id = sub.get("id")
                 sub_state = ((sub.get("attributes") or {}).get("state") or "").upper()
                 sub_name = (sub.get("attributes") or {}).get("name", "")
-                info(f"Found subscription '{sub_name}' (id={sub_id}, state={sub_state})")
                 if sub_state in ("READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW"):
-                    payload = {
-                        "data": {
-                            "type": "reviewSubmissionItems",
-                            "relationships": {
-                                "reviewSubmission": {"data": {"type": "reviewSubmissions", "id": submission_id}},
-                                "subscription": {"data": {"type": "subscriptions", "id": sub_id}},
-                            },
-                        }
-                    }
-                    try:
-                        client.request("POST", "/reviewSubmissionItems", payload=payload)
-                        info(f"Attached subscription '{sub_name}' to review submission.")
-                    except Exception as e:
-                        info(f"Could not attach subscription '{sub_name}': {e}")
+                    blockers.append((sub_name or "Unnamed subscription", sub_state))
     except Exception as e:
         info(f"Warning: could not enumerate subscriptions for review: {e}")
+        return
+
+    if not blockers:
+        return
+
+    details = ", ".join(f"{name} [{state}]" for name, state in blockers)
+    die(
+        "Subscription review cannot be completed through this API submit path. "
+        f"Pending subscription(s): {details}. "
+        "Apple requires the first subscription to be submitted with the app binary "
+        "through appstoreconnect.apple.com, and later subscription-only reviews use "
+        "/v1/subscriptionSubmissions. Attach the subscription from the iOS App version "
+        "page's In-App Purchases and Subscriptions section before retrying this workflow. "
+        f"Reference: {SUBSCRIPTION_REVIEW_DOC_URL}"
+    )
 
 
 def submit_for_review(client: ASCClient, app_id: str, version_id: str) -> None:
+    _guard_pending_subscription_review(client, app_id=app_id)
+
     submission, item = _find_submission_for_version(client, app_id=app_id, version_id=version_id)
     if submission:
         info(
@@ -929,9 +943,6 @@ def submit_for_review(client: ASCClient, app_id: str, version_id: str) -> None:
             die("Existing review submission is missing an id.")
         if not item:
             item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
-
-    # Attach subscription IAPs to the review submission (Apple requires this)
-    _attach_subscriptions_to_submission(client, app_id=app_id, submission_id=submission_id)
 
     item_id = str((item or {}).get("id") or "")
     item_state = ((item or {}).get("attributes") or {}).get("state", "UNKNOWN")

--- a/scripts/tests/test_asc_submit_for_review_submission_flow.py
+++ b/scripts/tests/test_asc_submit_for_review_submission_flow.py
@@ -56,10 +56,9 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
 
         submit_for_review(client, "app-1", version_id)
 
-        self.assertEqual(client.calls[0]["path"], "/apps/app-1/reviewSubmissions")
-        self.assertEqual(client.calls[1]["path"], f"/reviewSubmissions/{submission_id}/items")
-        # calls[2] is the subscription groups lookup (returns empty)
-        self.assertEqual(client.calls[2]["path"], "/apps/app-1/subscriptionGroups")
+        self.assertEqual(client.calls[0]["path"], "/apps/app-1/subscriptionGroups")
+        self.assertEqual(client.calls[1]["path"], "/apps/app-1/reviewSubmissions")
+        self.assertEqual(client.calls[2]["path"], f"/reviewSubmissions/{submission_id}/items")
         self.assertEqual(client.calls[3]["path"], f"/reviewSubmissionItems/{item_id}")
         self.assertEqual(
             client.calls[3]["payload"],
@@ -91,6 +90,9 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
 
         client = RouterClient(
             {
+                ("GET", "/apps/app-1/subscriptionGroups"): {
+                    "data": []
+                },
                 ("GET", "/apps/app-1/reviewSubmissions"): {"data": []},
                 ("POST", "/reviewSubmissions"): {
                     "data": {
@@ -118,9 +120,11 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
 
         submit_for_review(client, "app-1", version_id)
 
-        self.assertEqual(client.calls[1]["path"], "/reviewSubmissions")
+        self.assertEqual(client.calls[0]["path"], "/apps/app-1/subscriptionGroups")
+        self.assertEqual(client.calls[1]["path"], "/apps/app-1/reviewSubmissions")
+        self.assertEqual(client.calls[2]["path"], "/reviewSubmissions")
         self.assertEqual(
-            client.calls[1]["payload"],
+            client.calls[2]["payload"],
             {
                 "data": {
                     "type": "reviewSubmissions",
@@ -129,9 +133,9 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
                 }
             },
         )
-        self.assertEqual(client.calls[2]["path"], "/reviewSubmissionItems")
+        self.assertEqual(client.calls[3]["path"], "/reviewSubmissionItems")
         self.assertEqual(
-            client.calls[2]["payload"],
+            client.calls[3]["payload"],
             {
                 "data": {
                     "type": "reviewSubmissionItems",
@@ -141,6 +145,46 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
                     },
                 }
             },
+        )
+
+    def test_submit_for_review_fails_when_subscription_requires_manual_review_attachment(self):
+        from scripts.asc_submit_for_review import submit_for_review
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/subscriptionGroups"): {
+                    "data": [
+                        {
+                            "id": "group-1",
+                            "type": "subscriptionGroups",
+                        }
+                    ]
+                },
+                ("GET", "/subscriptionGroups/group-1/subscriptions"): {
+                    "data": [
+                        {
+                            "id": "sub-1",
+                            "type": "subscriptions",
+                            "attributes": {
+                                "name": "Pro Tactical Annual",
+                                "state": "WAITING_FOR_REVIEW",
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+
+        with self.assertRaises(SystemExit) as exc:
+            submit_for_review(client, "app-1", "ver-1")
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertEqual(
+            [call["path"] for call in client.calls],
+            [
+                "/apps/app-1/subscriptionGroups",
+                "/subscriptionGroups/group-1/subscriptions",
+            ],
         )
 
 


### PR DESCRIPTION
## What changed
- fail fast in `scripts/asc_submit_for_review.py` when any subscription is still in a pending review state instead of creating a false-green app-only review submission
- document the Apple first-subscription review constraint in the workflow error message with the official reference URL
- update submit-flow tests to cover the new guard and the reordered API calls

## Why
App Store Connect rejected the iOS submission because our workflow submitted only the app version. The current API path cannot attach the first subscription to the review submission, but the old script swallowed that failure and still reported success.

## Impact
- prevents future app-only submissions from being treated as successful in CI
- forces the release flow to stop before creating another Apple rejection
- makes the remaining store-side work explicit: attach the subscription through App Store Connect web UI

## Validation
- `python3 -m unittest scripts.tests.test_asc_submit_for_review_submission_flow`
- `python3 -m unittest discover -s scripts/tests -p "test_asc_submit_for_review*.py"`
