### PR TITLE
hotfix(v1.3.16): submit subscriptions via ASC API

### DIFF
--- a/scripts/asc_submit_for_review.py
+++ b/scripts/asc_submit_for_review.py
@@ -861,64 +861,183 @@ def _submit_review_submission(
     raise AssertionError("unreachable")
 
 
-def _guard_pending_subscription_review(client: ASCClient, app_id: str) -> None:
-    """Fail fast when subscriptions require manual App Store Connect review handling.
+SUBSCRIPTION_SUBMITTABLE_STATES = {"READY_TO_SUBMIT"}
+SUBSCRIPTION_ACCEPTED_STATES = {
+    "WAITING_FOR_REVIEW",
+    "IN_REVIEW",
+    "APPROVED",
+    "PENDING_DEVELOPER_RELEASE",
+    "READY_FOR_SALE",
+}
+SUBSCRIPTION_BLOCKED_STATES = {
+    "MISSING_METADATA",
+    "DEVELOPER_ACTION_NEEDED",
+    "REJECTED",
+    "DEVELOPER_REJECTED",
+    "REMOVED_FROM_SALE",
+}
 
-    Apple does not support attaching the first subscription to an app review submission
-    through the App Store Connect API. Submitting the app version alone produces a false
-    green in CI and gets rejected by App Review, so stop before creating/submitting a
-    review submission when any subscription is still pending review work.
-    """
-    blockers: list[tuple[str, str]] = []
 
-    try:
-        resp = client.request(
+def _subscription_name(sub: dict[str, Any]) -> str:
+    attrs = sub.get("attributes") or {}
+    return str(attrs.get("name") or attrs.get("productId") or sub.get("id") or "Unnamed subscription")
+
+
+def _subscription_state(sub: dict[str, Any]) -> str:
+    return str(((sub.get("attributes") or {}).get("state") or "")).upper()
+
+
+def _list_app_subscriptions(client: ASCClient, app_id: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    resp = client.request(
+        "GET",
+        f"/apps/{app_id}/subscriptionGroups",
+        params={"limit": 50},
+    )
+    groups = (resp.get("data") if isinstance(resp.get("data"), list) else [resp.get("data")]) if resp.get("data") else []
+    for group in groups:
+        if not group:
+            continue
+        group_id = group.get("id")
+        if not group_id:
+            continue
+        subs_resp = client.request(
             "GET",
-            f"/apps/{app_id}/subscriptionGroups",
+            f"/subscriptionGroups/{group_id}/subscriptions",
             params={"limit": 50},
         )
-        groups = (resp.get("data") if isinstance(resp.get("data"), list) else [resp.get("data")]) if resp.get("data") else []
-        for group in groups:
-            if not group:
+        subs = subs_resp.get("data") or []
+        if not isinstance(subs, list):
+            subs = [subs]
+        for sub in subs:
+            if not sub:
                 continue
-            group_id = group.get("id")
-            if not group_id:
-                continue
-            subs_resp = client.request(
-                "GET",
-                f"/subscriptionGroups/{group_id}/subscriptions",
-                params={"limit": 50},
+            items.append(
+                {
+                    "group_id": str(group_id),
+                    "subscription": sub,
+                }
             )
-            subs = subs_resp.get("data") or []
-            if not isinstance(subs, list):
-                subs = [subs]
-            for sub in subs:
-                if not sub:
-                    continue
-                sub_state = ((sub.get("attributes") or {}).get("state") or "").upper()
-                sub_name = (sub.get("attributes") or {}).get("name", "")
-                if sub_state in ("READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW"):
-                    blockers.append((sub_name or "Unnamed subscription", sub_state))
+    return items
+
+
+def _get_subscription(client: ASCClient, subscription_id: str) -> dict[str, Any]:
+    data = client.request(
+        "GET",
+        f"/subscriptions/{subscription_id}",
+        params={"fields[subscriptions]": "name,productId,state"},
+    ).get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _create_subscription_submission(client: ASCClient, subscription_id: str) -> dict[str, Any]:
+    payload = {
+        "data": {
+            "type": "subscriptionSubmissions",
+            "relationships": {
+                "subscription": {"data": {"type": "subscriptions", "id": subscription_id}},
+            },
+        }
+    }
+    return client.request("POST", "/subscriptionSubmissions", payload=payload).get("data") or {}
+
+
+def _wait_for_subscription_state(
+    client: ASCClient,
+    *,
+    subscription_id: str,
+    acceptable_states: set[str],
+    timeout_seconds: int = 60,
+    poll_seconds: int = 5,
+) -> dict[str, Any]:
+    last_seen: dict[str, Any] = {}
+    deadline = time.time() + timeout_seconds
+    while time.time() <= deadline:
+        last_seen = _get_subscription(client, subscription_id)
+        if _subscription_state(last_seen) in acceptable_states:
+            return last_seen
+        time.sleep(poll_seconds)
+    return last_seen
+
+
+def _ensure_subscription_review_state(client: ASCClient, app_id: str) -> None:
+    """Submit pending subscriptions for review and verify the resulting state.
+
+    Apple documents subscription review as a separate submission flow from app review.
+    We therefore submit subscriptions with /v1/subscriptionSubmissions and require a
+    read-back state transition before allowing the app review submission to continue.
+    """
+    try:
+        subscriptions = _list_app_subscriptions(client, app_id)
     except Exception as e:
-        info(f"Warning: could not enumerate subscriptions for review: {e}")
+        die(
+            "Could not enumerate subscriptions before App Review submission: "
+            f"{e}. Reference: {SUBSCRIPTION_REVIEW_DOC_URL}"
+        )
+
+    if not subscriptions:
+        info("No subscriptions found for this app; skipping subscription review submission.")
         return
 
-    if not blockers:
-        return
+    blockers: list[tuple[str, str]] = []
 
-    details = ", ".join(f"{name} [{state}]" for name, state in blockers)
-    die(
-        "Subscription review cannot be completed through this API submit path. "
-        f"Pending subscription(s): {details}. "
-        "Apple requires the first subscription to be submitted with the app binary "
-        "through appstoreconnect.apple.com, and later subscription-only reviews use "
-        "/v1/subscriptionSubmissions. Attach the subscription from the iOS App version "
-        "page's In-App Purchases and Subscriptions section before retrying this workflow. "
-        f"Reference: {SUBSCRIPTION_REVIEW_DOC_URL}"
-    )
+    for item in subscriptions:
+        sub = item["subscription"]
+        sub_id = str(sub.get("id") or "")
+        sub_name = _subscription_name(sub)
+        sub_state = _subscription_state(sub)
+
+        if not sub_id:
+            blockers.append((sub_name, "MISSING_ID"))
+            continue
+
+        if sub_state in SUBSCRIPTION_ACCEPTED_STATES:
+            info(f"Subscription '{sub_name}' already in acceptable review state: {sub_state}")
+            continue
+
+        if sub_state in SUBSCRIPTION_SUBMITTABLE_STATES:
+            info(f"Submitting subscription '{sub_name}' for App Review via /v1/subscriptionSubmissions.")
+            try:
+                _create_subscription_submission(client, sub_id)
+            except Exception as exc:
+                msg = str(exc)
+                # Treat duplicate-submission style errors as retryable read-back cases.
+                if "already" not in msg.lower() and "exists" not in msg.lower() and "409" not in msg:
+                    die(
+                        f"Failed to create subscription submission for '{sub_name}' ({sub_id}): {exc}. "
+                        f"Reference: {SUBSCRIPTION_REVIEW_DOC_URL}"
+                    )
+            refreshed = _wait_for_subscription_state(
+                client,
+                subscription_id=sub_id,
+                acceptable_states=SUBSCRIPTION_ACCEPTED_STATES,
+            )
+            refreshed_state = _subscription_state(refreshed)
+            if refreshed_state in SUBSCRIPTION_ACCEPTED_STATES:
+                info(f"Subscription '{sub_name}' is now in review state: {refreshed_state}")
+                continue
+            blockers.append((sub_name, refreshed_state or sub_state or "UNKNOWN"))
+            continue
+
+        if sub_state in SUBSCRIPTION_BLOCKED_STATES:
+            blockers.append((sub_name, sub_state))
+            continue
+
+        blockers.append((sub_name, sub_state or "UNKNOWN"))
+
+    if blockers:
+        details = ", ".join(f"{name} [{state}]" for name, state in blockers)
+        die(
+            "Subscription review is not in a reviewable state. "
+            f"Problem subscription(s): {details}. "
+            "Apple requires subscriptions to be submitted through the separate "
+            "/v1/subscriptionSubmissions flow and to transition into a review state "
+            "before the app submission can be treated as valid. "
+            f"Reference: {SUBSCRIPTION_REVIEW_DOC_URL}"
+        )
 
 def submit_for_review(client: ASCClient, app_id: str, version_id: str) -> None:
-    _guard_pending_subscription_review(client, app_id=app_id)
+    _ensure_subscription_review_state(client, app_id=app_id)
 
     submission, item = _find_submission_for_version(client, app_id=app_id, version_id=version_id)
     if submission:

--- a/scripts/tests/test_asc_submit_for_review_submission_flow.py
+++ b/scripts/tests/test_asc_submit_for_review_submission_flow.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from scripts.tests.router_client import RouterClient
 
@@ -112,6 +113,7 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
                         "attributes": {"state": "WAITING_FOR_REVIEW"},
                     }
                 },
+                ("GET", "/apps/app-1/subscriptionGroups"): {"data": []},
             }
         )
 
