### PR TITLE
fix(ci): sync hotfix voice contract and require CEO signoff

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -118,7 +118,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
     runs-on: macos-26
-    environment: production
+    environment: testflight-signoff
     steps:
       - uses: actions/checkout@v6
         with:
@@ -271,7 +271,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'android_play')
     runs-on: ubuntu-latest
-    environment: production
+    environment: internal-play
     steps:
       - uses: actions/checkout@v6
         with:
@@ -424,7 +424,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'android_firebase')
     runs-on: ubuntu-latest
-    environment: production
+    environment: firebase-signoff
     steps:
       - name: Note Play Protect mitigation
         run: |

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [release-intent-gate]
     if: ${{ inputs.platform == 'ios' || inputs.platform == 'both' }}
     runs-on: macos-26
-    environment: production
+    environment: testflight-signoff
     steps:
       - uses: actions/checkout@v4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@
 
 All AI replies, code comments, commit messages, and documentation use **English**.
 
+## Communication Style
+
+**Default to concise, action-first replies.** This is a standing rule.
+
+1. **Keep routine replies short.** Prefer `1-3` bullets or a short paragraph.
+2. **Lead with the action being taken.** Example: "I am patching `AGENTS.md` now."
+3. **Do not give long explanations unless explicitly requested.**
+4. **When the CEO asks for action steps, respond with action steps only.**
+5. **If a deeper explanation is necessary, keep it brief and evidence-based.**
+
 ## PR management & secrets (cross-reference)
 
 Autonomous PR/branch hygiene and **never committing PATs** are defined in `CLAUDE.md` (including rotating leaked tokens, verifying `gh pr checks` before merge, and resolving automated review threads that gate CI). Do not embed CEO credentials in repo docs.
@@ -154,6 +164,15 @@ Do not infer progress from draft campaign configs.
 ### Release Flow
 1. `develop` → `release/vX.Y.Z` → TestFlight + Google Play → tag on `main` → merge back to `develop`
 2. Hotfix: `main` → `hotfix/vX.Y.Z` → stores → tag on `main` → merge to `develop`
+
+## Internal Distribution Approval
+
+**CEO sign-off is mandatory before any internal mobile distribution leaves CI.**
+
+1. **TestFlight internal runs must target the `testflight-signoff` environment.**
+2. **Firebase internal Android runs must target the `firebase-signoff` environment.**
+3. **Google Play internal Android runs use the `internal-play` environment and stay branch-restricted to `develop`, `release/*`, or `hotfix/*`.**
+4. **Do not claim an internal iOS or Firebase build was queued or started unless the required environment approval was actually granted.**
 
 ## Commands
 

--- a/native-ios/RandomTimer/Resources/Audio/female/voice_callouts.json
+++ b/native-ios/RandomTimer/Resources/Audio/female/voice_callouts.json
@@ -193,7 +193,7 @@
     }
   ],
   "voiceGender": "female",
-  "voiceId": "AZnzlk1XvdvUeBnXmlld",
-  "voiceName": "Domi",
+  "voiceId": "gE0owC0H9C8SzfDyIUtB",
+  "voiceName": "Ivanna",
   "modelId": "eleven_multilingual_v2"
 }

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -33,6 +33,9 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
 
     assert "preflight-release" in source or "Preflight release" in source
     assert "ios-testflight-internal" in source or "android-internal" in source
+    assert "environment: testflight-signoff" in source
+    assert "environment: internal-play" in source
+    assert "environment: firebase-signoff" in source
     assert "check_ios_version_lineage.py" in source
     assert "Install App Store Connect Python dependencies" in source
     assert source.index("Install App Store Connect Python dependencies") < source.index(
@@ -182,6 +185,7 @@ def test_native_release_workflow_dispatches_android_firebase_mirror_from_release
 def test_native_release_workflow_verifies_public_play_listing_for_production():
     source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
+    assert "environment: testflight-signoff" in source
     assert "Verify public Google Play listing (production only)" in source
     assert "python scripts/verify_play_public_listing.py" in source
     assert "--expected-version" in source

--- a/scripts/tests/test_voice_regression_contracts.py
+++ b/scripts/tests/test_voice_regression_contracts.py
@@ -57,8 +57,8 @@ def test_voice_contract_tracks_real_elevenlabs_personas() -> None:
     assert contract["male"]["voiceId"] == "DGzg6RaUqxGRTHSBjfgF"
     assert contract["male"]["probeText"] == "Stay sharp."
     assert contract["female"]["modelId"] == "eleven_multilingual_v2"
-    assert contract["female"]["primaryVoice"]["voiceName"] == "Domi"
-    assert contract["female"]["primaryVoice"]["voiceId"] == "AZnzlk1XvdvUeBnXmlld"
+    assert contract["female"]["primaryVoice"]["voiceName"] == "Ivanna"
+    assert contract["female"]["primaryVoice"]["voiceId"] == "gE0owC0H9C8SzfDyIUtB"
     assert contract["female"]["primaryVoice"]["probeText"] == "Move with purpose."
     assert {voice["voiceName"] for voice in contract["female"]["fallbackVoices"]} == {"Anvi"}
     assert {voice["probeText"] for voice in contract["female"]["fallbackVoices"]} == {"Stay in the fight."}

--- a/scripts/verify_elevenlabs_voices.py
+++ b/scripts/verify_elevenlabs_voices.py
@@ -15,6 +15,7 @@ API_BASE_URL = "https://api.elevenlabs.io"
 OUTPUT_FORMAT = "mp3_44100_128"
 SUPPORTED_VOICE_ENDPOINTS = {
     "DGzg6RaUqxGRTHSBjfgF": f"{API_BASE_URL}/v1/text-to-speech/DGzg6RaUqxGRTHSBjfgF?output_format={OUTPUT_FORMAT}",
+    "gE0owC0H9C8SzfDyIUtB": f"{API_BASE_URL}/v1/text-to-speech/gE0owC0H9C8SzfDyIUtB?output_format={OUTPUT_FORMAT}",
     "AZnzlk1XvdvUeBnXmlld": f"{API_BASE_URL}/v1/text-to-speech/AZnzlk1XvdvUeBnXmlld?output_format={OUTPUT_FORMAT}",
     "sS5fXGlqomdGXa7mxBcy": f"{API_BASE_URL}/v1/text-to-speech/sS5fXGlqomdGXa7mxBcy?output_format={OUTPUT_FORMAT}",
 }


### PR DESCRIPTION
## Summary
- sync the hotfix branch voice contract, ElevenLabs allowlist, and iOS metadata with the Ivanna female voice swap
- port TestFlight and Firebase signoff environments onto the hotfix branch workflows
- add workflow contract coverage plus AGENTS rules for concise replies and internal approval

## Verification
- source /tmp/random-timer-test-venv/bin/activate && python -m pytest -q scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_voice_regression_contracts.py
- python3 - <<'PY'
from scripts.verify_elevenlabs_voices import _supported_voice_id
print(_supported_voice_id('gE0owC0H9C8SzfDyIUtB'))
PY