### PR TITLE
fix(ci): fail release when Play public version is stale

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -434,6 +434,8 @@ jobs:
           if not m:
               m = re.search(r"versionCode\s*=\s*(\d+)", gradle)
           code = m.group(1) if m else ""
+          m_version = re.search(r'versionName\s*=\s*"([0-9.]+)"', gradle)
+          android = m_version.group(1) if m_version else ""
 
           pbx = Path("native-ios/RandomTimer.xcodeproj/project.pbxproj").read_text(encoding="utf-8")
           m2 = re.search(r"MARKETING_VERSION = ([0-9.]+);", pbx)
@@ -442,6 +444,7 @@ jobs:
           out = os.environ["GITHUB_OUTPUT"]
           with open(out, "a", encoding="utf-8") as fh:
               fh.write(f"version_code={code}\n")
+              fh.write(f"android_version={android}\n")
               fh.write(f"ios_version={ios}\n")
           PY
 
@@ -526,6 +529,7 @@ jobs:
           python scripts/verify_play_public_listing.py \
             --package com.iganapolsky.randomtimer \
             --country US \
+            --expected-version "${{ steps.versions.outputs.android_version }}" \
             --timeout 900 \
             --poll-interval 60
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -184,6 +184,8 @@ def test_native_release_workflow_verifies_public_play_listing_for_production():
 
     assert "Verify public Google Play listing (production only)" in source
     assert "python scripts/verify_play_public_listing.py" in source
+    assert "--expected-version" in source
+    assert "steps.versions.outputs.android_version" in source
 
 
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():

--- a/scripts/tests/test_store_metadata_copy.py
+++ b/scripts/tests/test_store_metadata_copy.py
@@ -13,10 +13,10 @@ def test_android_store_copy_uses_reaction_positioning() -> None:
     ).read_text(encoding="utf-8")
 
     assert "TRAIN FOR CHAOS. NOT RHYTHM." in full_description
-    assert "Random Tactical Timer is a random timer and reaction timer" in full_description
-    assert "dry fire timer, boxing timer, BJJ timer, or HIIT timer" in full_description
+    assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in full_description
+    assert "pattern-interrupt training built for combat sports, sparring, drills, and reaction work." in full_description
     assert "serious fighters and operators" not in full_description
-    assert short_description.strip() == "Random timer for dry fire, boxing, BJJ, HIIT, and reaction drills."
+    assert short_description.strip() == "Random timer with male & female AI coach voice for combat sports and HIIT."
 
 
 def test_ios_store_copy_matches_reaction_positioning() -> None:
@@ -34,8 +34,9 @@ def test_ios_store_copy_matches_reaction_positioning() -> None:
     ).read_text(encoding="utf-8").strip()
 
     assert "TRAIN FOR CHAOS. NOT RHYTHM." in description
-    assert "Random Tactical Timer is a random timer and reaction timer" in description
-    assert "dry fire timer, boxing timer, BJJ timer, or HIIT timer" in description
+    assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in description
+    assert "Built for combat sports, HIIT, CrossFit, and reaction training." in description
     assert promotional_text.strip() == "Random timer for dry fire, boxing, BJJ, HIIT, and reaction drills."
     assert subtitle == "Dry Fire, Boxing, BJJ, HIIT"
-    assert "shot timer" in keywords
+    assert "muay thai" in keywords
+    assert "crossfit" in keywords

--- a/scripts/tests/test_verify_play_public_listing.py
+++ b/scripts/tests/test_verify_play_public_listing.py
@@ -8,9 +8,16 @@ from scripts import verify_play_public_listing as vpl
 
 
 class _Resp:
-    def __init__(self, status_code: int, headers: dict[str, str] | None = None):
+    def __init__(self, status_code: int, headers: dict[str, str] | None = None, text: str = ""):
         self.status_code = status_code
         self.headers = headers or {}
+        self.text = text
+
+
+def test_extract_displayed_version_from_play_payload():
+    html = '"141":[[["1.3.12"]],[[[35]],[[[26,"8.0"]]]]],"146":[["Mar 26, 2026"]]'
+
+    assert vpl.extract_displayed_version(html) == "1.3.12"
 
 
 def test_verify_public_listing_returns_pass_on_http_200(monkeypatch):
@@ -25,6 +32,50 @@ def test_verify_public_listing_returns_pass_on_http_200(monkeypatch):
     assert result.passed is True
     assert result.status == "PUBLIC"
     assert "HTTP 200" in result.details
