### PR TITLE
fix(ci): stop project automation from using stale PAT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: read
+      repository-projects: read
     env:
       PROJECTS_V2_OWNER: IgorGanapolsky
       PROJECTS_V2_NUMBER: 1
@@ -23,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PROJECT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
## Summary
- switch Project Automation from the stale  secret to the built-in workflow token for repo reads/writes
- add explicit  and  permissions
- keep Projects v2 access best-effort instead of letting an expired PAT break the whole workflow

## Why
The current workflow is failing with  before it can even list issues and PRs. The repo token is valid for those operations and the Projects v2 section already degrades gracefully when project data is unavailable.

## Validation
- yaml_ok
- inspected failing GitHub Actions run  showing  401 on repo issue listing
