### PR TITLE
fix: restore internal distribution on new runners

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -151,7 +151,7 @@ jobs:
           python-version: "3.11"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           ruby-version: "3.2"
           bundler-cache: true
@@ -286,7 +286,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           ruby-version: "3.2"
           bundler-cache: true

--- a/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
+++ b/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
@@ -4,12 +4,12 @@ This document is the canonical reference for Android Firebase wiring in Random T
 
 ## Current Split
 
-Android Firebase is intentionally split across two projects:
+Android Firebase is intentionally split across two backends:
 
 | Purpose | Project ID | Project Number | App ID |
 |---|---|---:|---|
 | Runtime services (`google-services.json`, Crashlytics BigQuery export) | `random-timer-486213` | `624873778337` | Runtime app ID is supplied by `GOOGLE_SERVICES_JSON` |
-| Firebase App Distribution | `random-timer-dist-20260323` | `712918404489` | `1:712918404489:android:5fb1dfde1d712f53e7a558` |
+| Firebase App Distribution | `random-timer-dist-new` | Verify from `FIREBASE_ANDROID_APP_ID` secret or live run log | Supplied by `FIREBASE_ANDROID_APP_ID` |
 
 ## Why The Split Exists
 
@@ -60,7 +60,9 @@ If you look in `random-timer-486213`, you will not see current Android App Distr
 
 The current Android internal distribution console is:
 
-- `https://console.firebase.google.com/project/random-timer-dist-20260323/appdistribution/app/android:com.iganapolsky.randomtimer`
+- `https://console.firebase.google.com/project/random-timer-dist-new/appdistribution/app/android:com.iganapolsky.randomtimer`
+
+If you are looking in an older Firebase App Distribution project, the console will appear empty even when GitHub Actions distribution succeeded.
 
 ## Verification Commands
 
@@ -90,10 +92,13 @@ creds = service_account.Credentials.from_service_account_file(
 creds.refresh(Request())
 headers = {"Authorization": f"Bearer {creds.token}"}
 
+project_number = os.environ["FIREBASE_PROJECT_NUMBER"]
+app_id = os.environ["FIREBASE_ANDROID_APP_ID"]
+
 for url in [
-    "https://firebaseappdistribution.googleapis.com/v1/projects/712918404489/groups",
-    "https://firebaseappdistribution.googleapis.com/v1/projects/712918404489/testers",
-    "https://firebaseappdistribution.googleapis.com/v1/projects/712918404489/apps/1:712918404489:android:5fb1dfde1d712f53e7a558/releases",
+    f"https://firebaseappdistribution.googleapis.com/v1/projects/{project_number}/groups",
+    f"https://firebaseappdistribution.googleapis.com/v1/projects/{project_number}/testers",
+    f"https://firebaseappdistribution.googleapis.com/v1/projects/{project_number}/apps/{app_id}/releases",
 ]:
     resp = requests.get(url, headers=headers, timeout=30)
     print(resp.status_code, url)
@@ -110,13 +115,15 @@ PY
 
 ## Release Evidence
 
-First healthy Android Firebase release on the new backend:
+Most recent verified Android Firebase release evidence:
 
-- GitHub Actions run: `23440692946`
-- Version: `1.3.9`
-- Build version: `1773900000`
-- Firebase release resource:
-  - `projects/712918404489/apps/1:712918404489:android:5fb1dfde1d712f53e7a558/releases/28u136g4k64ag`
+- GitHub Actions run: `23806206042`
+- Version: `1.3.15`
+- Build version: `504`
+- Console project in live run log:
+  - `random-timer-dist-new`
+- Distribution audience in live run log:
+  - tester `iganapolsky@gmail.com`
 
 ## Change Rules
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -196,6 +196,15 @@ As of March 26, 2026, Android Firebase APK delivery is not the default internal-
 
 Use `target=android_firebase` only when Firebase APK delivery is explicitly required for debugging or appeal evidence collection.
 
+Target behavior:
+- `all_safe`: iOS TestFlight + Android Google Play internal
+- `all`: iOS TestFlight + Android Google Play internal + Android Firebase App Distribution
+- `ios`: iOS TestFlight only
+- `android_play`: Android Google Play internal only
+- `android_firebase`: Android Firebase App Distribution only
+
+There is no iOS Firebase App Distribution path in CI. iOS internal delivery is TestFlight-only.
+
 Important: Android runtime Firebase and Android App Distribution do not currently use the same Firebase project. Check that document before rotating any Firebase secret.
 
 ### Android (Google Play)

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -41,6 +41,15 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
     assert "TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}" in source
 
 
+def test_internal_distribution_workflow_keeps_ruby_setup_pin_in_sync_with_native_release():
+    internal_source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
+    release_source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    ruby_pin = "ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd"
+    assert ruby_pin in internal_source
+    assert ruby_pin in release_source
+
+
 def test_internal_distribution_workflow_emits_platform_specific_release_artifacts():
     source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -27,7 +27,7 @@ def test_security_sensitive_workflows_pin_third_party_actions() -> None:
     expected_pins = {
         ".github/workflows/android17-canary.yml": "android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407",
         ".github/workflows/device-tests.yml": "reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7",
-        ".github/workflows/internal-distribution.yml": "ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005",
+        ".github/workflows/internal-distribution.yml": "ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd",
         ".github/workflows/internal-distribution.yml#firebase": "wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6",
         ".github/workflows/release.yml#expo": "expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e",
         ".github/workflows/release.yml#sbom": "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610",


### PR DESCRIPTION
## Summary
- align internal-distribution ruby/setup-ruby pin with the working native-release workflow
- document the active Firebase App Distribution project and internal target behavior
- add regression coverage for the ruby pin so this does not drift again

## Verification
- pytest -q scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_workflow_security_contracts.py
- reproduced failing internal-distribution run 23814350097 where iOS TestFlight and Android Play both died in Setup Ruby
- direct workflow verification from a fix branch was blocked by production environment protection, so this PR targets release/v1.3.15 for allowed rerun