### PR TITLE
fix: harden iOS and Play release version lineage

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1774900001
-        versionName = "1.3.17"
+        versionCode = ciVersionCode ?: 1774900002
+        versionName = "1.3.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -689,7 +689,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.17;
+				MARKETING_VERSION = 1.3.18;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -711,7 +711,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.17;
+				MARKETING_VERSION = 1.3.18;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -799,7 +799,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.17;
+				MARKETING_VERSION = 1.3.18;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -821,7 +821,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.17;
+				MARKETING_VERSION = 1.3.18;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/scripts/check_ios_version_lineage.py
+++ b/scripts/check_ios_version_lineage.py
@@ -20,6 +20,23 @@ except ModuleNotFoundError:
 
 
 SEMVER_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)\s*$")
+APP_STORE_CLOSED_STATES = {
+    "ACCEPTED",
+    "APPROVED",
+    "IN_REVIEW",
+    "PENDING_APPLE_RELEASE",
+    "PENDING_DEVELOPER_RELEASE",
+    "PENDING_DEVELOPER_RELEASE_REJECTED",
+    "PENDING_RELEASE",
+    "PREORDER_READY_FOR_SALE",
+    "PROCESSING_FOR_DISTRIBUTION",
+    "READY_FOR_DISTRIBUTION",
+    "READY_FOR_SALE",
+    "REMOVED_FROM_SALE",
+    "REPLACED_WITH_NEW_VERSION",
+    "WAITING_FOR_EXPORT_COMPLIANCE",
+    "WAITING_FOR_REVIEW",
+}
 
 
 class LineageError(RuntimeError):
@@ -32,6 +49,9 @@ class LineageReport:
     local_version: str
     local_build: int
     highest_remote_version: Optional[str]
+    highest_remote_app_store_version: Optional[str]
+    highest_remote_app_store_state: Optional[str]
+    highest_closed_app_store_version: Optional[str]
     highest_remote_build_for_highest_version: Optional[int]
     highest_remote_build_for_local_version: Optional[int]
     passed: bool
@@ -76,6 +96,20 @@ def _highest_build(build_numbers: list[int]) -> Optional[int]:
     return max(build_numbers) if build_numbers else None
 
 
+def _highest_version_by_state(version_states: dict[str, str]) -> tuple[Optional[str], Optional[str]]:
+    ranked: list[tuple[tuple[int, int, int], str, str]] = []
+    for version, state in version_states.items():
+        parsed = _semver_or_none(version)
+        if parsed is None:
+            continue
+        ranked.append((parsed, version.strip(), str(state or "").strip().upper()))
+    if not ranked:
+        return None, None
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    _, version, state = ranked[0]
+    return version, state
+
+
 def _get_app_id(client: ASCClient, bundle_id: str) -> str:
     data = client.get("/apps", params={"filter[bundleId]": bundle_id})
     apps = data.get("data", [])