@@ -144,7 +146,89 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
             },
         )
 
-    def test_submit_for_review_fails_when_subscription_requires_manual_review_attachment(self):
+    def test_submit_for_review_creates_subscription_submission_before_app_submission(self):
+        from scripts.asc_submit_for_review import submit_for_review
+
+        submission_id = "sub-new"
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/subscriptionGroups"): {
+                    "data": [
+                        {
+                            "id": "group-1",
+                            "type": "subscriptionGroups",
+                        }
+                    ]
+                },
+                ("GET", "/subscriptionGroups/group-1/subscriptions"): {
+                    "data": [
+                        {
+                            "id": "sub-1",
+                            "type": "subscriptions",
+                            "attributes": {
+                                "name": "Pro Tactical Annual",
+                                "state": "READY_TO_SUBMIT",
+                            },
+                        }
+                    ]
+                },
+                ("POST", "/subscriptionSubmissions"): {
+                    "data": {
+                        "id": "subm-1",
+                        "type": "subscriptionSubmissions",
+                    }
+                },
+                ("GET", "/subscriptions/sub-1"): {
+                    "data": {
+                        "id": "sub-1",
+                        "type": "subscriptions",
+                        "attributes": {
+                            "name": "Pro Tactical Annual",
+                            "state": "WAITING_FOR_REVIEW",
+                        },
+                    }
+                },
+                ("GET", "/apps/app-1/reviewSubmissions"): {"data": []},
+                ("POST", "/reviewSubmissions"): {
+                    "data": {
+                        "id": submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
+                    }
+                },
+                ("POST", "/reviewSubmissionItems"): {
+                    "data": {
+                        "id": "item-new",
+                        "type": "reviewSubmissionItems",
+                        "attributes": {"state": "READY_FOR_REVIEW"},
+                    }
+                },
+                ("PATCH", f"/reviewSubmissions/{submission_id}"): {
+                    "data": {
+                        "id": submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "WAITING_FOR_REVIEW"},
+                    }
+                },
+            }
+        )
+
+        submit_for_review(client, "app-1", "ver-1")
+        self.assertEqual(
+            [call["path"] for call in client.calls],
+            [
+                "/apps/app-1/subscriptionGroups",
+                "/subscriptionGroups/group-1/subscriptions",
+                "/subscriptionSubmissions",
+                "/subscriptions/sub-1",
+                "/apps/app-1/reviewSubmissions",
+                "/reviewSubmissions",
+                "/reviewSubmissionItems",
+                f"/reviewSubmissions/{submission_id}",
+            ],
+        )
+
+    def test_submit_for_review_fails_when_subscription_does_not_transition_to_review_state(self):
         from scripts.asc_submit_for_review import submit_for_review
 
         client = RouterClient(
@@ -164,16 +248,43 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
                             "type": "subscriptions",
                             "attributes": {
                                 "name": "Pro Tactical Annual",
-                                "state": "WAITING_FOR_REVIEW",
+                                "state": "READY_TO_SUBMIT",
                             },
                         }
                     ]
                 },
