### PR TITLE
fix(ui): remove activation banner from both platforms

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -232,8 +232,6 @@ fun TimerSetupScreen(
         )
     }
 
-    var bannerDismissed by remember { mutableStateOf(false) }
-
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
         val isCompactHeight = TimerSetupLayoutPolicy.isCompactHeightViewport(maxHeight.value.toInt())
         val spacing = if (isCompactHeight) SetupSpacing.compact else SetupSpacing.regular
@@ -291,38 +289,6 @@ fun TimerSetupScreen(
                         bottom = spacing.listBottom,
                     ),
             ) {
-                if (!hasCompletedFirstTimer && !bannerDismissed) {
-                    item {
-                        Card(
-                            colors =
-                                CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.primary,
-                                ),
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Box(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
-                                Text(
-                                    text = "Tap Start for a random 20s\u20131min drill. Customize later.",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onPrimary,
-                                    modifier = Modifier.padding(end = 32.dp),
-                                )
-                                IconButton(
-                                    onClick = { bannerDismissed = true },
-                                    modifier = Modifier.align(Alignment.TopEnd).size(24.dp),
-                                ) {
-                                    Icon(
-                                        Icons.Default.Close,
-                                        contentDescription = "Dismiss",
-                                        tint = MaterialTheme.colorScheme.onPrimary,
-                                        modifier = Modifier.size(16.dp),
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-
                 // Training Stats
                 if (hasCompletedFirstTimer) {
                     item {

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -8,7 +8,6 @@ struct TimerSetupScreen: View {
     @State private var paywallEntryPoint: PaywallEntryPoint = .unknown
     @State private var showArsenal = true
     @State private var screenAppearedAt: Date?
-    @State private var bannerDismissed = false
     @AppStorage("hasCompletedFirstTimer") private var hasCompletedFirstTimer = false
     @AppStorage("timer_range_free_min") private var storedFreeMinSeconds = TimerConfig.minimumFloorSeconds
     @AppStorage("timer_range_free_max") private var storedFreeMaxSeconds = TimerConfig.maxSecondsFree
@@ -32,25 +31,6 @@ struct TimerSetupScreen: View {
                     .foregroundColor(.textMuted)
                     .padding(.top, 16)
                     .padding(.leading, 4)
-
-                if !hasCompletedFirstTimer && !bannerDismissed {
-                    HStack {
-                        Text("Tap Start for a random 20s\u{2013}1min drill. Customize later.")
-                            .font(.subheadline)
-                            .foregroundStyle(.white)
-                        Spacer()
-                        Button {
-                            bannerDismissed = true
-                        } label: {
-                            Image(systemName: "xmark")
-                                .font(.caption.weight(.bold))
-                                .foregroundStyle(.white.opacity(0.8))
-                        }
-                    }
-                    .padding(12)
-                    .background(Color.accentColor)
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                }
 
                 // 1. Timer Range Card
                 GlassCard {


### PR DESCRIPTION
## Summary
- Remove blue "Tap Start for a random 20s-1min drill" banner from iOS and Android
- Banner was added without CEO approval in P0-P2 activation PR

## Test plan
- [x] Android builds
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)