@@ -101,6 +135,25 @@ def _list_remote_pre_release_versions(client: ASCClient, app_id: str) -> list[st
         version = str(attrs.get("version") or "").strip()
         if version:
             versions.append(version)
+    return versions
+
+
+def _list_remote_app_store_versions(client: ASCClient, app_id: str) -> dict[str, str]:
+    items = client.get_all(
+        f"/apps/{app_id}/appStoreVersions",
+        params={
+            "filter[platform]": "IOS",
+            "limit": 200,
+            "fields[appStoreVersions]": "versionString,appStoreState",
+        },
+    )
+    versions: dict[str, str] = {}
+    for item in items:
+        attrs = item.get("attributes") or {}
+        version = str(attrs.get("versionString") or "").strip()
+        if not version:
+            continue
+        versions[version] = str(attrs.get("appStoreState") or "UNKNOWN").strip().upper()
     return versions
 
 
@@ -147,9 +200,23 @@ def evaluate_lineage(
     local_version: str,
     local_build: int,
     remote_versions: list[str],
+    remote_app_store_versions: dict[str, str],
     remote_builds_by_version: dict[str, list[int]],
 ) -> LineageReport:
-    highest_remote_version = _highest_semver(remote_versions)
+    highest_remote_pre_release_version = _highest_semver(remote_versions)
+    highest_remote_app_store_version, highest_remote_app_store_state = _highest_version_by_state(
+        remote_app_store_versions
+    )
+    highest_closed_app_store_version, _ = _highest_version_by_state(
+        {
+            version: state
+            for version, state in remote_app_store_versions.items()
+            if state in APP_STORE_CLOSED_STATES
+        }
+    )
+    highest_remote_version = _highest_semver(
+        remote_versions + list(remote_app_store_versions.keys())
+    )
     highest_remote_build_for_local_version = _highest_build(remote_builds_by_version.get(local_version, []))
     highest_remote_build_for_highest_version = (
         _highest_build(remote_builds_by_version.get(highest_remote_version, []))
@@ -163,10 +230,13 @@ def evaluate_lineage(
             local_version=local_version,
             local_build=local_build,
             highest_remote_version=None,
+            highest_remote_app_store_version=highest_remote_app_store_version,
+            highest_remote_app_store_state=highest_remote_app_store_state,
+            highest_closed_app_store_version=highest_closed_app_store_version,
             highest_remote_build_for_highest_version=None,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=True,
-            reason="no_remote_ios_pre_release_versions_found",
+            reason="no_remote_ios_versions_found",
         )
 
     if _parse_semver(local_version) < _parse_semver(highest_remote_version):
@@ -175,12 +245,36 @@ def evaluate_lineage(
             local_version=local_version,
             local_build=local_build,
             highest_remote_version=highest_remote_version,
+            highest_remote_app_store_version=highest_remote_app_store_version,
+            highest_remote_app_store_state=highest_remote_app_store_state,
+            highest_closed_app_store_version=highest_closed_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
             reason=(
                 f"Local iOS marketing version {local_version} regresses behind "
-                f"App Store Connect pre-release version {highest_remote_version}"
+                f"App Store Connect version {highest_remote_version}"
+            ),
+        )
+
+    if (
+        highest_closed_app_store_version is not None
+        and _parse_semver(local_version) <= _parse_semver(highest_closed_app_store_version)
+    ):
+        return LineageReport(
+            bundle_id=bundle_id,
+            local_version=local_version,
+            local_build=local_build,
+            highest_remote_version=highest_remote_version,
+            highest_remote_app_store_version=highest_remote_app_store_version,
+            highest_remote_app_store_state=highest_remote_app_store_state,
+            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
+            highest_remote_build_for_local_version=highest_remote_build_for_local_version,
+            passed=False,
+            reason=(
+                f"Local iOS marketing version {local_version} is blocked by closed App Store "
+                f"version {highest_closed_app_store_version}; bump the marketing version first"
             ),
         )
 
@@ -197,6 +291,9 @@ def evaluate_lineage(
         local_version=local_version,
         local_build=local_build,
         highest_remote_version=highest_remote_version,
+        highest_remote_app_store_version=highest_remote_app_store_version,
+        highest_remote_app_store_state=highest_remote_app_store_state,
+        highest_closed_app_store_version=highest_closed_app_store_version,
         highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
         highest_remote_build_for_local_version=highest_remote_build_for_local_version,
         passed=True,
@@ -228,6 +325,7 @@ def main() -> int:
         client = ASCClient.from_env(timeout=30)
         app_id = _get_app_id(client, args.bundle_id)
         remote_versions = _list_remote_pre_release_versions(client, app_id)
+        remote_app_store_versions = _list_remote_app_store_versions(client, app_id)
         remote_builds_by_version = _list_remote_builds_by_marketing_version(client, app_id)
     except (AscClientError, LineageError) as exc:
         print(f"❌ {exc}", file=sys.stderr)
@@ -238,11 +336,23 @@ def main() -> int:
         local_version=str(versions["ios"]["version_name"]),
         local_build=int(versions["ios"]["build_number"]),
         remote_versions=remote_versions,
+        remote_app_store_versions=remote_app_store_versions,
         remote_builds_by_version=remote_builds_by_version,
     )
 
     print(f"Local iOS source version: {report.local_version} ({report.local_build})")
     print(f"ASC highest pre-release version: {report.highest_remote_version or 'none'}")
+    if report.highest_remote_app_store_version is not None:
+        print(
+            "ASC highest App Store version: "
+            f"{report.highest_remote_app_store_version} "
+            f"(state={report.highest_remote_app_store_state or 'UNKNOWN'})"
+        )
+    if report.highest_closed_app_store_version is not None:
+        print(
+            "ASC highest closed App Store version: "
+            f"{report.highest_closed_app_store_version}"
+        )
     if report.highest_remote_build_for_highest_version is not None:
         print(
             "ASC highest build for highest version: "

--- a/scripts/compute_android_release_version_code.py
+++ b/scripts/compute_android_release_version_code.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -107,12 +108,17 @@ def _fetch_existing_track_codes(
                 pass
 
 
-def compute_next_version_code(base_version_code: int, existing_track_codes: dict[str, list[int]]) -> int:
+def compute_next_version_code(
+    base_version_code: int,
+    existing_track_codes: dict[str, list[int]],
+    monotonic_floor: int | None = None,
+) -> int:
     highest_existing = max(
         (code for codes in existing_track_codes.values() for code in codes),
         default=0,
     )
-    return max(base_version_code, highest_existing) + 1
+    floor = monotonic_floor if monotonic_floor is not None else int(time.time())
+    return max(base_version_code, highest_existing, floor) + 1
 
 
 def _parse_args() -> argparse.Namespace:
@@ -150,7 +156,12 @@ def main() -> int:
             tracks,
             request_retries=args.request_retries,
         )
-        next_version_code = compute_next_version_code(base_version_code, existing_track_codes)
+        monotonic_floor = int(time.time())
+        next_version_code = compute_next_version_code(
+            base_version_code,
+            existing_track_codes,
+            monotonic_floor=monotonic_floor,
+        )
     except Exception as error:
         print(f"❌ Failed to compute Android release versionCode: {error}", file=sys.stderr)
         return 1
@@ -162,6 +173,7 @@ def main() -> int:
             "base_version_code": base_version_code,
             "tracks": tracks,
             "existing_track_codes": existing_track_codes,
+            "monotonic_floor": monotonic_floor,
             "next_version_code": next_version_code,
         }
         output_path = Path(args.json_output)

--- a/scripts/tests/test_check_ios_version_lineage.py
+++ b/scripts/tests/test_check_ios_version_lineage.py
@@ -9,6 +9,7 @@ def test_evaluate_lineage_rejects_local_marketing_version_behind_remote():
         local_version="1.2.6",
         local_build=172,
         remote_versions=["1.0", "1.2.6", "1.3.9"],
+        remote_app_store_versions={},
         remote_builds_by_version={"1.2.6": [194], "1.3.9": [409]},
     )
 
@@ -24,6 +25,7 @@ def test_evaluate_lineage_allows_current_marketing_version_with_lower_local_buil
         local_version="1.3.9",
         local_build=409,
         remote_versions=["1.0", "1.2.6", "1.3.9"],
+        remote_app_store_versions={},
         remote_builds_by_version={"1.2.6": [194], "1.3.9": [409]},
     )
 
