### PR TITLE
fix(timer): enforce 5-second minimum range parity

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt
@@ -16,6 +16,7 @@ import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
 import com.iganapolsky.randomtimer.domain.model.VoiceGender
+import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -46,11 +47,16 @@ class TimerRepositoryImpl
                 }
             val allowedSounds = proManager.availableSounds(level)
             val clampedMax = maxSeconds.coerceAtMost(maxAllowed)
-            val clampedMin = minSeconds.coerceAtMost(clampedMax)
+            val sanitizedRange =
+                sanitizedStoredRange(
+                    minSeconds = minSeconds,
+                    maxSeconds = clampedMax,
+                    maxSecondsLimit = maxAllowed,
+                )
             val clampedSound = if (soundType in allowedSounds) soundType else SoundType.INTENSE
             return copy(
-                minSeconds = clampedMin,
-                maxSeconds = clampedMax,
+                minSeconds = sanitizedRange.first,
+                maxSeconds = sanitizedRange.second,
                 soundType = clampedSound,
                 useExtendedRange = if (isPro) useExtendedRange else false,
             )

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimeRangeAdjuster.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimeRangeAdjuster.kt
@@ -8,7 +8,7 @@ package com.iganapolsky.randomtimer.domain.model
  * - Dragging one thumb should "push/pull" the other thumb as needed, rather than blocking.
  */
 object TimeRangeAdjuster {
-    const val DEFAULT_MIN_SECONDS = 0
+    const val DEFAULT_MIN_SECONDS = 5
     const val DEFAULT_MAX_SECONDS = 3600
     const val DEFAULT_MIN_GAP_SECONDS = 5
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -94,7 +94,7 @@ data class TimerConfig(
 
         val DEFAULT =
             TimerConfig(
-                minSeconds = 5,
+                minSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS,
                 maxSeconds = 30,
                 alarmDuration = 10,
                 hiddenMode = false,
@@ -111,7 +111,7 @@ data class TimerConfig(
         val ALARM_DURATION_OPTIONS = listOf(5, 10, 15, 30, 60)
 
         /** Min seconds for first-session activation preset (mirrors iOS TimerModels). */
-        const val ACTIVATION_FIRST_RUN_MIN_SECONDS = 5
+        const val ACTIVATION_FIRST_RUN_MIN_SECONDS = TimeRangeAdjuster.DEFAULT_MIN_SECONDS
 
         /** Max seconds for first-session activation preset (mirrors iOS TimerModels). */
         const val ACTIVATION_FIRST_RUN_MAX_SECONDS = 30
@@ -198,7 +198,7 @@ fun toggleExtendedRange(
     }
 
 /**
- * Migrates legacy canonical defaults (30–120s) to activation-first 0–30s for users who have
+ * Migrates legacy canonical defaults (30–120s) to activation-first 5–30s for users who have
  * not completed their first timer. New installs already use [TimerConfig.DEFAULT]; returns null
  * when no migration applies.
  */

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -1072,6 +1072,7 @@ private fun TimeRangeSliders(
     val haptic = LocalHapticFeedback.current
     val coarseNudgeStep = 5
     val fineNudgeStep = 1
+    val minFloorSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS
     val minGapSeconds = TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS
     val maxSliderRangeInt = maxSliderRange.toInt()
     val minSliderMaxInt = minSliderMax.toInt()
@@ -1120,7 +1121,7 @@ private fun TimeRangeSliders(
             ) {
                 NudgeButton(
                     label = "\u2212",
-                    enabled = enabled && minValue >= coarseNudgeStep,
+                    enabled = enabled && minValue >= (minFloorSeconds + coarseNudgeStep),
                     onClick = { onMinChange(minValue - coarseNudgeStep) },
                     width = nudgeSize,
                     height = nudgeSize,
@@ -1128,11 +1129,11 @@ private fun TimeRangeSliders(
                 Slider(
                     value = minValue.toFloat(),
                     onValueChange = { raw ->
-                        val snapped = snapToStep(raw, coarseNudgeStep, 0, maxSliderRangeInt - minGapSeconds)
+                        val snapped = snapToStep(raw, coarseNudgeStep, minFloorSeconds, maxSliderRangeInt - minGapSeconds)
                         onMinChange(snapped)
                     },
                     enabled = enabled,
-                    valueRange = 0f..(maxSliderRangeInt - minGapSeconds).toFloat(),
+                    valueRange = minFloorSeconds.toFloat()..(maxSliderRangeInt - minGapSeconds).toFloat(),
                     modifier = Modifier.weight(1f).semantics { contentDescription = "Minimum time slider" },
                     colors =
                         SliderDefaults.colors(

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplProValidationTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplProValidationTest.kt
@@ -2,8 +2,8 @@ package com.iganapolsky.randomtimer.data.repository
 
 import com.google.common.truth.Truth.assertThat
 import com.iganapolsky.randomtimer.domain.model.SoundType
-import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
 import org.junit.Test
 
 /**
@@ -12,7 +12,6 @@ import org.junit.Test
  * and Pro soundTypes reset to SoundType.INTENSE.
  */
 class TimerConfigProClampingTest {
-
     // Simulate the clamping logic extracted from TimerRepositoryImpl.
     // Mirrors the exact copy() logic used in the production clampedForPro() helper.
     private fun TimerConfig.clampedForPro(isPro: Boolean): TimerConfig {
@@ -30,7 +29,7 @@ class TimerConfigProClampingTest {
             minSeconds = sanitizedRange.first,
             maxSeconds = sanitizedRange.second,
             soundType = clampedSound,
-            useExtendedRange = if (isPro) useExtendedRange else false
+            useExtendedRange = if (isPro) useExtendedRange else false,
         )
     }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplProValidationTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImplProValidationTest.kt
@@ -2,6 +2,7 @@ package com.iganapolsky.randomtimer.data.repository
 
 import com.google.common.truth.Truth.assertThat
 import com.iganapolsky.randomtimer.domain.model.SoundType
+import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import org.junit.Test
 
@@ -18,11 +19,16 @@ class TimerConfigProClampingTest {
         val maxAllowed = if (isPro && useExtendedRange) TimerConfig.MAX_SECONDS_PRO else TimerConfig.MAX_SECONDS_FREE
         val allowedSounds = if (isPro) SoundType.entries.toList() else SoundType.FREE
         val clampedMax = maxSeconds.coerceAtMost(maxAllowed)
-        val clampedMin = minSeconds.coerceAtMost(clampedMax)
+        val sanitizedRange =
+            sanitizedStoredRange(
+                minSeconds = minSeconds,
+                maxSeconds = clampedMax,
+                maxSecondsLimit = maxAllowed,
+            )
         val clampedSound = if (soundType in allowedSounds) soundType else SoundType.INTENSE
         return copy(
-            minSeconds = clampedMin,
-            maxSeconds = clampedMax,
+            minSeconds = sanitizedRange.first,
+            maxSeconds = sanitizedRange.second,
             soundType = clampedSound,
             useExtendedRange = if (isPro) useExtendedRange else false
         )
@@ -45,6 +51,7 @@ class TimerConfigProClampingTest {
         val clamped = proConfig.clampedForPro(isPro = false)
 
         assertThat(clamped.maxSeconds).isEqualTo(TimerConfig.MAX_SECONDS_FREE)
+        assertThat(clamped.minSeconds).isEqualTo(5)
         assertThat(clamped.useExtendedRange).isFalse()
     }
 
@@ -138,9 +145,9 @@ class TimerConfigProClampingTest {
             )
         val clamped = proConfig.clampedForPro(isPro = false)
 
-        // min=0 is already safe; verify clamped max is 300 and min <= max
+        // Saved zero-second minima must be lifted to the safe floor after expiry too.
         assertThat(clamped.maxSeconds).isEqualTo(300)
-        assertThat(clamped.minSeconds).isAtMost(clamped.maxSeconds)
+        assertThat(clamped.minSeconds).isEqualTo(5)
         assertThat(clamped.useExtendedRange).isFalse()
     }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimeRangeAdjusterTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimeRangeAdjusterTest.kt
@@ -8,7 +8,7 @@ class TimeRangeAdjusterTest {
     fun `min change within gap keeps max unchanged`() {
         val (min, max) =
             TimeRangeAdjuster.adjustForMinChange(
-                currentMinSeconds = 0,
+                currentMinSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS,
                 currentMaxSeconds = 300,
                 newMinSeconds = 120,
             )
@@ -21,7 +21,7 @@ class TimeRangeAdjusterTest {
     fun `min change beyond max minus gap pushes max forward`() {
         val (min, max) =
             TimeRangeAdjuster.adjustForMinChange(
-                currentMinSeconds = 0,
+                currentMinSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS,
                 currentMaxSeconds = 60,
                 newMinSeconds = 60,
             )
@@ -51,12 +51,12 @@ class TimeRangeAdjusterTest {
     fun `max change within gap keeps min unchanged`() {
         val (min, max) =
             TimeRangeAdjuster.adjustForMaxChange(
-                currentMinSeconds = 0,
+                currentMinSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS,
                 currentMaxSeconds = 300,
                 newMaxSeconds = 200,
             )
 
-        assertThat(min).isEqualTo(0)
+        assertThat(min).isEqualTo(TimeRangeAdjuster.DEFAULT_MIN_SECONDS)
         assertThat(max).isEqualTo(200)
     }
 
@@ -118,5 +118,10 @@ class TimeRangeAdjusterTest {
         assertThat(max).isEqualTo(cap)
         assertThat(min).isEqualTo(cap - TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS)
         assertThat(max - min).isAtLeast(TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS)
+    }
+
+    @Test
+    fun `default minimum stays at 5 seconds to prevent instant fire`() {
+        assertThat(TimeRangeAdjuster.DEFAULT_MIN_SECONDS).isEqualTo(5)
     }
 }

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -84,7 +84,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
 
     private static let activationRangeNudgeAppliedKey = "activation_first_run_range_nudge_applied"
 
-    /// Migrates legacy 30–120s to 0–30s once for users who have not finished a first timer.
+    /// Migrates legacy 30–120s to 5–30s once for users who have not finished a first timer.
     func applyActivationPresetForFirstCompletionIfNeeded() {
         if UserDefaults.standard.bool(forKey: Self.activationRangeNudgeAppliedKey) { return }
         let done = UserDefaults.standard.bool(forKey: "hasCompletedFirstTimer")

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -10,9 +10,9 @@ struct TimerSetupScreen: View {
     @State private var screenAppearedAt: Date?
     @State private var bannerDismissed = false
     @AppStorage("hasCompletedFirstTimer") private var hasCompletedFirstTimer = false
-    @AppStorage("timer_range_free_min") private var storedFreeMinSeconds = 0
+    @AppStorage("timer_range_free_min") private var storedFreeMinSeconds = TimerConfig.minimumFloorSeconds
     @AppStorage("timer_range_free_max") private var storedFreeMaxSeconds = TimerConfig.maxSecondsFree
-    @AppStorage("timer_range_extended_min") private var storedExtendedMinSeconds = 0
+    @AppStorage("timer_range_extended_min") private var storedExtendedMinSeconds = TimerConfig.minimumFloorSeconds
     @AppStorage("timer_range_extended_max") private var storedExtendedMaxSeconds = TimerConfig.maxSecondsPro
 
     // Read directly from timerManager.config to avoid animation issues
@@ -629,7 +629,7 @@ private struct TimeRangeSliders: View {
     private let minGap = TimeRangeAdjuster.defaultMinGapSeconds
 
     private var minSliderUpperBound: Int {
-        Swift.max(0, maxValue - minGap)
+        Swift.max(TimeRangeAdjuster.defaultMinSecondsLimit, maxValue - minGap)
     }
 
     private var maxSliderLowerBound: Int {
@@ -637,7 +637,7 @@ private struct TimeRangeSliders: View {
     }
 
     private var minSliderRange: ClosedRange<Double> {
-        let lower = 0.0
+        let lower = Double(TimeRangeAdjuster.defaultMinSecondsLimit)
         let upper = Double(minSliderUpperBound)
         return lower < upper ? lower...upper : lower...(lower + 1)
     }
@@ -686,7 +686,14 @@ private struct TimeRangeSliders: View {
 
                     Slider(
                         value: Binding(
-                            get: { Double(Swift.min(Swift.max(minValue, 0), minSliderUpperBound)) },
+                            get: {
+                                Double(
+                                    Swift.min(
+                                        Swift.max(minValue, TimeRangeAdjuster.defaultMinSecondsLimit),
+                                        minSliderUpperBound
+                                    )
+                                )
+                            },
                             set: { newValue in
                                 let snapped = Int((newValue / Double(coarseStep)).rounded()) * coarseStep
                                 adjustMin(to: snapped)
@@ -783,7 +790,7 @@ private struct TimeRangeSliders: View {
         TimeRangeAdjuster.adjustForMinChange(
             currentMinSeconds: minValue,
             currentMaxSeconds: maxValue,
-            newMinSeconds: Swift.max(0, newValue),
+            newMinSeconds: Swift.max(TimeRangeAdjuster.defaultMinSecondsLimit, newValue),
             maxSecondsLimit: maxSecondsLimit
         )
     }
@@ -792,7 +799,7 @@ private struct TimeRangeSliders: View {
         TimeRangeAdjuster.adjustForMaxChange(
             currentMinSeconds: minValue,
             currentMaxSeconds: maxValue,
-            newMaxSeconds: Swift.max(minGap, newValue),
+            newMaxSeconds: Swift.max(TimeRangeAdjuster.defaultMinSecondsLimit + minGap, newValue),
             maxSecondsLimit: maxSecondsLimit
         )
     }

--- a/native-ios/RandomTimerTests/ActivationDefaultsTests.swift
+++ b/native-ios/RandomTimerTests/ActivationDefaultsTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 final class ActivationDefaultsTests: XCTestCase {
 
-    func testDefaultMinSecondsIsZeroForActivationFirstQuickStart() {
+    func testDefaultMinSecondsIsFiveForActivationFirstQuickStart() {
         let config = TimerConfig.default
-        XCTAssertEqual(config.minSeconds, 0)
+        XCTAssertEqual(config.minSeconds, 5)
     }
 
     func testDefaultMaxSecondsIs30ForActivationFirstQuickStart() {
@@ -19,9 +19,9 @@ final class ActivationDefaultsTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(config.maxSeconds - config.minSeconds, 5)
     }
 
-    func testDefaultMinDurationIsZeroSeconds() {
+    func testDefaultMinDurationIsFiveSeconds() {
         let config = TimerConfig.default
-        XCTAssertEqual(config.minDuration, 0.0, accuracy: 0.001)
+        XCTAssertEqual(config.minDuration, 5.0, accuracy: 0.001)
     }
 
     func testDefaultMaxDurationIs30Seconds() {
@@ -29,13 +29,13 @@ final class ActivationDefaultsTests: XCTestCase {
         XCTAssertEqual(config.maxDuration, 30.0, accuracy: 0.001)
     }
 
-    func testExplicitZeroMinStillAllowed() {
+    func testExplicitZeroMinClampsToSafeFloor() {
         let config = TimerConfig(minSeconds: 0, maxSeconds: 60)
-        XCTAssertEqual(config.minSeconds, 0)
+        XCTAssertEqual(config.minSeconds, 5)
     }
 
     func testExplicit300MaxStillAllowed() {
-        let config = TimerConfig(minSeconds: 0, maxSeconds: 300)
+        let config = TimerConfig(minSeconds: 5, maxSeconds: 300)
         XCTAssertEqual(config.maxSeconds, 300)
     }
 
@@ -43,14 +43,14 @@ final class ActivationDefaultsTests: XCTestCase {
         let config = TimerConfig.default
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(TimerConfig.self, from: data)
-        XCTAssertEqual(decoded.minSeconds, 0)
+        XCTAssertEqual(decoded.minSeconds, 5)
         XCTAssertEqual(decoded.maxSeconds, 30)
     }
 
     func testEmptyJsonDecodesToNewDefaults() throws {
         let data = Data("{}".utf8)
         let decoded = try JSONDecoder().decode(TimerConfig.self, from: data)
-        XCTAssertEqual(decoded.minSeconds, 0)
+        XCTAssertEqual(decoded.minSeconds, 5)
         XCTAssertEqual(decoded.maxSeconds, 30)
     }
 

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -7,7 +7,7 @@ final class TimerConfigTests: XCTestCase {
     func testDefaultConfigHasValidRange() {
         let config = RandomTimer.TimerConfig.default
 
-        XCTAssertEqual(config.minSeconds, 0)
+        XCTAssertEqual(config.minSeconds, 5)
         XCTAssertEqual(config.maxSeconds, 30)
         XCTAssertEqual(config.alarmDuration, 10)
         XCTAssertFalse(config.voiceEnabled)
@@ -17,7 +17,7 @@ final class TimerConfigTests: XCTestCase {
         let legacy = TimerConfig(minSeconds: 30, maxSeconds: 120)
         let next = legacy.applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: false)
         XCTAssertNotNil(next)
-        XCTAssertEqual(next?.minSeconds, 0)
+        XCTAssertEqual(next?.minSeconds, 5)
         XCTAssertEqual(next?.maxSeconds, 30)
         XCTAssertEqual(next?.soundType, legacy.soundType)
     }
@@ -85,7 +85,7 @@ final class TimerConfigTests: XCTestCase {
 
         let decoded = try JSONDecoder().decode(RandomTimer.TimerConfig.self, from: payload)
 
-        XCTAssertEqual(decoded.minSeconds, 0)
+        XCTAssertEqual(decoded.minSeconds, 5)
         XCTAssertEqual(decoded.maxSeconds, RandomTimer.TimerConfig.maxSecondsPro)
         XCTAssertEqual(decoded.alarmDuration, 1)
         XCTAssertTrue(decoded.hiddenMode)
@@ -123,7 +123,7 @@ final class TimerConfigTests: XCTestCase {
         let decoded = try JSONDecoder().decode(RandomTimer.TimerConfig.self, from: payload)
 
         let expected = RandomTimer.TimerConfig(
-            minSeconds: 0,
+            minSeconds: 5,
             maxSeconds: 30,
             alarmDuration: 10,
             hiddenMode: false,
@@ -153,7 +153,7 @@ final class TimerConfigTests: XCTestCase {
             repeatRounds: -4
         )
 
-        XCTAssertEqual(config.minSeconds, 0)
+        XCTAssertEqual(config.minSeconds, 5)
         XCTAssertEqual(config.maxSeconds, RandomTimer.TimerConfig.maxSecondsPro)
         XCTAssertEqual(config.alarmDuration, 1)
         XCTAssertEqual(config.volume, 1.0, accuracy: 0.0001)
@@ -243,7 +243,7 @@ final class TimerConfigTests: XCTestCase {
             repeatRounds: 0
         )
         let profiles = RangeToggleProfiles(
-            freeMinSeconds: 0,
+            freeMinSeconds: 5,
             freeMaxSeconds: 30,
             extendedMinSeconds: 900,
             extendedMaxSeconds: 1800
@@ -252,7 +252,7 @@ final class TimerConfigTests: XCTestCase {
         let result = toggleExtendedRange(current: current, profiles: profiles)
 
         XCTAssertFalse(result.config.useExtendedRange)
-        XCTAssertEqual(result.config.minSeconds, 0)
+        XCTAssertEqual(result.config.minSeconds, 5)
         XCTAssertEqual(result.config.maxSeconds, 30)
         XCTAssertEqual(result.profiles.extendedMinSeconds, 900)
         XCTAssertEqual(result.profiles.extendedMaxSeconds, 1800)

--- a/native-ios/RandomTimerWidget/SharedTypes.swift
+++ b/native-ios/RandomTimerWidget/SharedTypes.swift
@@ -32,7 +32,7 @@ public struct TimerActivityAttributes: ActivityAttributes {
     public let minSeconds: Int
     public let maxSeconds: Int
 
-    public init(timerName: String = "Random Tactical Timer", endDate: Date, minSeconds: Int = 0, maxSeconds: Int = 30) {
+    public init(timerName: String = "Random Tactical Timer", endDate: Date, minSeconds: Int = 5, maxSeconds: Int = 30) {
         self.timerName = timerName
         self.endDate = endDate
         self.minSeconds = minSeconds

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -95,6 +95,8 @@ public enum VoiceGender: String, Codable, Sendable, CaseIterable {
 
 /// Configuration for a random timer with all settings.
 public struct TimerConfig: Codable, Sendable, Equatable {
+    public static let minimumFloorSeconds = 5
+
     /// Minimum time in seconds
     public let minSeconds: Int
     /// Maximum time in seconds
@@ -135,8 +137,14 @@ public struct TimerConfig: Codable, Sendable, Equatable {
         volume: Float,
         repeatRounds: Int
     ) -> SanitizedValues {
-        let clampedMax = Swift.min(Swift.max(maxSeconds, 0), maxSecondsPro)
-        let clampedMin = Swift.min(Swift.min(Swift.max(minSeconds, 0), maxSecondsPro), clampedMax)
+        let clampedMax = Swift.min(
+            Swift.max(maxSeconds, minimumFloorSeconds + TimeRangeAdjuster.defaultMinGapSeconds),
+            maxSecondsPro
+        )
+        let clampedMin = Swift.min(
+            Swift.min(Swift.max(minSeconds, minimumFloorSeconds), maxSecondsPro),
+            clampedMax
+        )
         let clampedAlarm = Swift.max(1, alarmDuration)
         let clampedVolume = Swift.min(Swift.max(volume, 0), 1)
         let clampedRounds = Swift.max(0, repeatRounds)
@@ -151,7 +159,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     }
 
     public init(
-        minSeconds: Int = 0,
+        minSeconds: Int = minimumFloorSeconds,
         maxSeconds: Int = 30,
         alarmDuration: Int = 10,
         hiddenMode: Bool = false,
@@ -202,14 +210,14 @@ public struct TimerConfig: Codable, Sendable, Equatable {
 
     public static let alarmDurationOptions = [5, 10, 15, 30, 60]
 
-    /// Migrates legacy canonical defaults (30–120s) to activation-first 0–30s when the user
+    /// Migrates legacy canonical defaults (30–120s) to activation-first 5–30s when the user
     /// has not completed a first timer. Returns nil when no migration applies.
     public func applyingActivationPresetForFirstCompletionIfEligible(hasCompletedFirstTimer: Bool) -> TimerConfig? {
         guard !hasCompletedFirstTimer else { return nil }
         guard !useExtendedRange else { return nil }
         guard minSeconds == 30, maxSeconds == 120 else { return nil }
         return TimerConfig(
-            minSeconds: 0,
+            minSeconds: Self.minimumFloorSeconds,
             maxSeconds: 30,
             alarmDuration: alarmDuration,
             hiddenMode: hiddenMode,
@@ -278,7 +286,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
 
         let rawMin = container.decodeFirstInt(
             forKeys: [.minSeconds, .minDuration, .min_seconds, .min_time],
-            defaultValue: 0
+            defaultValue: Self.minimumFloorSeconds
         )
         let rawMax = container.decodeFirstInt(
             forKeys: [.maxSeconds, .maxDuration, .max_seconds, .max_time],
@@ -382,7 +390,7 @@ public struct TimerConfig: Codable, Sendable, Equatable {
 /// - Min/max must keep at least `minGapSeconds` between them.
 /// - Dragging one thumb should "push/pull" the other thumb as needed, rather than blocking.
 enum TimeRangeAdjuster {
-    static let defaultMinSecondsLimit = 0
+    static let defaultMinSecondsLimit = TimerConfig.minimumFloorSeconds
     static let defaultMaxSecondsLimit = TimerConfig.maxSecondsFree
     static let defaultMinGapSeconds = 5
 
@@ -464,7 +472,10 @@ internal func sanitizedStoredRange(
     maxSecondsLimit: Int
 ) -> (min: Int, max: Int) {
     let clampedMax = Swift.max(TimeRangeAdjuster.defaultMinGapSeconds, Swift.min(maxSeconds, maxSecondsLimit))
-    let clampedMin = Swift.max(0, Swift.min(minSeconds, clampedMax - TimeRangeAdjuster.defaultMinGapSeconds))
+    let clampedMin = Swift.max(
+        TimeRangeAdjuster.defaultMinSecondsLimit,
+        Swift.min(minSeconds, clampedMax - TimeRangeAdjuster.defaultMinGapSeconds)
+    )
     return TimeRangeAdjuster.adjustForMaxChange(
         currentMinSeconds: clampedMin,
         currentMaxSeconds: clampedMax,
@@ -750,7 +761,7 @@ public struct TimerActivityAttributes: ActivityAttributes {
     public init(
         timerName: String = "Random Tactical Timer",
         endDate: Date,
-        minSeconds: Int = 0,
+        minSeconds: Int = TimerConfig.minimumFloorSeconds,
         maxSeconds: Int = 30
     ) {
         self.timerName = timerName

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -31,14 +31,17 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def test_default_timer_range_is_0_to_30_on_both_platforms():
+def test_default_timer_range_is_5_to_30_on_both_platforms():
     """Activation-first default range in TimerConfig.DEFAULT / Swift defaults (free-tier cap remains 300s)."""
     android_source = _read(ANDROID_TIMER_CONFIG)
+    android_range_adjuster = _read(ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimeRangeAdjuster.kt")
     ios_source = _read(IOS_TIMER_MODELS)
 
-    assert re.search(r"minSeconds\s*=\s*0", android_source)
+    assert "const val DEFAULT_MIN_SECONDS = 5" in android_range_adjuster
+    assert "minSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS" in android_source
     assert re.search(r"maxSeconds\s*=\s*30", android_source)
-    assert re.search(r"minSeconds:\s*Int\s*=\s*0", ios_source)
+    assert "public static let minimumFloorSeconds = 5" in ios_source
+    assert re.search(r"minSeconds:\s*Int\s*=\s*minimumFloorSeconds", ios_source)
     assert re.search(r"maxSeconds:\s*Int\s*=\s*30", ios_source)
 
 

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -75,12 +75,13 @@ def test_timer_defaults_match_across_mobile_platforms():
     android_repository = ANDROID_REPOSITORY.read_text(encoding="utf-8")
     ios_models = IOS_MODELS.read_text(encoding="utf-8")
 
-    assert "minSeconds = 0" in android_config
+    assert "minSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS" in android_config
     assert "maxSeconds = 30" in android_config
     assert "private fun Preferences.toTimerConfig()" in android_repository
     assert android_repository.count("maxSeconds = this[KEY_MAX_SECONDS] ?: 30") == 1
     assert android_repository.count("preferences.toTimerConfig()") == 2
-    assert re.search(r"minSeconds: Int = 0,\n\s*maxSeconds: Int = 30,", ios_models)
+    assert "public static let minimumFloorSeconds = 5" in ios_models
+    assert re.search(r"minSeconds: Int = minimumFloorSeconds,\n\s*maxSeconds: Int = 30,", ios_models)
     assert "maxSecondsFree = 300" in ios_models
 
 
@@ -95,10 +96,10 @@ def test_timer_limits_and_gap_rules_match_across_mobile_platforms():
     assert "public static let maxSecondsFree = 300" in ios_models
     assert "public static let maxSecondsPro = 3600" in ios_models
 
-    assert "const val DEFAULT_MIN_SECONDS = 0" in android_range_adjuster
+    assert "const val DEFAULT_MIN_SECONDS = 5" in android_range_adjuster
     assert "const val DEFAULT_MAX_SECONDS = 3600" in android_range_adjuster
     assert "const val DEFAULT_MIN_GAP_SECONDS = 5" in android_range_adjuster
-    assert "static let defaultMinSecondsLimit = 0" in ios_models
+    assert "static let defaultMinSecondsLimit = TimerConfig.minimumFloorSeconds" in ios_models
     assert "static let defaultMaxSecondsLimit = TimerConfig.maxSecondsFree" in ios_models
     assert "static let defaultMinGapSeconds = 5" in ios_models
 


### PR DESCRIPTION
## Summary
- enforce a real 5-second floor across Android and iOS timer configuration paths
- clamp legacy stored 0-second minima on load and block both sliders from dialing back to 0
- update parity and platform regression tests so CI catches future default-boundary drift

## Verification
- `uvx --with pytest==8.4.2 --with pytest-cov==7.0.0 --with pillow==11.3.0 --with google-auth==2.43.0 --with requests==2.32.5 --from pytest pytest scripts/tests/ -q`
- `cd native-android && ./gradlew :app:testDebugUnitTest`
- `cd native-ios && xcodebuild test -project RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 16' OTHER_SWIFT_FLAGS='-D RT_SKIP_FIREBASE_FOR_CI' -only-testing:RandomTimerTests/ActivationDefaultsTests -only-testing:RandomTimerTests/TimerConfigTests -only-testing:RandomTimerTests/TimerConfigProClampingTests`
