### PR TITLE
fix(ci): sync Ivanna voice contract with hotfix branch

### DIFF
--- a/native-ios/RandomTimer/Resources/Audio/female/voice_callouts.json
+++ b/native-ios/RandomTimer/Resources/Audio/female/voice_callouts.json
@@ -193,7 +193,7 @@
     }
   ],
   "voiceGender": "female",
-  "voiceId": "AZnzlk1XvdvUeBnXmlld",
-  "voiceName": "Domi",
+  "voiceId": "gE0owC0H9C8SzfDyIUtB",
+  "voiceName": "Ivanna",
   "modelId": "eleven_multilingual_v2"
 }

--- a/scripts/tests/test_voice_regression_contracts.py
+++ b/scripts/tests/test_voice_regression_contracts.py
@@ -57,8 +57,8 @@ def test_voice_contract_tracks_real_elevenlabs_personas() -> None:
     assert contract["male"]["voiceId"] == "DGzg6RaUqxGRTHSBjfgF"
     assert contract["male"]["probeText"] == "Stay sharp."
     assert contract["female"]["modelId"] == "eleven_multilingual_v2"
-    assert contract["female"]["primaryVoice"]["voiceName"] == "Domi"
-    assert contract["female"]["primaryVoice"]["voiceId"] == "AZnzlk1XvdvUeBnXmlld"
+    assert contract["female"]["primaryVoice"]["voiceName"] == "Ivanna"
+    assert contract["female"]["primaryVoice"]["voiceId"] == "gE0owC0H9C8SzfDyIUtB"
     assert contract["female"]["primaryVoice"]["probeText"] == "Move with purpose."
     assert {voice["voiceName"] for voice in contract["female"]["fallbackVoices"]} == {"Anvi"}
     assert {voice["probeText"] for voice in contract["female"]["fallbackVoices"]} == {"Stay in the fight."}

--- a/scripts/verify_elevenlabs_voices.py
+++ b/scripts/verify_elevenlabs_voices.py
@@ -15,6 +15,7 @@ API_BASE_URL = "https://api.elevenlabs.io"
 OUTPUT_FORMAT = "mp3_44100_128"
 SUPPORTED_VOICE_ENDPOINTS = {
     "DGzg6RaUqxGRTHSBjfgF": f"{API_BASE_URL}/v1/text-to-speech/DGzg6RaUqxGRTHSBjfgF?output_format={OUTPUT_FORMAT}",
+    "gE0owC0H9C8SzfDyIUtB": f"{API_BASE_URL}/v1/text-to-speech/gE0owC0H9C8SzfDyIUtB?output_format={OUTPUT_FORMAT}",
     "AZnzlk1XvdvUeBnXmlld": f"{API_BASE_URL}/v1/text-to-speech/AZnzlk1XvdvUeBnXmlld?output_format={OUTPUT_FORMAT}",
     "sS5fXGlqomdGXa7mxBcy": f"{API_BASE_URL}/v1/text-to-speech/sS5fXGlqomdGXa7mxBcy?output_format={OUTPUT_FORMAT}",
 }


### PR DESCRIPTION
## Summary
- align hotfix voice regression test expectations with the Ivanna female voice swap
- allow the Ivanna ElevenLabs voice ID in CI live smoke verification
- sync iOS female voice metadata with the shipped contract

## Verification
- source /tmp/random-timer-test-venv/bin/activate && python -m pytest -q scripts/tests/test_voice_regression_contracts.py
- python3 - <<'PY'
from scripts.verify_elevenlabs_voices import _supported_voice_id
print(_supported_voice_id('gE0owC0H9C8SzfDyIUtB'))
PY