@@ -39,8 +41,39 @@ def test_evaluate_lineage_ignores_non_semver_remote_versions_when_choosing_highe
         local_version="1.3.9",
         local_build=409,
         remote_versions=["1.0", "1.3.9", "not-a-version"],
+        remote_app_store_versions={},
         remote_builds_by_version={"1.3.9": [409]},
     )
 
     assert report.passed is True
     assert report.highest_remote_version == "1.3.9"
+
+
+def test_evaluate_lineage_rejects_closed_app_store_train_even_when_pre_release_matches():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.17",
+        local_build=434,
+        remote_versions=["1.3.17"],
+        remote_app_store_versions={"1.3.17": "READY_FOR_DISTRIBUTION"},
+        remote_builds_by_version={"1.3.17": [435]},
+    )
+
+    assert report.passed is False
+    assert report.highest_closed_app_store_version == "1.3.17"
+    assert "closed App Store version 1.3.17" in report.reason
+
+
+def test_evaluate_lineage_rejects_local_version_behind_higher_app_store_version():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.17",
+        local_build=434,
+        remote_versions=["1.3.17"],
+        remote_app_store_versions={"1.3.18": "PREPARE_FOR_SUBMISSION"},
+        remote_builds_by_version={"1.3.17": [435]},
+    )
+
+    assert report.passed is False
+    assert report.highest_remote_version == "1.3.18"
+    assert "regresses behind App Store Connect version 1.3.18" in report.reason

--- a/scripts/tests/test_compute_android_release_version_code.py
+++ b/scripts/tests/test_compute_android_release_version_code.py
@@ -62,6 +62,7 @@ def test_compute_next_version_code_prefers_higher_play_code():
             "beta": [],
             "internal": [1774399999],
         },
+        monotonic_floor=1774300000,
     )
 
     assert next_code == 1774400006
@@ -74,9 +75,23 @@ def test_compute_next_version_code_prefers_higher_gradle_code_when_tracks_lower(
             "production": [1773900000],
             "alpha": [1773899999],
         },
+        monotonic_floor=1774300000,
     )
 
     assert next_code == 1774400001
+
+
+def test_compute_next_version_code_uses_monotonic_floor_to_avoid_historical_reuse():
+    next_code = calc.compute_next_version_code(
+        1774900001,
+        {
+            "production": [1774900021],
+            "internal": [],
+        },
+        monotonic_floor=1775592800,
+    )
+
+    assert next_code == 1775592801
 
 
 def test_fetch_existing_track_codes_reads_each_track_and_cleans_up():
@@ -213,6 +228,7 @@ def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.Cap
         "_fetch_existing_track_codes",
         lambda _service, _package, _tracks, request_retries=calc.DEFAULT_REQUEST_RETRIES: {"production": [1774400002], "beta": []},
     )
+    monkeypatch.setattr(calc.time, "time", lambda: 1774400002)
     monkeypatch.setattr(
         calc,
         "_parse_args",
@@ -234,3 +250,4 @@ def test_main_writes_json_output(monkeypatch, tmp_path: Path, capsys: pytest.Cap
     assert calc.main() == 0
     assert capsys.readouterr().out.strip() == "1774400003"
     assert '"next_version_code": 1774400003' in json_output.read_text(encoding="utf-8")
+    assert '"monotonic_floor": 1774400002' in json_output.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- bump mobile release version to 1.3.18 to unblock closed iOS 1.3.17 train
- fail iOS lineage checks when App Store Connect version trains are closed
- harden Play version code allocation with a monotonic time floor to avoid reused codes
- add targeted regression tests for both lineage guards

## Verification
- python3 scripts/source_versions.py --repo-root . --format json
- source /tmp/random-timer-test-venv/bin/activate && python -m pytest -q scripts/tests/test_check_ios_version_lineage.py scripts/tests/test_compute_android_release_version_code.py scripts/tests/test_source_versions.py scripts/tests/test_growth_workflow_contracts.py

## Live proof in progress
- Internal Distribution run 24102429640 on branch fix/ios-version-lineage-guard