### PR TITLE
fix: mirror release refs to firebase internal

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -21,6 +21,14 @@ on:
           - alpha
         required: false
         default: 'production'
+      android_internal_mirror:
+        description: 'Release/hotfix branches: mirror the released ref to Android Firebase internal'
+        type: choice
+        options:
+          - 'firebase'
+          - 'skip'
+        required: false
+        default: 'firebase'
       submit_review:
         description: 'iOS only: submit the App Store version for App Review after verification'
         # `type: boolean` can be unreliable when dispatched via `gh workflow run -f submit_review=true`
@@ -488,6 +496,30 @@ jobs:
         if: always()
         run: |
           rm -f /tmp/play-service-account.json /tmp/appstore_key.p8
+
+  android-firebase-mirror:
+    needs: [verify-releases]
+    if: >-
+      always() &&
+      needs.verify-releases.result == 'success' &&
+      inputs.android_internal_mirror == 'firebase' &&
+      (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Dispatch Internal Distribution (Android Firebase mirror)
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run internal-distribution.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref develop \
+            -f ref="${GITHUB_REF_NAME}" \
+            -f target=android_firebase
+          echo "✅ Dispatched internal-distribution.yml for Android Firebase mirror on ${GITHUB_REF_NAME}"
 
   ios-submit-review:
     needs: [verify-releases]

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -183,6 +183,8 @@ As of March 26, 2026, Android Firebase APK delivery is not the default internal-
 
 Use `target=android_firebase` only when Firebase APK delivery is explicitly required for debugging or appeal evidence collection.
 
+`Native App Release` now mirrors release/hotfix refs to Android Firebase internal by default via the `android_internal_mirror=firebase` input so the latest release candidate does not drift between TestFlight and Firebase. Set `android_internal_mirror=skip` when you intentionally do not want Firebase delivery for that release run.
+
 Important: Android runtime Firebase and Android App Distribution do not currently use the same Firebase project. Check that document before rotating any Firebase secret.
 
 ### Android (Google Play)

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -112,6 +112,29 @@ def test_native_release_workflow_keeps_ios_review_submission_opt_in():
     assert "default: 'false'" in submit_review_block
 
 
+def test_native_release_workflow_defaults_release_branch_android_firebase_mirror_on():
+    source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    mirror_block = source.split("android_internal_mirror:", 1)[1].split("submit_review:", 1)[0]
+    assert "default: 'firebase'" in mirror_block
+    assert "'firebase'" in mirror_block
+    assert "'skip'" in mirror_block
+
+
+def test_native_release_workflow_dispatches_android_firebase_mirror_from_release_refs():
+    source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "android-firebase-mirror:" in source
+    mirror_job = source.split("android-firebase-mirror:", 1)[1].split("ios-submit-review:", 1)[0]
+    assert "needs: [verify-releases]" in mirror_job
+    assert "inputs.android_internal_mirror == 'firebase'" in mirror_job
+    assert "startsWith(github.ref_name, 'release/')" in mirror_job
+    assert "startsWith(github.ref_name, 'hotfix/')" in mirror_job
+    assert "gh workflow run internal-distribution.yml" in mirror_job
+    assert "-f ref=\"${GITHUB_REF_NAME}\"" in mirror_job
+    assert "-f target=android_firebase" in mirror_job
+
+
 def test_native_release_workflow_verifies_public_play_listing_for_production():
     source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add an explicit Android Firebase mirror input to Native App Release
- dispatch Internal Distribution with target=android_firebase for release/hotfix refs after release verification succeeds
- document the behavior and lock it with workflow-contract tests

## Verification
- python3.11 venv + pytest: scripts/tests/test_growth_workflow_contracts.py
- manual recovery run 23801065887 succeeded for release/v1.3.15 and distributed Android 1.3.15 to Firebase internal