### PR TITLE
fix(ci): retry Android production when Play public version is stale

### DIFF
--- a/.github/workflows/android-production-retry.yml
+++ b/.github/workflows/android-production-retry.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Play listing probe dependencies
+        run: python -m pip install --upgrade pip requests==2.32.5
+
       - name: Check if retry is required
         id: gate
         env:

--- a/.github/workflows/android-production-retry.yml
+++ b/.github/workflows/android-production-retry.yml
@@ -19,32 +19,53 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: read
     outputs:
       should_retry: ${{ steps.gate.outputs.should_retry }}
       reason: ${{ steps.gate.outputs.reason }}
+      expected_version: ${{ steps.gate.outputs.expected_version }}
+      public_status: ${{ steps.gate.outputs.public_status }}
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Check if retry is required
         id: gate
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
-          ISSUE_TITLE: Android production publish blocked by Play FAILED_PRECONDITION
           FORCE_RETRY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_retry || 'false' }}
         run: |
           if [ "$FORCE_RETRY" = "true" ]; then
             echo "should_retry=true" >> "$GITHUB_OUTPUT"
             echo "reason=manual_force_retry" >> "$GITHUB_OUTPUT"
+            echo "expected_version=" >> "$GITHUB_OUTPUT"
+            echo "public_status=SKIPPED_MANUAL_FORCE" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          ISSUE_NUMBER="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "\"$ISSUE_TITLE\" in:title" --json number,title --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' | head -1)"
-          if [ -n "$ISSUE_NUMBER" ]; then
-            echo "should_retry=true" >> "$GITHUB_OUTPUT"
-            echo "reason=open_blocker_issue_$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_retry=false" >> "$GITHUB_OUTPUT"
-            echo "reason=no_open_blocker_issue" >> "$GITHUB_OUTPUT"
-          fi
+          EXPECTED_VERSION="$(python3 scripts/source_versions.py --format value --key ANDROID_VERSION_NAME)"
+          export EXPECTED_VERSION
+
+          python3 <<'PY'
+import os
+
+from scripts.verify_play_public_listing import build_store_url, verify_public_listing
+
+expected_version = os.environ["EXPECTED_VERSION"].strip()
+result = verify_public_listing(
+    build_store_url("com.iganapolsky.randomtimer", "US"),
+    expected_version=expected_version,
+)
+should_retry = not result.passed
+reason = "play_public_current" if result.passed else f"play_public_{result.status.lower()}"
+
+with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+    fh.write(f"should_retry={'true' if should_retry else 'false'}\n")
+    fh.write(f"reason={reason}\n")
+    fh.write(f"expected_version={expected_version}\n")
+    fh.write(f"public_status={result.status}\n")
+PY
 
   dispatch-production-retry:
     needs: [gate]
@@ -72,4 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Skip retry
-        run: echo "Skipping production retry. reason=${{ needs.gate.outputs.reason }}"
+        run: |
+          echo "Skipping production retry. reason=${{ needs.gate.outputs.reason }}"
+          echo "Expected Android version: ${{ needs.gate.outputs.expected_version }}"
+          echo "Public listing status: ${{ needs.gate.outputs.public_status }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,62 @@ jobs:
         if: steps.gate.outputs.run_live_smoke != 'true'
         run: echo "Live ElevenLabs smoke was skipped because ELEVENLABS_API_KEY is not exposed in this workflow context."
 