+                ("POST", "/subscriptionSubmissions"): {
+                    "data": {
+                        "id": "subm-1",
+                        "type": "subscriptionSubmissions",
+                    }
+                },
+                ("GET", "/subscriptions/sub-1"): {
+                    "data": {
+                        "id": "sub-1",
+                        "type": "subscriptions",
+                        "attributes": {
+                            "name": "Pro Tactical Annual",
+                            "state": "READY_TO_SUBMIT",
+                        },
+                    }
+                },
             }
         )
 
-        with self.assertRaises(SystemExit) as exc:
-            submit_for_review(client, "app-1", "ver-1")
+        with mock.patch(
+            "scripts.asc_submit_for_review._wait_for_subscription_state",
+            return_value={
+                "id": "sub-1",
+                "type": "subscriptions",
+                "attributes": {
+                    "name": "Pro Tactical Annual",
+                    "state": "READY_TO_SUBMIT",
+                },
+            },
+        ):
+            with self.assertRaises(SystemExit) as exc:
+                submit_for_review(client, "app-1", "ver-1")
 
         self.assertEqual(exc.exception.code, 1)
         self.assertEqual(
@@ -181,6 +292,7 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
             [
                 "/apps/app-1/subscriptionGroups",
                 "/subscriptionGroups/group-1/subscriptions",
+                "/subscriptionSubmissions",
             ],
         )
 

