### PR TITLE
fix: harden Play version code probe

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -334,7 +334,9 @@ jobs:
           python -m pip install google-api-python-client==2.190.0 google-auth==2.48.0 google-auth-httplib2==0.3.0
           NEXT_CODE="$(python scripts/compute_android_release_version_code.py \
             --service-account-json "$KEY_PATH" \
-            --gradle-file native-android/app/build.gradle.kts)"
+            --gradle-file native-android/app/build.gradle.kts \
+            --timeout-seconds 180 \
+            --request-retries 3)"
           echo "next_version_code=$NEXT_CODE" >> "$GITHUB_OUTPUT"
 
       - name: Create google-services.json

--- a/scripts/compute_android_release_version_code.py
+++ b/scripts/compute_android_release_version_code.py
@@ -17,6 +17,8 @@ except ModuleNotFoundError:
 
 ANDROID_PACKAGE_DEFAULT = "com.iganapolsky.randomtimer"
 DEFAULT_TRACKS = ("production", "beta", "alpha", "internal")
+DEFAULT_HTTP_TIMEOUT_SECONDS = 180
+DEFAULT_REQUEST_RETRIES = 3
 
 
 def _read_gradle_version_code(gradle_file: Path) -> int:
@@ -26,15 +28,25 @@ def _read_gradle_version_code(gradle_file: Path) -> int:
         raise ValueError(f"Unable to find versionCode in {gradle_file}") from exc
 
 
-def _load_play_service(service_account_json: Path):
+def _load_play_service(
+    service_account_json: Path,
+    timeout_seconds: int = DEFAULT_HTTP_TIMEOUT_SECONDS,
+):
     from google.oauth2 import service_account
+    from google_auth_httplib2 import AuthorizedHttp
     from googleapiclient.discovery import build
+    import httplib2
 
     credentials = service_account.Credentials.from_service_account_file(
         str(service_account_json),
         scopes=["https://www.googleapis.com/auth/androidpublisher"],
     )
-    return build("androidpublisher", "v3", credentials=credentials)
+    http = AuthorizedHttp(credentials, http=httplib2.Http(timeout=timeout_seconds))
+    return build("androidpublisher", "v3", credentials=credentials, http=http, cache_discovery=False)
+
+
+def _execute_request(request: Any, request_retries: int = DEFAULT_REQUEST_RETRIES):
+    return request.execute(num_retries=request_retries)
 
 
 def _extract_release_codes(track_payload: dict[str, Any]) -> list[int]:
@@ -48,22 +60,33 @@ def _extract_release_codes(track_payload: dict[str, Any]) -> list[int]:
     return codes
 
 
-def _fetch_existing_track_codes(service: Any, package_name: str, tracks: list[str]) -> dict[str, list[int]]:
+def _fetch_existing_track_codes(
+    service: Any,
+    package_name: str,
+    tracks: list[str],
+    request_retries: int = DEFAULT_REQUEST_RETRIES,
+) -> dict[str, list[int]]:
     edits = service.edits()
     edit_id = None
     codes_by_track: dict[str, list[int]] = {}
 
     try:
-        edit = edits.insert(body={}, packageName=package_name).execute()
+        edit = _execute_request(
+            edits.insert(body={}, packageName=package_name),
+            request_retries=request_retries,
+        )
         edit_id = edit["id"]
 
         for track in tracks:
             try:
-                payload = edits.tracks().get(
-                    packageName=package_name,
-                    editId=edit_id,
-                    track=track,
-                ).execute()
+                payload = _execute_request(
+                    edits.tracks().get(
+                        packageName=package_name,
+                        editId=edit_id,
+                        track=track,
+                    ),
+                    request_retries=request_retries,
+                )
                 codes_by_track[track] = _extract_release_codes(payload)
             except Exception as error:
                 status = getattr(getattr(error, "resp", None), "status", None)
