### PR TITLE
fix(ci): stabilize Play version code test on develop

### DIFF
--- a/scripts/tests/test_compute_android_release_version_code.py
+++ b/scripts/tests/test_compute_android_release_version_code.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 from unittest import mock
 
@@ -139,7 +141,7 @@ def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
 
 
 def test_load_play_service_uses_authorized_http_timeout(tmp_path: Path):
-    """Patch real Google client entry points — sys.modules stubs lose if another test imported google.oauth2 first."""
+    """Patch the real google-auth entry point, but keep sys.modules stubs for optional Play HTTP deps."""
     service_account = tmp_path / "play.json"
     service_account.write_text("{}", encoding="utf-8")
     observed: dict[str, object] = {}
@@ -169,14 +171,17 @@ def test_load_play_service_uses_authorized_http_timeout(tmp_path: Path):
     creds_path = str(service_account)
     expected_scopes = ["https://www.googleapis.com/auth/androidpublisher"]
 
+    monkeypatch_modules = {
+        "google_auth_httplib2": types.SimpleNamespace(AuthorizedHttp=_authorized_http),
+        "googleapiclient.discovery": types.SimpleNamespace(build=_build),
+        "httplib2": types.SimpleNamespace(Http=_http_factory),
+    }
     with (
         mock.patch(
             "google.oauth2.service_account.Credentials.from_service_account_file",
             autospec=True,
         ) as mock_from_file,
-        mock.patch("google_auth_httplib2.AuthorizedHttp", side_effect=_authorized_http),
-        mock.patch("googleapiclient.discovery.build", side_effect=_build),
-        mock.patch("httplib2.Http", side_effect=_http_factory),
+        mock.patch.dict(sys.modules, monkeypatch_modules),
     ):
         mock_from_file.return_value = _Credentials()
         result = calc._load_play_service(service_account, timeout_seconds=240)

--- a/scripts/tests/test_compute_android_release_version_code.py
+++ b/scripts/tests/test_compute_android_release_version_code.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import sys
-import types
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -139,7 +138,8 @@ def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
     ]
 
 
-def test_load_play_service_uses_authorized_http_timeout(monkeypatch, tmp_path: Path):
+def test_load_play_service_uses_authorized_http_timeout(tmp_path: Path):
+    """Patch real Google client entry points — sys.modules stubs lose if another test imported google.oauth2 first."""
     service_account = tmp_path / "play.json"
     service_account.write_text("{}", encoding="utf-8")
     observed: dict[str, object] = {}
@@ -147,19 +147,12 @@ def test_load_play_service_uses_authorized_http_timeout(monkeypatch, tmp_path: P
     class _Credentials:
         pass
 
-    class _ServiceAccountCredentials:
-        @staticmethod
-        def from_service_account_file(path: str, scopes):
-            observed["service_account_path"] = path
-            observed["scopes"] = list(scopes)
-            return _Credentials()
-
     def _authorized_http(credentials, http):
         observed["authorized_http_credentials"] = credentials
         observed["authorized_http_http"] = http
         return "authorized-http"
 
-    def _http(timeout=None):
+    def _http_factory(timeout=None):
         observed["http_timeout"] = timeout
         return {"timeout": timeout}
 
@@ -173,15 +166,23 @@ def test_load_play_service_uses_authorized_http_timeout(monkeypatch, tmp_path: P
         }
         return "service"
 
-    monkeypatch.setitem(sys.modules, "google.oauth2.service_account", types.SimpleNamespace(Credentials=_ServiceAccountCredentials))
-    monkeypatch.setitem(sys.modules, "google_auth_httplib2", types.SimpleNamespace(AuthorizedHttp=_authorized_http))
-    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", types.SimpleNamespace(build=_build))
-    monkeypatch.setitem(sys.modules, "httplib2", types.SimpleNamespace(Http=_http))
+    creds_path = str(service_account)
+    expected_scopes = ["https://www.googleapis.com/auth/androidpublisher"]
 
-    result = calc._load_play_service(service_account, timeout_seconds=240)
+    with (
+        mock.patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            autospec=True,
+        ) as mock_from_file,
+        mock.patch("google_auth_httplib2.AuthorizedHttp", side_effect=_authorized_http),
+        mock.patch("googleapiclient.discovery.build", side_effect=_build),
+        mock.patch("httplib2.Http", side_effect=_http_factory),
+    ):
+        mock_from_file.return_value = _Credentials()
+        result = calc._load_play_service(service_account, timeout_seconds=240)
 
     assert result == "service"
-    assert observed["service_account_path"] == str(service_account)
+    mock_from_file.assert_called_once_with(creds_path, scopes=expected_scopes)
     assert observed["http_timeout"] == 240
     assert observed["build_args"] == {
         "api_name": "androidpublisher",


### PR DESCRIPTION
## What changed
- replace the brittle `sys.modules` monkeypatch in `test_compute_android_release_version_code.py` with direct patches on the real Google client entry points
- keep the test asserting timeout + AuthorizedHttp wiring without depending on import order inside the pytest session

## Why
- `develop` merged the voice preview fix, but CI on commit `6ecb7ed64430ee840400d9a5d4cdaf3af992183f` failed in `Python Script Tests`
- the failure was order-dependent: when `google.oauth2` was already imported, the old monkeypatch was bypassed and real `from_service_account_file({})` executed

## Verification
- Python 3.11 fresh venv: `405 passed` for `scripts/tests/`
- `git diff --check`

## Impact
- restores green `develop` CI so the next internal Firebase/TestFlight build can be cut from a verified commit