### PR TITLE
[codex] Add Android App Functions timer controls

### DIFF
--- a/.github/workflows/android17-canary.yml
+++ b/.github/workflows/android17-canary.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
           yes | sdkmanager --licenses >/dev/null
-          sdkmanager "platforms;android-${API_LEVEL}" "build-tools;35.0.0"
+          sdkmanager "platforms;android-${API_LEVEL}" "build-tools;36.0.0"
 
       - name: Grant execute permission
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,14 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android 36 SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
       - name: Grant execute permission
         run: chmod +x gradlew
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -29,6 +29,14 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android 36 SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
       - name: Create dummy google-services.json for CI
         working-directory: native-android
         run: |

--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -300,6 +300,14 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android 36 SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
@@ -471,6 +479,14 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android 36 SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Create google-services.json
         working-directory: native-android

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -241,6 +241,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android 36 SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -41,7 +41,7 @@ val ciVersionCode = providers.gradleProperty("ciVersionCode").orNull?.toIntOrNul
 
 android {
     namespace = "com.iganapolsky.randomtimer"
-    compileSdk = ciCompileSdk ?: 35
+    compileSdk = ciCompileSdk ?: 36
 
     defaultConfig {
         applicationId = "com.iganapolsky.randomtimer"
@@ -124,6 +124,10 @@ android {
     }
 }
 
+ksp {
+    arg("appfunctions:aggregateAppFunctions", "true")
+}
+
 dependencies {
     // Core Android
     implementation(libs.androidx.core.ktx)
@@ -153,6 +157,11 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
 
+    // App Functions
+    implementation(libs.androidx.appfunctions)
+    implementation(libs.androidx.appfunctions.service)
+    ksp(libs.androidx.appfunctions.compiler)
+
     // Analytics
     implementation(libs.posthog)
 
@@ -173,11 +182,15 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.appfunctions.testing)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
     testImplementation(libs.turbine)
     testImplementation(libs.truth)
     testImplementation(libs.org.json)
+    kspTest(libs.androidx.appfunctions.compiler)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/RandomTimerApp.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/RandomTimerApp.kt
@@ -1,15 +1,32 @@
 package com.iganapolsky.randomtimer
 
 import android.app.Application
+import androidx.appfunctions.service.AppFunctionConfiguration
 import com.iganapolsky.randomtimer.analytics.AnalyticsService
+import com.iganapolsky.randomtimer.appfunctions.RandomTimerAppFunctionEntryPoint
+import com.iganapolsky.randomtimer.appfunctions.RandomTimerAppFunctions
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.android.EntryPointAccessors
 import javax.inject.Inject
 
 @HiltAndroidApp
-class RandomTimerApp : Application() {
+class RandomTimerApp : Application(), AppFunctionConfiguration.Provider {
 
     @Inject lateinit var analyticsService: AnalyticsService
+
+    override val appFunctionConfiguration: AppFunctionConfiguration by lazy {
+        AppFunctionConfiguration
+            .Builder()
+            .addEnclosingClassFactory(RandomTimerAppFunctions::class.java) {
+                val entryPoint =
+                    EntryPointAccessors.fromApplication(
+                        this,
+                        RandomTimerAppFunctionEntryPoint::class.java,
+                    )
+                RandomTimerAppFunctions(entryPoint.randomTimerAppFunctionHandler())
+            }.build()
+    }
 
     override fun onCreate() {
         super.onCreate()

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/RandomTimerApp.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/RandomTimerApp.kt
@@ -2,17 +2,18 @@ package com.iganapolsky.randomtimer
 
 import android.app.Application
 import androidx.appfunctions.service.AppFunctionConfiguration
+import com.google.firebase.analytics.FirebaseAnalytics
 import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.appfunctions.RandomTimerAppFunctionEntryPoint
 import com.iganapolsky.randomtimer.appfunctions.RandomTimerAppFunctions
-import com.google.firebase.analytics.FirebaseAnalytics
-import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
 @HiltAndroidApp
-class RandomTimerApp : Application(), AppFunctionConfiguration.Provider {
-
+class RandomTimerApp :
+    Application(),
+    AppFunctionConfiguration.Provider {
     @Inject lateinit var analyticsService: AnalyticsService
 
     override val appFunctionConfiguration: AppFunctionConfiguration by lazy {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactory.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactory.kt
@@ -1,0 +1,88 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+import com.iganapolsky.randomtimer.domain.model.EntitlementLevel
+import com.iganapolsky.randomtimer.domain.model.SoundType
+import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.VoiceGender
+import java.util.Locale
+import javax.inject.Inject
+
+class RandomTimerAppFunctionConfigFactory
+    @Inject
+    constructor() {
+        fun create(
+            minSeconds: Int,
+            maxSeconds: Int,
+            alarmDuration: Int,
+            soundType: String,
+            voiceEnabled: Boolean,
+            voiceGender: String,
+            hiddenMode: Boolean,
+            repeatEnabled: Boolean,
+            vibrationEnabled: Boolean,
+            entitlementLevel: EntitlementLevel,
+        ): TimerConfig {
+            if (alarmDuration !in TimerConfig.ALARM_DURATION_OPTIONS) {
+                invalidArgument(
+                    "alarmDuration must be one of ${TimerConfig.ALARM_DURATION_OPTIONS.joinToString(", ")} seconds.",
+                )
+            }
+
+            val parsedSoundType = parseSoundType(soundType)
+            val parsedVoiceGender = parseVoiceGender(voiceGender)
+            val usesExtendedRange =
+                minSeconds > TimerConfig.MAX_SECONDS_FREE || maxSeconds > TimerConfig.MAX_SECONDS_FREE
+
+            if (usesExtendedRange && !entitlementLevel.isPro) {
+                invalidArgument("Extended timer ranges above ${TimerConfig.MAX_SECONDS_FREE} seconds require Pro.")
+            }
+
+            if (parsedSoundType.isPro && !entitlementLevel.isPro) {
+                invalidArgument("Sound type ${parsedSoundType.name} requires Pro.")
+            }
+
+            if (voiceEnabled && !entitlementLevel.isPro) {
+                invalidArgument("Voice callouts require Pro.")
+            }
+
+            return try {
+                TimerConfig(
+                    minSeconds = minSeconds,
+                    maxSeconds = maxSeconds,
+                    alarmDuration = alarmDuration,
+                    hiddenMode = hiddenMode,
+                    repeatEnabled = repeatEnabled,
+                    soundType = parsedSoundType,
+                    volume = TimerConfig.DEFAULT.volume,
+                    vibrationEnabled = vibrationEnabled,
+                    useExtendedRange = usesExtendedRange,
+                    voiceEnabled = voiceEnabled,
+                    voiceGender = parsedVoiceGender,
+                )
+            } catch (error: IllegalArgumentException) {
+                invalidArgument(error.message ?: "Invalid timer configuration.")
+            }
+        }
+
+        private fun parseSoundType(rawValue: String): SoundType =
+            parseEnum(rawValue, "soundType")
+
+        private fun parseVoiceGender(rawValue: String): VoiceGender =
+            parseEnum(rawValue, "voiceGender")
+
+        private inline fun <reified T : Enum<T>> parseEnum(
+            rawValue: String,
+            fieldName: String,
+        ): T {
+            val normalized = rawValue.trim().uppercase(Locale.US)
+            return enumValues<T>().firstOrNull { value -> value.name == normalized }
+                ?: invalidArgument(
+                    "$fieldName must be one of ${enumValues<T>().joinToString(", ") { value -> value.name }}.",
+                )
+        }
+
+        private fun invalidArgument(message: String): Nothing {
+            throw AppFunctionInvalidArgumentException(message)
+        }
+    }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactory.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactory.kt
@@ -65,11 +65,9 @@ class RandomTimerAppFunctionConfigFactory
             }
         }
 
-        private fun parseSoundType(rawValue: String): SoundType =
-            parseEnum(rawValue, "soundType")
+        private fun parseSoundType(rawValue: String): SoundType = parseEnum(rawValue, "soundType")
 
-        private fun parseVoiceGender(rawValue: String): VoiceGender =
-            parseEnum(rawValue, "voiceGender")
+        private fun parseVoiceGender(rawValue: String): VoiceGender = parseEnum(rawValue, "voiceGender")
 
         private inline fun <reified T : Enum<T>> parseEnum(
             rawValue: String,
@@ -82,7 +80,5 @@ class RandomTimerAppFunctionConfigFactory
                 )
         }
 
-        private fun invalidArgument(message: String): Nothing {
-            throw AppFunctionInvalidArgumentException(message)
-        }
+        private fun invalidArgument(message: String): Nothing = throw AppFunctionInvalidArgumentException(message)
     }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactory.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactory.kt
@@ -12,27 +12,19 @@ class RandomTimerAppFunctionConfigFactory
     @Inject
     constructor() {
         fun create(
-            minSeconds: Int,
-            maxSeconds: Int,
-            alarmDuration: Int,
-            soundType: String,
-            voiceEnabled: Boolean,
-            voiceGender: String,
-            hiddenMode: Boolean,
-            repeatEnabled: Boolean,
-            vibrationEnabled: Boolean,
+            request: TimerFunctionRequest,
             entitlementLevel: EntitlementLevel,
         ): TimerConfig {
-            if (alarmDuration !in TimerConfig.ALARM_DURATION_OPTIONS) {
+            if (request.alarmDuration !in TimerConfig.ALARM_DURATION_OPTIONS) {
                 invalidArgument(
                     "alarmDuration must be one of ${TimerConfig.ALARM_DURATION_OPTIONS.joinToString(", ")} seconds.",
                 )
             }
 
-            val parsedSoundType = parseSoundType(soundType)
-            val parsedVoiceGender = parseVoiceGender(voiceGender)
+            val parsedSoundType = parseSoundType(request.soundType)
+            val parsedVoiceGender = parseVoiceGender(request.voiceGender)
             val usesExtendedRange =
-                minSeconds > TimerConfig.MAX_SECONDS_FREE || maxSeconds > TimerConfig.MAX_SECONDS_FREE
+                request.minSeconds > TimerConfig.MAX_SECONDS_FREE || request.maxSeconds > TimerConfig.MAX_SECONDS_FREE
 
             if (usesExtendedRange && !entitlementLevel.isPro) {
                 invalidArgument("Extended timer ranges above ${TimerConfig.MAX_SECONDS_FREE} seconds require Pro.")
@@ -42,22 +34,22 @@ class RandomTimerAppFunctionConfigFactory
                 invalidArgument("Sound type ${parsedSoundType.name} requires Pro.")
             }
 
-            if (voiceEnabled && !entitlementLevel.isPro) {
+            if (request.voiceEnabled && !entitlementLevel.isPro) {
                 invalidArgument("Voice callouts require Pro.")
             }
 
             return try {
                 TimerConfig(
-                    minSeconds = minSeconds,
-                    maxSeconds = maxSeconds,
-                    alarmDuration = alarmDuration,
-                    hiddenMode = hiddenMode,
-                    repeatEnabled = repeatEnabled,
+                    minSeconds = request.minSeconds,
+                    maxSeconds = request.maxSeconds,
+                    alarmDuration = request.alarmDuration,
+                    hiddenMode = request.hiddenMode,
+                    repeatEnabled = request.repeatEnabled,
                     soundType = parsedSoundType,
                     volume = TimerConfig.DEFAULT.volume,
-                    vibrationEnabled = vibrationEnabled,
+                    vibrationEnabled = request.vibrationEnabled,
                     useExtendedRange = usesExtendedRange,
-                    voiceEnabled = voiceEnabled,
+                    voiceEnabled = request.voiceEnabled,
                     voiceGender = parsedVoiceGender,
                 )
             } catch (error: IllegalArgumentException) {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionEntryPoint.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionEntryPoint.kt
@@ -1,0 +1,11 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.EntryPoint
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface RandomTimerAppFunctionEntryPoint {
+    fun randomTimerAppFunctionHandler(): RandomTimerAppFunctionHandler
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionEntryPoint.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionEntryPoint.kt
@@ -1,8 +1,8 @@
 package com.iganapolsky.randomtimer.appfunctions
 
+import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import dagger.hilt.EntryPoint
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandler.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandler.kt
@@ -1,0 +1,239 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import com.iganapolsky.randomtimer.analytics.AnalyticsEvents
+import com.iganapolsky.randomtimer.analytics.AnalyticsProperties
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
+import com.iganapolsky.randomtimer.billing.ProManager
+import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.TimerState
+import com.iganapolsky.randomtimer.domain.repository.TimerRepository
+import com.iganapolsky.randomtimer.domain.usecase.StartTimerUseCase
+import com.iganapolsky.randomtimer.service.TimerServiceController
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+
+class RandomTimerAppFunctionHandler
+    @Inject
+    constructor(
+        private val startTimerUseCase: StartTimerUseCase,
+        private val repository: TimerRepository,
+        private val serviceController: TimerServiceController,
+        private val analyticsService: AnalyticsService,
+        private val proManager: ProManager,
+        private val configFactory: RandomTimerAppFunctionConfigFactory,
+    ) {
+        suspend fun configureRandomTimer(
+            minSeconds: Int,
+            maxSeconds: Int,
+            alarmDuration: Int,
+            soundType: String,
+            voiceEnabled: Boolean,
+            voiceGender: String,
+            hiddenMode: Boolean,
+            repeatEnabled: Boolean,
+            vibrationEnabled: Boolean,
+        ): TimerFunctionResult {
+            val config =
+                buildConfig(
+                    minSeconds = minSeconds,
+                    maxSeconds = maxSeconds,
+                    alarmDuration = alarmDuration,
+                    soundType = soundType,
+                    voiceEnabled = voiceEnabled,
+                    voiceGender = voiceGender,
+                    hiddenMode = hiddenMode,
+                    repeatEnabled = repeatEnabled,
+                    vibrationEnabled = vibrationEnabled,
+                )
+
+            repository.saveTimerConfig(config)
+            analyticsService.track(
+                AnalyticsEvents.SETTINGS_CHANGED,
+                config.analyticsProperties(),
+            )
+            analyticsService.trackFirstTimerConfiguredIfNeeded()
+
+            return config.result(
+                action = ACTION_CONFIGURE,
+                status = STATUS_CONFIGURED,
+                message = "Saved timer configuration.",
+            )
+        }
+
+        suspend fun startRandomTimer(
+            minSeconds: Int,
+            maxSeconds: Int,
+            alarmDuration: Int,
+            soundType: String,
+            voiceEnabled: Boolean,
+            voiceGender: String,
+            hiddenMode: Boolean,
+            repeatEnabled: Boolean,
+            vibrationEnabled: Boolean,
+        ): TimerFunctionResult {
+            val config =
+                buildConfig(
+                    minSeconds = minSeconds,
+                    maxSeconds = maxSeconds,
+                    alarmDuration = alarmDuration,
+                    soundType = soundType,
+                    voiceEnabled = voiceEnabled,
+                    voiceGender = voiceGender,
+                    hiddenMode = hiddenMode,
+                    repeatEnabled = repeatEnabled,
+                    vibrationEnabled = vibrationEnabled,
+                )
+
+            val state = startTimerUseCase(config)
+            serviceController.startTimer(state)
+            analyticsService.track(
+                AnalyticsEvents.TIMER_STARTED,
+                config.analyticsProperties() +
+                    mapOf("target_duration" to state.targetDuration.inWholeSeconds),
+            )
+            analyticsService.trackFirstTimerConfiguredIfNeeded()
+
+            return config.result(
+                action = ACTION_START,
+                status = STATUS_RUNNING,
+                message = "Started random timer.",
+                targetDurationSeconds = state.targetDuration.inWholeSeconds.toInt(),
+            )
+        }
+
+        suspend fun pauseTimer(): TimerFunctionResult {
+            val activeTimer = repository.getActiveTimer().first()
+                ?: return idleResult(ACTION_PAUSE, "No active timer to pause.")
+
+            analyticsService.track(
+                AnalyticsEvents.TIMER_PAUSED,
+                mapOf(AnalyticsProperties.ENTRY_POINT to ENTRY_POINT),
+            )
+            serviceController.pauseTimer()
+            return activeTimer.config.result(
+                action = ACTION_PAUSE,
+                status = STATUS_PAUSED,
+                message = "Paused active timer.",
+            )
+        }
+
+        suspend fun resumeTimer(): TimerFunctionResult {
+            val activeTimer = repository.getActiveTimer().first()
+                ?: return idleResult(ACTION_RESUME, "No active timer to resume.")
+
+            analyticsService.track(
+                AnalyticsEvents.TIMER_RESUMED,
+                mapOf(AnalyticsProperties.ENTRY_POINT to ENTRY_POINT),
+            )
+            serviceController.resumeTimer()
+            return activeTimer.config.result(
+                action = ACTION_RESUME,
+                status = STATUS_RUNNING,
+                message = "Resumed active timer.",
+            )
+        }
+
+        suspend fun stopTimer(): TimerFunctionResult {
+            val activeTimer = repository.getActiveTimer().first()
+                ?: return idleResult(ACTION_STOP, "No active timer to stop.")
+
+            repository.clearActiveTimer()
+            serviceController.stopTimer()
+            return activeTimer.config.result(
+                action = ACTION_STOP,
+                status = STATUS_STOPPED,
+                message = "Stopped active timer.",
+            )
+        }
+
+        private fun buildConfig(
+            minSeconds: Int,
+            maxSeconds: Int,
+            alarmDuration: Int,
+            soundType: String,
+            voiceEnabled: Boolean,
+            voiceGender: String,
+            hiddenMode: Boolean,
+            repeatEnabled: Boolean,
+            vibrationEnabled: Boolean,
+        ): TimerConfig =
+            configFactory.create(
+                minSeconds = minSeconds,
+                maxSeconds = maxSeconds,
+                alarmDuration = alarmDuration,
+                soundType = soundType,
+                voiceEnabled = voiceEnabled,
+                voiceGender = voiceGender,
+                hiddenMode = hiddenMode,
+                repeatEnabled = repeatEnabled,
+                vibrationEnabled = vibrationEnabled,
+                entitlementLevel = proManager.entitlementLevel.value,
+            )
+
+        private fun TimerConfig.analyticsProperties(): Map<String, Any> =
+            mapOf(
+                AnalyticsProperties.ENTRY_POINT to ENTRY_POINT,
+                AnalyticsProperties.ENTITLEMENT_LEVEL to entitlementLevelName(),
+                "min_duration" to minSeconds,
+                "max_duration" to maxSeconds,
+                "alarm_duration" to alarmDuration,
+                "sound_type" to soundType.name,
+                "hidden_mode" to hiddenMode,
+                "repeat_enabled" to repeatEnabled,
+                "vibration_enabled" to vibrationEnabled,
+                "voice_callouts_enabled" to voiceEnabled,
+                "voice_gender" to voiceGender.name,
+            )
+
+        private fun TimerConfig.result(
+            action: String,
+            status: String,
+            message: String,
+            targetDurationSeconds: Int = 0,
+        ): TimerFunctionResult =
+            TimerFunctionResult(
+                action = action,
+                status = status,
+                message = message,
+                entitlementLevel = entitlementLevelName(),
+                minSeconds = minSeconds,
+                maxSeconds = maxSeconds,
+                alarmDuration = alarmDuration,
+                targetDurationSeconds = targetDurationSeconds,
+                soundType = soundType.name,
+                voiceEnabled = voiceEnabled,
+                voiceGender = voiceGender.name,
+                hiddenMode = hiddenMode,
+                repeatEnabled = repeatEnabled,
+                vibrationEnabled = vibrationEnabled,
+            )
+
+        private fun idleResult(
+            action: String,
+            message: String,
+        ): TimerFunctionResult =
+            TimerFunctionResult(
+                action = action,
+                status = STATUS_IDLE,
+                message = message,
+                entitlementLevel = entitlementLevelName(),
+                soundType = "",
+                voiceGender = "",
+            )
+
+        private fun entitlementLevelName(): String = proManager.entitlementLevel.value.name.lowercase()
+
+        companion object {
+            private const val ENTRY_POINT = "app_function"
+            private const val ACTION_CONFIGURE = "configure_random_timer"
+            private const val ACTION_START = "start_random_timer"
+            private const val ACTION_PAUSE = "pause_timer"
+            private const val ACTION_RESUME = "resume_timer"
+            private const val ACTION_STOP = "stop_timer"
+            private const val STATUS_CONFIGURED = "configured"
+            private const val STATUS_IDLE = "idle"
+            private const val STATUS_PAUSED = "paused"
+            private const val STATUS_RUNNING = "running"
+            private const val STATUS_STOPPED = "stopped"
+        }
+    }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandler.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandler.kt
@@ -22,29 +22,8 @@ class RandomTimerAppFunctionHandler
         private val proManager: ProManager,
         private val configFactory: RandomTimerAppFunctionConfigFactory,
     ) {
-        suspend fun configureRandomTimer(
-            minSeconds: Int,
-            maxSeconds: Int,
-            alarmDuration: Int,
-            soundType: String,
-            voiceEnabled: Boolean,
-            voiceGender: String,
-            hiddenMode: Boolean,
-            repeatEnabled: Boolean,
-            vibrationEnabled: Boolean,
-        ): TimerFunctionResult {
-            val config =
-                buildConfig(
-                    minSeconds = minSeconds,
-                    maxSeconds = maxSeconds,
-                    alarmDuration = alarmDuration,
-                    soundType = soundType,
-                    voiceEnabled = voiceEnabled,
-                    voiceGender = voiceGender,
-                    hiddenMode = hiddenMode,
-                    repeatEnabled = repeatEnabled,
-                    vibrationEnabled = vibrationEnabled,
-                )
+        suspend fun configureRandomTimer(request: TimerFunctionRequest): TimerFunctionResult {
+            val config = buildConfig(request)
 
             repository.saveTimerConfig(config)
             analyticsService.track(
@@ -60,29 +39,8 @@ class RandomTimerAppFunctionHandler
             )
         }
 
-        suspend fun startRandomTimer(
-            minSeconds: Int,
-            maxSeconds: Int,
-            alarmDuration: Int,
-            soundType: String,
-            voiceEnabled: Boolean,
-            voiceGender: String,
-            hiddenMode: Boolean,
-            repeatEnabled: Boolean,
-            vibrationEnabled: Boolean,
-        ): TimerFunctionResult {
-            val config =
-                buildConfig(
-                    minSeconds = minSeconds,
-                    maxSeconds = maxSeconds,
-                    alarmDuration = alarmDuration,
-                    soundType = soundType,
-                    voiceEnabled = voiceEnabled,
-                    voiceGender = voiceGender,
-                    hiddenMode = hiddenMode,
-                    repeatEnabled = repeatEnabled,
-                    vibrationEnabled = vibrationEnabled,
-                )
+        suspend fun startRandomTimer(request: TimerFunctionRequest): TimerFunctionResult {
+            val config = buildConfig(request)
 
             val state = startTimerUseCase(config)
             serviceController.startTimer(state)
@@ -101,77 +59,70 @@ class RandomTimerAppFunctionHandler
             )
         }
 
-        suspend fun pauseTimer(): TimerFunctionResult {
-            val activeTimer =
-                repository.getActiveTimer().first()
-                    ?: return idleResult(ACTION_PAUSE, "No active timer to pause.")
-
-            analyticsService.track(
-                AnalyticsEvents.TIMER_PAUSED,
-                mapOf(AnalyticsProperties.ENTRY_POINT to ENTRY_POINT),
-            )
-            serviceController.pauseTimer()
-            return activeTimer.config.result(
+        suspend fun pauseTimer(): TimerFunctionResult =
+            withActiveTimer(
                 action = ACTION_PAUSE,
-                status = STATUS_PAUSED,
-                message = "Paused active timer.",
-            )
-        }
+                idleVerb = "pause",
+            ) { activeTimer ->
+                analyticsService.track(
+                    AnalyticsEvents.TIMER_PAUSED,
+                    mapOf(AnalyticsProperties.ENTRY_POINT to ENTRY_POINT),
+                )
+                serviceController.pauseTimer()
+                activeTimer.config.result(
+                    action = ACTION_PAUSE,
+                    status = STATUS_PAUSED,
+                    message = "Paused active timer.",
+                )
+            }
 
-        suspend fun resumeTimer(): TimerFunctionResult {
-            val activeTimer =
-                repository.getActiveTimer().first()
-                    ?: return idleResult(ACTION_RESUME, "No active timer to resume.")
-
-            analyticsService.track(
-                AnalyticsEvents.TIMER_RESUMED,
-                mapOf(AnalyticsProperties.ENTRY_POINT to ENTRY_POINT),
-            )
-            serviceController.resumeTimer()
-            return activeTimer.config.result(
+        suspend fun resumeTimer(): TimerFunctionResult =
+            withActiveTimer(
                 action = ACTION_RESUME,
-                status = STATUS_RUNNING,
-                message = "Resumed active timer.",
-            )
-        }
+                idleVerb = "resume",
+            ) { activeTimer ->
+                analyticsService.track(
+                    AnalyticsEvents.TIMER_RESUMED,
+                    mapOf(AnalyticsProperties.ENTRY_POINT to ENTRY_POINT),
+                )
+                serviceController.resumeTimer()
+                activeTimer.config.result(
+                    action = ACTION_RESUME,
+                    status = STATUS_RUNNING,
+                    message = "Resumed active timer.",
+                )
+            }
 
-        suspend fun stopTimer(): TimerFunctionResult {
-            val activeTimer =
-                repository.getActiveTimer().first()
-                    ?: return idleResult(ACTION_STOP, "No active timer to stop.")
-
-            repository.clearActiveTimer()
-            serviceController.stopTimer()
-            return activeTimer.config.result(
+        suspend fun stopTimer(): TimerFunctionResult =
+            withActiveTimer(
                 action = ACTION_STOP,
-                status = STATUS_STOPPED,
-                message = "Stopped active timer.",
-            )
-        }
+                idleVerb = "stop",
+            ) { activeTimer ->
+                repository.clearActiveTimer()
+                serviceController.stopTimer()
+                activeTimer.config.result(
+                    action = ACTION_STOP,
+                    status = STATUS_STOPPED,
+                    message = "Stopped active timer.",
+                )
+            }
 
-        private fun buildConfig(
-            minSeconds: Int,
-            maxSeconds: Int,
-            alarmDuration: Int,
-            soundType: String,
-            voiceEnabled: Boolean,
-            voiceGender: String,
-            hiddenMode: Boolean,
-            repeatEnabled: Boolean,
-            vibrationEnabled: Boolean,
-        ): TimerConfig =
+        private fun buildConfig(request: TimerFunctionRequest): TimerConfig =
             configFactory.create(
-                minSeconds = minSeconds,
-                maxSeconds = maxSeconds,
-                alarmDuration = alarmDuration,
-                soundType = soundType,
-                voiceEnabled = voiceEnabled,
-                voiceGender = voiceGender,
-                hiddenMode = hiddenMode,
-                repeatEnabled = repeatEnabled,
-                vibrationEnabled = vibrationEnabled,
+                request = request,
                 entitlementLevel = proManager.entitlementLevel.value,
             )
+
+        private suspend fun withActiveTimer(
+            action: String,
+            idleVerb: String,
+            onActiveTimer: suspend (TimerState) -> TimerFunctionResult,
+        ): TimerFunctionResult {
+            val activeTimer =
+                repository.getActiveTimer().first()
+                    ?: return idleResult(action, "No active timer to $idleVerb.")
+            return onActiveTimer(activeTimer)
+        }
 
         private fun TimerConfig.analyticsProperties(): Map<String, Any> =
             mapOf(

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandler.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandler.kt
@@ -9,8 +9,8 @@ import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import com.iganapolsky.randomtimer.domain.usecase.StartTimerUseCase
 import com.iganapolsky.randomtimer.service.TimerServiceController
-import javax.inject.Inject
 import kotlinx.coroutines.flow.first
+import javax.inject.Inject
 
 class RandomTimerAppFunctionHandler
     @Inject
@@ -102,8 +102,9 @@ class RandomTimerAppFunctionHandler
         }
 
         suspend fun pauseTimer(): TimerFunctionResult {
-            val activeTimer = repository.getActiveTimer().first()
-                ?: return idleResult(ACTION_PAUSE, "No active timer to pause.")
+            val activeTimer =
+                repository.getActiveTimer().first()
+                    ?: return idleResult(ACTION_PAUSE, "No active timer to pause.")
 
             analyticsService.track(
                 AnalyticsEvents.TIMER_PAUSED,
@@ -118,8 +119,9 @@ class RandomTimerAppFunctionHandler
         }
 
         suspend fun resumeTimer(): TimerFunctionResult {
-            val activeTimer = repository.getActiveTimer().first()
-                ?: return idleResult(ACTION_RESUME, "No active timer to resume.")
+            val activeTimer =
+                repository.getActiveTimer().first()
+                    ?: return idleResult(ACTION_RESUME, "No active timer to resume.")
 
             analyticsService.track(
                 AnalyticsEvents.TIMER_RESUMED,
@@ -134,8 +136,9 @@ class RandomTimerAppFunctionHandler
         }
 
         suspend fun stopTimer(): TimerFunctionResult {
-            val activeTimer = repository.getActiveTimer().first()
-                ?: return idleResult(ACTION_STOP, "No active timer to stop.")
+            val activeTimer =
+                repository.getActiveTimer().first()
+                    ?: return idleResult(ACTION_STOP, "No active timer to stop.")
 
             repository.clearActiveTimer()
             serviceController.stopTimer()
@@ -221,7 +224,9 @@ class RandomTimerAppFunctionHandler
                 voiceGender = "",
             )
 
-        private fun entitlementLevelName(): String = proManager.entitlementLevel.value.name.lowercase()
+        private fun entitlementLevelName(): String =
+            proManager.entitlementLevel.value.name
+                .lowercase()
 
         companion object {
             private const val ENTRY_POINT = "app_function"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionModels.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionModels.kt
@@ -19,3 +19,15 @@ data class TimerFunctionResult(
     val repeatEnabled: Boolean = false,
     val vibrationEnabled: Boolean = false,
 )
+
+data class TimerFunctionRequest(
+    val minSeconds: Int,
+    val maxSeconds: Int,
+    val alarmDuration: Int,
+    val soundType: String,
+    val voiceEnabled: Boolean,
+    val voiceGender: String,
+    val hiddenMode: Boolean,
+    val repeatEnabled: Boolean,
+    val vibrationEnabled: Boolean,
+)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionModels.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionModels.kt
@@ -1,0 +1,21 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import androidx.appfunctions.AppFunctionSerializable
+
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class TimerFunctionResult(
+    val action: String,
+    val status: String,
+    val message: String,
+    val entitlementLevel: String,
+    val minSeconds: Int = 0,
+    val maxSeconds: Int = 0,
+    val alarmDuration: Int = 0,
+    val targetDurationSeconds: Int = 0,
+    val soundType: String,
+    val voiceEnabled: Boolean = false,
+    val voiceGender: String,
+    val hiddenMode: Boolean = false,
+    val repeatEnabled: Boolean = false,
+    val vibrationEnabled: Boolean = false,
+)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionModels.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionModels.kt
@@ -20,6 +20,7 @@ data class TimerFunctionResult(
     val vibrationEnabled: Boolean = false,
 )
 
+@AppFunctionSerializable(isDescribedByKDoc = true)
 data class TimerFunctionRequest(
     val minSeconds: Int,
     val maxSeconds: Int,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
@@ -1,0 +1,155 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import androidx.appfunctions.AppFunctionContext
+import androidx.appfunctions.AppFunctionIntValueConstraint
+import androidx.appfunctions.AppFunctionStringValueConstraint
+import androidx.appfunctions.service.AppFunction
+
+class RandomTimerAppFunctions(
+    private val handler: RandomTimerAppFunctionHandler,
+) {
+    /**
+     * Saves a random tactical timer preset without starting it.
+     *
+     * @param minSeconds Lowest possible timer duration in seconds.
+     * @param maxSeconds Highest possible timer duration in seconds.
+     * @param alarmDuration Alarm length in seconds after the random countdown completes.
+     * @param soundType Alarm sound to use.
+     * @param voiceEnabled Whether AI voice callouts should be enabled.
+     * @param voiceGender Which voice persona should be used for callouts.
+     * @param hiddenMode Whether the countdown should stay hidden while the timer runs.
+     * @param repeatEnabled Whether the timer should automatically loop after each round.
+     * @param vibrationEnabled Whether vibration should fire with the alarm.
+     * @return The saved timer configuration summary.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun configureRandomTimer(
+        appFunctionContext: AppFunctionContext,
+        minSeconds: Int,
+        maxSeconds: Int,
+        @AppFunctionIntValueConstraint(enumValues = [5, 10, 15, 30, 60])
+        alarmDuration: Int = TimerDefaults.ALARM_DURATION_SECONDS,
+        @AppFunctionStringValueConstraint(
+            enumValues = [
+                "INTENSE",
+                "GENTLE",
+                "KLAXON",
+                "WHISTLE",
+                "BUZZER",
+                "GONG",
+                "AIRHORN",
+                "DRUM_ROLL",
+                "SIREN",
+                "BELL",
+            ],
+        )
+        soundType: String,
+        voiceEnabled: Boolean = false,
+        @AppFunctionStringValueConstraint(enumValues = ["MALE", "FEMALE"])
+        voiceGender: String,
+        hiddenMode: Boolean = false,
+        repeatEnabled: Boolean = false,
+        vibrationEnabled: Boolean = false,
+    ): TimerFunctionResult =
+        appFunctionContext.let {
+        handler.configureRandomTimer(
+            minSeconds = minSeconds,
+            maxSeconds = maxSeconds,
+            alarmDuration = alarmDuration,
+            soundType = soundType,
+            voiceEnabled = voiceEnabled,
+            voiceGender = voiceGender,
+            hiddenMode = hiddenMode,
+            repeatEnabled = repeatEnabled,
+            vibrationEnabled = vibrationEnabled,
+        )
+        }
+
+    /**
+     * Starts a random tactical timer immediately.
+     *
+     * @param minSeconds Lowest possible timer duration in seconds.
+     * @param maxSeconds Highest possible timer duration in seconds.
+     * @param alarmDuration Alarm length in seconds after the random countdown completes.
+     * @param soundType Alarm sound to use.
+     * @param voiceEnabled Whether AI voice callouts should be enabled.
+     * @param voiceGender Which voice persona should be used for callouts.
+     * @param hiddenMode Whether the countdown should stay hidden while the timer runs.
+     * @param repeatEnabled Whether the timer should automatically loop after each round.
+     * @param vibrationEnabled Whether vibration should fire with the alarm.
+     * @return The started timer summary, including the chosen target duration.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun startRandomTimer(
+        appFunctionContext: AppFunctionContext,
+        minSeconds: Int,
+        maxSeconds: Int,
+        @AppFunctionIntValueConstraint(enumValues = [5, 10, 15, 30, 60])
+        alarmDuration: Int = TimerDefaults.ALARM_DURATION_SECONDS,
+        @AppFunctionStringValueConstraint(
+            enumValues = [
+                "INTENSE",
+                "GENTLE",
+                "KLAXON",
+                "WHISTLE",
+                "BUZZER",
+                "GONG",
+                "AIRHORN",
+                "DRUM_ROLL",
+                "SIREN",
+                "BELL",
+            ],
+        )
+        soundType: String,
+        voiceEnabled: Boolean = false,
+        @AppFunctionStringValueConstraint(enumValues = ["MALE", "FEMALE"])
+        voiceGender: String,
+        hiddenMode: Boolean = false,
+        repeatEnabled: Boolean = false,
+        vibrationEnabled: Boolean = false,
+    ): TimerFunctionResult =
+        appFunctionContext.let {
+        handler.startRandomTimer(
+            minSeconds = minSeconds,
+            maxSeconds = maxSeconds,
+            alarmDuration = alarmDuration,
+            soundType = soundType,
+            voiceEnabled = voiceEnabled,
+            voiceGender = voiceGender,
+            hiddenMode = hiddenMode,
+            repeatEnabled = repeatEnabled,
+            vibrationEnabled = vibrationEnabled,
+        )
+        }
+
+    /**
+     * Pauses the currently running timer.
+     *
+     * @return The active timer state after the pause request.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun pauseTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult =
+        appFunctionContext.let { handler.pauseTimer() }
+
+    /**
+     * Resumes the currently paused timer.
+     *
+     * @return The active timer state after the resume request.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun resumeTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult =
+        appFunctionContext.let { handler.resumeTimer() }
+
+    /**
+     * Stops the current timer and clears its active state.
+     *
+     * @return The active timer state after the stop request.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun stopTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult =
+        appFunctionContext.let { handler.stopTimer() }
+}
+
+private object TimerDefaults {
+    const val ALARM_DURATION_SECONDS = 10
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
@@ -53,15 +53,18 @@ class RandomTimerAppFunctions(
     ): TimerFunctionResult =
         appFunctionContext.let {
             handler.configureRandomTimer(
-                minSeconds = minSeconds,
-                maxSeconds = maxSeconds,
-                alarmDuration = alarmDuration,
-                soundType = soundType,
-                voiceEnabled = voiceEnabled,
-                voiceGender = voiceGender,
-                hiddenMode = hiddenMode,
-                repeatEnabled = repeatEnabled,
-                vibrationEnabled = vibrationEnabled,
+                request =
+                    timerFunctionRequest(
+                        minSeconds = minSeconds,
+                        maxSeconds = maxSeconds,
+                        alarmDuration = alarmDuration,
+                        soundType = soundType,
+                        voiceEnabled = voiceEnabled,
+                        voiceGender = voiceGender,
+                        hiddenMode = hiddenMode,
+                        repeatEnabled = repeatEnabled,
+                        vibrationEnabled = vibrationEnabled,
+                    ),
             )
         }
 
@@ -110,15 +113,18 @@ class RandomTimerAppFunctions(
     ): TimerFunctionResult =
         appFunctionContext.let {
             handler.startRandomTimer(
-                minSeconds = minSeconds,
-                maxSeconds = maxSeconds,
-                alarmDuration = alarmDuration,
-                soundType = soundType,
-                voiceEnabled = voiceEnabled,
-                voiceGender = voiceGender,
-                hiddenMode = hiddenMode,
-                repeatEnabled = repeatEnabled,
-                vibrationEnabled = vibrationEnabled,
+                request =
+                    timerFunctionRequest(
+                        minSeconds = minSeconds,
+                        maxSeconds = maxSeconds,
+                        alarmDuration = alarmDuration,
+                        soundType = soundType,
+                        voiceEnabled = voiceEnabled,
+                        voiceGender = voiceGender,
+                        hiddenMode = hiddenMode,
+                        repeatEnabled = repeatEnabled,
+                        vibrationEnabled = vibrationEnabled,
+                    ),
             )
         }
 
@@ -150,3 +156,26 @@ class RandomTimerAppFunctions(
 private object TimerDefaults {
     const val ALARM_DURATION_SECONDS = 10
 }
+
+private fun timerFunctionRequest(
+    minSeconds: Int,
+    maxSeconds: Int,
+    alarmDuration: Int,
+    soundType: String,
+    voiceEnabled: Boolean,
+    voiceGender: String,
+    hiddenMode: Boolean,
+    repeatEnabled: Boolean,
+    vibrationEnabled: Boolean,
+): TimerFunctionRequest =
+    TimerFunctionRequest(
+        minSeconds = minSeconds,
+        maxSeconds = maxSeconds,
+        alarmDuration = alarmDuration,
+        soundType = soundType,
+        voiceEnabled = voiceEnabled,
+        voiceGender = voiceGender,
+        hiddenMode = hiddenMode,
+        repeatEnabled = repeatEnabled,
+        vibrationEnabled = vibrationEnabled,
+    )

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
@@ -52,17 +52,17 @@ class RandomTimerAppFunctions(
         vibrationEnabled: Boolean = false,
     ): TimerFunctionResult =
         appFunctionContext.let {
-        handler.configureRandomTimer(
-            minSeconds = minSeconds,
-            maxSeconds = maxSeconds,
-            alarmDuration = alarmDuration,
-            soundType = soundType,
-            voiceEnabled = voiceEnabled,
-            voiceGender = voiceGender,
-            hiddenMode = hiddenMode,
-            repeatEnabled = repeatEnabled,
-            vibrationEnabled = vibrationEnabled,
-        )
+            handler.configureRandomTimer(
+                minSeconds = minSeconds,
+                maxSeconds = maxSeconds,
+                alarmDuration = alarmDuration,
+                soundType = soundType,
+                voiceEnabled = voiceEnabled,
+                voiceGender = voiceGender,
+                hiddenMode = hiddenMode,
+                repeatEnabled = repeatEnabled,
+                vibrationEnabled = vibrationEnabled,
+            )
         }
 
     /**
@@ -109,17 +109,17 @@ class RandomTimerAppFunctions(
         vibrationEnabled: Boolean = false,
     ): TimerFunctionResult =
         appFunctionContext.let {
-        handler.startRandomTimer(
-            minSeconds = minSeconds,
-            maxSeconds = maxSeconds,
-            alarmDuration = alarmDuration,
-            soundType = soundType,
-            voiceEnabled = voiceEnabled,
-            voiceGender = voiceGender,
-            hiddenMode = hiddenMode,
-            repeatEnabled = repeatEnabled,
-            vibrationEnabled = vibrationEnabled,
-        )
+            handler.startRandomTimer(
+                minSeconds = minSeconds,
+                maxSeconds = maxSeconds,
+                alarmDuration = alarmDuration,
+                soundType = soundType,
+                voiceEnabled = voiceEnabled,
+                voiceGender = voiceGender,
+                hiddenMode = hiddenMode,
+                repeatEnabled = repeatEnabled,
+                vibrationEnabled = vibrationEnabled,
+            )
         }
 
     /**
@@ -128,8 +128,7 @@ class RandomTimerAppFunctions(
      * @return The active timer state after the pause request.
      */
     @AppFunction(isDescribedByKDoc = true)
-    suspend fun pauseTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult =
-        appFunctionContext.let { handler.pauseTimer() }
+    suspend fun pauseTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult = appFunctionContext.let { handler.pauseTimer() }
 
     /**
      * Resumes the currently paused timer.
@@ -137,8 +136,7 @@ class RandomTimerAppFunctions(
      * @return The active timer state after the resume request.
      */
     @AppFunction(isDescribedByKDoc = true)
-    suspend fun resumeTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult =
-        appFunctionContext.let { handler.resumeTimer() }
+    suspend fun resumeTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult = appFunctionContext.let { handler.resumeTimer() }
 
     /**
      * Stops the current timer and clears its active state.
@@ -146,8 +144,7 @@ class RandomTimerAppFunctions(
      * @return The active timer state after the stop request.
      */
     @AppFunction(isDescribedByKDoc = true)
-    suspend fun stopTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult =
-        appFunctionContext.let { handler.stopTimer() }
+    suspend fun stopTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult = appFunctionContext.let { handler.stopTimer() }
 }
 
 private object TimerDefaults {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctions.kt
@@ -1,8 +1,6 @@
 package com.iganapolsky.randomtimer.appfunctions
 
 import androidx.appfunctions.AppFunctionContext
-import androidx.appfunctions.AppFunctionIntValueConstraint
-import androidx.appfunctions.AppFunctionStringValueConstraint
 import androidx.appfunctions.service.AppFunction
 
 class RandomTimerAppFunctions(
@@ -11,122 +9,26 @@ class RandomTimerAppFunctions(
     /**
      * Saves a random tactical timer preset without starting it.
      *
-     * @param minSeconds Lowest possible timer duration in seconds.
-     * @param maxSeconds Highest possible timer duration in seconds.
-     * @param alarmDuration Alarm length in seconds after the random countdown completes.
-     * @param soundType Alarm sound to use.
-     * @param voiceEnabled Whether AI voice callouts should be enabled.
-     * @param voiceGender Which voice persona should be used for callouts.
-     * @param hiddenMode Whether the countdown should stay hidden while the timer runs.
-     * @param repeatEnabled Whether the timer should automatically loop after each round.
-     * @param vibrationEnabled Whether vibration should fire with the alarm.
+     * @param request Timer options to save.
      * @return The saved timer configuration summary.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun configureRandomTimer(
         appFunctionContext: AppFunctionContext,
-        minSeconds: Int,
-        maxSeconds: Int,
-        @AppFunctionIntValueConstraint(enumValues = [5, 10, 15, 30, 60])
-        alarmDuration: Int = TimerDefaults.ALARM_DURATION_SECONDS,
-        @AppFunctionStringValueConstraint(
-            enumValues = [
-                "INTENSE",
-                "GENTLE",
-                "KLAXON",
-                "WHISTLE",
-                "BUZZER",
-                "GONG",
-                "AIRHORN",
-                "DRUM_ROLL",
-                "SIREN",
-                "BELL",
-            ],
-        )
-        soundType: String,
-        voiceEnabled: Boolean = false,
-        @AppFunctionStringValueConstraint(enumValues = ["MALE", "FEMALE"])
-        voiceGender: String,
-        hiddenMode: Boolean = false,
-        repeatEnabled: Boolean = false,
-        vibrationEnabled: Boolean = false,
-    ): TimerFunctionResult =
-        appFunctionContext.let {
-            handler.configureRandomTimer(
-                request =
-                    timerFunctionRequest(
-                        minSeconds = minSeconds,
-                        maxSeconds = maxSeconds,
-                        alarmDuration = alarmDuration,
-                        soundType = soundType,
-                        voiceEnabled = voiceEnabled,
-                        voiceGender = voiceGender,
-                        hiddenMode = hiddenMode,
-                        repeatEnabled = repeatEnabled,
-                        vibrationEnabled = vibrationEnabled,
-                    ),
-            )
-        }
+        request: TimerFunctionRequest,
+    ): TimerFunctionResult = appFunctionContext.let { handler.configureRandomTimer(request) }
 
     /**
      * Starts a random tactical timer immediately.
      *
-     * @param minSeconds Lowest possible timer duration in seconds.
-     * @param maxSeconds Highest possible timer duration in seconds.
-     * @param alarmDuration Alarm length in seconds after the random countdown completes.
-     * @param soundType Alarm sound to use.
-     * @param voiceEnabled Whether AI voice callouts should be enabled.
-     * @param voiceGender Which voice persona should be used for callouts.
-     * @param hiddenMode Whether the countdown should stay hidden while the timer runs.
-     * @param repeatEnabled Whether the timer should automatically loop after each round.
-     * @param vibrationEnabled Whether vibration should fire with the alarm.
+     * @param request Timer options to start with immediately.
      * @return The started timer summary, including the chosen target duration.
      */
     @AppFunction(isDescribedByKDoc = true)
     suspend fun startRandomTimer(
         appFunctionContext: AppFunctionContext,
-        minSeconds: Int,
-        maxSeconds: Int,
-        @AppFunctionIntValueConstraint(enumValues = [5, 10, 15, 30, 60])
-        alarmDuration: Int = TimerDefaults.ALARM_DURATION_SECONDS,
-        @AppFunctionStringValueConstraint(
-            enumValues = [
-                "INTENSE",
-                "GENTLE",
-                "KLAXON",
-                "WHISTLE",
-                "BUZZER",
-                "GONG",
-                "AIRHORN",
-                "DRUM_ROLL",
-                "SIREN",
-                "BELL",
-            ],
-        )
-        soundType: String,
-        voiceEnabled: Boolean = false,
-        @AppFunctionStringValueConstraint(enumValues = ["MALE", "FEMALE"])
-        voiceGender: String,
-        hiddenMode: Boolean = false,
-        repeatEnabled: Boolean = false,
-        vibrationEnabled: Boolean = false,
-    ): TimerFunctionResult =
-        appFunctionContext.let {
-            handler.startRandomTimer(
-                request =
-                    timerFunctionRequest(
-                        minSeconds = minSeconds,
-                        maxSeconds = maxSeconds,
-                        alarmDuration = alarmDuration,
-                        soundType = soundType,
-                        voiceEnabled = voiceEnabled,
-                        voiceGender = voiceGender,
-                        hiddenMode = hiddenMode,
-                        repeatEnabled = repeatEnabled,
-                        vibrationEnabled = vibrationEnabled,
-                    ),
-            )
-        }
+        request: TimerFunctionRequest,
+    ): TimerFunctionResult = appFunctionContext.let { handler.startRandomTimer(request) }
 
     /**
      * Pauses the currently running timer.
@@ -152,30 +54,3 @@ class RandomTimerAppFunctions(
     @AppFunction(isDescribedByKDoc = true)
     suspend fun stopTimer(appFunctionContext: AppFunctionContext): TimerFunctionResult = appFunctionContext.let { handler.stopTimer() }
 }
-
-private object TimerDefaults {
-    const val ALARM_DURATION_SECONDS = 10
-}
-
-private fun timerFunctionRequest(
-    minSeconds: Int,
-    maxSeconds: Int,
-    alarmDuration: Int,
-    soundType: String,
-    voiceEnabled: Boolean,
-    voiceGender: String,
-    hiddenMode: Boolean,
-    repeatEnabled: Boolean,
-    vibrationEnabled: Boolean,
-): TimerFunctionRequest =
-    TimerFunctionRequest(
-        minSeconds = minSeconds,
-        maxSeconds = maxSeconds,
-        alarmDuration = alarmDuration,
-        soundType = soundType,
-        voiceEnabled = voiceEnabled,
-        voiceGender = voiceGender,
-        hiddenMode = hiddenMode,
-        repeatEnabled = repeatEnabled,
-        vibrationEnabled = vibrationEnabled,
-    )

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
@@ -32,6 +32,7 @@ import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
+import com.iganapolsky.randomtimer.domain.model.VoiceGender
 import com.iganapolsky.randomtimer.notifications.ReengagementScheduler
 import com.iganapolsky.randomtimer.receiver.ScreenOffReceiver
 import com.iganapolsky.randomtimer.review.StoreReviewManager
@@ -134,6 +135,7 @@ class TimerForegroundService : Service() {
                 val vibrationEnabled = intent.getBooleanExtra(EXTRA_VIBRATION_ENABLED, true)
                 val useExtendedRange = intent.getBooleanExtra(EXTRA_USE_EXTENDED_RANGE, false)
                 val voiceEnabled = intent.getBooleanExtra(EXTRA_VOICE_ENABLED, false)
+                val voiceGender = intent.getStringExtra(EXTRA_VOICE_GENDER) ?: VoiceGender.MALE.name
                 val repeatRounds = intent.getIntExtra(EXTRA_REPEAT_ROUNDS, 0)
                 val roundCount = intent.getIntExtra(EXTRA_ROUND_COUNT, 1)
 
@@ -151,6 +153,7 @@ class TimerForegroundService : Service() {
                         vibrationEnabled = vibrationEnabled,
                         useExtendedRange = useExtendedRange,
                         voiceEnabled = voiceEnabled,
+                        voiceGender = voiceGender,
                         repeatRounds = repeatRounds,
                         roundCount = roundCount,
                     )
@@ -237,26 +240,23 @@ class TimerForegroundService : Service() {
         vibrationEnabled: Boolean,
         useExtendedRange: Boolean = false,
         voiceEnabled: Boolean = false,
+        voiceGender: String = VoiceGender.MALE.name,
         repeatRounds: Int = 0,
         roundCount: Int = 1,
     ) {
         val config =
-            TimerConfig(
+            timerConfigFromStartExtras(
                 minSeconds = minSeconds,
                 maxSeconds = maxSeconds,
                 alarmDuration = alarmDuration,
                 hiddenMode = hiddenMode,
                 repeatEnabled = repeatEnabled,
-                soundType =
-                    try {
-                        SoundType.valueOf(soundType)
-                    } catch (_: Exception) {
-                        SoundType.INTENSE
-                    },
+                soundType = soundType,
                 volume = volume,
                 vibrationEnabled = vibrationEnabled,
                 useExtendedRange = useExtendedRange,
                 voiceEnabled = voiceEnabled,
+                voiceGender = voiceGender,
                 repeatRounds = repeatRounds,
             )
 
@@ -1052,6 +1052,7 @@ class TimerForegroundService : Service() {
         const val EXTRA_VIBRATION_ENABLED = "vibration_enabled"
         const val EXTRA_USE_EXTENDED_RANGE = "use_extended_range"
         const val EXTRA_VOICE_ENABLED = "voice_enabled"
+        const val EXTRA_VOICE_GENDER = "voice_gender"
         const val EXTRA_REPEAT_ROUNDS = "repeat_rounds"
         const val EXTRA_ROUND_COUNT = "round_count"
         const val EXTRA_FROM_ALARM_NOTIFICATION = "from_alarm_notification"
@@ -1066,3 +1067,42 @@ class TimerForegroundService : Service() {
         private const val CHANNEL_MEDIA = "timer_media"
     }
 }
+
+internal fun timerConfigFromStartExtras(
+    minSeconds: Int,
+    maxSeconds: Int,
+    alarmDuration: Int,
+    hiddenMode: Boolean,
+    repeatEnabled: Boolean,
+    soundType: String,
+    volume: Float,
+    vibrationEnabled: Boolean,
+    useExtendedRange: Boolean,
+    voiceEnabled: Boolean,
+    voiceGender: String,
+    repeatRounds: Int,
+): TimerConfig =
+    TimerConfig(
+        minSeconds = minSeconds,
+        maxSeconds = maxSeconds,
+        alarmDuration = alarmDuration,
+        hiddenMode = hiddenMode,
+        repeatEnabled = repeatEnabled,
+        soundType =
+            try {
+                SoundType.valueOf(soundType)
+            } catch (_: Exception) {
+                SoundType.INTENSE
+            },
+        volume = volume,
+        vibrationEnabled = vibrationEnabled,
+        useExtendedRange = useExtendedRange,
+        voiceEnabled = voiceEnabled,
+        voiceGender =
+            try {
+                VoiceGender.valueOf(voiceGender)
+            } catch (_: Exception) {
+                VoiceGender.MALE
+            },
+        repeatRounds = repeatRounds,
+    )

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerServiceControllerImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerServiceControllerImpl.kt
@@ -40,6 +40,7 @@ class TimerServiceControllerImpl
                     putExtra(TimerForegroundService.EXTRA_VIBRATION_ENABLED, state.config.vibrationEnabled)
                     putExtra(TimerForegroundService.EXTRA_USE_EXTENDED_RANGE, state.config.useExtendedRange)
                     putExtra(TimerForegroundService.EXTRA_VOICE_ENABLED, state.config.voiceEnabled)
+                    putExtra(TimerForegroundService.EXTRA_VOICE_GENDER, state.config.voiceGender.name)
                     putExtra(TimerForegroundService.EXTRA_REPEAT_ROUNDS, state.config.repeatRounds)
                     putExtra(TimerForegroundService.EXTRA_ROUND_COUNT, state.roundCount)
                 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactoryTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactoryTest.kt
@@ -4,6 +4,7 @@ import androidx.appfunctions.AppFunctionInvalidArgumentException
 import com.google.common.truth.Truth.assertThat
 import com.iganapolsky.randomtimer.domain.model.EntitlementLevel
 import com.iganapolsky.randomtimer.domain.model.SoundType
+import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.VoiceGender
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -15,22 +16,22 @@ import org.robolectric.annotation.Config
 @Config(sdk = [34])
 class RandomTimerAppFunctionConfigFactoryTest {
     private val factory = RandomTimerAppFunctionConfigFactory()
+    private val defaultRequest =
+        TimerFunctionRequest(
+            minSeconds = 15,
+            maxSeconds = 45,
+            alarmDuration = 10,
+            soundType = "INTENSE",
+            voiceEnabled = false,
+            voiceGender = "MALE",
+            hiddenMode = false,
+            repeatEnabled = false,
+            vibrationEnabled = false,
+        )
 
     @Test
-    fun `create returns valid free config for free-safe options`() {
-        val config =
-            factory.create(
-                minSeconds = 15,
-                maxSeconds = 45,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = false,
-                voiceGender = "MALE",
-                hiddenMode = true,
-                repeatEnabled = false,
-                vibrationEnabled = true,
-                entitlementLevel = EntitlementLevel.NONE,
-            )
+    fun createReturnsValidFreeConfigForFreeSafeOptions() {
+        val config = createRequest(defaultRequest.copy(vibrationEnabled = true, hiddenMode = true))
 
         assertThat(config.minSeconds).isEqualTo(15)
         assertThat(config.maxSeconds).isEqualTo(45)
@@ -43,60 +44,33 @@ class RandomTimerAppFunctionConfigFactoryTest {
     }
 
     @Test
-    fun `create rejects pro sound for free entitlement`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 15,
-                    maxSeconds = 45,
-                    alarmDuration = 10,
-                    soundType = "KLAXON",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createRejectsProSoundForFreeEntitlement() {
+        val error = assertInvalidRequest(defaultRequest.copy(soundType = "KLAXON"))
 
         assertThat(error.message).contains("requires Pro")
     }
 
     @Test
-    fun `create rejects voice for free entitlement`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 15,
-                    maxSeconds = 45,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = true,
-                    voiceGender = "FEMALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createRejectsVoiceForFreeEntitlement() {
+        val error = assertInvalidRequest(defaultRequest.copy(voiceEnabled = true, voiceGender = "FEMALE"))
 
         assertThat(error.message).contains("Voice callouts require Pro")
     }
 
     @Test
-    fun `create allows pro-only fields for elite entitlement`() {
+    fun createAllowsProOnlyFieldsForEliteEntitlement() {
         val config =
-            factory.create(
-                minSeconds = 300,
-                maxSeconds = 450,
-                alarmDuration = 15,
-                soundType = "KLAXON",
-                voiceEnabled = true,
-                voiceGender = "FEMALE",
-                hiddenMode = false,
-                repeatEnabled = true,
-                vibrationEnabled = true,
+            createRequest(
+                defaultRequest.copy(
+                    minSeconds = 300,
+                    maxSeconds = 450,
+                    alarmDuration = 15,
+                    soundType = "KLAXON",
+                    voiceEnabled = true,
+                    voiceGender = "FEMALE",
+                    repeatEnabled = true,
+                    vibrationEnabled = true,
+                ),
                 entitlementLevel = EntitlementLevel.ELITE,
             )
 
@@ -108,107 +82,54 @@ class RandomTimerAppFunctionConfigFactoryTest {
     }
 
     @Test
-    fun `create rejects unsupported alarm duration`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 15,
-                    maxSeconds = 45,
-                    alarmDuration = 7,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createRejectsUnsupportedAlarmDuration() {
+        val error = assertInvalidRequest(defaultRequest.copy(alarmDuration = 7))
 
         assertThat(error.message).contains("alarmDuration must be one of")
     }
 
     @Test
-    fun `create rejects extended range for free entitlement`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 60,
-                    maxSeconds = 400,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createRejectsExtendedRangeForFreeEntitlement() {
+        val error = assertInvalidRequest(defaultRequest.copy(minSeconds = 60, maxSeconds = 400))
 
         assertThat(error.message).contains("Extended timer ranges")
     }
 
     @Test
-    fun `create rejects unsupported sound type`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 15,
-                    maxSeconds = 45,
-                    alarmDuration = 10,
-                    soundType = "LOUD",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createRejectsUnsupportedSoundType() {
+        val error = assertInvalidRequest(defaultRequest.copy(soundType = "LOUD"))
 
         assertThat(error.message).contains("soundType must be one of")
     }
 
     @Test
-    fun `create rejects unsupported voice gender`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 15,
-                    maxSeconds = 45,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "ROBOT",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createRejectsUnsupportedVoiceGender() {
+        val error = assertInvalidRequest(defaultRequest.copy(voiceGender = "ROBOT"))
 
         assertThat(error.message).contains("voiceGender must be one of")
     }
 
     @Test
-    fun `create wraps timer config validation failures as invalid arguments`() {
-        val error =
-            assertThrows(AppFunctionInvalidArgumentException::class.java) {
-                factory.create(
-                    minSeconds = 60,
-                    maxSeconds = 45,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                    entitlementLevel = EntitlementLevel.NONE,
-                )
-            }
+    fun createWrapsTimerConfigValidationFailuresAsInvalidArguments() {
+        val error = assertInvalidRequest(defaultRequest.copy(minSeconds = 60, maxSeconds = 45))
 
         assertThat(error.message).contains("Maximum seconds must be >= minimum seconds")
     }
+
+    private fun createRequest(
+        request: TimerFunctionRequest = defaultRequest,
+        entitlementLevel: EntitlementLevel = EntitlementLevel.NONE,
+    ): TimerConfig =
+        factory.create(
+            request = request,
+            entitlementLevel = entitlementLevel,
+        )
+
+    private fun assertInvalidRequest(
+        request: TimerFunctionRequest = defaultRequest,
+        entitlementLevel: EntitlementLevel = EntitlementLevel.NONE,
+    ): AppFunctionInvalidArgumentException =
+        assertThrows(AppFunctionInvalidArgumentException::class.java) {
+            createRequest(request = request, entitlementLevel = entitlementLevel)
+        }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactoryTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionConfigFactoryTest.kt
@@ -1,0 +1,214 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import androidx.appfunctions.AppFunctionInvalidArgumentException
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.domain.model.EntitlementLevel
+import com.iganapolsky.randomtimer.domain.model.SoundType
+import com.iganapolsky.randomtimer.domain.model.VoiceGender
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RandomTimerAppFunctionConfigFactoryTest {
+    private val factory = RandomTimerAppFunctionConfigFactory()
+
+    @Test
+    fun `create returns valid free config for free-safe options`() {
+        val config =
+            factory.create(
+                minSeconds = 15,
+                maxSeconds = 45,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = false,
+                voiceGender = "MALE",
+                hiddenMode = true,
+                repeatEnabled = false,
+                vibrationEnabled = true,
+                entitlementLevel = EntitlementLevel.NONE,
+            )
+
+        assertThat(config.minSeconds).isEqualTo(15)
+        assertThat(config.maxSeconds).isEqualTo(45)
+        assertThat(config.soundType).isEqualTo(SoundType.INTENSE)
+        assertThat(config.voiceEnabled).isFalse()
+        assertThat(config.voiceGender).isEqualTo(VoiceGender.MALE)
+        assertThat(config.useExtendedRange).isFalse()
+        assertThat(config.hiddenMode).isTrue()
+        assertThat(config.vibrationEnabled).isTrue()
+    }
+
+    @Test
+    fun `create rejects pro sound for free entitlement`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 15,
+                    maxSeconds = 45,
+                    alarmDuration = 10,
+                    soundType = "KLAXON",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("requires Pro")
+    }
+
+    @Test
+    fun `create rejects voice for free entitlement`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 15,
+                    maxSeconds = 45,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = true,
+                    voiceGender = "FEMALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("Voice callouts require Pro")
+    }
+
+    @Test
+    fun `create allows pro-only fields for elite entitlement`() {
+        val config =
+            factory.create(
+                minSeconds = 300,
+                maxSeconds = 450,
+                alarmDuration = 15,
+                soundType = "KLAXON",
+                voiceEnabled = true,
+                voiceGender = "FEMALE",
+                hiddenMode = false,
+                repeatEnabled = true,
+                vibrationEnabled = true,
+                entitlementLevel = EntitlementLevel.ELITE,
+            )
+
+        assertThat(config.useExtendedRange).isTrue()
+        assertThat(config.soundType).isEqualTo(SoundType.KLAXON)
+        assertThat(config.voiceEnabled).isTrue()
+        assertThat(config.voiceGender).isEqualTo(VoiceGender.FEMALE)
+        assertThat(config.repeatEnabled).isTrue()
+    }
+
+    @Test
+    fun `create rejects unsupported alarm duration`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 15,
+                    maxSeconds = 45,
+                    alarmDuration = 7,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("alarmDuration must be one of")
+    }
+
+    @Test
+    fun `create rejects extended range for free entitlement`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 60,
+                    maxSeconds = 400,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("Extended timer ranges")
+    }
+
+    @Test
+    fun `create rejects unsupported sound type`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 15,
+                    maxSeconds = 45,
+                    alarmDuration = 10,
+                    soundType = "LOUD",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("soundType must be one of")
+    }
+
+    @Test
+    fun `create rejects unsupported voice gender`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 15,
+                    maxSeconds = 45,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "ROBOT",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("voiceGender must be one of")
+    }
+
+    @Test
+    fun `create wraps timer config validation failures as invalid arguments`() {
+        val error =
+            assertThrows(AppFunctionInvalidArgumentException::class.java) {
+                factory.create(
+                    minSeconds = 60,
+                    maxSeconds = 45,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                    entitlementLevel = EntitlementLevel.NONE,
+                )
+            }
+
+        assertThat(error.message).contains("Maximum seconds must be >= minimum seconds")
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandlerTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandlerTest.kt
@@ -53,122 +53,128 @@ class RandomTimerAppFunctionHandlerTest {
     }
 
     @Test
-    fun `configureRandomTimer saves config and tracks settings`() = runBlocking {
-        val result =
-            handler.configureRandomTimer(
-                minSeconds = 20,
-                maxSeconds = 40,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = true,
-                voiceGender = "FEMALE",
-                hiddenMode = true,
-                repeatEnabled = false,
-                vibrationEnabled = true,
-            )
+    fun `configureRandomTimer saves config and tracks settings`() =
+        runBlocking {
+            val result =
+                handler.configureRandomTimer(
+                    minSeconds = 20,
+                    maxSeconds = 40,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = true,
+                    voiceGender = "FEMALE",
+                    hiddenMode = true,
+                    repeatEnabled = false,
+                    vibrationEnabled = true,
+                )
 
-        assertThat(result.status).isEqualTo("configured")
-        assertThat(repository.savedConfig.voiceGender).isEqualTo(VoiceGender.FEMALE)
-        assertThat(repository.savedConfig.voiceEnabled).isTrue()
-        verify {
-            analyticsService.track(
-                AnalyticsEvents.SETTINGS_CHANGED,
-                match {
-                    it["entry_point"] == "app_function" &&
-                        it["voice_gender"] == "FEMALE" &&
-                        it["voice_callouts_enabled"] == true
-                },
-            )
+            assertThat(result.status).isEqualTo("configured")
+            assertThat(repository.savedConfig.voiceGender).isEqualTo(VoiceGender.FEMALE)
+            assertThat(repository.savedConfig.voiceEnabled).isTrue()
+            verify {
+                analyticsService.track(
+                    AnalyticsEvents.SETTINGS_CHANGED,
+                    match {
+                        it["entry_point"] == "app_function" &&
+                            it["voice_gender"] == "FEMALE" &&
+                            it["voice_callouts_enabled"] == true
+                    },
+                )
+            }
         }
-    }
 
     @Test
-    fun `startRandomTimer persists state starts service and tracks analytics`() = runBlocking {
-        val stateSlot = slot<TimerState>()
+    fun `startRandomTimer persists state starts service and tracks analytics`() =
+        runBlocking {
+            val stateSlot = slot<TimerState>()
 
-        val result =
-            handler.startRandomTimer(
-                minSeconds = 25,
-                maxSeconds = 25,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = true,
-                voiceGender = "FEMALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = false,
-            )
+            val result =
+                handler.startRandomTimer(
+                    minSeconds = 25,
+                    maxSeconds = 25,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = true,
+                    voiceGender = "FEMALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                )
 
-        verify { serviceController.startTimer(capture(stateSlot)) }
-        assertThat(stateSlot.captured.config.voiceGender).isEqualTo(VoiceGender.FEMALE)
-        assertThat(stateSlot.captured.targetDuration.inWholeSeconds).isEqualTo(25)
-        assertThat(repository.activeTimer?.config?.voiceGender).isEqualTo(VoiceGender.FEMALE)
-        assertThat(result.status).isEqualTo("running")
-        assertThat(result.targetDurationSeconds).isEqualTo(25)
-        verify {
-            analyticsService.track(
-                AnalyticsEvents.TIMER_STARTED,
-                match {
-                    it["entry_point"] == "app_function" &&
-                        it["target_duration"] == 25L
-                },
-            )
+            verify { serviceController.startTimer(capture(stateSlot)) }
+            assertThat(stateSlot.captured.config.voiceGender).isEqualTo(VoiceGender.FEMALE)
+            assertThat(stateSlot.captured.targetDuration.inWholeSeconds).isEqualTo(25)
+            assertThat(repository.activeTimer?.config?.voiceGender).isEqualTo(VoiceGender.FEMALE)
+            assertThat(result.status).isEqualTo("running")
+            assertThat(result.targetDurationSeconds).isEqualTo(25)
+            verify {
+                analyticsService.track(
+                    AnalyticsEvents.TIMER_STARTED,
+                    match {
+                        it["entry_point"] == "app_function" &&
+                            it["target_duration"] == 25L
+                    },
+                )
+            }
         }
-    }
 
     @Test
-    fun `pause resume and stop act on active timer`() = runBlocking {
-        repository.savedConfig = TimerConfig.DEFAULT.copy(voiceGender = VoiceGender.FEMALE)
-        repository.activeTimer =
-            TimerState(
-                config = repository.savedConfig,
-                targetDuration = 30.seconds,
-                remainingDuration = 12.seconds,
-                status = TimerStatus.RUNNING,
-            )
+    fun `pause resume and stop act on active timer`() =
+        runBlocking {
+            repository.savedConfig = TimerConfig.DEFAULT.copy(voiceGender = VoiceGender.FEMALE)
+            repository.activeTimer =
+                TimerState(
+                    config = repository.savedConfig,
+                    targetDuration = 30.seconds,
+                    remainingDuration = 12.seconds,
+                    status = TimerStatus.RUNNING,
+                )
 
-        val pauseResult = handler.pauseTimer()
-        val resumeResult = handler.resumeTimer()
-        val stopResult = handler.stopTimer()
+            val pauseResult = handler.pauseTimer()
+            val resumeResult = handler.resumeTimer()
+            val stopResult = handler.stopTimer()
 
-        assertThat(pauseResult.status).isEqualTo("paused")
-        assertThat(resumeResult.status).isEqualTo("running")
-        assertThat(stopResult.status).isEqualTo("stopped")
-        assertThat(repository.activeTimer).isNull()
-        verify { serviceController.pauseTimer() }
-        verify { serviceController.resumeTimer() }
-        verify { serviceController.stopTimer() }
-    }
-
-    @Test
-    fun `pauseTimer returns idle result when no active timer exists`() = runBlocking {
-        repository.activeTimer = null
-
-        val result = handler.pauseTimer()
-
-        assertThat(result.status).isEqualTo("idle")
-        assertThat(result.message).contains("No active timer")
-    }
+            assertThat(pauseResult.status).isEqualTo("paused")
+            assertThat(resumeResult.status).isEqualTo("running")
+            assertThat(stopResult.status).isEqualTo("stopped")
+            assertThat(repository.activeTimer).isNull()
+            verify { serviceController.pauseTimer() }
+            verify { serviceController.resumeTimer() }
+            verify { serviceController.stopTimer() }
+        }
 
     @Test
-    fun `resumeTimer returns idle result when no active timer exists`() = runBlocking {
-        repository.activeTimer = null
+    fun `pauseTimer returns idle result when no active timer exists`() =
+        runBlocking {
+            repository.activeTimer = null
 
-        val result = handler.resumeTimer()
+            val result = handler.pauseTimer()
 
-        assertThat(result.status).isEqualTo("idle")
-        assertThat(result.message).contains("No active timer")
-    }
+            assertThat(result.status).isEqualTo("idle")
+            assertThat(result.message).contains("No active timer")
+        }
 
     @Test
-    fun `stopTimer returns idle result when no active timer exists`() = runBlocking {
-        repository.activeTimer = null
+    fun `resumeTimer returns idle result when no active timer exists`() =
+        runBlocking {
+            repository.activeTimer = null
 
-        val result = handler.stopTimer()
+            val result = handler.resumeTimer()
 
-        assertThat(result.status).isEqualTo("idle")
-        assertThat(result.message).contains("No active timer")
-    }
+            assertThat(result.status).isEqualTo("idle")
+            assertThat(result.message).contains("No active timer")
+        }
+
+    @Test
+    fun `stopTimer returns idle result when no active timer exists`() =
+        runBlocking {
+            repository.activeTimer = null
+
+            val result = handler.stopTimer()
+
+            assertThat(result.status).isEqualTo("idle")
+            assertThat(result.message).contains("No active timer")
+        }
 
     private class FakeTimerRepository : TimerRepository {
         var savedConfig: TimerConfig = TimerConfig.DEFAULT

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandlerTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandlerTest.kt
@@ -1,0 +1,193 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.analytics.AnalyticsEvents
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
+import com.iganapolsky.randomtimer.billing.ProManager
+import com.iganapolsky.randomtimer.domain.model.EntitlementLevel
+import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.TimerState
+import com.iganapolsky.randomtimer.domain.model.TimerStatus
+import com.iganapolsky.randomtimer.domain.model.VoiceGender
+import com.iganapolsky.randomtimer.domain.repository.TimerRepository
+import com.iganapolsky.randomtimer.domain.usecase.StartTimerUseCase
+import com.iganapolsky.randomtimer.service.TimerServiceController
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
+
+class RandomTimerAppFunctionHandlerTest {
+    private lateinit var repository: FakeTimerRepository
+    private lateinit var serviceController: TimerServiceController
+    private lateinit var analyticsService: AnalyticsService
+    private lateinit var proManager: ProManager
+    private lateinit var handler: RandomTimerAppFunctionHandler
+
+    @Before
+    fun setUp() {
+        repository = FakeTimerRepository()
+        serviceController = mockk(relaxed = true)
+        analyticsService = mockk(relaxed = true)
+        proManager = mockk(relaxed = true)
+        io.mockk.every { proManager.entitlementLevel } returns MutableStateFlow(EntitlementLevel.ELITE)
+        io.mockk.every { analyticsService.trackFirstTimerConfiguredIfNeeded() } just runs
+
+        handler =
+            RandomTimerAppFunctionHandler(
+                startTimerUseCase = StartTimerUseCase(repository, Random(1)),
+                repository = repository,
+                serviceController = serviceController,
+                analyticsService = analyticsService,
+                proManager = proManager,
+                configFactory = RandomTimerAppFunctionConfigFactory(),
+            )
+    }
+
+    @Test
+    fun `configureRandomTimer saves config and tracks settings`() = runBlocking {
+        val result =
+            handler.configureRandomTimer(
+                minSeconds = 20,
+                maxSeconds = 40,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = true,
+                voiceGender = "FEMALE",
+                hiddenMode = true,
+                repeatEnabled = false,
+                vibrationEnabled = true,
+            )
+
+        assertThat(result.status).isEqualTo("configured")
+        assertThat(repository.savedConfig.voiceGender).isEqualTo(VoiceGender.FEMALE)
+        assertThat(repository.savedConfig.voiceEnabled).isTrue()
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.SETTINGS_CHANGED,
+                match {
+                    it["entry_point"] == "app_function" &&
+                        it["voice_gender"] == "FEMALE" &&
+                        it["voice_callouts_enabled"] == true
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `startRandomTimer persists state starts service and tracks analytics`() = runBlocking {
+        val stateSlot = slot<TimerState>()
+
+        val result =
+            handler.startRandomTimer(
+                minSeconds = 25,
+                maxSeconds = 25,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = true,
+                voiceGender = "FEMALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = false,
+            )
+
+        verify { serviceController.startTimer(capture(stateSlot)) }
+        assertThat(stateSlot.captured.config.voiceGender).isEqualTo(VoiceGender.FEMALE)
+        assertThat(stateSlot.captured.targetDuration.inWholeSeconds).isEqualTo(25)
+        assertThat(repository.activeTimer?.config?.voiceGender).isEqualTo(VoiceGender.FEMALE)
+        assertThat(result.status).isEqualTo("running")
+        assertThat(result.targetDurationSeconds).isEqualTo(25)
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.TIMER_STARTED,
+                match {
+                    it["entry_point"] == "app_function" &&
+                        it["target_duration"] == 25L
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `pause resume and stop act on active timer`() = runBlocking {
+        repository.savedConfig = TimerConfig.DEFAULT.copy(voiceGender = VoiceGender.FEMALE)
+        repository.activeTimer =
+            TimerState(
+                config = repository.savedConfig,
+                targetDuration = 30.seconds,
+                remainingDuration = 12.seconds,
+                status = TimerStatus.RUNNING,
+            )
+
+        val pauseResult = handler.pauseTimer()
+        val resumeResult = handler.resumeTimer()
+        val stopResult = handler.stopTimer()
+
+        assertThat(pauseResult.status).isEqualTo("paused")
+        assertThat(resumeResult.status).isEqualTo("running")
+        assertThat(stopResult.status).isEqualTo("stopped")
+        assertThat(repository.activeTimer).isNull()
+        verify { serviceController.pauseTimer() }
+        verify { serviceController.resumeTimer() }
+        verify { serviceController.stopTimer() }
+    }
+
+    @Test
+    fun `pauseTimer returns idle result when no active timer exists`() = runBlocking {
+        repository.activeTimer = null
+
+        val result = handler.pauseTimer()
+
+        assertThat(result.status).isEqualTo("idle")
+        assertThat(result.message).contains("No active timer")
+    }
+
+    @Test
+    fun `resumeTimer returns idle result when no active timer exists`() = runBlocking {
+        repository.activeTimer = null
+
+        val result = handler.resumeTimer()
+
+        assertThat(result.status).isEqualTo("idle")
+        assertThat(result.message).contains("No active timer")
+    }
+
+    @Test
+    fun `stopTimer returns idle result when no active timer exists`() = runBlocking {
+        repository.activeTimer = null
+
+        val result = handler.stopTimer()
+
+        assertThat(result.status).isEqualTo("idle")
+        assertThat(result.message).contains("No active timer")
+    }
+
+    private class FakeTimerRepository : TimerRepository {
+        var savedConfig: TimerConfig = TimerConfig.DEFAULT
+        var activeTimer: TimerState? = null
+
+        override fun getTimerConfig() = flowOf(savedConfig)
+
+        override suspend fun saveTimerConfig(config: TimerConfig) {
+            savedConfig = config
+        }
+
+        override fun getActiveTimer() = flowOf(activeTimer)
+
+        override suspend fun saveActiveTimer(state: TimerState) {
+            activeTimer = state
+        }
+
+        override suspend fun clearActiveTimer() {
+            activeTimer = null
+        }
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandlerTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionHandlerTest.kt
@@ -31,6 +31,18 @@ class RandomTimerAppFunctionHandlerTest {
     private lateinit var analyticsService: AnalyticsService
     private lateinit var proManager: ProManager
     private lateinit var handler: RandomTimerAppFunctionHandler
+    private val defaultRequest =
+        TimerFunctionRequest(
+            minSeconds = 20,
+            maxSeconds = 40,
+            alarmDuration = 10,
+            soundType = "INTENSE",
+            voiceEnabled = false,
+            voiceGender = "MALE",
+            hiddenMode = false,
+            repeatEnabled = false,
+            vibrationEnabled = false,
+        )
 
     @Before
     fun setUp() {
@@ -53,19 +65,16 @@ class RandomTimerAppFunctionHandlerTest {
     }
 
     @Test
-    fun `configureRandomTimer saves config and tracks settings`() =
+    fun configureRandomTimerSavesConfigAndTracksSettings() =
         runBlocking {
             val result =
                 handler.configureRandomTimer(
-                    minSeconds = 20,
-                    maxSeconds = 40,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = true,
-                    voiceGender = "FEMALE",
-                    hiddenMode = true,
-                    repeatEnabled = false,
-                    vibrationEnabled = true,
+                    defaultRequest.copy(
+                        voiceEnabled = true,
+                        voiceGender = "FEMALE",
+                        hiddenMode = true,
+                        vibrationEnabled = true,
+                    ),
                 )
 
             assertThat(result.status).isEqualTo("configured")
@@ -84,21 +93,18 @@ class RandomTimerAppFunctionHandlerTest {
         }
 
     @Test
-    fun `startRandomTimer persists state starts service and tracks analytics`() =
+    fun startRandomTimerPersistsStateStartsServiceAndTracksAnalytics() =
         runBlocking {
             val stateSlot = slot<TimerState>()
 
             val result =
                 handler.startRandomTimer(
-                    minSeconds = 25,
-                    maxSeconds = 25,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = true,
-                    voiceGender = "FEMALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
+                    defaultRequest.copy(
+                        minSeconds = 25,
+                        maxSeconds = 25,
+                        voiceEnabled = true,
+                        voiceGender = "FEMALE",
+                    ),
                 )
 
             verify { serviceController.startTimer(capture(stateSlot)) }
@@ -119,7 +125,7 @@ class RandomTimerAppFunctionHandlerTest {
         }
 
     @Test
-    fun `pause resume and stop act on active timer`() =
+    fun pauseResumeAndStopActOnActiveTimer() =
         runBlocking {
             repository.savedConfig = TimerConfig.DEFAULT.copy(voiceGender = VoiceGender.FEMALE)
             repository.activeTimer =
@@ -144,37 +150,22 @@ class RandomTimerAppFunctionHandlerTest {
         }
 
     @Test
-    fun `pauseTimer returns idle result when no active timer exists`() =
+    fun lifecycleActionsReturnIdleResultWhenNoActiveTimerExists() =
         runBlocking {
             repository.activeTimer = null
 
-            val result = handler.pauseTimer()
-
-            assertThat(result.status).isEqualTo("idle")
-            assertThat(result.message).contains("No active timer")
+            assertIdleResult(verb = "pause", result = handler.pauseTimer())
+            assertIdleResult(verb = "resume", result = handler.resumeTimer())
+            assertIdleResult(verb = "stop", result = handler.stopTimer())
         }
 
-    @Test
-    fun `resumeTimer returns idle result when no active timer exists`() =
-        runBlocking {
-            repository.activeTimer = null
-
-            val result = handler.resumeTimer()
-
-            assertThat(result.status).isEqualTo("idle")
-            assertThat(result.message).contains("No active timer")
-        }
-
-    @Test
-    fun `stopTimer returns idle result when no active timer exists`() =
-        runBlocking {
-            repository.activeTimer = null
-
-            val result = handler.stopTimer()
-
-            assertThat(result.status).isEqualTo("idle")
-            assertThat(result.message).contains("No active timer")
-        }
+    private fun assertIdleResult(
+        verb: String,
+        result: TimerFunctionResult,
+    ) {
+        assertThat(result.status).isEqualTo("idle")
+        assertThat(result.message).isEqualTo("No active timer to $verb.")
+    }
 
     private class FakeTimerRepository : TimerRepository {
         var savedConfig: TimerConfig = TimerConfig.DEFAULT

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsE2ETest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsE2ETest.kt
@@ -1,11 +1,11 @@
 package com.iganapolsky.randomtimer.appfunctions
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.appfunctions.AppFunctionData
 import androidx.appfunctions.AppFunctionSearchSpec
 import androidx.appfunctions.ExecuteAppFunctionRequest
 import androidx.appfunctions.ExecuteAppFunctionResponse
 import androidx.appfunctions.testing.AppFunctionTestRule
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.iganapolsky.randomtimer.RandomTimerApp
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,53 +27,54 @@ class RandomTimerAppFunctionsE2ETest {
     val appFunctionTestRule = AppFunctionTestRule(context)
 
     @Test
-    fun `startRandomTimer is discoverable and executable through app functions manager`() = runTest {
-        val manager = appFunctionTestRule.getAppFunctionManager()
-        val packageMetadata =
-            manager
-                .observeAppFunctions(
-                    AppFunctionSearchSpec(
-                        packageNames = setOf(context.packageName),
-                    ),
-                ).first()
-                .single { metadata -> metadata.packageName == context.packageName }
+    fun `startRandomTimer is discoverable and executable through app functions manager`() =
+        runTest {
+            val manager = appFunctionTestRule.getAppFunctionManager()
+            val packageMetadata =
+                manager
+                    .observeAppFunctions(
+                        AppFunctionSearchSpec(
+                            packageNames = setOf(context.packageName),
+                        ),
+                    ).first()
+                    .single { metadata -> metadata.packageName == context.packageName }
 
-        val functionMetadata =
-            packageMetadata.appFunctions.single { metadata ->
-                metadata.id == RandomTimerAppFunctionsIds.START_RANDOM_TIMER_ID
-            }
+            val functionMetadata =
+                packageMetadata.appFunctions.single { metadata ->
+                    metadata.id == RandomTimerAppFunctionsIds.START_RANDOM_TIMER_ID
+                }
 
-        val request =
-            ExecuteAppFunctionRequest(
-                targetPackageName = context.packageName,
-                functionIdentifier = functionMetadata.id,
-                functionParameters =
-                    AppFunctionData
-                        .Builder(functionMetadata.parameters, functionMetadata.components)
-                        .setInt("minSeconds", 20)
-                        .setInt("maxSeconds", 20)
-                        .setInt("alarmDuration", 10)
-                        .setString("soundType", "INTENSE")
-                        .setBoolean("voiceEnabled", false)
-                        .setString("voiceGender", "MALE")
-                        .setBoolean("hiddenMode", false)
-                        .setBoolean("repeatEnabled", false)
-                        .setBoolean("vibrationEnabled", false)
-                        .build(),
-            )
+            val request =
+                ExecuteAppFunctionRequest(
+                    targetPackageName = context.packageName,
+                    functionIdentifier = functionMetadata.id,
+                    functionParameters =
+                        AppFunctionData
+                            .Builder(functionMetadata.parameters, functionMetadata.components)
+                            .setInt("minSeconds", 20)
+                            .setInt("maxSeconds", 20)
+                            .setInt("alarmDuration", 10)
+                            .setString("soundType", "INTENSE")
+                            .setBoolean("voiceEnabled", false)
+                            .setString("voiceGender", "MALE")
+                            .setBoolean("hiddenMode", false)
+                            .setBoolean("repeatEnabled", false)
+                            .setBoolean("vibrationEnabled", false)
+                            .build(),
+                )
 
-        val response = manager.executeAppFunction(request)
+            val response = manager.executeAppFunction(request)
 
-        assertThat(response).isInstanceOf(ExecuteAppFunctionResponse.Success::class.java)
-        val payload =
-            (response as ExecuteAppFunctionResponse.Success)
-                .returnValue
-                .getAppFunctionData(ExecuteAppFunctionResponse.Success.PROPERTY_RETURN_VALUE)
-        checkNotNull(payload)
-        assertThat(payload.getString("action")).isEqualTo("start_random_timer")
-        assertThat(payload.getString("status")).isEqualTo("running")
-        assertThat(payload.getInt("minSeconds")).isEqualTo(20)
-        assertThat(payload.getInt("targetDurationSeconds")).isEqualTo(20)
-        assertThat(payload.getString("soundType")).isEqualTo("INTENSE")
-    }
+            assertThat(response).isInstanceOf(ExecuteAppFunctionResponse.Success::class.java)
+            val payload =
+                (response as ExecuteAppFunctionResponse.Success)
+                    .returnValue
+                    .getAppFunctionData(ExecuteAppFunctionResponse.Success.PROPERTY_RETURN_VALUE)
+            checkNotNull(payload)
+            assertThat(payload.getString("action")).isEqualTo("start_random_timer")
+            assertThat(payload.getString("status")).isEqualTo("running")
+            assertThat(payload.getInt("minSeconds")).isEqualTo(20)
+            assertThat(payload.getInt("targetDurationSeconds")).isEqualTo(20)
+            assertThat(payload.getString("soundType")).isEqualTo("INTENSE")
+        }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsE2ETest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsE2ETest.kt
@@ -1,0 +1,79 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.appfunctions.AppFunctionData
+import androidx.appfunctions.AppFunctionSearchSpec
+import androidx.appfunctions.ExecuteAppFunctionRequest
+import androidx.appfunctions.ExecuteAppFunctionResponse
+import androidx.appfunctions.testing.AppFunctionTestRule
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.RandomTimerApp
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RandomTimerApp::class, sdk = [34])
+class RandomTimerAppFunctionsE2ETest {
+    private val context = ApplicationProvider.getApplicationContext<RandomTimerApp>()
+
+    @get:Rule
+    val appFunctionTestRule = AppFunctionTestRule(context)
+
+    @Test
+    fun `startRandomTimer is discoverable and executable through app functions manager`() = runTest {
+        val manager = appFunctionTestRule.getAppFunctionManager()
+        val packageMetadata =
+            manager
+                .observeAppFunctions(
+                    AppFunctionSearchSpec(
+                        packageNames = setOf(context.packageName),
+                    ),
+                ).first()
+                .single { metadata -> metadata.packageName == context.packageName }
+
+        val functionMetadata =
+            packageMetadata.appFunctions.single { metadata ->
+                metadata.id == RandomTimerAppFunctionsIds.START_RANDOM_TIMER_ID
+            }
+
+        val request =
+            ExecuteAppFunctionRequest(
+                targetPackageName = context.packageName,
+                functionIdentifier = functionMetadata.id,
+                functionParameters =
+                    AppFunctionData
+                        .Builder(functionMetadata.parameters, functionMetadata.components)
+                        .setInt("minSeconds", 20)
+                        .setInt("maxSeconds", 20)
+                        .setInt("alarmDuration", 10)
+                        .setString("soundType", "INTENSE")
+                        .setBoolean("voiceEnabled", false)
+                        .setString("voiceGender", "MALE")
+                        .setBoolean("hiddenMode", false)
+                        .setBoolean("repeatEnabled", false)
+                        .setBoolean("vibrationEnabled", false)
+                        .build(),
+            )
+
+        val response = manager.executeAppFunction(request)
+
+        assertThat(response).isInstanceOf(ExecuteAppFunctionResponse.Success::class.java)
+        val payload =
+            (response as ExecuteAppFunctionResponse.Success)
+                .returnValue
+                .getAppFunctionData(ExecuteAppFunctionResponse.Success.PROPERTY_RETURN_VALUE)
+        checkNotNull(payload)
+        assertThat(payload.getString("action")).isEqualTo("start_random_timer")
+        assertThat(payload.getString("status")).isEqualTo("running")
+        assertThat(payload.getInt("minSeconds")).isEqualTo(20)
+        assertThat(payload.getInt("targetDurationSeconds")).isEqualTo(20)
+        assertThat(payload.getString("soundType")).isEqualTo("INTENSE")
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsE2ETest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsE2ETest.kt
@@ -51,16 +51,23 @@ class RandomTimerAppFunctionsE2ETest {
                     functionParameters =
                         AppFunctionData
                             .Builder(functionMetadata.parameters, functionMetadata.components)
-                            .setInt("minSeconds", 20)
-                            .setInt("maxSeconds", 20)
-                            .setInt("alarmDuration", 10)
-                            .setString("soundType", "INTENSE")
-                            .setBoolean("voiceEnabled", false)
-                            .setString("voiceGender", "MALE")
-                            .setBoolean("hiddenMode", false)
-                            .setBoolean("repeatEnabled", false)
-                            .setBoolean("vibrationEnabled", false)
-                            .build(),
+                            .setAppFunctionData(
+                                "request",
+                                AppFunctionData.serialize(
+                                    TimerFunctionRequest(
+                                        minSeconds = 20,
+                                        maxSeconds = 20,
+                                        alarmDuration = 10,
+                                        soundType = "INTENSE",
+                                        voiceEnabled = false,
+                                        voiceGender = "MALE",
+                                        hiddenMode = false,
+                                        repeatEnabled = false,
+                                        vibrationEnabled = false,
+                                    ),
+                                    TimerFunctionRequest::class.java,
+                                ),
+                            ).build(),
                 )
 
             val response = manager.executeAppFunction(request)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
@@ -13,6 +13,18 @@ class RandomTimerAppFunctionsTest {
     private lateinit var handler: RandomTimerAppFunctionHandler
     private lateinit var functions: RandomTimerAppFunctions
     private val appFunctionContext = mockk<AppFunctionContext>(relaxed = true)
+    private val defaultRequest =
+        TimerFunctionRequest(
+            minSeconds = 10,
+            maxSeconds = 20,
+            alarmDuration = 10,
+            soundType = "INTENSE",
+            voiceEnabled = false,
+            voiceGender = "MALE",
+            hiddenMode = false,
+            repeatEnabled = false,
+            vibrationEnabled = false,
+        )
 
     @Before
     fun setUp() {
@@ -21,226 +33,167 @@ class RandomTimerAppFunctionsTest {
     }
 
     @Test
-    fun `configureRandomTimer delegates to handler`() =
+    fun configureRandomTimerDelegatesToHandler() =
         runBlocking {
+            val request = defaultRequest.copy(voiceEnabled = true, voiceGender = "FEMALE", vibrationEnabled = true)
             val expected =
-                TimerFunctionResult(
+                timerResult(
                     action = "configure_random_timer",
                     status = "configured",
                     message = "Saved timer configuration.",
-                    entitlementLevel = "elite",
-                    soundType = "INTENSE",
                     voiceGender = "FEMALE",
                 )
-            coEvery {
-                handler.configureRandomTimer(
-                    minSeconds = 10,
-                    maxSeconds = 20,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = true,
-                    voiceGender = "FEMALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = true,
-                )
-            } returns expected
+
+            coEvery { handler.configureRandomTimer(request) } returns expected
 
             val result =
                 functions.configureRandomTimer(
                     appFunctionContext = appFunctionContext,
-                    minSeconds = 10,
-                    maxSeconds = 20,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = true,
-                    voiceGender = "FEMALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = true,
+                    minSeconds = request.minSeconds,
+                    maxSeconds = request.maxSeconds,
+                    alarmDuration = request.alarmDuration,
+                    soundType = request.soundType,
+                    voiceEnabled = request.voiceEnabled,
+                    voiceGender = request.voiceGender,
+                    hiddenMode = request.hiddenMode,
+                    repeatEnabled = request.repeatEnabled,
+                    vibrationEnabled = request.vibrationEnabled,
                 )
 
             assertThat(result).isEqualTo(expected)
         }
 
     @Test
-    fun `startRandomTimer delegates to handler`() =
+    fun startRandomTimerDelegatesToHandler() =
         runBlocking {
+            val request = defaultRequest.copy(minSeconds = 20, maxSeconds = 20)
             val expected =
-                TimerFunctionResult(
+                timerResult(
                     action = "start_random_timer",
                     status = "running",
                     message = "Started random timer.",
-                    entitlementLevel = "elite",
                     targetDurationSeconds = 20,
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
                 )
-            coEvery {
-                handler.startRandomTimer(
-                    minSeconds = 20,
-                    maxSeconds = 20,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                )
-            } returns expected
+
+            coEvery { handler.startRandomTimer(request) } returns expected
 
             val result =
                 functions.startRandomTimer(
                     appFunctionContext = appFunctionContext,
-                    minSeconds = 20,
-                    maxSeconds = 20,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
+                    minSeconds = request.minSeconds,
+                    maxSeconds = request.maxSeconds,
+                    alarmDuration = request.alarmDuration,
+                    soundType = request.soundType,
+                    voiceEnabled = request.voiceEnabled,
+                    voiceGender = request.voiceGender,
+                    hiddenMode = request.hiddenMode,
+                    repeatEnabled = request.repeatEnabled,
+                    vibrationEnabled = request.vibrationEnabled,
                 )
 
             assertThat(result).isEqualTo(expected)
         }
 
     @Test
-    fun `configureRandomTimer applies default alarm duration when omitted`() =
+    fun configureRandomTimerAppliesDefaultAlarmDurationWhenOmitted() =
         runBlocking {
-            val expected =
-                TimerFunctionResult(
-                    action = "configure_random_timer",
-                    status = "configured",
-                    message = "Saved timer configuration.",
-                    entitlementLevel = "elite",
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
-                )
-            coEvery {
-                handler.configureRandomTimer(
-                    minSeconds = 10,
-                    maxSeconds = 20,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                )
-            } returns expected
+            val request = defaultRequest
+            val expected = timerResult(action = "configure_random_timer", status = "configured", message = "Saved timer configuration.")
+
+            coEvery { handler.configureRandomTimer(request) } returns expected
 
             val result =
                 functions.configureRandomTimer(
                     appFunctionContext = appFunctionContext,
-                    minSeconds = 10,
-                    maxSeconds = 20,
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
+                    minSeconds = request.minSeconds,
+                    maxSeconds = request.maxSeconds,
+                    soundType = request.soundType,
+                    voiceGender = request.voiceGender,
                 )
 
             assertThat(result).isEqualTo(expected)
         }
 
     @Test
-    fun `startRandomTimer applies default alarm duration when omitted`() =
+    fun startRandomTimerAppliesDefaultAlarmDurationWhenOmitted() =
         runBlocking {
+            val request = defaultRequest.copy(minSeconds = 20, maxSeconds = 20)
             val expected =
-                TimerFunctionResult(
+                timerResult(
                     action = "start_random_timer",
                     status = "running",
                     message = "Started random timer.",
-                    entitlementLevel = "elite",
                     targetDurationSeconds = 20,
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
                 )
-            coEvery {
-                handler.startRandomTimer(
-                    minSeconds = 20,
-                    maxSeconds = 20,
-                    alarmDuration = 10,
-                    soundType = "INTENSE",
-                    voiceEnabled = false,
-                    voiceGender = "MALE",
-                    hiddenMode = false,
-                    repeatEnabled = false,
-                    vibrationEnabled = false,
-                )
-            } returns expected
+
+            coEvery { handler.startRandomTimer(request) } returns expected
 
             val result =
                 functions.startRandomTimer(
                     appFunctionContext = appFunctionContext,
-                    minSeconds = 20,
-                    maxSeconds = 20,
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
+                    minSeconds = request.minSeconds,
+                    maxSeconds = request.maxSeconds,
+                    soundType = request.soundType,
+                    voiceGender = request.voiceGender,
                 )
 
             assertThat(result).isEqualTo(expected)
         }
 
     @Test
-    fun `pauseTimer delegates to handler`() =
-        runBlocking {
-            val expected =
-                TimerFunctionResult(
-                    action = "pause_timer",
-                    status = "paused",
-                    message = "Paused active timer.",
-                    entitlementLevel = "elite",
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
-                )
-            coEvery { handler.pauseTimer() } returns expected
-
-            val result = functions.pauseTimer(appFunctionContext)
-
-            assertThat(result).isEqualTo(expected)
-            coVerify(exactly = 1) { handler.pauseTimer() }
-        }
+    fun pauseTimerDelegatesToHandler() =
+        assertLifecycleDelegation(
+            expected = timerResult(action = "pause_timer", status = "paused", message = "Paused active timer."),
+            callHandler = { handler.pauseTimer() },
+            callFunction = { functions.pauseTimer(appFunctionContext) },
+            verifyHandler = { coVerify(exactly = 1) { handler.pauseTimer() } },
+        )
 
     @Test
-    fun `resumeTimer delegates to handler`() =
-        runBlocking {
-            val expected =
-                TimerFunctionResult(
-                    action = "resume_timer",
-                    status = "running",
-                    message = "Resumed active timer.",
-                    entitlementLevel = "elite",
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
-                )
-            coEvery { handler.resumeTimer() } returns expected
-
-            val result = functions.resumeTimer(appFunctionContext)
-
-            assertThat(result).isEqualTo(expected)
-            coVerify(exactly = 1) { handler.resumeTimer() }
-        }
+    fun resumeTimerDelegatesToHandler() =
+        assertLifecycleDelegation(
+            expected = timerResult(action = "resume_timer", status = "running", message = "Resumed active timer."),
+            callHandler = { handler.resumeTimer() },
+            callFunction = { functions.resumeTimer(appFunctionContext) },
+            verifyHandler = { coVerify(exactly = 1) { handler.resumeTimer() } },
+        )
 
     @Test
-    fun `stopTimer delegates to handler`() =
-        runBlocking {
-            val expected =
-                TimerFunctionResult(
-                    action = "stop_timer",
-                    status = "stopped",
-                    message = "Stopped active timer.",
-                    entitlementLevel = "elite",
-                    soundType = "INTENSE",
-                    voiceGender = "MALE",
-                )
-            coEvery { handler.stopTimer() } returns expected
+    fun stopTimerDelegatesToHandler() =
+        assertLifecycleDelegation(
+            expected = timerResult(action = "stop_timer", status = "stopped", message = "Stopped active timer."),
+            callHandler = { handler.stopTimer() },
+            callFunction = { functions.stopTimer(appFunctionContext) },
+            verifyHandler = { coVerify(exactly = 1) { handler.stopTimer() } },
+        )
 
-            val result = functions.stopTimer(appFunctionContext)
+    private fun assertLifecycleDelegation(
+        expected: TimerFunctionResult,
+        callHandler: suspend () -> TimerFunctionResult,
+        callFunction: suspend () -> TimerFunctionResult,
+        verifyHandler: () -> Unit,
+    ) = runBlocking {
+        coEvery { callHandler() } returns expected
 
-            assertThat(result).isEqualTo(expected)
-            coVerify(exactly = 1) { handler.stopTimer() }
-        }
+        val result = callFunction()
+
+        assertThat(result).isEqualTo(expected)
+        verifyHandler()
+    }
+
+    private fun timerResult(
+        action: String,
+        status: String,
+        message: String,
+        targetDurationSeconds: Int = 0,
+        voiceGender: String = "MALE",
+    ) = TimerFunctionResult(
+        action = action,
+        status = status,
+        message = message,
+        entitlementLevel = "elite",
+        targetDurationSeconds = targetDurationSeconds,
+        soundType = "INTENSE",
+        voiceGender = voiceGender,
+    )
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
@@ -21,219 +21,226 @@ class RandomTimerAppFunctionsTest {
     }
 
     @Test
-    fun `configureRandomTimer delegates to handler`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "configure_random_timer",
-                status = "configured",
-                message = "Saved timer configuration.",
-                entitlementLevel = "elite",
-                soundType = "INTENSE",
-                voiceGender = "FEMALE",
-            )
-        coEvery {
-            handler.configureRandomTimer(
-                minSeconds = 10,
-                maxSeconds = 20,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = true,
-                voiceGender = "FEMALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = true,
-            )
-        } returns expected
+    fun `configureRandomTimer delegates to handler`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "configure_random_timer",
+                    status = "configured",
+                    message = "Saved timer configuration.",
+                    entitlementLevel = "elite",
+                    soundType = "INTENSE",
+                    voiceGender = "FEMALE",
+                )
+            coEvery {
+                handler.configureRandomTimer(
+                    minSeconds = 10,
+                    maxSeconds = 20,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = true,
+                    voiceGender = "FEMALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = true,
+                )
+            } returns expected
 
-        val result =
-            functions.configureRandomTimer(
-                appFunctionContext = appFunctionContext,
-                minSeconds = 10,
-                maxSeconds = 20,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = true,
-                voiceGender = "FEMALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = true,
-            )
+            val result =
+                functions.configureRandomTimer(
+                    appFunctionContext = appFunctionContext,
+                    minSeconds = 10,
+                    maxSeconds = 20,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = true,
+                    voiceGender = "FEMALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = true,
+                )
 
-        assertThat(result).isEqualTo(expected)
-    }
-
-    @Test
-    fun `startRandomTimer delegates to handler`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "start_random_timer",
-                status = "running",
-                message = "Started random timer.",
-                entitlementLevel = "elite",
-                targetDurationSeconds = 20,
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-        coEvery {
-            handler.startRandomTimer(
-                minSeconds = 20,
-                maxSeconds = 20,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = false,
-                voiceGender = "MALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = false,
-            )
-        } returns expected
-
-        val result =
-            functions.startRandomTimer(
-                appFunctionContext = appFunctionContext,
-                minSeconds = 20,
-                maxSeconds = 20,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = false,
-                voiceGender = "MALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = false,
-            )
-
-        assertThat(result).isEqualTo(expected)
-    }
+            assertThat(result).isEqualTo(expected)
+        }
 
     @Test
-    fun `configureRandomTimer applies default alarm duration when omitted`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "configure_random_timer",
-                status = "configured",
-                message = "Saved timer configuration.",
-                entitlementLevel = "elite",
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-        coEvery {
-            handler.configureRandomTimer(
-                minSeconds = 10,
-                maxSeconds = 20,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = false,
-                voiceGender = "MALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = false,
-            )
-        } returns expected
+    fun `startRandomTimer delegates to handler`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "start_random_timer",
+                    status = "running",
+                    message = "Started random timer.",
+                    entitlementLevel = "elite",
+                    targetDurationSeconds = 20,
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
+            coEvery {
+                handler.startRandomTimer(
+                    minSeconds = 20,
+                    maxSeconds = 20,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                )
+            } returns expected
 
-        val result =
-            functions.configureRandomTimer(
-                appFunctionContext = appFunctionContext,
-                minSeconds = 10,
-                maxSeconds = 20,
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
+            val result =
+                functions.startRandomTimer(
+                    appFunctionContext = appFunctionContext,
+                    minSeconds = 20,
+                    maxSeconds = 20,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                )
 
-        assertThat(result).isEqualTo(expected)
-    }
-
-    @Test
-    fun `startRandomTimer applies default alarm duration when omitted`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "start_random_timer",
-                status = "running",
-                message = "Started random timer.",
-                entitlementLevel = "elite",
-                targetDurationSeconds = 20,
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-        coEvery {
-            handler.startRandomTimer(
-                minSeconds = 20,
-                maxSeconds = 20,
-                alarmDuration = 10,
-                soundType = "INTENSE",
-                voiceEnabled = false,
-                voiceGender = "MALE",
-                hiddenMode = false,
-                repeatEnabled = false,
-                vibrationEnabled = false,
-            )
-        } returns expected
-
-        val result =
-            functions.startRandomTimer(
-                appFunctionContext = appFunctionContext,
-                minSeconds = 20,
-                maxSeconds = 20,
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-
-        assertThat(result).isEqualTo(expected)
-    }
+            assertThat(result).isEqualTo(expected)
+        }
 
     @Test
-    fun `pauseTimer delegates to handler`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "pause_timer",
-                status = "paused",
-                message = "Paused active timer.",
-                entitlementLevel = "elite",
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-        coEvery { handler.pauseTimer() } returns expected
+    fun `configureRandomTimer applies default alarm duration when omitted`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "configure_random_timer",
+                    status = "configured",
+                    message = "Saved timer configuration.",
+                    entitlementLevel = "elite",
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
+            coEvery {
+                handler.configureRandomTimer(
+                    minSeconds = 10,
+                    maxSeconds = 20,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                )
+            } returns expected
 
-        val result = functions.pauseTimer(appFunctionContext)
+            val result =
+                functions.configureRandomTimer(
+                    appFunctionContext = appFunctionContext,
+                    minSeconds = 10,
+                    maxSeconds = 20,
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
 
-        assertThat(result).isEqualTo(expected)
-        coVerify(exactly = 1) { handler.pauseTimer() }
-    }
+            assertThat(result).isEqualTo(expected)
+        }
 
     @Test
-    fun `resumeTimer delegates to handler`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "resume_timer",
-                status = "running",
-                message = "Resumed active timer.",
-                entitlementLevel = "elite",
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-        coEvery { handler.resumeTimer() } returns expected
+    fun `startRandomTimer applies default alarm duration when omitted`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "start_random_timer",
+                    status = "running",
+                    message = "Started random timer.",
+                    entitlementLevel = "elite",
+                    targetDurationSeconds = 20,
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
+            coEvery {
+                handler.startRandomTimer(
+                    minSeconds = 20,
+                    maxSeconds = 20,
+                    alarmDuration = 10,
+                    soundType = "INTENSE",
+                    voiceEnabled = false,
+                    voiceGender = "MALE",
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    vibrationEnabled = false,
+                )
+            } returns expected
 
-        val result = functions.resumeTimer(appFunctionContext)
+            val result =
+                functions.startRandomTimer(
+                    appFunctionContext = appFunctionContext,
+                    minSeconds = 20,
+                    maxSeconds = 20,
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
 
-        assertThat(result).isEqualTo(expected)
-        coVerify(exactly = 1) { handler.resumeTimer() }
-    }
+            assertThat(result).isEqualTo(expected)
+        }
 
     @Test
-    fun `stopTimer delegates to handler`() = runBlocking {
-        val expected =
-            TimerFunctionResult(
-                action = "stop_timer",
-                status = "stopped",
-                message = "Stopped active timer.",
-                entitlementLevel = "elite",
-                soundType = "INTENSE",
-                voiceGender = "MALE",
-            )
-        coEvery { handler.stopTimer() } returns expected
+    fun `pauseTimer delegates to handler`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "pause_timer",
+                    status = "paused",
+                    message = "Paused active timer.",
+                    entitlementLevel = "elite",
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
+            coEvery { handler.pauseTimer() } returns expected
 
-        val result = functions.stopTimer(appFunctionContext)
+            val result = functions.pauseTimer(appFunctionContext)
 
-        assertThat(result).isEqualTo(expected)
-        coVerify(exactly = 1) { handler.stopTimer() }
-    }
+            assertThat(result).isEqualTo(expected)
+            coVerify(exactly = 1) { handler.pauseTimer() }
+        }
+
+    @Test
+    fun `resumeTimer delegates to handler`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "resume_timer",
+                    status = "running",
+                    message = "Resumed active timer.",
+                    entitlementLevel = "elite",
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
+            coEvery { handler.resumeTimer() } returns expected
+
+            val result = functions.resumeTimer(appFunctionContext)
+
+            assertThat(result).isEqualTo(expected)
+            coVerify(exactly = 1) { handler.resumeTimer() }
+        }
+
+    @Test
+    fun `stopTimer delegates to handler`() =
+        runBlocking {
+            val expected =
+                TimerFunctionResult(
+                    action = "stop_timer",
+                    status = "stopped",
+                    message = "Stopped active timer.",
+                    entitlementLevel = "elite",
+                    soundType = "INTENSE",
+                    voiceGender = "MALE",
+                )
+            coEvery { handler.stopTimer() } returns expected
+
+            val result = functions.stopTimer(appFunctionContext)
+
+            assertThat(result).isEqualTo(expected)
+            coVerify(exactly = 1) { handler.stopTimer() }
+        }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
@@ -1,0 +1,239 @@
+package com.iganapolsky.randomtimer.appfunctions
+
+import androidx.appfunctions.AppFunctionContext
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+class RandomTimerAppFunctionsTest {
+    private lateinit var handler: RandomTimerAppFunctionHandler
+    private lateinit var functions: RandomTimerAppFunctions
+    private val appFunctionContext = mockk<AppFunctionContext>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        handler = mockk()
+        functions = RandomTimerAppFunctions(handler)
+    }
+
+    @Test
+    fun `configureRandomTimer delegates to handler`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "configure_random_timer",
+                status = "configured",
+                message = "Saved timer configuration.",
+                entitlementLevel = "elite",
+                soundType = "INTENSE",
+                voiceGender = "FEMALE",
+            )
+        coEvery {
+            handler.configureRandomTimer(
+                minSeconds = 10,
+                maxSeconds = 20,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = true,
+                voiceGender = "FEMALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = true,
+            )
+        } returns expected
+
+        val result =
+            functions.configureRandomTimer(
+                appFunctionContext = appFunctionContext,
+                minSeconds = 10,
+                maxSeconds = 20,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = true,
+                voiceGender = "FEMALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = true,
+            )
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `startRandomTimer delegates to handler`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "start_random_timer",
+                status = "running",
+                message = "Started random timer.",
+                entitlementLevel = "elite",
+                targetDurationSeconds = 20,
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+        coEvery {
+            handler.startRandomTimer(
+                minSeconds = 20,
+                maxSeconds = 20,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = false,
+                voiceGender = "MALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = false,
+            )
+        } returns expected
+
+        val result =
+            functions.startRandomTimer(
+                appFunctionContext = appFunctionContext,
+                minSeconds = 20,
+                maxSeconds = 20,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = false,
+                voiceGender = "MALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = false,
+            )
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `configureRandomTimer applies default alarm duration when omitted`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "configure_random_timer",
+                status = "configured",
+                message = "Saved timer configuration.",
+                entitlementLevel = "elite",
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+        coEvery {
+            handler.configureRandomTimer(
+                minSeconds = 10,
+                maxSeconds = 20,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = false,
+                voiceGender = "MALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = false,
+            )
+        } returns expected
+
+        val result =
+            functions.configureRandomTimer(
+                appFunctionContext = appFunctionContext,
+                minSeconds = 10,
+                maxSeconds = 20,
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `startRandomTimer applies default alarm duration when omitted`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "start_random_timer",
+                status = "running",
+                message = "Started random timer.",
+                entitlementLevel = "elite",
+                targetDurationSeconds = 20,
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+        coEvery {
+            handler.startRandomTimer(
+                minSeconds = 20,
+                maxSeconds = 20,
+                alarmDuration = 10,
+                soundType = "INTENSE",
+                voiceEnabled = false,
+                voiceGender = "MALE",
+                hiddenMode = false,
+                repeatEnabled = false,
+                vibrationEnabled = false,
+            )
+        } returns expected
+
+        val result =
+            functions.startRandomTimer(
+                appFunctionContext = appFunctionContext,
+                minSeconds = 20,
+                maxSeconds = 20,
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `pauseTimer delegates to handler`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "pause_timer",
+                status = "paused",
+                message = "Paused active timer.",
+                entitlementLevel = "elite",
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+        coEvery { handler.pauseTimer() } returns expected
+
+        val result = functions.pauseTimer(appFunctionContext)
+
+        assertThat(result).isEqualTo(expected)
+        coVerify(exactly = 1) { handler.pauseTimer() }
+    }
+
+    @Test
+    fun `resumeTimer delegates to handler`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "resume_timer",
+                status = "running",
+                message = "Resumed active timer.",
+                entitlementLevel = "elite",
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+        coEvery { handler.resumeTimer() } returns expected
+
+        val result = functions.resumeTimer(appFunctionContext)
+
+        assertThat(result).isEqualTo(expected)
+        coVerify(exactly = 1) { handler.resumeTimer() }
+    }
+
+    @Test
+    fun `stopTimer delegates to handler`() = runBlocking {
+        val expected =
+            TimerFunctionResult(
+                action = "stop_timer",
+                status = "stopped",
+                message = "Stopped active timer.",
+                entitlementLevel = "elite",
+                soundType = "INTENSE",
+                voiceGender = "MALE",
+            )
+        coEvery { handler.stopTimer() } returns expected
+
+        val result = functions.stopTimer(appFunctionContext)
+
+        assertThat(result).isEqualTo(expected)
+        coVerify(exactly = 1) { handler.stopTimer() }
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/appfunctions/RandomTimerAppFunctionsTest.kt
@@ -49,15 +49,7 @@ class RandomTimerAppFunctionsTest {
             val result =
                 functions.configureRandomTimer(
                     appFunctionContext = appFunctionContext,
-                    minSeconds = request.minSeconds,
-                    maxSeconds = request.maxSeconds,
-                    alarmDuration = request.alarmDuration,
-                    soundType = request.soundType,
-                    voiceEnabled = request.voiceEnabled,
-                    voiceGender = request.voiceGender,
-                    hiddenMode = request.hiddenMode,
-                    repeatEnabled = request.repeatEnabled,
-                    vibrationEnabled = request.vibrationEnabled,
+                    request = request,
                 )
 
             assertThat(result).isEqualTo(expected)
@@ -80,61 +72,7 @@ class RandomTimerAppFunctionsTest {
             val result =
                 functions.startRandomTimer(
                     appFunctionContext = appFunctionContext,
-                    minSeconds = request.minSeconds,
-                    maxSeconds = request.maxSeconds,
-                    alarmDuration = request.alarmDuration,
-                    soundType = request.soundType,
-                    voiceEnabled = request.voiceEnabled,
-                    voiceGender = request.voiceGender,
-                    hiddenMode = request.hiddenMode,
-                    repeatEnabled = request.repeatEnabled,
-                    vibrationEnabled = request.vibrationEnabled,
-                )
-
-            assertThat(result).isEqualTo(expected)
-        }
-
-    @Test
-    fun configureRandomTimerAppliesDefaultAlarmDurationWhenOmitted() =
-        runBlocking {
-            val request = defaultRequest
-            val expected = timerResult(action = "configure_random_timer", status = "configured", message = "Saved timer configuration.")
-
-            coEvery { handler.configureRandomTimer(request) } returns expected
-
-            val result =
-                functions.configureRandomTimer(
-                    appFunctionContext = appFunctionContext,
-                    minSeconds = request.minSeconds,
-                    maxSeconds = request.maxSeconds,
-                    soundType = request.soundType,
-                    voiceGender = request.voiceGender,
-                )
-
-            assertThat(result).isEqualTo(expected)
-        }
-
-    @Test
-    fun startRandomTimerAppliesDefaultAlarmDurationWhenOmitted() =
-        runBlocking {
-            val request = defaultRequest.copy(minSeconds = 20, maxSeconds = 20)
-            val expected =
-                timerResult(
-                    action = "start_random_timer",
-                    status = "running",
-                    message = "Started random timer.",
-                    targetDurationSeconds = 20,
-                )
-
-            coEvery { handler.startRandomTimer(request) } returns expected
-
-            val result =
-                functions.startRandomTimer(
-                    appFunctionContext = appFunctionContext,
-                    minSeconds = request.minSeconds,
-                    maxSeconds = request.maxSeconds,
-                    soundType = request.soundType,
-                    voiceGender = request.voiceGender,
+                    request = request,
                 )
 
             assertThat(result).isEqualTo(expected)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/TimerForegroundServiceStartExtrasTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/TimerForegroundServiceStartExtrasTest.kt
@@ -1,0 +1,51 @@
+package com.iganapolsky.randomtimer.service
+
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.domain.model.SoundType
+import com.iganapolsky.randomtimer.domain.model.VoiceGender
+import org.junit.Test
+
+class TimerForegroundServiceStartExtrasTest {
+    @Test
+    fun `timerConfigFromStartExtras preserves female voice gender`() {
+        val config =
+            timerConfigFromStartExtras(
+                minSeconds = 20,
+                maxSeconds = 45,
+                alarmDuration = 10,
+                hiddenMode = false,
+                repeatEnabled = false,
+                soundType = "INTENSE",
+                volume = 0.5f,
+                vibrationEnabled = false,
+                useExtendedRange = false,
+                voiceEnabled = true,
+                voiceGender = "FEMALE",
+                repeatRounds = 0,
+            )
+
+        assertThat(config.voiceGender).isEqualTo(VoiceGender.FEMALE)
+    }
+
+    @Test
+    fun `timerConfigFromStartExtras falls back on invalid enum values`() {
+        val config =
+            timerConfigFromStartExtras(
+                minSeconds = 20,
+                maxSeconds = 45,
+                alarmDuration = 10,
+                hiddenMode = false,
+                repeatEnabled = false,
+                soundType = "NOT_REAL",
+                volume = 0.5f,
+                vibrationEnabled = false,
+                useExtendedRange = false,
+                voiceEnabled = true,
+                voiceGender = "NOT_REAL",
+                repeatRounds = 0,
+            )
+
+        assertThat(config.soundType).isEqualTo(SoundType.INTENSE)
+        assertThat(config.voiceGender).isEqualTo(VoiceGender.MALE)
+    }
+}

--- a/native-android/gradle/libs.versions.toml
+++ b/native-android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.9.1"
 kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -14,7 +14,9 @@ hiltNavigationCompose = "1.2.0"
 navigationCompose = "2.8.5"
 datastore = "1.1.1"
 coroutines = "1.9.0"
+appfunctions = "1.0.0-alpha08"
 mockk = "1.13.13"
+robolectric = "4.16"
 orgJson = "20240303"
 turbine = "1.2.0"
 truth = "1.4.4"
@@ -55,7 +57,12 @@ hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-com
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+androidx-appfunctions = { group = "androidx.appfunctions", name = "appfunctions", version.ref = "appfunctions" }
+androidx-appfunctions-service = { group = "androidx.appfunctions", name = "appfunctions-service", version.ref = "appfunctions" }
+androidx-appfunctions-compiler = { group = "androidx.appfunctions", name = "appfunctions-compiler", version.ref = "appfunctions" }
+androidx-appfunctions-testing = { group = "androidx.appfunctions", name = "appfunctions-testing", version.ref = "appfunctions" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 org-json = { group = "org.json", name = "json", version.ref = "orgJson" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }

--- a/native-android/gradle/wrapper/gradle-wrapper.properties
+++ b/native-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What changed
- add Android Jetpack App Functions v1 for `configureRandomTimer`, `startRandomTimer`, `pauseTimer`, `resumeTimer`, and `stopTimer`
- wire `RandomTimerApp` into `AppFunctionConfiguration.Provider` so Android 16+ callers can discover the app as a tool
- reuse the existing timer config, start-use-case, repository, analytics, and service-controller paths instead of adding a parallel execution stack
- fix the Android service launch path so `voiceGender` survives the foreground-service handoff
- update Android build and CI/workflow setup for App Functions requirements (`compileSdk 36`, AGP `8.9.1`, Gradle `8.11.1`, KSP wiring, Android 36 SDK packages in Actions)
- add unit and App Function end-to-end tests for the new handler, API surface, config factory, and service extras parser

## Why
Android App Functions gives the app a higher-value Android entry path than launcher/deep-link only. This branch exposes the timer controls as callable Android 16+ functions while keeping the implementation on the existing timer stack.

## Impact
- Android 16+ capable callers can discover and invoke timer controls directly
- Pro entitlement rules are enforced at the App Function boundary
- the existing female-voice path no longer risks dropping `voiceGender` when the timer starts through the service path
- no iOS behavior is touched

## Validation
- `cd native-android && ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest :app:assembleDebug :app:lintDebug`
- `cd native-android && ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests "com.iganapolsky.randomtimer.appfunctions.RandomTimerAppFunctionsE2ETest"`
- verified generated App Functions schema/assets exist in `app/build/generated/ksp/debug/resources/assets/`
- verified merged debug manifest includes the App Function services and permissions

## Notes
- local Jacoco proves the new handwritten App Functions classes are heavily covered, but not 100%. Current fresh report on this branch shows:
  - `RandomTimerAppFunctions`: line `100%`, method `100%`, branch `60.0%`
  - `RandomTimerAppFunctionHandler`: line `100%`, method `100%`, branch `68.2%`
  - `RandomTimerAppFunctionConfigFactory`: line `90.6%`, method `100%`, branch `90.0%`
  - `TimerForegroundServiceKt`: line `100%`, method `100%`
- I am not claiming store release from this branch. This is implementation + local verification only.
