### PR TITLE
fix(android,ios): activation-first default timer range 0-30s

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
@@ -58,8 +58,8 @@ class TimerRepositoryImpl
 
         private fun Preferences.toTimerConfig(): TimerConfig =
             TimerConfig(
-                minSeconds = this[KEY_MIN_SECONDS] ?: 30,
-                maxSeconds = this[KEY_MAX_SECONDS] ?: 120,
+                minSeconds = this[KEY_MIN_SECONDS] ?: 0,
+                maxSeconds = this[KEY_MAX_SECONDS] ?: 30,
                 alarmDuration = this[KEY_ALARM_DURATION] ?: 10,
                 hiddenMode = this[KEY_HIDDEN_MODE] ?: false,
                 repeatEnabled = this[KEY_REPEAT_ENABLED] ?: false,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/RandomDurationPick.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/RandomDurationPick.kt
@@ -1,0 +1,23 @@
+package com.iganapolsky.randomtimer.domain.model
+
+import kotlin.random.Random
+
+/**
+ * Inclusive random duration in milliseconds. When [maxMillis] is at least one full second,
+ * the result is never below 1000 ms so a running timer does not complete on the first tick.
+ */
+fun pickRandomDurationMillisInclusive(
+    minMillis: Long,
+    maxMillis: Long,
+    random: Random,
+): Long {
+    require(maxMillis >= minMillis)
+    val lower =
+        if (maxMillis >= 1000L) {
+            maxOf(minMillis, 1000L)
+        } else {
+            minMillis
+        }
+    val from = minOf(lower, maxMillis)
+    return random.nextLong(from, maxMillis + 1)
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -94,8 +94,8 @@ data class TimerConfig(
 
         val DEFAULT =
             TimerConfig(
-                minSeconds = 30,
-                maxSeconds = 120,
+                minSeconds = 0,
+                maxSeconds = 30,
                 alarmDuration = 10,
                 hiddenMode = false,
                 repeatEnabled = false,
@@ -109,18 +109,13 @@ data class TimerConfig(
             )
 
         val ALARM_DURATION_OPTIONS = listOf(5, 10, 15, 30, 60)
-
-        /** Min seconds for first-session activation preset (mirrors iOS SharedModels). */
-        const val ACTIVATION_FIRST_RUN_MIN_SECONDS = 20
-
-        /** Max seconds for first-session activation preset (mirrors iOS SharedModels). */
-        const val ACTIVATION_FIRST_RUN_MAX_SECONDS = 60
     }
 }
 
 /**
- * Tighter 20–60s range for users who have not completed their first timer while still on
- * canonical free-tier defaults (30–120, not extended). Returns null if no change applies.
+ * Migrates legacy canonical defaults (30–120s) to activation-first 0–30s for users who have
+ * not completed their first timer. New installs already use [TimerConfig.DEFAULT]; returns null
+ * when no migration applies.
  */
 fun activationPresetForFirstCompletionIfEligible(
     hasCompletedFirstTimer: Boolean,
@@ -128,15 +123,10 @@ fun activationPresetForFirstCompletionIfEligible(
 ): TimerConfig? {
     if (hasCompletedFirstTimer) return null
     if (current.useExtendedRange) return null
-    if (current.minSeconds != TimerConfig.DEFAULT.minSeconds ||
-        current.maxSeconds != TimerConfig.DEFAULT.maxSeconds
-    ) {
+    if (current.minSeconds != 30 || current.maxSeconds != 120) {
         return null
     }
-    return current.copy(
-        minSeconds = TimerConfig.ACTIVATION_FIRST_RUN_MIN_SECONDS,
-        maxSeconds = TimerConfig.ACTIVATION_FIRST_RUN_MAX_SECONDS,
-    )
+    return current.copy(minSeconds = 0, maxSeconds = 30)
 }
 
 data class RangeToggleProfiles(

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/usecase/StartTimerUseCase.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/usecase/StartTimerUseCase.kt
@@ -3,6 +3,7 @@ package com.iganapolsky.randomtimer.domain.usecase
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
+import com.iganapolsky.randomtimer.domain.model.pickRandomDurationMillisInclusive
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import javax.inject.Inject
 import kotlin.random.Random
@@ -47,7 +48,7 @@ class StartTimerUseCase
 
             val minMillis = min.inWholeMilliseconds
             val maxMillis = max.inWholeMilliseconds
-            val randomMillis = random.nextLong(minMillis, maxMillis + 1)
+            val randomMillis = pickRandomDurationMillisInclusive(minMillis, maxMillis, random)
 
             return randomMillis.milliseconds
         }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
@@ -32,6 +32,7 @@ import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
+import com.iganapolsky.randomtimer.domain.model.pickRandomDurationMillisInclusive
 import com.iganapolsky.randomtimer.notifications.ReengagementScheduler
 import com.iganapolsky.randomtimer.receiver.ScreenOffReceiver
 import com.iganapolsky.randomtimer.review.StoreReviewManager
@@ -563,7 +564,7 @@ class TimerForegroundService : Service() {
         // Generate new random duration
         val minMs = currentConfig.minSeconds * 1000L
         val maxMs = currentConfig.maxSeconds * 1000L
-        val randomMs = kotlin.random.Random.nextLong(minMs, maxMs + 1)
+        val randomMs = pickRandomDurationMillisInclusive(minMs, maxMs, kotlin.random.Random.Default)
 
         val newState =
             TimerState(

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/ActivationDefaultsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/ActivationDefaultsTest.kt
@@ -6,13 +6,13 @@ import kotlin.time.Duration.Companion.seconds
 
 class ActivationDefaultsTest {
     @Test
-    fun `default min is 30 seconds for quick start`() {
-        assertThat(TimerConfig.DEFAULT.minSeconds).isEqualTo(30)
+    fun `default min is 0 seconds for activation-first quick start`() {
+        assertThat(TimerConfig.DEFAULT.minSeconds).isEqualTo(0)
     }
 
     @Test
-    fun `default max is 120 seconds for quick start`() {
-        assertThat(TimerConfig.DEFAULT.maxSeconds).isEqualTo(120)
+    fun `default max is 30 seconds for activation-first quick start`() {
+        assertThat(TimerConfig.DEFAULT.maxSeconds).isEqualTo(30)
     }
 
     @Test
@@ -23,13 +23,13 @@ class ActivationDefaultsTest {
     }
 
     @Test
-    fun `default min duration is 30 seconds`() {
-        assertThat(TimerConfig.DEFAULT.minDuration).isEqualTo(30.seconds)
+    fun `default min duration is 0 seconds`() {
+        assertThat(TimerConfig.DEFAULT.minDuration).isEqualTo(0.seconds)
     }
 
     @Test
-    fun `default max duration is 120 seconds`() {
-        assertThat(TimerConfig.DEFAULT.maxDuration).isEqualTo(120.seconds)
+    fun `default max duration is 30 seconds`() {
+        assertThat(TimerConfig.DEFAULT.maxDuration).isEqualTo(30.seconds)
     }
 
     @Test

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/RandomDurationPickTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/RandomDurationPickTest.kt
@@ -1,0 +1,30 @@
+package com.iganapolsky.randomtimer.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import kotlin.random.Random
+
+class RandomDurationPickTest {
+    private class AlwaysPickLowerBound : Random() {
+        override fun nextBits(bitCount: Int) = 0
+
+        override fun nextLong(
+            from: Long,
+            until: Long,
+        ) = from
+    }
+
+    @Test
+    fun `floors at 1 second when max allows full second`() {
+        val picked =
+            pickRandomDurationMillisInclusive(0, 30_000, AlwaysPickLowerBound())
+        assertThat(picked).isEqualTo(1000L)
+    }
+
+    @Test
+    fun `does not raise min when already at least 1 second`() {
+        val picked =
+            pickRandomDurationMillisInclusive(5000, 10_000, AlwaysPickLowerBound())
+        assertThat(picked).isEqualTo(5000L)
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
@@ -10,8 +10,8 @@ class TimerConfigTest {
     fun `default config has valid range`() {
         val config = TimerConfig.DEFAULT
 
-        assertThat(config.minSeconds).isEqualTo(30)
-        assertThat(config.maxSeconds).isEqualTo(120)
+        assertThat(config.minSeconds).isEqualTo(0)
+        assertThat(config.maxSeconds).isEqualTo(30)
         assertThat(config.volume).isEqualTo(0.5f)
         assertThat(config.vibrationEnabled).isFalse()
         assertThat(config.voiceEnabled).isFalse()
@@ -176,8 +176,8 @@ class TimerConfigTest {
             )
         val profiles =
             RangeToggleProfiles(
-                freeMinSeconds = 30,
-                freeMaxSeconds = 120,
+                freeMinSeconds = 0,
+                freeMaxSeconds = 30,
                 extendedMinSeconds = 900,
                 extendedMaxSeconds = 1800,
             )
@@ -185,31 +185,63 @@ class TimerConfigTest {
         val result = toggleExtendedRange(current, profiles)
 
         assertThat(result.config.useExtendedRange).isFalse()
-        assertThat(result.config.minSeconds).isEqualTo(30)
-        assertThat(result.config.maxSeconds).isEqualTo(120)
+        assertThat(result.config.minSeconds).isEqualTo(0)
+        assertThat(result.config.maxSeconds).isEqualTo(30)
         assertThat(result.profiles.extendedMinSeconds).isEqualTo(900)
         assertThat(result.profiles.extendedMaxSeconds).isEqualTo(1800)
     }
 
     @Test
-    fun `activation preset tightens canonical default range when first timer not done`() {
+    fun `activation preset migrates legacy 30-120 to 0-30 when first timer not done`() {
+        val legacy =
+            TimerConfig(
+                minSeconds = 30,
+                maxSeconds = 120,
+                alarmDuration = 10,
+                hiddenMode = false,
+                repeatEnabled = false,
+                soundType = SoundType.INTENSE,
+                volume = 0.5f,
+                vibrationEnabled = false,
+            )
+        val next =
+            activationPresetForFirstCompletionIfEligible(
+                hasCompletedFirstTimer = false,
+                current = legacy,
+            )
+        assertThat(next).isNotNull()
+        assertThat(next!!.minSeconds).isEqualTo(0)
+        assertThat(next.maxSeconds).isEqualTo(30)
+        assertThat(next.soundType).isEqualTo(legacy.soundType)
+    }
+
+    @Test
+    fun `activation preset skipped when already on new default range`() {
         val next =
             activationPresetForFirstCompletionIfEligible(
                 hasCompletedFirstTimer = false,
                 current = TimerConfig.DEFAULT,
             )
-        assertThat(next).isNotNull()
-        assertThat(next!!.minSeconds).isEqualTo(TimerConfig.ACTIVATION_FIRST_RUN_MIN_SECONDS)
-        assertThat(next.maxSeconds).isEqualTo(TimerConfig.ACTIVATION_FIRST_RUN_MAX_SECONDS)
-        assertThat(next.soundType).isEqualTo(TimerConfig.DEFAULT.soundType)
+        assertThat(next).isNull()
     }
 
     @Test
     fun `activation preset skipped after first timer completed`() {
+        val legacy =
+            TimerConfig(
+                minSeconds = 30,
+                maxSeconds = 120,
+                alarmDuration = 10,
+                hiddenMode = false,
+                repeatEnabled = false,
+                soundType = SoundType.INTENSE,
+                volume = 0.5f,
+                vibrationEnabled = false,
+            )
         val next =
             activationPresetForFirstCompletionIfEligible(
                 hasCompletedFirstTimer = true,
-                current = TimerConfig.DEFAULT,
+                current = legacy,
             )
         assertThat(next).isNull()
     }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerStateTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerStateTest.kt
@@ -9,6 +9,19 @@ import kotlin.time.Duration.Companion.seconds
 class TimerStateTest {
     private val defaultConfig = TimerConfig.DEFAULT
 
+    /** Fixed wide max for progress ratio tests (denominator is config.maxSeconds). */
+    private val progressWideMaxConfig =
+        TimerConfig(
+            minSeconds = 0,
+            maxSeconds = 120,
+            alarmDuration = 10,
+            hiddenMode = false,
+            repeatEnabled = false,
+            soundType = SoundType.INTENSE,
+            volume = 0.5f,
+            vibrationEnabled = false,
+        )
+
     @Test
     fun `progress is 0 at start`() {
         val state =
@@ -28,7 +41,7 @@ class TimerStateTest {
         // progress = elapsed/max = 60/120 = 0.5
         val state =
             TimerState(
-                config = defaultConfig, // maxSeconds = 120
+                config = progressWideMaxConfig,
                 targetDuration = 2.minutes,
                 remainingDuration = 1.minutes,
                 status = TimerStatus.RUNNING,
@@ -58,7 +71,7 @@ class TimerStateTest {
         // progress = 15/120 = 0.125
         val state =
             TimerState(
-                config = defaultConfig,
+                config = progressWideMaxConfig,
                 targetDuration = 30.seconds,
                 remainingDuration = 15.seconds,
                 status = TimerStatus.RUNNING,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/usecase/StartTimerUseCaseTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/usecase/StartTimerUseCaseTest.kt
@@ -18,7 +18,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class StartTimerUseCaseTest {
-
     private lateinit var repository: TimerRepository
     private lateinit var useCase: StartTimerUseCase
 
@@ -30,100 +29,111 @@ class StartTimerUseCaseTest {
     }
 
     @Test
-    fun `generates random duration within range`() = runTest {
-        val seededRandom = Random(42) // Deterministic for testing
-        useCase = StartTimerUseCase(repository, seededRandom)
+    fun `generates random duration within range`() =
+        runTest {
+            val seededRandom = Random(42) // Deterministic for testing
+            useCase = StartTimerUseCase(repository, seededRandom)
 
-        val config = TimerConfig(
-            minSeconds = 300, // 5 minutes
-            maxSeconds = 300, // 5 minutes (same for predictable test)
-            alarmDuration = 10,
-            hiddenMode = false,
-            repeatEnabled = false,
-            soundType = SoundType.INTENSE,
-            volume = 0.5f,
-            vibrationEnabled = false
-        )
+            val config =
+                TimerConfig(
+                    minSeconds = 300, // 5 minutes
+                    maxSeconds = 300, // 5 minutes (same for predictable test)
+                    alarmDuration = 10,
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    soundType = SoundType.INTENSE,
+                    volume = 0.5f,
+                    vibrationEnabled = false,
+                )
 
-        val result = useCase(config)
+            val result = useCase(config)
 
-        assertThat(result.targetDuration).isAtLeast(5.minutes)
-        assertThat(result.targetDuration).isAtMost(5.minutes)
-    }
-
-    @Test
-    fun `returns same duration when min equals max`() = runTest {
-        useCase = StartTimerUseCase(repository)
-
-        val config = TimerConfig(
-            minSeconds = 300, // 5 minutes
-            maxSeconds = 300, // 5 minutes
-            alarmDuration = 10,
-            hiddenMode = false,
-            repeatEnabled = false,
-            soundType = SoundType.INTENSE,
-            volume = 0.5f,
-            vibrationEnabled = false
-        )
-
-        val result = useCase(config)
-
-        assertThat(result.targetDuration).isEqualTo(5.minutes)
-    }
+            assertThat(result.targetDuration).isAtLeast(5.minutes)
+            assertThat(result.targetDuration).isAtMost(5.minutes)
+        }
 
     @Test
-    fun `returns state with RUNNING status`() = runTest {
-        useCase = StartTimerUseCase(repository)
+    fun `returns same duration when min equals max`() =
+        runTest {
+            useCase = StartTimerUseCase(repository)
 
-        val result = useCase(TimerConfig.DEFAULT)
+            val config =
+                TimerConfig(
+                    minSeconds = 300, // 5 minutes
+                    maxSeconds = 300, // 5 minutes
+                    alarmDuration = 10,
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    soundType = SoundType.INTENSE,
+                    volume = 0.5f,
+                    vibrationEnabled = false,
+                )
 
-        assertThat(result.status).isEqualTo(TimerStatus.RUNNING)
-    }
+            val result = useCase(config)
 
-    @Test
-    fun `remaining equals target at start`() = runTest {
-        useCase = StartTimerUseCase(repository)
-
-        val result = useCase(TimerConfig.DEFAULT)
-
-        assertThat(result.remainingDuration).isEqualTo(result.targetDuration)
-    }
-
-    @Test
-    fun `saves config to repository`() = runTest {
-        useCase = StartTimerUseCase(repository)
-        val config = TimerConfig(
-            minSeconds = 180, // 3 minutes
-            maxSeconds = 300, // 5 minutes (max allowed)
-            alarmDuration = 10,
-            hiddenMode = false,
-            repeatEnabled = false,
-            soundType = SoundType.INTENSE,
-            volume = 0.5f,
-            vibrationEnabled = false
-        )
-
-        useCase(config)
-
-        coVerify { repository.saveTimerConfig(config) }
-    }
+            assertThat(result.targetDuration).isEqualTo(5.minutes)
+        }
 
     @Test
-    fun `saves active timer to repository`() = runTest {
-        useCase = StartTimerUseCase(repository)
+    fun `returns state with RUNNING status`() =
+        runTest {
+            useCase = StartTimerUseCase(repository)
 
-        useCase(TimerConfig.DEFAULT)
+            val result = useCase(TimerConfig.DEFAULT)
 
-        coVerify { repository.saveActiveTimer(any()) }
-    }
+            assertThat(result.status).isEqualTo(TimerStatus.RUNNING)
+        }
+
+    @Test
+    fun `remaining equals target at start`() =
+        runTest {
+            useCase = StartTimerUseCase(repository)
+
+            val result = useCase(TimerConfig.DEFAULT)
+
+            assertThat(result.remainingDuration).isEqualTo(result.targetDuration)
+        }
+
+    @Test
+    fun `saves config to repository`() =
+        runTest {
+            useCase = StartTimerUseCase(repository)
+            val config =
+                TimerConfig(
+                    minSeconds = 180, // 3 minutes
+                    maxSeconds = 300, // 5 minutes (max allowed)
+                    alarmDuration = 10,
+                    hiddenMode = false,
+                    repeatEnabled = false,
+                    soundType = SoundType.INTENSE,
+                    volume = 0.5f,
+                    vibrationEnabled = false,
+                )
+
+            useCase(config)
+
+            coVerify { repository.saveTimerConfig(config) }
+        }
+
+    @Test
+    fun `saves active timer to repository`() =
+        runTest {
+            useCase = StartTimerUseCase(repository)
+
+            useCase(TimerConfig.DEFAULT)
+
+            coVerify { repository.saveActiveTimer(any()) }
+        }
 
     @Test
     fun `generateRandomDuration produces varied results`() {
         useCase = StartTimerUseCase(repository)
 
-        val results = (1..100).map {
-            useCase.generateRandomDuration(1.minutes, 5.minutes) // Max is 5 min (300s)
-        }.distinct()
+        val results =
+            (1..100)
+                .map {
+                    useCase.generateRandomDuration(1.minutes, 5.minutes) // Max is 5 min (300s)
+                }.distinct()
 
         // Should have some variety (not all the same)
         assertThat(results.size).isGreaterThan(1)
@@ -138,6 +148,19 @@ class StartTimerUseCaseTest {
         repeat(100) {
             val duration = useCase.generateRandomDuration(min, max)
             assertThat(duration).isAtLeast(min)
+            assertThat(duration).isAtMost(max)
+        }
+    }
+
+    @Test
+    fun `generateRandomDuration never picks zero when range spans at least one second`() {
+        useCase = StartTimerUseCase(repository)
+        val min = 0.seconds
+        val max = 30.seconds
+
+        repeat(200) {
+            val duration = useCase.generateRandomDuration(min, max)
+            assertThat(duration).isAtLeast(1.seconds)
             assertThat(duration).isAtMost(max)
         }
     }

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -557,7 +557,9 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
 
     private func generateRandomDuration(min: TimeInterval, max: TimeInterval) -> TimeInterval {
         guard min < max else { return min }
-        return TimeInterval.random(in: min...max)
+        let lowerCandidate = max >= 1.0 ? Swift.max(min, 1.0) : min
+        let lower = Swift.min(lowerCandidate, max)
+        return TimeInterval.random(in: lower...max)
     }
 
     private func loadSavedConfig() async {

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -84,7 +84,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
 
     private static let activationRangeNudgeAppliedKey = "activation_first_run_range_nudge_applied"
 
-    /// Applies 20–60s range once for users on canonical 30–120 defaults who have not finished a timer yet.
+    /// Migrates legacy 30–120s to 0–30s once for users who have not finished a first timer.
     func applyActivationPresetForFirstCompletionIfNeeded() {
         if UserDefaults.standard.bool(forKey: Self.activationRangeNudgeAppliedKey) { return }
         let done = UserDefaults.standard.bool(forKey: "hasCompletedFirstTimer")

--- a/native-ios/RandomTimerTests/ActivationDefaultsTests.swift
+++ b/native-ios/RandomTimerTests/ActivationDefaultsTests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 final class ActivationDefaultsTests: XCTestCase {
 
-    func testDefaultMinSecondsIs30ForQuickStart() {
+    func testDefaultMinSecondsIsZeroForActivationFirstQuickStart() {
         let config = TimerConfig.default
-        XCTAssertEqual(config.minSeconds, 30)
+        XCTAssertEqual(config.minSeconds, 0)
     }
 
-    func testDefaultMaxSecondsIs120ForQuickStart() {
+    func testDefaultMaxSecondsIs30ForActivationFirstQuickStart() {
         let config = TimerConfig.default
-        XCTAssertEqual(config.maxSeconds, 120)
+        XCTAssertEqual(config.maxSeconds, 30)
     }
 
     func testDefaultConfigProducesValidDurationRange() {
@@ -19,14 +19,14 @@ final class ActivationDefaultsTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(config.maxSeconds - config.minSeconds, 5)
     }
 
-    func testDefaultMinDurationIs30Seconds() {
+    func testDefaultMinDurationIsZeroSeconds() {
         let config = TimerConfig.default
-        XCTAssertEqual(config.minDuration, 30.0, accuracy: 0.001)
+        XCTAssertEqual(config.minDuration, 0.0, accuracy: 0.001)
     }
 
-    func testDefaultMaxDurationIs120Seconds() {
+    func testDefaultMaxDurationIs30Seconds() {
         let config = TimerConfig.default
-        XCTAssertEqual(config.maxDuration, 120.0, accuracy: 0.001)
+        XCTAssertEqual(config.maxDuration, 30.0, accuracy: 0.001)
     }
 
     func testExplicitZeroMinStillAllowed() {
@@ -43,15 +43,15 @@ final class ActivationDefaultsTests: XCTestCase {
         let config = TimerConfig.default
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(TimerConfig.self, from: data)
-        XCTAssertEqual(decoded.minSeconds, 30)
-        XCTAssertEqual(decoded.maxSeconds, 120)
+        XCTAssertEqual(decoded.minSeconds, 0)
+        XCTAssertEqual(decoded.maxSeconds, 30)
     }
 
     func testEmptyJsonDecodesToNewDefaults() throws {
         let data = Data("{}".utf8)
         let decoded = try JSONDecoder().decode(TimerConfig.self, from: data)
-        XCTAssertEqual(decoded.minSeconds, 30)
-        XCTAssertEqual(decoded.maxSeconds, 120)
+        XCTAssertEqual(decoded.minSeconds, 0)
+        XCTAssertEqual(decoded.maxSeconds, 30)
     }
 
     func testMaxSecondsFreeUnchangedAt300() {

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -7,23 +7,30 @@ final class TimerConfigTests: XCTestCase {
     func testDefaultConfigHasValidRange() {
         let config = RandomTimer.TimerConfig.default
 
-        XCTAssertEqual(config.minSeconds, 30)
-        XCTAssertEqual(config.maxSeconds, 120)
+        XCTAssertEqual(config.minSeconds, 0)
+        XCTAssertEqual(config.maxSeconds, 30)
         XCTAssertEqual(config.alarmDuration, 10)
         XCTAssertFalse(config.voiceEnabled)
     }
 
-    func testActivationPresetTightensDefaultWhenFirstTimerNotDone() {
-        let base = TimerConfig.default
-        let next = base.applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: false)
+    func testActivationPresetMigratesLegacy30To120WhenFirstTimerNotDone() {
+        let legacy = TimerConfig(minSeconds: 30, maxSeconds: 120)
+        let next = legacy.applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: false)
         XCTAssertNotNil(next)
-        XCTAssertEqual(next?.minSeconds, TimerConfig.activationFirstRunMinSeconds)
-        XCTAssertEqual(next?.maxSeconds, TimerConfig.activationFirstRunMaxSeconds)
-        XCTAssertEqual(next?.soundType, base.soundType)
+        XCTAssertEqual(next?.minSeconds, 0)
+        XCTAssertEqual(next?.maxSeconds, 30)
+        XCTAssertEqual(next?.soundType, legacy.soundType)
+    }
+
+    func testActivationPresetSkippedWhenAlreadyOnNewDefault() {
+        let next = TimerConfig.default
+            .applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: false)
+        XCTAssertNil(next)
     }
 
     func testActivationPresetSkippedAfterFirstTimer() {
-        let next = TimerConfig.default
+        let legacy = TimerConfig(minSeconds: 30, maxSeconds: 120)
+        let next = legacy
             .applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: true)
         XCTAssertNil(next)
     }
@@ -116,8 +123,8 @@ final class TimerConfigTests: XCTestCase {
         let decoded = try JSONDecoder().decode(RandomTimer.TimerConfig.self, from: payload)
 
         let expected = RandomTimer.TimerConfig(
-            minSeconds: 30,
-            maxSeconds: 120,
+            minSeconds: 0,
+            maxSeconds: 30,
             alarmDuration: 10,
             hiddenMode: false,
             repeatEnabled: false,
@@ -236,8 +243,8 @@ final class TimerConfigTests: XCTestCase {
             repeatRounds: 0
         )
         let profiles = RangeToggleProfiles(
-            freeMinSeconds: 30,
-            freeMaxSeconds: 120,
+            freeMinSeconds: 0,
+            freeMaxSeconds: 30,
             extendedMinSeconds: 900,
             extendedMaxSeconds: 1800
         )
@@ -245,8 +252,8 @@ final class TimerConfigTests: XCTestCase {
         let result = toggleExtendedRange(current: current, profiles: profiles)
 
         XCTAssertFalse(result.config.useExtendedRange)
-        XCTAssertEqual(result.config.minSeconds, 30)
-        XCTAssertEqual(result.config.maxSeconds, 120)
+        XCTAssertEqual(result.config.minSeconds, 0)
+        XCTAssertEqual(result.config.maxSeconds, 30)
         XCTAssertEqual(result.profiles.extendedMinSeconds, 900)
         XCTAssertEqual(result.profiles.extendedMaxSeconds, 1800)
     }

--- a/native-ios/RandomTimerWidget/SharedTypes.swift
+++ b/native-ios/RandomTimerWidget/SharedTypes.swift
@@ -32,7 +32,7 @@ public struct TimerActivityAttributes: ActivityAttributes {
     public let minSeconds: Int
     public let maxSeconds: Int
 
-    public init(timerName: String = "Random Tactical Timer", endDate: Date, minSeconds: Int = 30, maxSeconds: Int = 120) {
+    public init(timerName: String = "Random Tactical Timer", endDate: Date, minSeconds: Int = 0, maxSeconds: Int = 30) {
         self.timerName = timerName
         self.endDate = endDate
         self.minSeconds = minSeconds

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -151,8 +151,8 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     }
 
     public init(
-        minSeconds: Int = 30,
-        maxSeconds: Int = 120,
+        minSeconds: Int = 0,
+        maxSeconds: Int = 30,
         alarmDuration: Int = 10,
         hiddenMode: Bool = false,
         repeatEnabled: Bool = false, // Default to LOOP OFF
@@ -202,20 +202,15 @@ public struct TimerConfig: Codable, Sendable, Equatable {
 
     public static let alarmDurationOptions = [5, 10, 15, 30, 60]
 
-    /// Min seconds for first-session activation preset (mirrors Android `TimerConfig`).
-    public static let activationFirstRunMinSeconds = 20
-
-    /// Max seconds for first-session activation preset (mirrors Android `TimerConfig`).
-    public static let activationFirstRunMaxSeconds = 60
-
-    /// Tighter 20–60s range when the user has not completed a first timer and is still on canonical free defaults.
+    /// Migrates legacy canonical defaults (30–120s) to activation-first 0–30s when the user
+    /// has not completed a first timer. Returns nil when no migration applies.
     public func applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: Bool) -> TimerConfig? {
         guard !hasCompletedFirstTimer else { return nil }
         guard !useExtendedRange else { return nil }
         guard minSeconds == 30, maxSeconds == 120 else { return nil }
         return TimerConfig(
-            minSeconds: Self.activationFirstRunMinSeconds,
-            maxSeconds: Self.activationFirstRunMaxSeconds,
+            minSeconds: 0,
+            maxSeconds: 30,
             alarmDuration: alarmDuration,
             hiddenMode: hiddenMode,
             repeatEnabled: repeatEnabled,
@@ -283,11 +278,11 @@ public struct TimerConfig: Codable, Sendable, Equatable {
 
         let rawMin = container.decodeFirstInt(
             forKeys: [.minSeconds, .minDuration, .min_seconds, .min_time],
-            defaultValue: 30
+            defaultValue: 0
         )
         let rawMax = container.decodeFirstInt(
             forKeys: [.maxSeconds, .maxDuration, .max_seconds, .max_time],
-            defaultValue: 120
+            defaultValue: 30
         )
         let rawAlarm = container.decodeFirstInt(
             forKeys: [.alarmDuration, .alarm_duration],
@@ -755,8 +750,8 @@ public struct TimerActivityAttributes: ActivityAttributes {
     public init(
         timerName: String = "Random Tactical Timer",
         endDate: Date,
-        minSeconds: Int = 30,
-        maxSeconds: Int = 120
+        minSeconds: Int = 0,
+        maxSeconds: Int = 30
     ) {
         self.timerName = timerName
         self.endDate = endDate

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -31,15 +31,15 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def test_default_timer_range_is_30_to_120_on_both_platforms():
-    """Canonical quick-start range in TimerConfig.default / Swift defaults (free-tier cap remains 300s)."""
+def test_default_timer_range_is_0_to_30_on_both_platforms():
+    """Activation-first default range in TimerConfig.DEFAULT / Swift defaults (free-tier cap remains 300s)."""
     android_source = _read(ANDROID_TIMER_CONFIG)
     ios_source = _read(IOS_TIMER_MODELS)
 
-    assert re.search(r"minSeconds\s*=\s*30", android_source)
-    assert re.search(r"maxSeconds\s*=\s*120", android_source)
-    assert re.search(r"minSeconds:\s*Int\s*=\s*30", ios_source)
-    assert re.search(r"maxSeconds:\s*Int\s*=\s*120", ios_source)
+    assert re.search(r"minSeconds\s*=\s*0", android_source)
+    assert re.search(r"maxSeconds\s*=\s*30", android_source)
+    assert re.search(r"minSeconds:\s*Int\s*=\s*0", ios_source)
+    assert re.search(r"maxSeconds:\s*Int\s*=\s*30", ios_source)
 
 
 def test_time_range_limits_and_gap_match_between_platforms():

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -75,12 +75,12 @@ def test_timer_defaults_match_across_mobile_platforms():
     android_repository = ANDROID_REPOSITORY.read_text(encoding="utf-8")
     ios_models = IOS_MODELS.read_text(encoding="utf-8")
 
-    assert "minSeconds = 30" in android_config
-    assert "maxSeconds = 120" in android_config
+    assert "minSeconds = 0" in android_config
+    assert "maxSeconds = 30" in android_config
     assert "private fun Preferences.toTimerConfig()" in android_repository
-    assert android_repository.count("maxSeconds = this[KEY_MAX_SECONDS] ?: 120") == 1
+    assert android_repository.count("maxSeconds = this[KEY_MAX_SECONDS] ?: 30") == 1
     assert android_repository.count("preferences.toTimerConfig()") == 2
-    assert re.search(r"minSeconds: Int = 30,\n\s*maxSeconds: Int = 120,", ios_models)
+    assert re.search(r"minSeconds: Int = 0,\n\s*maxSeconds: Int = 30,", ios_models)
     assert "maxSecondsFree = 300" in ios_models
 
 


### PR DESCRIPTION
Ships the North Star activation lever: new installs default to a 0–30s random range. Legacy 30–120 free defaults migrate to 0–30 until the first timer completes. Includes Android/iOS unit test and parity script updates.

Made with [Cursor](https://cursor.com)