--- a/scripts/tests/test_asc_submit_for_review_submission_flow.py
+++ b/scripts/tests/test_asc_submit_for_review_submission_flow.py
@@ -5,6 +5,82 @@ from scripts.tests.router_client import RouterClient
 
 
 class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
+    @staticmethod
+    def _subscription_groups_routes(*, state, group_id="group-1", subscription_id="sub-1"):
+        return {
+            ("GET", "/apps/app-1/subscriptionGroups"): {
+                "data": [
+                    {
+                        "id": group_id,
+                        "type": "subscriptionGroups",
+                    }
+                ]
+            },
+            ("GET", f"/subscriptionGroups/{group_id}/subscriptions"): {
+                "data": [
+                    {
+                        "id": subscription_id,
+                        "type": "subscriptions",
+                        "attributes": {
+                            "name": "Pro Tactical Annual",
+                            "state": state,
+                        },
+                    }
+                ]
+            },
+        }
+
+    @staticmethod
+    def _subscription_submission_routes(*, state_after_submit, subscription_id="sub-1"):
+        return {
+            ("POST", "/subscriptionSubmissions"): {
+                "data": {
+                    "id": "subm-1",
+                    "type": "subscriptionSubmissions",
+                }
+            },
+            ("GET", f"/subscriptions/{subscription_id}"): {
+                "data": {
+                    "id": subscription_id,
+                    "type": "subscriptions",
+                    "attributes": {
+                        "name": "Pro Tactical Annual",
+                        "state": state_after_submit,
+                    },
+                }
+            },
+        }
+
+    @staticmethod
+    def _new_review_submission_routes(*, submission_id, version_id="ver-1"):
+        return {
+            ("GET", "/apps/app-1/reviewSubmissions"): {"data": []},
+            ("POST", "/reviewSubmissions"): {
+                "data": {
+                    "id": submission_id,
+                    "type": "reviewSubmissions",
+                    "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
+                }
+            },
+            ("POST", "/reviewSubmissionItems"): {
+                "data": {
+                    "id": "item-new",
+                    "type": "reviewSubmissionItems",
+                    "attributes": {"state": "READY_FOR_REVIEW"},
+                    "relationships": {
+                        "appStoreVersion": {"data": {"type": "appStoreVersions", "id": version_id}}
+                    },
+                }
+            },
+            ("PATCH", f"/reviewSubmissions/{submission_id}"): {
+                "data": {
+                    "id": submission_id,
+                    "type": "reviewSubmissions",
+                    "attributes": {"state": "WAITING_FOR_REVIEW"},
+                }
+            },
+        }
+
     def test_submit_for_review_resolves_rejected_item_and_resubmits_existing_submission(self):
         from scripts.asc_submit_for_review import submit_for_review
 