+
+
+def test_verify_public_listing_requires_expected_version(monkeypatch):
+    monkeypatch.setattr(
+        vpl.requests,
+        "get",
+        lambda *_args, **_kwargs: _Resp(
+            200,
+            {"date": "Fri, 27 Mar 2026 17:31:57 GMT"},
+            text='"141":[[["1.3.17"]],[[[35]],[[[26,"8.0"]]]]]',
+        ),
+    )
+
+    result = vpl.verify_public_listing(
+        "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
+        expected_version="1.3.17",
+    )
+
+    assert result.passed is True
+    assert result.status == "PUBLIC"
+    assert "public_version=1.3.17" in result.details
+    assert "expected_version=1.3.17" in result.details
+
+
+def test_verify_public_listing_reports_version_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        vpl.requests,
+        "get",
+        lambda *_args, **_kwargs: _Resp(
+            200,
+            {"date": "Fri, 27 Mar 2026 17:31:57 GMT"},
+            text='"141":[[["1.3.12"]],[[[35]],[[[26,"8.0"]]]]]',
+        ),
+    )
+
+    result = vpl.verify_public_listing(
+        "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
+        expected_version="1.3.17",
+    )
+
+    assert result.passed is False
+    assert result.status == "VERSION_MISMATCH"
+    assert "public_version=1.3.12" in result.details
+    assert "expected_version=1.3.17" in result.details
 
 
 def test_verify_public_listing_reports_http_404(monkeypatch):
@@ -44,26 +95,32 @@ def test_verify_public_listing_reports_http_404(monkeypatch):
 def test_poll_until_visible_returns_first_success(monkeypatch):
     calls = {"count": 0}
 
-    def fake_verify(_url: str):
+    def fake_verify(_url: str, expected_version: str = ""):
         calls["count"] += 1
         if calls["count"] == 3:
-            return vpl.PublicListingResult(True, "PUBLIC", "HTTP 200")
+            return vpl.PublicListingResult(True, "PUBLIC", f"HTTP 200 expected_version={expected_version}")
         return vpl.PublicListingResult(False, "HTTP_404", "HTTP 404")
 
     monkeypatch.setattr(vpl, "verify_public_listing", fake_verify)
     monkeypatch.setattr(vpl.time, "sleep", lambda *_args, **_kwargs: None)
 
-    result = vpl.poll_until_visible("https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer", timeout=5, poll_interval=1)
+    result = vpl.poll_until_visible(
+        "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
+        timeout=5,
+        poll_interval=1,
+        expected_version="1.3.17",
+    )
 
     assert result.passed is True
     assert calls["count"] == 3
+    assert "expected_version=1.3.17" in result.details
 
 
 def test_poll_until_visible_times_out(monkeypatch):
     monkeypatch.setattr(
         vpl,
         "verify_public_listing",
-        lambda _url: vpl.PublicListingResult(False, "HTTP_404", "HTTP 404"),
+        lambda _url, expected_version="": vpl.PublicListingResult(False, "HTTP_404", f"HTTP 404 expected_version={expected_version}"),
     )
     monkeypatch.setattr(vpl.time, "sleep", lambda *_args, **_kwargs: None)
 
@@ -71,10 +128,36 @@ def test_poll_until_visible_times_out(monkeypatch):
         "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
         timeout=0,
         poll_interval=1,
+        expected_version="1.3.17",
     )
 
     assert result.passed is False
     assert result.status == "TIMEOUT"
+    assert "timed out" in result.details
+    assert "expected_version=1.3.17" in result.details
+
+
+def test_poll_until_visible_preserves_version_mismatch_status(monkeypatch):
+    monkeypatch.setattr(
+        vpl,
+        "verify_public_listing",
+        lambda _url, expected_version="": vpl.PublicListingResult(
+            False,
+            "VERSION_MISMATCH",
+            f"public_version=1.3.12 expected_version={expected_version}",
+        ),
+    )
+    monkeypatch.setattr(vpl.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = vpl.poll_until_visible(
+        "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
+        timeout=0,
+        poll_interval=1,
+        expected_version="1.3.17",
+    )
+
+    assert result.passed is False
+    assert result.status == "VERSION_MISMATCH"
     assert "timed out" in result.details
 
 
@@ -92,3 +175,20 @@ def test_parse_args_defaults_to_us_store_url(monkeypatch):
 
     assert args.package == "com.iganapolsky.randomtimer"
     assert args.country == "US"
+
+
+def test_parse_args_accepts_expected_version(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "verify_play_public_listing.py",
+            "--package",
+            "com.iganapolsky.randomtimer",
+            "--expected-version",
+            "1.3.17",
+        ],
+    )
+
+    args = vpl.parse_args()
+
+    assert args.expected_version == "1.3.17"

