### PR TITLE
fix: require CEO approval for internal mobile distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -118,7 +118,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
     runs-on: macos-26
-    environment: production
+    environment: testflight-signoff
     steps:
       - uses: actions/checkout@v6
         with:
@@ -271,7 +271,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'android_play')
     runs-on: ubuntu-latest
-    environment: production
+    environment: internal-play
     steps:
       - uses: actions/checkout@v6
         with:
@@ -424,7 +424,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'android_firebase')
     runs-on: ubuntu-latest
-    environment: production
+    environment: firebase-signoff
     steps:
       - name: Note Play Protect mitigation
         run: |

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [release-intent-gate]
     if: ${{ inputs.platform == 'ios' || inputs.platform == 'both' }}
     runs-on: macos-26
-    environment: production
+    environment: testflight-signoff
     steps:
       - uses: actions/checkout@v4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@
 
 All AI replies, code comments, commit messages, and documentation use **English**.
 
+## Communication Style
+
+**Default to concise, action-first replies.** This is a standing rule.
+
+1. **Keep routine replies short.** Prefer `1-3` bullets or a short paragraph.
+2. **Lead with the action being taken.** Example: "I am patching `AGENTS.md` now."
+3. **Do not give long explanations unless explicitly requested.**
+4. **When the CEO asks for action steps, respond with action steps only.**
+5. **If a deeper explanation is necessary, keep it brief and evidence-based.**
+
 ## PR management & secrets (cross-reference)
 
 Autonomous PR/branch hygiene and **never committing PATs** are defined in `CLAUDE.md` (including rotating leaked tokens, verifying `gh pr checks` before merge, and resolving automated review threads that gate CI). Do not embed CEO credentials in repo docs.
@@ -154,6 +164,13 @@ Do not infer progress from draft campaign configs.
 ### Release Flow
 1. `develop` → `release/vX.Y.Z` → TestFlight + Google Play → tag on `main` → merge back to `develop`
 2. Hotfix: `main` → `hotfix/vX.Y.Z` → stores → tag on `main` → merge to `develop`
+
+## Internal Distribution Approval
+
+- **CEO sign-off is mandatory before TestFlight internal distribution starts.**
+- **CEO sign-off is mandatory before Firebase internal distribution starts.**
+- GitHub Actions environments enforce this via `testflight-signoff` and `firebase-signoff`.
+- Do not claim an internal iOS/Firebase build is queued or running until the environment approval is granted.
 
 ## Commands
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -40,6 +40,9 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
     )
     assert "Internal Testers" in source
     assert "TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}" in source
+    assert "environment: testflight-signoff" in source
+    assert "environment: internal-play" in source
+    assert "environment: firebase-signoff" in source
 
 
 def test_internal_distribution_workflow_keeps_ruby_setup_pin_in_sync_with_native_release():
@@ -134,6 +137,7 @@ def test_native_release_workflow_disables_hidden_play_fallback_and_verifies_requ
     source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
     assert 'PLAY_FALLBACK_TRACK: ""' in source
+    assert "environment: testflight-signoff" in source
     assert "(inputs.platform == 'both' && needs.ios-testflight.result == 'success' && needs.android-release.result == 'success')" in source
     assert "(inputs.platform == 'ios' && needs.ios-testflight.result == 'success')" in source
     assert "(inputs.platform == 'android' && needs.android-release.result == 'success')" in source


### PR DESCRIPTION
## Summary
- require explicit GitHub environment approval for TestFlight internal distribution
- require explicit GitHub environment approval for Firebase internal distribution
- move internal Play delivery off the production environment
- document the approval rule in AGENTS.md and lock it with workflow contract tests

## Live environment changes applied
- created environment  with required reviewer 
- created environment  with required reviewer 
- created environment  without reviewer but with branch allowlists
- branch allowlists on all three: , , 

## Verification
- source /tmp/random-timer-test-venv/bin/activate && python -m pytest -q scripts/tests/test_growth_workflow_contracts.py
- gh api repos/IgorGanapolsky/Random-Timer/environments/testflight-signoff
- gh api repos/IgorGanapolsky/Random-Timer/environments/firebase-signoff
- gh api repos/IgorGanapolsky/Random-Timer/environments/internal-play