@@ -76,7 +99,10 @@ def _fetch_existing_track_codes(service: Any, package_name: str, tracks: list[st
     finally:
         if edit_id is not None:
             try:
-                edits.delete(packageName=package_name, editId=edit_id).execute()
+                _execute_request(
+                    edits.delete(packageName=package_name, editId=edit_id),
+                    request_retries=request_retries,
+                )
             except Exception:
                 pass
 
@@ -95,6 +121,8 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--package", default=ANDROID_PACKAGE_DEFAULT)
     parser.add_argument("--gradle-file", default="native-android/app/build.gradle.kts")
     parser.add_argument("--tracks", default=",".join(DEFAULT_TRACKS))
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_HTTP_TIMEOUT_SECONDS)
+    parser.add_argument("--request-retries", type=int, default=DEFAULT_REQUEST_RETRIES)
     parser.add_argument("--json-output", default="")
     return parser.parse_args()
 
@@ -115,8 +143,13 @@ def main() -> int:
 
     try:
         base_version_code = _read_gradle_version_code(gradle_file)
-        service = _load_play_service(service_account_json)
-        existing_track_codes = _fetch_existing_track_codes(service, args.package, tracks)
+        service = _load_play_service(service_account_json, timeout_seconds=args.timeout_seconds)
+        existing_track_codes = _fetch_existing_track_codes(
+            service,
+            args.package,
+            tracks,
+            request_retries=args.request_retries,
+        )
         next_version_code = compute_next_version_code(base_version_code, existing_track_codes)
     except Exception as error:
         print(f"❌ Failed to compute Android release versionCode: {error}", file=sys.stderr)

--- a/scripts/tests/test_compute_android_release_version_code.py
+++ b/scripts/tests/test_compute_android_release_version_code.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -77,14 +79,15 @@ def test_compute_next_version_code_prefers_higher_gradle_code_when_tracks_lower(
 
 
 def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
-    events: list[tuple[str, str | None]] = []
+    events: list[tuple[str, str | None, int | None]] = []
 
     class _Tracks:
         def get(self, *, packageName: str, editId: str, track: str):
-            events.append(("get", track))
+            events.append(("get", track, None))
 
             class _Request:
-                def execute(self_nonlocal):
+                def execute(self_nonlocal, num_retries=None):
+                    events.append(("execute", track, num_retries))
                     payloads = {
                         "production": {"releases": [{"versionCodes": ["100", "101"]}]},
                         "beta": {"releases": []},
@@ -95,10 +98,11 @@ def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
 
     class _Edits:
         def insert(self, *, body: dict, packageName: str):
-            events.append(("insert", None))
+            events.append(("insert", None, None))
 
             class _Request:
-                def execute(self_nonlocal):
+                def execute(self_nonlocal, num_retries=None):
+                    events.append(("execute", "insert", num_retries))
                     return {"id": "edit-1"}
 
             return _Request()
@@ -107,10 +111,11 @@ def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
             return _Tracks()
 
         def delete(self, *, packageName: str, editId: str):
-            events.append(("delete", None))
+            events.append(("delete", None, None))
 
             class _Request:
-                def execute(self_nonlocal):
+                def execute(self_nonlocal, num_retries=None):
+                    events.append(("execute", "delete", num_retries))
                     return {}
 
             return _Request()
@@ -119,15 +124,72 @@ def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
         def edits(self):
             return _Edits()
 
-    result = calc._fetch_existing_track_codes(_Service(), "pkg", ["production", "beta"])
+    result = calc._fetch_existing_track_codes(_Service(), "pkg", ["production", "beta"], request_retries=5)
 
     assert result == {"production": [100, 101], "beta": []}
     assert events == [
-        ("insert", None),
-        ("get", "production"),
-        ("get", "beta"),
-        ("delete", None),
+        ("insert", None, None),
+        ("execute", "insert", 5),
+        ("get", "production", None),
+        ("execute", "production", 5),
+        ("get", "beta", None),
+        ("execute", "beta", 5),
+        ("delete", None, None),
+        ("execute", "delete", 5),
     ]
+
+
+def test_load_play_service_uses_authorized_http_timeout(monkeypatch, tmp_path: Path):
+    service_account = tmp_path / "play.json"
+    service_account.write_text("{}", encoding="utf-8")
+    observed: dict[str, object] = {}
+
+    class _Credentials:
+        pass
+
+    class _ServiceAccountCredentials:
+        @staticmethod
+        def from_service_account_file(path: str, scopes):
+            observed["service_account_path"] = path
+            observed["scopes"] = list(scopes)
+            return _Credentials()
+
+    def _authorized_http(credentials, http):
+        observed["authorized_http_credentials"] = credentials
+        observed["authorized_http_http"] = http
+        return "authorized-http"
+
+    def _http(timeout=None):
+        observed["http_timeout"] = timeout
+        return {"timeout": timeout}
+
+    def _build(api_name, api_version, *, credentials, http, cache_discovery):
+        observed["build_args"] = {
+            "api_name": api_name,
+            "api_version": api_version,
+            "credentials": credentials,
+            "http": http,
+            "cache_discovery": cache_discovery,
+        }
+        return "service"
+
+    monkeypatch.setitem(sys.modules, "google.oauth2.service_account", types.SimpleNamespace(Credentials=_ServiceAccountCredentials))
+    monkeypatch.setitem(sys.modules, "google_auth_httplib2", types.SimpleNamespace(AuthorizedHttp=_authorized_http))
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", types.SimpleNamespace(build=_build))
+    monkeypatch.setitem(sys.modules, "httplib2", types.SimpleNamespace(Http=_http))
+
+    result = calc._load_play_service(service_account, timeout_seconds=240)
+
+    assert result == "service"
+    assert observed["service_account_path"] == str(service_account)
+    assert observed["http_timeout"] == 240
+    assert observed["build_args"] == {
+        "api_name": "androidpublisher",
+        "api_version": "v3",
+        "credentials": observed["authorized_http_credentials"],
+        "http": "authorized-http",
+        "cache_discovery": False,
+    }
 
 
 def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
@@ -137,11 +199,11 @@ def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.Cap
     service_account.write_text("{}", encoding="utf-8")
     json_output = tmp_path / "result.json"
 
-    monkeypatch.setattr(calc, "_load_play_service", lambda _: object())
+    monkeypatch.setattr(calc, "_load_play_service", lambda _path, timeout_seconds=calc.DEFAULT_HTTP_TIMEOUT_SECONDS: object())
     monkeypatch.setattr(
         calc,
         "_fetch_existing_track_codes",
-        lambda _service, _package, _tracks: {"production": [1774400002], "beta": []},
+        lambda _service, _package, _tracks, request_retries=calc.DEFAULT_REQUEST_RETRIES: {"production": [1774400002], "beta": []},
     )
     monkeypatch.setattr(
         calc,
@@ -154,6 +216,8 @@ def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.Cap
                 "package": "com.iganapolsky.randomtimer",
                 "gradle_file": str(gradle_file),
                 "tracks": "production,beta",
+                "timeout_seconds": 240,
+                "request_retries": 5,
                 "json_output": str(json_output),
             },
         )(),

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -67,6 +67,17 @@ def test_internal_distribution_workflow_passes_play_json_key_into_distribution_s
     assert "GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}" in play_distribute_section
 
 
+def test_internal_distribution_workflow_hardens_play_version_probe_with_timeout_and_retries():
+    source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
+
+    compute_section = source.split("- name: Compute monotonic Play version code", 1)[1].split(
+        "- name: Create google-services.json", 1
+    )[0]
+    assert "scripts/compute_android_release_version_code.py" in compute_section
+    assert "--timeout-seconds 180" in compute_section
+    assert "--request-retries 3" in compute_section
+
+
 def test_internal_distribution_workflow_supports_targeted_reruns_and_firebase_delivery():
     source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- harden the Google Play version-code probe with explicit HTTP timeout and request retries
- keep the timeout and retry settings explicit in internal-distribution workflow wiring
- add regression coverage for the Play probe client behavior and workflow contract

## Verification
- /Users/igorganapolsky/workspace/git/igor/Random-Timer/.venv/bin/python -m pytest scripts/tests/test_compute_android_release_version_code.py scripts/tests/test_growth_workflow_contracts.py -q