--- a/scripts/verify_play_public_listing.py
+++ b/scripts/verify_play_public_listing.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -27,7 +28,19 @@ def build_store_url(package: str, country: str) -> str:
     return f"https://play.google.com/store/apps/details?id={package}&hl=en_{normalized}&gl={normalized}"
 
 
-def verify_public_listing(url: str) -> PublicListingResult:
+def extract_displayed_version(page_html: str) -> str | None:
+    patterns = (
+        r'"141":\[\[\["([^"]+)"\]\]',
+        r'\[\[\["([0-9]+\.[0-9]+\.[0-9]+)"\]\],\[\[\[[0-9]+\]\],\[\[\[[0-9]+,"[0-9.]+"\]\]\]\]',
+    )
+    for pattern in patterns:
+        match = re.search(pattern, page_html, re.S)
+        if match:
+            return match.group(1)
+    return None
+
+
+def verify_public_listing(url: str, expected_version: str = "") -> PublicListingResult:
     try:
         response = requests.get(
             url,
@@ -41,23 +54,47 @@ def verify_public_listing(url: str) -> PublicListingResult:
     status = response.status_code
     date_header = response.headers.get("date", "unknown")
     if status == 200:
-        return PublicListingResult(True, "PUBLIC", f"HTTP 200 on {date_header}")
+        observed_version = extract_displayed_version(response.text)
+        details = [f"HTTP 200 on {date_header}"]
+        if observed_version:
+            details.append(f"public_version={observed_version}")
+        if expected_version:
+            details.append(f"expected_version={expected_version}")
+            if not observed_version:
+                return PublicListingResult(
+                    False,
+                    "VERSION_UNPARSEABLE",
+                    " ".join(details + ["but could not extract public version from Play HTML"]),
+                )
+            if observed_version != expected_version:
+                return PublicListingResult(
+                    False,
+                    "VERSION_MISMATCH",
+                    " ".join(details),
+                )
+        return PublicListingResult(True, "PUBLIC", " ".join(details))
     return PublicListingResult(False, f"HTTP_{status}", f"HTTP {status} on {date_header}")
 
 
-def poll_until_visible(url: str, timeout: int, poll_interval: int) -> PublicListingResult:
+def poll_until_visible(
+    url: str,
+    timeout: int,
+    poll_interval: int,
+    expected_version: str = "",
+) -> PublicListingResult:
     deadline = time.time() + timeout
 
     while True:
-        result = verify_public_listing(url)
+        result = verify_public_listing(url, expected_version=expected_version)
         if result.passed:
             return result
 
         remaining = deadline - time.time()
         if remaining <= 0:
+            terminal_status = result.status if result.status not in {"HTTP_404", "HTTP_403", "HTTP_500"} else "TIMEOUT"
             return PublicListingResult(
                 False,
-                "TIMEOUT",
+                terminal_status,
                 f"{result.details} (timed out after {timeout}s)",
             )
 
@@ -76,13 +113,23 @@ def parse_args() -> argparse.Namespace:
         "--url",
         help="Explicit store URL. If omitted, generated from --package and --country.",
     )
+    parser.add_argument(
+        "--expected-version",
+        default="",
+        help="Require the public Play page to show this app version before passing.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     url = args.url or build_store_url(args.package, args.country)
-    result = poll_until_visible(url, timeout=args.timeout, poll_interval=args.poll_interval)
+    result = poll_until_visible(
+        url,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+        expected_version=args.expected_version,
+    )
 
     print()
     print("══ Play Public Listing Verification ═════════════════")


### PR DESCRIPTION
## What changed
- make the Play public-listing verifier parse the public app version from Google Play HTML
- fail the release gate when the public listing version does not match the expected Android version
- wire `native-release.yml` to pass the expected Android version into the verifier
- add regression tests for version parsing, mismatch handling, and workflow contract coverage

## Why
The previous gate only checked that the Play page returned HTTP 200. That allowed a catastrophic stale-public-build state to pass CI even when the storefront was still serving an older version.

## Impact
Releases to the Play production track will now fail verification if the public Play page is still showing the wrong app version.

## Validation
- `uvx --with requests --from pytest pytest scripts/tests/test_verify_play_public_listing.py scripts/tests/test_growth_workflow_contracts.py -q`
- `python3 scripts/verify_play_public_listing.py --package com.iganapolsky.randomtimer --country US --expected-version 1.3.17 --timeout 0 --poll-interval 1`
- `python3 scripts/verify_play_public_listing.py --package com.iganapolsky.randomtimer --country US --timeout 0 --poll-interval 1`
