### PR TITLE
fix(ui): move Male/Female voice chips next to PREVIEW button

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -677,9 +677,9 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
 
-      - name: Check current App Store version state
+      - name: Check current App Store version state (pre-metadata)
         if: steps.gate.outputs.enabled == 'true'
-        id: asc_state
+        id: asc_state_meta
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
@@ -689,10 +689,10 @@ jobs:
           STATE_JSON="$(python scripts/asc_poll_version_state.py --version "$IOS_VERSION" --json 2>/dev/null)" || true
           STATE="$(echo "$STATE_JSON" | python -c 'import json,sys; print(json.loads(sys.stdin.read()).get("state","UNKNOWN"))' 2>/dev/null)" || STATE="UNKNOWN"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
-          echo "ASC version state: $STATE"
+          echo "ASC version state (pre-metadata): $STATE"
 
       - name: Upload App Store metadata/screenshots
-        if: ${{ steps.gate.outputs.enabled == 'true' && steps.asc_state.outputs.state != 'READY_FOR_REVIEW' && steps.asc_state.outputs.state != 'WAITING_FOR_REVIEW' && steps.asc_state.outputs.state != 'IN_REVIEW' }}
+        if: ${{ steps.gate.outputs.enabled == 'true' && steps.asc_state_meta.outputs.state != 'READY_FOR_REVIEW' && steps.asc_state_meta.outputs.state != 'WAITING_FOR_REVIEW' && steps.asc_state_meta.outputs.state != 'IN_REVIEW' }}
         env:
           CI: "true"
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -527,51 +527,23 @@ fun TimerSetupScreen(
                             Spacer(modifier = Modifier.height(16.dp))
 
                             // AI Voice Callouts (Elite Feature)
-                            Row(
+                            Column(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
                                         .padding(vertical = 8.dp),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                Column(modifier = Modifier.weight(1f)) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
                                     Text(
                                         text = "\uD83D\uDCE2 Voice Callouts",
                                         style = MaterialTheme.typography.labelMedium,
                                         fontWeight = FontWeight.SemiBold,
                                         color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
                                     )
-                                    Text(
-                                        text = "Time checks and command cues that keep you sharp under pressure",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = TimerColors.TextMuted,
-                                    )
-                                }
-
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    if (isPro) {
-                                        // Pro users only see the voice toggle
-                                    } else {
-                                        // Preview Button only for free users (to sell the feature)
-                                        Surface(
-                                            onClick = {
-                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                onCommandCuePreview(config.voiceGender)
-                                            },
-                                            shape = RoundedCornerShape(4.dp),
-                                            color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
-                                            modifier = Modifier.padding(end = 8.dp),
-                                        ) {
-                                            Text(
-                                                text = "PREVIEW",
-                                                style = MaterialTheme.typography.labelSmall,
-                                                fontWeight = FontWeight.Bold,
-                                                color = TimerColors.AccentPrimary,
-                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                            )
-                                        }
-                                    }
 
                                     if (isPro) {
                                         Switch(
@@ -611,44 +583,64 @@ fun TimerSetupScreen(
                                         }
                                     }
                                 }
-                            }
 
-                            // Voice Gender selector stays visible so free users can preview both voices.
-                            Row(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 8.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                VoiceGender.entries.forEach { gender ->
-                                    FilterChip(
-                                        selected = config.voiceGender == gender,
-                                        onClick = {
-                                            updateConfig(voiceGender = gender)
-                                            onVoiceGenderSelected(gender)
-                                        },
-                                        label = {
+                                // Male/Female chips + Preview — always visible, right below the title
+                                Row(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(top = 8.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    VoiceGender.entries.forEach { gender ->
+                                        FilterChip(
+                                            selected = config.voiceGender == gender,
+                                            onClick = {
+                                                updateConfig(voiceGender = gender)
+                                                onVoiceGenderSelected(gender)
+                                            },
+                                            label = {
+                                                Text(
+                                                    if (gender == VoiceGender.MALE) {
+                                                        "Male"
+                                                    } else {
+                                                        "Female"
+                                                    },
+                                                )
+                                            },
+                                            colors =
+                                                FilterChipDefaults.filterChipColors(
+                                                    selectedContainerColor = TimerColors.AccentPrimary.copy(alpha = 0.2f),
+                                                    selectedLabelColor = TimerColors.AccentPrimary,
+                                                ),
+                                            border =
+                                                FilterChipDefaults.filterChipBorder(
+                                                    selectedBorderColor = TimerColors.AccentPrimary,
+                                                    enabled = true,
+                                                    selected = config.voiceGender == gender,
+                                                ),
+                                        )
+                                    }
+
+                                    if (!isPro) {
+                                        Surface(
+                                            onClick = {
+                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                onCommandCuePreview(config.voiceGender)
+                                            },
+                                            shape = RoundedCornerShape(4.dp),
+                                            color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
+                                        ) {
                                             Text(
-                                                if (gender == VoiceGender.MALE) {
-                                                    "Male"
-                                                } else {
-                                                    "Female"
-                                                },
+                                                text = "PREVIEW",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                fontWeight = FontWeight.Bold,
+                                                color = TimerColors.AccentPrimary,
+                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                                             )
-                                        },
-                                        colors =
-                                            FilterChipDefaults.filterChipColors(
-                                                selectedContainerColor = TimerColors.AccentPrimary.copy(alpha = 0.2f),
-                                                selectedLabelColor = TimerColors.AccentPrimary,
-                                            ),
-                                        border =
-                                            FilterChipDefaults.filterChipBorder(
-                                                selectedBorderColor = TimerColors.AccentPrimary,
-                                                enabled = true,
-                                                selected = config.voiceGender == gender,
-                                            ),
-                                    )
+                                        }
+                                    }
                                 }
                             }
 

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -103,11 +103,13 @@ def test_voice_callouts_present_on_both_platforms():
     ios_setup = _read(IOS_SETUP)
     android_timer_config = _read(ANDROID_TIMER_CONFIG)
     ios_timer_models = _read(IOS_TIMER_MODELS)
-    expected_supporting_copy = "Time checks and command cues that keep you sharp under pressure"
 
-    for source in (android_setup, ios_setup):
-        assert "Voice Callouts" in source or "AI Voice Callouts" in source
-        assert expected_supporting_copy in source
+    assert "Voice Callouts" in android_setup or "AI Voice Callouts" in android_setup
+    assert "Voice Callouts" in ios_setup or "AI Voice Callouts" in ios_setup
+    assert "Time checks and command cues that keep you sharp under pressure" in ios_setup
+    assert "VoiceGender.entries.forEach" in android_setup
+    assert 'text = "PREVIEW"' in android_setup
+    assert 'if (gender == VoiceGender.MALE)' in android_setup
 
     assert "voiceEnabled" in android_timer_config
     assert "voiceEnabled" in ios_timer_models

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -171,12 +171,13 @@ def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():
 def test_voice_preview_actions_and_copy_match_across_mobile_platforms():
     android_setup = ANDROID_SETUP_SCREEN.read_text(encoding="utf-8")
     ios_setup = IOS_SETUP_SCREEN.read_text(encoding="utf-8")
-    expected_supporting_copy = "Time checks and command cues that keep you sharp under pressure"
 
     assert "Voice Callouts" in android_setup or "AI Voice Callouts" in android_setup
     assert "Voice Callouts" in ios_setup
-    assert expected_supporting_copy in android_setup
-    assert expected_supporting_copy in ios_setup
+    assert "Time checks and command cues that keep you sharp under pressure" in ios_setup
+    assert "VoiceGender.entries.forEach" in android_setup
+    assert "horizontalArrangement = Arrangement.spacedBy(8.dp)" in android_setup
+    assert "onCommandCuePreview(config.voiceGender)" in android_setup
 
 
 def test_sound_arsenal_is_expanded_by_default_for_free_users():

--- a/scripts/tests/test_voice_regression_contracts.py
+++ b/scripts/tests/test_voice_regression_contracts.py
@@ -120,9 +120,11 @@ def test_android_free_preview_keeps_voice_selector_visible() -> None:
     setup = _read(ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt")
 
     assert 'text = "PREVIEW"' in setup
-    assert "Voice Gender selector stays visible so free users can preview both voices." in setup
+    assert "Male/Female chips + Preview" in setup
     assert "VoiceGender.entries.forEach" in setup
     assert "VoiceGender.MALE" in setup
+    assert "if (!isPro) {" in setup
+    assert "onCommandCuePreview(config.voiceGender)" in setup
     assert "if (config.voiceEnabled) {" not in setup
 
 


### PR DESCRIPTION
## Summary
- Male/Female chips were below the fold — users couldn't find them
- Moved to same row as PREVIEW button, directly under Voice Callouts title
- Removed subtitle text to save vertical space

## Before
Voice Callouts title + subtitle → PREVIEW + PRO buttons → (scroll) → Male/Female chips

## After  
Voice Callouts title + PRO → Male | Female | PREVIEW (one row, no scroll)

## Test plan
- [x] Verified on emulator: chips visible without scrolling
- [x] Build succeeds
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)