+  regression-guards:
+    name: Regression Guards
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install regression test dependencies
+        run: python -m pip install --upgrade pip pytest==8.4.2 requests==2.32.5
+
+      - name: Run fast file-contract guards
+        run: python scripts/regression_guards.py --mode ci
+
+      - name: Run regression contract tests
+        run: |
+          python -m pytest -q \
+            scripts/tests/test_growth_workflow_contracts.py \
+            scripts/tests/test_regression_guards.py \
+            scripts/tests/test_verify_play_public_listing.py \
+            scripts/tests/test_mobile_feature_parity.py \
+            scripts/tests/test_voice_regression_contracts.py
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant Android execute permission
+        run: chmod +x native-android/gradlew
+
+      - name: Create dummy google-services.json for regression guards
+        run: |
+          cat > native-android/app/google-services.json << 'GSEOF'
+          {
+            "project_info": { "project_number": "000000000000", "project_id": "random-timer-ci", "storage_bucket": "random-timer-ci.appspot.com" },
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.iganapolsky.randomtimer" } }, "api_key": [{ "current_key": "CI_PLACEHOLDER" }] }],
+            "configuration_version": "1"
+          }
+          GSEOF
+
+      - name: Run Android regression unit tests
+        working-directory: native-android
+        run: |
+          ./gradlew testDebugUnitTest --no-daemon \
+            --tests 'com.iganapolsky.randomtimer.data.repository.TimerRepositoryImplTest' \
+            --tests 'com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest'
+
   android:
     name: Autonomous Android Tests
     runs-on: ubuntu-latest

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -308,6 +308,20 @@ if [ -n "$STAGED_SWIFT" ]; then
 fi
 
 # ═══════════════════════════════════════════════════════════════════
