### PR TITLE
fix(ci): stop wiki sync from using stale PAT

### DIFF
--- a/.github/workflows/weekly-shared.yml
+++ b/.github/workflows/weekly-shared.yml
@@ -169,7 +169,7 @@ jobs:
         with:
           strategy: init
           path: ${{ inputs.wiki_path }}
-          token: ${{ secrets.PROJECT_PAT }}
+          token: ${{ github.token }}
 
       - name: Create issue from report
         if: inputs.issue_title != '' && inputs.issue_content_path != ''

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           strategy: init
           path: wiki/
-          token: ${{ secrets.PROJECT_PAT }}
+          token: ${{ github.token }}
 
       - name: Upload dashboard snapshot
         if: always()


### PR DESCRIPTION
## Summary
- switch wiki publishing from the stale PROJECT_PAT secret to the built-in workflow token
- fix both the direct Wiki Sync workflow and the shared weekly wiki publisher used by other scheduled jobs

## Why
Wiki Sync failed on run 24046419777 with: Invalid username or token. Password authentication is not supported for Git operations.
That failure came from the wiki publish step using PROJECT_PAT.

## Validation
- ruby -e "require "yaml"; YAML.load_file(".github/workflows/wiki-sync.yml"); YAML.load_file(".github/workflows/weekly-shared.yml"); puts "yaml_ok""
- inspected failing Wiki Sync log from run 24046419777 showing wiki git auth failure on PROJECT_PAT