@@ -91,29 +167,8 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
 
         client = RouterClient(
             {
-                ("GET", "/apps/app-1/reviewSubmissions"): {"data": []},
-                ("POST", "/reviewSubmissions"): {
-                    "data": {
-                        "id": submission_id,
-                        "type": "reviewSubmissions",
-                        "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
-                    }
-                },
-                ("POST", "/reviewSubmissionItems"): {
-                    "data": {
-                        "id": "item-new",
-                        "type": "reviewSubmissionItems",
-                        "attributes": {"state": "READY_FOR_REVIEW"},
-                    }
-                },
-                ("PATCH", f"/reviewSubmissions/{submission_id}"): {
-                    "data": {
-                        "id": submission_id,
-                        "type": "reviewSubmissions",
-                        "attributes": {"state": "WAITING_FOR_REVIEW"},
-                    }
-                },
                 ("GET", "/apps/app-1/subscriptionGroups"): {"data": []},
+                **self._new_review_submission_routes(submission_id=submission_id, version_id=version_id),
             }
         )
 
@@ -152,64 +207,9 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
         submission_id = "sub-new"
         client = RouterClient(
             {
-                ("GET", "/apps/app-1/subscriptionGroups"): {
-                    "data": [
-                        {
-                            "id": "group-1",
-                            "type": "subscriptionGroups",
-                        }
-                    ]
-                },
-                ("GET", "/subscriptionGroups/group-1/subscriptions"): {
-                    "data": [
-                        {
-                            "id": "sub-1",
-                            "type": "subscriptions",
-                            "attributes": {
-                                "name": "Pro Tactical Annual",
-                                "state": "READY_TO_SUBMIT",
-                            },
-                        }
-                    ]
-                },
-                ("POST", "/subscriptionSubmissions"): {
-                    "data": {
-                        "id": "subm-1",
-                        "type": "subscriptionSubmissions",
-                    }
-                },
-                ("GET", "/subscriptions/sub-1"): {
-                    "data": {
-                        "id": "sub-1",
-                        "type": "subscriptions",
-                        "attributes": {
-                            "name": "Pro Tactical Annual",
-                            "state": "WAITING_FOR_REVIEW",
-                        },
-                    }
-                },
-                ("GET", "/apps/app-1/reviewSubmissions"): {"data": []},
-                ("POST", "/reviewSubmissions"): {
-                    "data": {
-                        "id": submission_id,
-                        "type": "reviewSubmissions",
-                        "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
-                    }
-                },
-                ("POST", "/reviewSubmissionItems"): {
-                    "data": {
-                        "id": "item-new",
-                        "type": "reviewSubmissionItems",
-                        "attributes": {"state": "READY_FOR_REVIEW"},
-                    }
-                },
-                ("PATCH", f"/reviewSubmissions/{submission_id}"): {
-                    "data": {
-                        "id": submission_id,
-                        "type": "reviewSubmissions",
-                        "attributes": {"state": "WAITING_FOR_REVIEW"},
-                    }
-                },
+                **self._subscription_groups_routes(state="READY_TO_SUBMIT"),
+                **self._subscription_submission_routes(state_after_submit="WAITING_FOR_REVIEW"),
+                **self._new_review_submission_routes(submission_id=submission_id),
             }
         )
 
@@ -233,42 +233,8 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
 
         client = RouterClient(
             {
-                ("GET", "/apps/app-1/subscriptionGroups"): {
-                    "data": [
-                        {
-                            "id": "group-1",
-                            "type": "subscriptionGroups",
-                        }
-                    ]
-                },
-                ("GET", "/subscriptionGroups/group-1/subscriptions"): {
-                    "data": [
-                        {
-                            "id": "sub-1",
-                            "type": "subscriptions",
-                            "attributes": {
-                                "name": "Pro Tactical Annual",
-                                "state": "READY_TO_SUBMIT",
-                            },
-                        }
-                    ]
-                },
-                ("POST", "/subscriptionSubmissions"): {
-                    "data": {
-                        "id": "subm-1",
-                        "type": "subscriptionSubmissions",
-                    }
-                },
-                ("GET", "/subscriptions/sub-1"): {
-                    "data": {
-                        "id": "sub-1",
-                        "type": "subscriptions",
-                        "attributes": {
-                            "name": "Pro Tactical Annual",
-                            "state": "READY_TO_SUBMIT",
-                        },
-                    }
-                },
+                **self._subscription_groups_routes(state="READY_TO_SUBMIT"),
+                **self._subscription_submission_routes(state_after_submit="READY_TO_SUBMIT"),
             }
         )
 


### PR DESCRIPTION
## Summary
- policy-compliant replacement for #988 using 
- submit subscriptions via ASC API and include dedupe fixture update

## Why
- satisfy branch policy gate for main promotions ()


Made with [Cursor](https://cursor.com)