+# REGRESSION GUARDS — Voice + Play release workflow truth
+# ═══════════════════════════════════════════════════════════════════
+
+if [ -n "$STAGED_ALL" ]; then
+  if command -v python3 > /dev/null 2>&1; then
+    if ! python3 scripts/regression_guards.py --mode staged; then
+      err "Regression guard failed — fix voice/store workflow regressions before committing"
+    fi
+  else
+    err "python3 is required to run scripts/regression_guards.py"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════
 # RESULT
 # ═══════════════════════════════════════════════════════════════════
 

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Fast regression guardrails for voice and Play release workflows."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+RELEASE_GUARD_PATHS = {
+    ".github/workflows/android-production-retry.yml",
+    ".github/workflows/native-release.yml",
+    "scripts/pre-commit",
+    "scripts/regression_guards.py",
+    "scripts/source_versions.py",
+    "scripts/verify_play_public_listing.py",
+    "scripts/tests/test_growth_workflow_contracts.py",
+    "scripts/tests/test_regression_guards.py",
+    "scripts/tests/test_verify_play_public_listing.py",
+}
+
+VOICE_GUARD_PATH_FRAGMENTS = (
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/data/SoundPreviewManagerImpl.kt",
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt",
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/SoundPreviewManager.kt",
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt",
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt",
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt",
+    "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt",
+    "native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift",
+    "native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift",
+    "content/pro_audio/voice_personas.json",
+    "scripts/tests/test_mobile_feature_parity.py",
+    "scripts/tests/test_voice_regression_contracts.py",
+)
+
+
+def _read(repo_root: Path, relative_path: str) -> str:
+    return (repo_root / relative_path).read_text(encoding="utf-8")
+
+
+def _git_staged_paths(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _normalize_paths(paths: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        path = raw.strip().replace("\\", "/")
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        normalized.append(path)
+    return normalized
+
+
+def _matches_voice_path(path: str) -> bool:
+    return any(fragment in path for fragment in VOICE_GUARD_PATH_FRAGMENTS)
+
+
+def _matches_release_path(path: str) -> bool:
+    return path in RELEASE_GUARD_PATHS
+
+
+def relevant_paths(paths: list[str]) -> list[str]:
+    return [path for path in _normalize_paths(paths) if _matches_release_path(path) or _matches_voice_path(path)]
+
+
+def _assert_contains(source: str, needle: str, *, errors: list[str], label: str) -> None:
+    if needle not in source:
+        errors.append(f"{label}: missing `{needle}`")
+
+
+def _assert_not_contains(source: str, needle: str, *, errors: list[str], label: str) -> None:
+    if needle in source:
+        errors.append(f"{label}: unexpected `{needle}`")
+
+
+def check_android_retry_contract(repo_root: Path, errors: list[str]) -> None:
+    source = _read(repo_root, ".github/workflows/android-production-retry.yml")
+    label = ".github/workflows/android-production-retry.yml"
+    _assert_contains(source, "actions/checkout@v4", errors=errors, label=label)
+    _assert_contains(source, "actions/setup-python@v5", errors=errors, label=label)
+    _assert_contains(
+        source,
+        "scripts/source_versions.py --format value --key ANDROID_VERSION_NAME",
+        errors=errors,
+        label=label,
+    )
+    _assert_contains(
+        source,
+        "from scripts.verify_play_public_listing import build_store_url, verify_public_listing",
+        errors=errors,
+        label=label,
+    )
+    _assert_contains(source, 'build_store_url("com.iganapolsky.randomtimer", "US")', errors=errors, label=label)
+    _assert_contains(source, "play_public_current", errors=errors, label=label)
+    _assert_contains(source, "play_public_", errors=errors, label=label)
+    _assert_not_contains(
+        source,
+        "ISSUE_TITLE: Android production publish blocked by Play FAILED_PRECONDITION",
+        errors=errors,
+        label=label,
+    )
+
+
+def check_native_release_contract(repo_root: Path, errors: list[str]) -> None:
+    source = _read(repo_root, ".github/workflows/native-release.yml")
+    label = ".github/workflows/native-release.yml"
+    _assert_contains(source, "Verify public Google Play listing (production only)", errors=errors, label=label)
+    _assert_contains(source, "python scripts/verify_play_public_listing.py", errors=errors, label=label)
+    _assert_contains(source, "--expected-version", errors=errors, label=label)
+    _assert_contains(source, "steps.versions.outputs.android_version", errors=errors, label=label)
+
+
+def check_play_public_listing_contract(repo_root: Path, errors: list[str]) -> None:
+    source = _read(repo_root, "scripts/verify_play_public_listing.py")
+    label = "scripts/verify_play_public_listing.py"
+    _assert_contains(source, "expected_version", errors=errors, label=label)
+    _assert_contains(source, "VERSION_MISMATCH", errors=errors, label=label)
+    _assert_contains(source, "public_version=", errors=errors, label=label)
+    _assert_contains(source, "poll_until_visible", errors=errors, label=label)
+
+
+def check_voice_contract(repo_root: Path, errors: list[str]) -> None:
+    android_setup = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt",
+    )
+    android_viewmodel = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt",
+    )
+    android_preview = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/SoundPreviewManager.kt",
+    )
+    android_preview_impl = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/data/SoundPreviewManagerImpl.kt",
+    )
+    android_repository = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/data/repository/TimerRepositoryImpl.kt",
+    )
+    android_config = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt",
+    )
+    android_voice_manager = _read(
+        repo_root,
+        "native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt",
+    )
+
+    _assert_contains(android_setup, "VoiceGender.entries.forEach", errors=errors, label="TimerSetupScreen.kt")
+    _assert_contains(android_setup, "onCommandCuePreview(config.voiceGender)", errors=errors, label="TimerSetupScreen.kt")
+    _assert_contains(android_setup, '"Male"', errors=errors, label="TimerSetupScreen.kt")
+    _assert_contains(android_setup, '"Female"', errors=errors, label="TimerSetupScreen.kt")
+    _assert_contains(android_viewmodel, "fun previewCommandCue(gender: VoiceGender)", errors=errors, label="TimerViewModel.kt")
+    _assert_contains(android_viewmodel, "trackVoiceGenderSelected", errors=errors, label="TimerViewModel.kt")
+    _assert_contains(android_preview, "fun previewCommandCue(gender: VoiceGender)", errors=errors, label="SoundPreviewManager.kt")
+    _assert_contains(android_preview_impl, "voiceCalloutManager.previewCommandCue(gender)", errors=errors, label="SoundPreviewManagerImpl.kt")
+    _assert_contains(android_repository, 'KEY_VOICE_GENDER = stringPreferencesKey("voice_gender")', errors=errors, label="TimerRepositoryImpl.kt")
+    _assert_contains(android_repository, "preferences[KEY_VOICE_GENDER] = config.voiceGender.name", errors=errors, label="TimerRepositoryImpl.kt")
+    _assert_contains(android_config, "enum class VoiceGender", errors=errors, label="TimerConfig.kt")
+    _assert_contains(android_config, "val voiceGender: VoiceGender = VoiceGender.MALE", errors=errors, label="TimerConfig.kt")
+    _assert_contains(android_voice_manager, "VoicePreviewSampleCatalog.femaleCommandFilenames", errors=errors, label="AIVoiceCalloutManager.kt")
+    _assert_contains(android_voice_manager, "VoicePreviewSampleCatalog.maleCommandFilenames", errors=errors, label="AIVoiceCalloutManager.kt")
+    _assert_contains(android_voice_manager, "fun previewCommandCue(gender: VoiceGender = currentGender)", errors=errors, label="AIVoiceCalloutManager.kt")
+    _assert_contains(android_voice_manager, "fun previewCountdownCue(gender: VoiceGender = currentGender)", errors=errors, label="AIVoiceCalloutManager.kt")
+    _assert_contains(android_voice_manager, "runtimeVoiceCueForElapsedMark", errors=errors, label="AIVoiceCalloutManager.kt")
+
+
+def run_checks(repo_root: Path, *, include_voice: bool) -> list[str]:
+    errors: list[str] = []
+    check_android_retry_contract(repo_root, errors)
+    check_native_release_contract(repo_root, errors)
+    check_play_public_listing_contract(repo_root, errors)
+    if include_voice:
+        check_voice_contract(repo_root, errors)
+    return errors
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run fast regression guardrails.")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--mode", choices=("staged", "ci"), default="staged")
+    parser.add_argument("--paths", nargs="*", default=None, help="Optional explicit paths to evaluate instead of git staged files.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    repo_root = Path(args.repo_root).resolve()
+
+    candidate_paths = _normalize_paths(args.paths) if args.paths is not None else _git_staged_paths(repo_root)
+    matched_paths = relevant_paths(candidate_paths)
+    include_voice = args.mode == "ci" or any(_matches_voice_path(path) for path in matched_paths)
+
+    if args.mode == "staged" and not matched_paths:
+        print("regression_guards: skip (no staged voice/store regression paths)")
+        return 0
+
+    errors = run_checks(repo_root, include_voice=include_voice)
+    if errors:
+        print("regression_guards: FAILED")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+
+    if matched_paths:
+        print("regression_guards: ok for")
+        for path in matched_paths:
+            print(f" - {path}")
+    else:
+        print("regression_guards: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -8,6 +8,7 @@ IOS_METADATA_SYNC_WORKFLOW = ROOT / ".github/workflows/ios-metadata-sync.yml"
 IOS_INTERNAL_RETRY_WORKFLOW = ROOT / ".github/workflows/ios-internal-retry.yml"
 IOS_SUBMIT_REVIEW_WORKFLOW = ROOT / ".github/workflows/ios-submit-review.yml"
 NATIVE_RELEASE_WORKFLOW = ROOT / ".github/workflows/native-release.yml"
+ANDROID_PRODUCTION_RETRY_WORKFLOW = ROOT / ".github/workflows/android-production-retry.yml"
 NORTH_STAR_GUARDRAIL_WORKFLOW = ROOT / ".github/workflows/north-star-guardrail.yml"
 NORTH_STAR_OPS_WORKFLOW = ROOT / ".github/workflows/north-star-ops.yml"
 WEEKLY_EXPERIMENT_WORKFLOW = ROOT / ".github/workflows/weekly-north-star-experiment.yml"
@@ -190,6 +191,19 @@ def test_native_release_workflow_verifies_public_play_listing_for_production():
     assert "python scripts/verify_play_public_listing.py" in source
     assert "--expected-version" in source
     assert "steps.versions.outputs.android_version" in source
+
+
+def test_android_production_retry_uses_public_storefront_truth_instead_of_issue_title():
+    source = ANDROID_PRODUCTION_RETRY_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actions/checkout@v4" in source
+    assert "actions/setup-python@v5" in source
+    assert "scripts/source_versions.py --format value --key ANDROID_VERSION_NAME" in source
+    assert "from scripts.verify_play_public_listing import build_store_url, verify_public_listing" in source
+    assert 'build_store_url("com.iganapolsky.randomtimer", "US")' in source
+    assert "play_public_current" in source
+    assert "play_public_" in source
+    assert "ISSUE_TITLE: Android production publish blocked by Play FAILED_PRECONDITION" not in source
 
 
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -198,6 +198,7 @@ def test_android_production_retry_uses_public_storefront_truth_instead_of_issue_
 
     assert "actions/checkout@v4" in source
     assert "actions/setup-python@v5" in source
+    assert "python -m pip install --upgrade pip requests==2.32.5" in source
     assert "scripts/source_versions.py --format value --key ANDROID_VERSION_NAME" in source
     assert "from scripts.verify_play_public_listing import build_store_url, verify_public_listing" in source
     assert 'build_store_url("com.iganapolsky.randomtimer", "US")' in source

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -206,6 +206,19 @@ def test_android_production_retry_uses_public_storefront_truth_instead_of_issue_
     assert "ISSUE_TITLE: Android production publish blocked by Play FAILED_PRECONDITION" not in source
 
 
+def test_ci_workflow_has_dedicated_regression_guards_job():
+    source = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "regression-guards:" in source
+    guard_job = source.split("regression-guards:", 1)[1].split("\n  android:\n", 1)[0]
+    assert "python scripts/regression_guards.py --mode ci" in guard_job
+    assert "scripts/tests/test_regression_guards.py" in guard_job
+    assert "scripts/tests/test_mobile_feature_parity.py" in guard_job
+    assert "scripts/tests/test_voice_regression_contracts.py" in guard_job
+    assert "TimerRepositoryImplTest" in guard_job
+    assert "AIVoiceCalloutManagerSelectionTest" in guard_job
+
+
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():
     source = NORTH_STAR_GUARDRAIL_WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_regression_guards.py
+++ b/scripts/tests/test_regression_guards.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import regression_guards as guards
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "regression_guards.py"
+
+
+def test_relevant_paths_detects_release_and_voice_regression_surfaces():
+    paths = guards.relevant_paths(
+        [
+            ".github/workflows/android-production-retry.yml",
+            "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt",
+            "README.md",
+        ]
+    )
+
+    assert ".github/workflows/android-production-retry.yml" in paths
+    assert "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt" in paths
+    assert "README.md" not in paths
+
+
+def test_relevant_paths_skips_unrelated_files():
+    assert guards.relevant_paths(["README.md", "docs/foo.md"]) == []
+
+
+def test_run_checks_passes_on_current_repo():
+    assert guards.run_checks(ROOT, include_voice=True) == []
+
+
+def test_cli_skips_unrelated_paths():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(ROOT), "--mode", "staged", "--paths", "README.md"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "skip" in result.stdout
+
+
+def test_cli_runs_for_release_guard_paths():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(ROOT),
+            "--mode",
+            "staged",
+            "--paths",
+            ".github/workflows/android-production-retry.yml",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "regression_guards: ok" in result.stdout
+
+
+def test_pre_commit_invokes_regression_guards():
+    source = (ROOT / "scripts" / "pre-commit").read_text(encoding="utf-8")
+
+    assert "python3 scripts/regression_guards.py --mode staged" in source
+


### PR DESCRIPTION
## Summary
- switch Android production retry gating from an old blocker issue title to the actual public Play version
- compare the public Play listing against the current Android source version before deciding to skip or retry
- add a workflow contract test so this guard cannot silently regress

## Verification
- python -m pytest scripts/tests/test_growth_workflow_contracts.py -q
- workflow contract sanity script

## Incident
Play public was still serving 1.3.12 while source/release expected 1.3.17. This change makes the scheduled retry react to that real mismatch.