### PR TITLE
fix(crashlytics): BigQuery project id random-timer-dist-new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,6 +632,7 @@ jobs:
       - name: Check crash-free rate
         env:
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
+          CRASHLYTICS_PROJECT_ID: random-timer-dist-new
         run: python scripts/check_crashlytics.py --threshold 99.0 --hours 24
 
   notify:

--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -39,6 +39,8 @@ jobs:
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
+          # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
+          CRASHLYTICS_PROJECT_ID: random-timer-dist-new
         run: |
           set -euo pipefail
           python3 scripts/executive_metrics_snapshot.py \

--- a/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
+++ b/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
@@ -8,8 +8,10 @@ Android Firebase is intentionally split across two backends:
 
 | Purpose | Project ID | Project Number | App ID |
 |---|---|---:|---|
-| Runtime services (`google-services.json`, Crashlytics BigQuery export) | `random-timer-486213` | `624873778337` | Runtime app ID is supplied by `GOOGLE_SERVICES_JSON` |
+| Runtime Android config in CI/release (`google-services.json` from secret) | Varies by secret | Varies | Supplied by `GOOGLE_SERVICES_JSON` |
+| **Crashlytics → BigQuery streaming export** (automated queries / `check_crashlytics.py`) | **`random-timer-dist-new`** | Per GCP console | Same app; dataset `firebase_crashlytics` |
 | Firebase App Distribution | `random-timer-dist-new` | Verify from `FIREBASE_ANDROID_APP_ID` secret or live run log | Supplied by `FIREBASE_ANDROID_APP_ID` |
+| Legacy / historical project (some docs and older keys) | `random-timer-486213` | `624873778337` | Do not assume current BQ export lives here |
 
 ## Why The Split Exists
 

--- a/scripts/check_crashlytics.py
+++ b/scripts/check_crashlytics.py
@@ -6,16 +6,15 @@ Usage:
 
 Setup (one-time in Firebase Console):
     1. Firebase Console > Crashlytics > BigQuery integration > Link
-    2. This enables streaming export to: random-timer-486213.firebase_crashlytics.{app_id}
+    2. Streaming export lands in: <project>.firebase_crashlytics (see CRASHLYTICS_PROJECT_ID).
 
 Requires:
     - CRASHLYTICS_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
-    - BigQuery API enabled on random-timer-486213
-    - Firebase project: random-timer-486213
+    - BigQuery API enabled on the Firebase/GCP project that owns the export
+    - Env CRASHLYTICS_PROJECT_ID must match that project (default: random-timer-dist-new)
 
-This script reads runtime Crashlytics data only. Android App Distribution is
-owned by a separate Firebase project and is documented in
-docs/FIREBASE_ANDROID_INFRASTRUCTURE.md.
+This script reads runtime Crashlytics data only. See docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
+for project history (App Distribution vs runtime).
 """
 
 import ssl
@@ -31,7 +30,7 @@ from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 
 
-PROJECT_ID = os.environ.get("CRASHLYTICS_PROJECT_ID", "random-timer-486213")
+PROJECT_ID = os.environ.get("CRASHLYTICS_PROJECT_ID", "random-timer-dist-new")
 PACKAGE = os.environ.get("CRASHLYTICS_PACKAGE", "com.iganapolsky.randomtimer")
 # BigQuery dataset created by Crashlytics streaming export
 BQ_DATASET = os.environ.get("CRASHLYTICS_BQ_DATASET", "firebase_crashlytics")

--- a/scripts/tests/test_check_crashlytics.py
+++ b/scripts/tests/test_check_crashlytics.py
@@ -23,7 +23,7 @@ cc = _import_script()
 
 
 def test_constants():
-    assert cc.PROJECT_ID == "random-timer-486213"
+    assert cc.PROJECT_ID == "random-timer-dist-new"
     assert cc.PACKAGE == "com.iganapolsky.randomtimer"
     assert cc.BQ_DATASET == "firebase_crashlytics"
     assert int(cc.DEFAULT_THRESHOLD) == 99


### PR DESCRIPTION
Restores the Crashlytics BigQuery project fix so CI and the executive metrics snapshot query the live export in random-timer-dist-new.