### PR TITLE
chore(metrics): operational reliability contract and Crashlytics fatal totals

### DIFF
--- a/.cursor/rules/operational-reliability.mdc
+++ b/.cursor/rules/operational-reliability.mdc
@@ -1,0 +1,16 @@
+---
+description: Operational reliability — evidence, metric semantics, contradiction protocol
+alwaysApply: true
+---
+
+## Operational reliability (binding)
+
+Follow `docs/OPERATIONAL_RELIABILITY.md` for the full contract. In every session:
+
+1. **Label proxies:** Store/API metrics MUST carry correct semantics (see `review_count_metric_id` in executive and `real_store_downloads` payloads). Never equate Play `reviews.list` counts with public listing totals.
+2. **Evidence:** Status claims need reproducible proof (command + path + sanitized output). No “done” without verified state.
+3. **Contradictions:** If the CEO sees different reality than automation, stop, reconcile with docs + re-run, or mark unverified.
+4. **Uncertainty:** Say “unknown” / “not verified” instead of guessing.
+5. **Secrets:** Never commit credentials; verify env/CI key names before blocking on access.
+
+English only for all output (see `english-only.mdc`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,14 @@ All AI replies, code comments, commit messages, and documentation use **English*
 4. **When the CEO asks for action steps, respond with action steps only.**
 5. **If a deeper explanation is necessary, keep it brief and evidence-based.**
 
+## Operational reliability contract
+
+**Canonical doc:** `docs/OPERATIONAL_RELIABILITY.md` (evidence protocol, proxy vs ground truth, contradiction handling, metric semantics).
+
+**Cursor:** `.cursor/rules/operational-reliability.mdc` (always applied).
+
+Store and executive JSON expose **`review_count_metric_id`** where applicable so counts are never read as undefined “total reviews.”
+
 ## PR management & secrets (cross-reference)
 
 Autonomous PR/branch hygiene and **never committing PATs** are defined in `CLAUDE.md` (including rotating leaked tokens, verifying `gh pr checks` before merge, and resolving automated review threads that gate CI). Do not embed CEO credentials in repo docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ You are the **autonomous CTO**. The user is the **CEO**. You have full agentic a
 - Primary business objective: **earn $100/day after-tax from app sales**.
 - Product-value NSM: **WQTU** (Weekly Qualified Training Users, users with >=3 `timer_completed` in trailing 7d).
 - Operational rule: never claim progress without live evidence from PostHog + store/release telemetry.
+- **Operational reliability contract:** `docs/OPERATIONAL_RELIABILITY.md` — label proxies vs ground truth, cite evidence, run the contradiction protocol when automation disagrees with observed reality.
 
 ## Operating Budget Mandate
 

--- a/docs/OPERATIONAL_RELIABILITY.md
+++ b/docs/OPERATIONAL_RELIABILITY.md
@@ -1,0 +1,73 @@
+# Operational reliability contract
+
+**Audience:** CEO, agents, CI, anyone interpreting automation output.
+
+This document defines **how** we stay trustworthy in operations. It does **not** claim infallibility; it claims **disciplined process** so errors are visible, scoped, and fixable.
+
+## 1. Ground truth vs proxy
+
+Every quantitative claim MUST identify:
+
+| Field | Meaning |
+| --- | --- |
+| **Source** | API name, SQL, file path, or UI surface |
+| **Time window** | e.g. trailing 7d, snapshot `generated_at` |
+| **Semantics** | What is included and excluded per vendor docs |
+
+**Rule:** Never present a **proxy** (API subset, sampled page, PostHog distinct persons) as **store or ledger ground truth** without saying so.
+
+**Examples:**
+
+- Play `reviews.list` counts are **not** “public Play review totals.” Use `review_count_metric_id` in `executive_metrics.json` / `real_store_downloads` output.
+- PostHog “installs” from `Application Installed` are **not** Play Console download units. Executive PostHog scalars map to `posthog.metric_field_ids` under `metric_bundle_id` `posthog_executive_pragmatic_live_hogql_v1`.
+- Crashlytics **`fatal_events_in_window`** is **COUNT(\*)** of fatal rows in the BQ lookback window (canonical crash volume). **`fatal_events`** is the sum of crash counts in the **parsed top-issue sample** (see `metric_field_ids` — not a full-window total if many issue groups exist).
+
+## 2. Evidence, not assertions
+
+For repo state, CI, releases, and metrics:
+
+- Prefer **reproducible proof**: command run, path, exit code, and **sanitized** excerpt of output or response body.
+- Do **not** rely on unstated memory of prior sessions for “current” status.
+
+## 3. Contradiction protocol
+
+If human-observed reality **conflicts** with automation:
+
+1. **Stop** treating the automation number as authoritative until reconciled.
+2. **Re-read** vendor documentation for that endpoint.
+3. **Re-run** the pipeline with the same inputs, or capture raw API response (redacted).
+4. If still unclear, label the metric **unverified** and file a bug on semantics or labeling.
+
+## 4. Explicit uncertainty
+
+- Use **“not verified in this session”** or **“unknown”** when proof is missing.
+- Do **not** fill gaps with plausible numbers or assumed API behavior.
+
+## 5. Metric definitions and schema drift
+
+When the meaning of a field changes:
+
+- Add or update **`review_count_metric_id`** (or equivalent) and human **`note`** text.
+- Update **`definitions`** in `executive_metrics_snapshot.py` so JSON is self-describing.
+- Avoid silently reusing a field name for a different meaning.
+
+## 6. Irreversible and spend actions
+
+- **Git:** No force-push to shared branches unless the CEO explicitly requests it. Merge only with green required checks per `CLAUDE.md`.
+- **Spend:** Respect the monthly cap in `AGENTS.md` / `CLAUDE.md`; document MTD estimate when reporting costs.
+- **Releases / store:** Follow verification checklists in `AGENTS.md` (screenshots, build state, metadata).
+
+## 7. Secrets
+
+- Never commit tokens, PATs, or private keys. Rotate anything exposed in logs or chat.
+- Verify `.env` key **names** and CI secret **names** exist before claiming “no access.”
+
+## 8. CEO veto
+
+The CEO may require explicit approval for any irreversible or high-blast-radius action. Agents must honor that when stated for a task.
+
+---
+
+**Canonical path:** `docs/OPERATIONAL_RELIABILITY.md`  
+**Cursor rule:** `.cursor/rules/operational-reliability.mdc`  
+**Cross-references:** `AGENTS.md`, `CLAUDE.md`

--- a/marketing/data/executive_metrics.json
+++ b/marketing/data/executive_metrics.json
@@ -1,14 +1,17 @@
 {
   "generated_at": "2026-04-06T12:51:00+00:00",
   "source": "executive_metrics_snapshot",
+  "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "definitions": {
     "install_proxy_posthog": "Distinct persons with event Application Installed (not store units).",
-    "reviews_store": "From Play/App Store APIs in store section (sample/pagination limits apply).",
+    "reviews_store": "Play: reviews.list is comment-bearing reviews touched in the last 7 days only (per Google); star-only ratings omitted; can read 0 while the public listing shows reviews; pagination max 100/page. App Store: customerReviews first page only (limit 50, newest first), not lifetime total. Use review_count_metric_id under store_apis.android / store_apis.ios when present.",
     "reviews_in_app": "PostHog review_prompt_requested / write_review_tapped (not published star count).",
     "paid_posthog": "paywall_purchase_success and paywall_purchase_result in PostHog; use Store/RevenueCat for ledger truth.",
-    "crashes": "Crashlytics via BigQuery export; PostHog $exception also listed if captured.",
+    "posthog_executive": "HogQL scalars use audience_sql (PRAGMATIC_LIVE) and window_days except wqtu_7d_distinct_persons (fixed 7d). See posthog.metric_field_ids.",
+    "crashes": "Crashlytics BigQuery streaming export; posthog_exception_events is separate. crashlytics_bigquery.fatal_events_in_window is COUNT(*) of fatal rows in the lookback hours. fatal_events sums crash_count only within parsed top_fatal_issues (up to 10 rows displayed from top 20 SQL groups) \u2014 see metric_field_ids.",
     "uninstalls": "Not available on iOS; Android uninstall metrics require Play reporting APIs (not in this script yet).",
-    "wqtu": "Distinct persons with >=3 timer_completed events in the same window (North Star proxy for that window).",
+    "wqtu": "Distinct persons with >=3 timer_completed events in the same window as window_days (supplementary).",
+    "wqtu_7d": "North Star WQTU: distinct persons with >=3 timer_completed in trailing 7 days (canonical).",
     "started_and_completed_persons": "Distinct persons with at least one timer_completed in-window who also have at least one timer_started in-window."
   },
   "posthog": {
@@ -44,7 +47,27 @@
         480
       ]
     ],
-    "posthog_exception_events": 0
+    "posthog_exception_events": 0,
+    "metric_bundle_id": "posthog_executive_pragmatic_live_hogql_v1",
+    "metric_field_ids": {
+      "distinct_persons_application_installed": "posthog_hogql_distinct_persons_event_application_installed",
+      "distinct_persons_first_open": "posthog_hogql_distinct_persons_event_first_open",
+      "timer_started_events": "posthog_hogql_count_events_timer_started",
+      "timer_completed_events": "posthog_hogql_count_events_timer_completed",
+      "distinct_persons_timer_started": "posthog_hogql_distinct_persons_event_timer_started",
+      "distinct_persons_timer_completed": "posthog_hogql_distinct_persons_event_timer_completed",
+      "distinct_persons_timer_started_and_completed": "posthog_hogql_distinct_persons_completed_also_started_same_window",
+      "wqtu_distinct_persons": "posthog_hogql_wqtu_timer_completed_ge3_trailing_window_days",
+      "wqtu_7d_distinct_persons": "posthog_hogql_wqtu_timer_completed_ge3_trailing_7d_fixed",
+      "timer_abandon_rate_event_level_pct": "posthog_derived_event_level_started_minus_completed_over_started_pct",
+      "distinct_persons_paywall_purchase_success": "posthog_hogql_distinct_persons_event_paywall_purchase_success",
+      "events_paywall_purchase_success": "posthog_hogql_count_events_paywall_purchase_success",
+      "in_app_review_prompt_events": "posthog_hogql_count_events_review_prompt_requested",
+      "in_app_review_prompt_distinct_persons": "posthog_hogql_distinct_persons_event_review_prompt_requested",
+      "top_screens_by_distinct_persons": "posthog_hogql_top_screens_by_distinct_persons_limit_12_order_desc",
+      "posthog_exception_events": "posthog_hogql_count_events_dollar_exception"
+    },
+    "wqtu_7d_distinct_persons": null
   },
   "store_apis": {
     "android": {
@@ -57,7 +80,8 @@
         "status": "completed",
         "name": "v1774900016"
       },
-      "note": "Google Play API does not expose download counts directly. Review count is from real users only."
+      "note": "Play reviews.list: comment-bearing reviews created or modified in the last 7 days only; star-only ratings are excluded. Not equal to public Play review totals. No per-app download count in this API.",
+      "review_count_metric_id": "google_play_androidpublisher_reviews_list_7d_commented_paginated"
     },
     "ios": {
       "status": "ok",
@@ -88,7 +112,9 @@
       ],
       "review_count": 0,
       "reviews": [],
-      "note": "App Store Connect Sales reports require async report generation. Review count and version state are live from the API."
+      "note": "App Store Connect Sales reports require async report generation. customerReviews count is the first page only (limit 50, newest first), not total lifetime App Store reviews. Version state is live from the API.",
+      "review_count_metric_id": "app_store_connect_customer_reviews_sort_created_desc_limit_50",
+      "review_count_request_limit": 50
     }
   },
   "crashlytics_bigquery": {
@@ -105,6 +131,17 @@
     "crash_free_users": 0,
     "crash_free_pct": null,
     "top_fatal_issues": [],
-    "reason": "BigQuery dataset exists but no tables yet"
+    "reason": "BigQuery dataset exists but no tables yet",
+    "metric_bundle_id": "crashlytics_bq_streaming_fatal_window_v1",
+    "metric_field_ids": {
+      "fatal_events": "crashlytics_bq_sum_crash_count_in_top_20_issue_groups_only_not_total_window",
+      "fatal_events_in_window": "crashlytics_bq_count_star_all_fatal_rows_in_lookback_window",
+      "top_fatal_issues": "crashlytics_bq_fatal_groups_limited_20_order_by_crash_count_desc",
+      "crash_free_pct": "crashlytics_bq_session_crash_free_rate_by_installation_uuid",
+      "total_users": "crashlytics_bq_distinct_installation_uuids_in_window",
+      "crash_free_users": "crashlytics_bq_installation_uuids_without_fatal_in_window",
+      "affected_users": "crashlytics_bq_total_users_minus_crash_free_users"
+    },
+    "fatal_events_in_window": 0
   }
 }

--- a/scripts/check_crashlytics.py
+++ b/scripts/check_crashlytics.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Query Firebase Crashlytics crash data via BigQuery streaming export.
 
+Snapshot payloads include fatal_events_in_window (full COUNT(*) of fatal rows in
+the lookback window) and fatal_events (sum of crash_count in the parsed top-issue
+sample — see metric_field_ids).
+
 Usage:
     python scripts/check_crashlytics.py [--threshold 99.0] [--hours 24]
 
@@ -149,6 +153,17 @@ def query_crash_summary(token, hours, table_id):
     return bq_query(token, sql)
 
 
+def query_fatal_events_total(token, hours, table_id):
+    """Count every fatal crash row in the lookback window (not limited to top issue groups)."""
+    sql = f"""
+    SELECT COUNT(*) as fatal_row_count
+    FROM `{PROJECT_ID}.{BQ_DATASET}.{table_id}`
+    WHERE event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {hours} HOUR)
+      AND COALESCE(is_fatal, FALSE) = TRUE
+    """
+    return bq_query(token, sql)
+
+
 def query_crash_free_rate(token, hours, table_id):
     """Calculate crash-free user rate from BigQuery."""
     sql = f"""
@@ -169,16 +184,36 @@ def query_crash_free_rate(token, hours, table_id):
     return bq_query(token, sql)
 
 
+CRASHLYTICS_SNAPSHOT_METRIC_BUNDLE_ID = "crashlytics_bq_streaming_fatal_window_v1"
+
+
 def _base_snapshot(hours):
     return {
         "status": "ok",
         "source": "crashlytics_bigquery",
+        "metric_bundle_id": CRASHLYTICS_SNAPSHOT_METRIC_BUNDLE_ID,
+        "metric_field_ids": {
+            "fatal_events": (
+                "crashlytics_bq_sum_crash_count_in_top_20_issue_groups_only_not_total_window"
+            ),
+            "fatal_events_in_window": (
+                "crashlytics_bq_count_star_all_fatal_rows_in_lookback_window"
+            ),
+            "top_fatal_issues": (
+                "crashlytics_bq_fatal_groups_limited_20_order_by_crash_count_desc"
+            ),
+            "crash_free_pct": "crashlytics_bq_session_crash_free_rate_by_installation_uuid",
+            "total_users": "crashlytics_bq_distinct_installation_uuids_in_window",
+            "crash_free_users": "crashlytics_bq_installation_uuids_without_fatal_in_window",
+            "affected_users": "crashlytics_bq_total_users_minus_crash_free_users",
+        },
         "project_id": PROJECT_ID,
         "dataset": BQ_DATASET,
         "package": PACKAGE,
         "hours": hours,
         "table_id": None,
         "fatal_events": 0,
+        "fatal_events_in_window": 0,
         "affected_users": 0,
         "total_users": 0,
         "crash_free_users": 0,
@@ -276,6 +311,15 @@ def collect_crashlytics_snapshot(hours=24):
     summary_rows = summary.get("rows") or []
     payload["top_fatal_issues"] = _parse_summary_rows(summary_rows)
     payload["fatal_events"] = sum(issue["crash_count"] for issue in payload["top_fatal_issues"])
+
+    total_fatal = query_fatal_events_total(token, hours, table_id)
+    if "error" in total_fatal:
+        return _error_snapshot(payload, total_fatal)
+    total_rows = total_fatal.get("rows") or []
+    if total_rows and total_rows[0].get("f"):
+        payload["fatal_events_in_window"] = int(total_rows[0]["f"][0].get("v") or 0)
+    else:
+        payload["fatal_events_in_window"] = 0
 
     rate_result = query_crash_free_rate(token, hours, table_id)
     if "error" in rate_result:

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -30,6 +30,40 @@ PRAGMATIC_LIVE = """(
   AND coalesce(toString(properties.is_internal), 'false') != 'true'
 )"""
 
+POSTHOG_EXECUTIVE_METRIC_BUNDLE_ID = "posthog_executive_pragmatic_live_hogql_v1"
+
+# Stable IDs for executive JSON fields under posthog.* (HogQL + derived).
+POSTHOG_EXECUTIVE_METRIC_FIELD_IDS: Dict[str, str] = {
+    "distinct_persons_application_installed": (
+        "posthog_hogql_distinct_persons_event_application_installed"
+    ),
+    "distinct_persons_first_open": "posthog_hogql_distinct_persons_event_first_open",
+    "timer_started_events": "posthog_hogql_count_events_timer_started",
+    "timer_completed_events": "posthog_hogql_count_events_timer_completed",
+    "distinct_persons_timer_started": "posthog_hogql_distinct_persons_event_timer_started",
+    "distinct_persons_timer_completed": "posthog_hogql_distinct_persons_event_timer_completed",
+    "distinct_persons_timer_started_and_completed": (
+        "posthog_hogql_distinct_persons_completed_also_started_same_window"
+    ),
+    "wqtu_distinct_persons": "posthog_hogql_wqtu_timer_completed_ge3_trailing_window_days",
+    "wqtu_7d_distinct_persons": "posthog_hogql_wqtu_timer_completed_ge3_trailing_7d_fixed",
+    "timer_abandon_rate_event_level_pct": (
+        "posthog_derived_event_level_started_minus_completed_over_started_pct"
+    ),
+    "distinct_persons_paywall_purchase_success": (
+        "posthog_hogql_distinct_persons_event_paywall_purchase_success"
+    ),
+    "events_paywall_purchase_success": "posthog_hogql_count_events_paywall_purchase_success",
+    "in_app_review_prompt_events": "posthog_hogql_count_events_review_prompt_requested",
+    "in_app_review_prompt_distinct_persons": (
+        "posthog_hogql_distinct_persons_event_review_prompt_requested"
+    ),
+    "top_screens_by_distinct_persons": (
+        "posthog_hogql_top_screens_by_distinct_persons_limit_12_order_desc"
+    ),
+    "posthog_exception_events": "posthog_hogql_count_events_dollar_exception",
+}
+
 
 def _posthog_credentials() -> tuple[str, str]:
     key = (
@@ -163,6 +197,8 @@ def _posthog_section(project_id: str, api_key: str, days: int) -> Dict[str, Any]
         f"AND timestamp > now() - interval {win} AND {f}"
     )
     out["posthog_exception_events"] = q_exc
+    out["metric_bundle_id"] = POSTHOG_EXECUTIVE_METRIC_BUNDLE_ID
+    out["metric_field_ids"] = dict(POSTHOG_EXECUTIVE_METRIC_FIELD_IDS)
     if errors:
         out["query_errors"] = errors[:20]
     return out
@@ -207,12 +243,28 @@ def run(
     payload: Dict[str, Any] = {
         "generated_at": generated_at,
         "source": "executive_metrics_snapshot",
+        "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
         "definitions": {
             "install_proxy_posthog": "Distinct persons with event Application Installed (not store units).",
-            "reviews_store": "From Play/App Store APIs in store section (sample/pagination limits apply).",
+            "reviews_store": (
+                "Play: reviews.list is comment-bearing reviews touched in the last 7 days only "
+                "(per Google); star-only ratings omitted; can read 0 while the public listing shows "
+                "reviews; pagination max 100/page. App Store: customerReviews first page only "
+                "(limit 50, newest first), not lifetime total. Use review_count_metric_id under "
+                "store_apis.android / store_apis.ios when present."
+            ),
             "reviews_in_app": "PostHog review_prompt_requested / write_review_tapped (not published star count).",
             "paid_posthog": "paywall_purchase_success and paywall_purchase_result in PostHog; use Store/RevenueCat for ledger truth.",
-            "crashes": "Crashlytics via BigQuery export; PostHog $exception also listed if captured.",
+            "posthog_executive": (
+                "HogQL scalars use audience_sql (PRAGMATIC_LIVE) and window_days except "
+                "wqtu_7d_distinct_persons (fixed 7d). See posthog.metric_field_ids."
+            ),
+            "crashes": (
+                "Crashlytics BigQuery streaming export; posthog_exception_events is separate. "
+                "crashlytics_bigquery.fatal_events_in_window is COUNT(*) of fatal rows in the "
+                "lookback hours. fatal_events sums crash_count only within parsed top_fatal_issues "
+                "(up to 10 rows displayed from top 20 SQL groups) — see metric_field_ids."
+            ),
             "uninstalls": "Not available on iOS; Android uninstall metrics require Play reporting APIs (not in this script yet).",
             "wqtu": "Distinct persons with >=3 timer_completed events in the same window as window_days (supplementary).",
             "wqtu_7d": "North Star WQTU: distinct persons with >=3 timer_completed in trailing 7 days (canonical).",
@@ -270,7 +322,11 @@ def main() -> int:
     print(f"  Android API: {(st.get('android') or {}).get('status')}")
     print(f"  iOS API: {(st.get('ios') or {}).get('status')}")
     cr = payload.get("crashlytics_bigquery") or {}
-    print(f"  Crashlytics BQ: {cr.get('status')} fatal_events={cr.get('fatal_crash_events')}")
+    print(
+        f"  Crashlytics BQ: {cr.get('status')} "
+        f"fatal_in_window={cr.get('fatal_events_in_window')} "
+        f"fatal_top_groups_sum={cr.get('fatal_events')}"
+    )
     print("=" * 60)
     if args.json_stdout:
         print(json.dumps(payload, indent=2))

--- a/scripts/real_store_downloads.py
+++ b/scripts/real_store_downloads.py
@@ -30,6 +30,34 @@ IOS_APP_ID = "6758355312"
 
 sys.path.append(str(Path(__file__).parent.resolve()))
 
+# Google Play Reply-to-Reviews API: list only includes reviews with user *comments*
+# (star-only ratings are omitted), and only those created or modified in the last 7 days.
+# Public Play Store totals can be higher. See:
+# https://developers.google.com/android-publisher/reply-to-reviews
+
+ANDROID_REVIEW_COUNT_METRIC_ID = (
+    "google_play_androidpublisher_reviews_list_7d_commented_paginated"
+)
+IOS_REVIEW_COUNT_METRIC_ID = (
+    "app_store_connect_customer_reviews_sort_created_desc_limit_50"
+)
+
+
+def _fetch_all_play_reviews_list(service: Any, package_name: str) -> list[dict[str, Any]]:
+    """Paginate reviews.list (max 100 per page per API)."""
+    accumulated: list[dict[str, Any]] = []
+    page_token: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {"packageName": package_name, "maxResults": 100}
+        if page_token:
+            kwargs["token"] = page_token
+        result = service.reviews().list(**kwargs).execute()
+        accumulated.extend(result.get("reviews", []))
+        page_token = (result.get("tokenPagination") or {}).get("nextPageToken")
+        if not page_token:
+            break
+    return accumulated
+
 
 def _get_android_data(days: int) -> dict[str, Any]:
     """Query Google Play Developer API for real install data."""
@@ -58,11 +86,8 @@ def _get_android_data(days: int) -> dict[str, Any]:
     try:
         service = build("androidpublisher", "v3", credentials=credentials)
 
-        # Get reviews (as a proxy for real users — only real users can leave reviews)
-        reviews_result = service.reviews().list(
-            packageName=ANDROID_PACKAGE,
-        ).execute()
-        reviews = reviews_result.get("reviews", [])
+        # Recent, comment-bearing reviews only (Google API rules — not public listing total).
+        reviews = _fetch_all_play_reviews_list(service, ANDROID_PACKAGE)
         review_count = len(reviews)
 
         # Get the current track info to confirm we're live
@@ -98,8 +123,13 @@ def _get_android_data(days: int) -> dict[str, Any]:
         return {
             "status": "ok",
             "review_count": review_count,
+            "review_count_metric_id": ANDROID_REVIEW_COUNT_METRIC_ID,
             "production_release": production_version,
-            "note": "Google Play API does not expose download counts directly. Review count is from real users only.",
+            "note": (
+                "Play reviews.list: comment-bearing reviews created or modified in the last "
+                "7 days only; star-only ratings are excluded. Not equal to public Play "
+                "review totals. No per-app download count in this API."
+            ),
         }
     except Exception as e:
         return {"status": "error", "reason": str(e)}
@@ -180,6 +210,8 @@ def _get_ios_data(days: int) -> dict[str, Any]:
         if resp.status_code == 200:
             reviews = resp.json().get("data", [])
             result["review_count"] = len(reviews)
+            result["review_count_metric_id"] = IOS_REVIEW_COUNT_METRIC_ID
+            result["review_count_request_limit"] = 50
             result["reviews"] = [
                 {
                     "rating": r["attributes"].get("rating"),
@@ -199,7 +231,8 @@ def _get_ios_data(days: int) -> dict[str, Any]:
     # and version state as ground truth.
     result["note"] = (
         "App Store Connect Sales reports require async report generation. "
-        "Review count and version state are live from the API."
+        "customerReviews count is the first page only (limit 50, newest first), "
+        "not total lifetime App Store reviews. Version state is live from the API."
     )
 
     return result
@@ -217,6 +250,7 @@ def run(repo_root: Path, days: int = 30) -> dict:
     payload = {
         "generated_at": generated_at,
         "source": "store_apis",
+        "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
         "note": "Real store API data, not PostHog proxy",
         "android": android,
         "ios": ios,
@@ -230,13 +264,17 @@ def run(repo_root: Path, days: int = 30) -> dict:
     print("=" * 60)
     print(f"  Android: {android.get('status')}")
     if android.get("review_count") is not None:
-        print(f"    Reviews: {android['review_count']}")
+        mid = android.get("review_count_metric_id") or ""
+        suffix = f" [{mid}]" if mid else ""
+        print(f"    Reviews: {android['review_count']}{suffix}")
     if android.get("production_release"):
         pr = android["production_release"]
         print(f"    Production: {pr.get('name')} ({pr.get('status')})")
     print(f"  iOS: {ios.get('status')}")
     if ios.get("review_count") is not None:
-        print(f"    Reviews: {ios['review_count']}")
+        mid = ios.get("review_count_metric_id") or ""
+        suffix = f" [{mid}]" if mid else ""
+        print(f"    Reviews: {ios['review_count']}{suffix}")
     if ios.get("versions"):
         for v in ios["versions"][:3]:
             print(f"    Version {v['version']}: {v['state']}")

--- a/scripts/tests/test_check_crashlytics.py
+++ b/scripts/tests/test_check_crashlytics.py
@@ -32,6 +32,15 @@ def test_constants():
     assert int(cc.DEFAULT_THRESHOLD) == 99
 
 
+def test_base_snapshot_includes_metric_metadata():
+    snap = cc._base_snapshot(24)
+    assert snap["metric_bundle_id"] == cc.CRASHLYTICS_SNAPSHOT_METRIC_BUNDLE_ID
+    assert "fatal_events" in snap["metric_field_ids"]
+    assert "top_20" in snap["metric_field_ids"]["fatal_events"]
+    assert "fatal_events_in_window" in snap["metric_field_ids"]
+    assert snap["fatal_events_in_window"] == 0
+
+
 def test_bq_query_returns_error_on_failure():
     with patch.object(cc.urllib.request, "urlopen") as mock_urlopen:
         import urllib.error
@@ -144,6 +153,18 @@ def test_get_access_token_uses_inline_service_account_json():
     fake_creds.refresh.assert_called_once()
 
 
+def test_query_fatal_events_total_uses_count_star_and_fatal_predicate():
+    with patch.object(cc, "bq_query") as mock_bq:
+        mock_bq.return_value = {"rows": [{"f": [{"v": "17"}]}]}
+        out = cc.query_fatal_events_total("tok", 6, "com_iganapolsky_randomtimer")
+    assert out == mock_bq.return_value
+    sql = mock_bq.call_args[0][1]
+    assert "COUNT(*)" in sql
+    assert "is_fatal" in sql
+    assert "INTERVAL 6 HOUR" in sql
+    assert "com_iganapolsky_randomtimer" in sql
+
+
 def test_collect_crashlytics_snapshot_returns_structured_payload():
     summary = {
         "rows": [
@@ -161,11 +182,13 @@ def test_collect_crashlytics_snapshot_returns_structured_payload():
             }
         ]
     }
+    total_fatal = {"rows": [{"f": [{"v": "3"}]}]}
     rate = {"rows": [{"f": [{"v": "10"}, {"v": "8"}, {"v": "80.0"}]}]}
 
     with patch.object(cc, "get_access_token", return_value="token"), \
          patch.object(cc, "check_bigquery_export", return_value=["com_iganapolsky_randomtimer"]), \
          patch.object(cc, "query_crash_summary", return_value=summary), \
+         patch.object(cc, "query_fatal_events_total", return_value=total_fatal), \
          patch.object(cc, "query_crash_free_rate", return_value=rate):
         payload = cc.collect_crashlytics_snapshot(hours=168)
 
@@ -173,11 +196,60 @@ def test_collect_crashlytics_snapshot_returns_structured_payload():
     assert payload["project_id"] == "random-timer-dist-new"
     assert payload["table_id"] == "com_iganapolsky_randomtimer"
     assert payload["fatal_events"] == 3
+    assert payload["fatal_events_in_window"] == 3
     assert payload["affected_users"] == 2
     assert payload["total_users"] == 10
     assert payload["crash_free_users"] == 8
     assert math.isclose(payload["crash_free_pct"], 80.0)
     assert payload["top_fatal_issues"][0]["issue_title"] == "Crash title"
+
+
+def test_collect_crashlytics_snapshot_top20_sum_can_differ_from_window_total():
+    """fatal_events sums only top 20 groups; fatal_events_in_window is full COUNT(*)."""
+    summary = {
+        "rows": [
+            {
+                "f": [
+                    {"v": "2"},
+                    {"v": "1"},
+                    {"v": "FATAL"},
+                    {"v": "A.kt"},
+                    {"v": "1"},
+                    {"v": "Issue A"},
+                    {"v": ""},
+                    {"v": "1.0"},
+                ]
+            }
+        ]
+    }
+    total_fatal = {"rows": [{"f": [{"v": "9"}]}]}
+    rate = {"rows": [{"f": [{"v": "5"}, {"v": "4"}, {"v": "80.0"}]}]}
+
+    with patch.object(cc, "get_access_token", return_value="token"), \
+         patch.object(cc, "check_bigquery_export", return_value=["com_iganapolsky_randomtimer"]), \
+         patch.object(cc, "query_crash_summary", return_value=summary), \
+         patch.object(cc, "query_fatal_events_total", return_value=total_fatal), \
+         patch.object(cc, "query_crash_free_rate", return_value=rate):
+        payload = cc.collect_crashlytics_snapshot(hours=24)
+
+    assert payload["fatal_events"] == 2
+    assert payload["fatal_events_in_window"] == 9
+
+
+def test_collect_crashlytics_snapshot_errors_when_fatal_total_query_fails():
+    summary = {"rows": []}
+    with patch.object(cc, "get_access_token", return_value="token"), \
+         patch.object(cc, "check_bigquery_export", return_value=["com_iganapolsky_randomtimer"]), \
+         patch.object(cc, "query_crash_summary", return_value=summary), \
+         patch.object(
+             cc,
+             "query_fatal_events_total",
+             return_value={"error": "Syntax error", "code": 400},
+         ):
+        payload = cc.collect_crashlytics_snapshot(hours=1)
+
+    assert payload["status"] == "error"
+    assert "Syntax error" in payload["reason"]
 
 
 def test_collect_crashlytics_snapshot_handles_missing_export():

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -12,6 +12,40 @@ def test_posthog_section_skipped_without_credentials() -> None:
     assert out["status"] == "skipped"
 
 
+def test_posthog_section_includes_metric_field_ids_when_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import executive_metrics_snapshot as ems
+
+    import store_downloads_snapshot as sds
+
+    def fake_posthog_query(
+        query: str,
+        api_key: str,
+        project_id: str,
+        errors: list,
+        **kwargs: object,
+    ):
+        if "interval 7 day" in query and "HAVING count() >= 3" in query:
+            return {"results": [[0]]}
+        if "review_prompt_requested" in query:
+            return {"results": [[0, 0]]}
+        if "$screen" in query:
+            return {"results": []}
+        return {"results": [[0]]}
+
+    monkeypatch.setattr(sds, "posthog_query", fake_posthog_query)
+
+    out = ems._posthog_section("299775", "test-key", 30)
+    assert out["status"] == "ok"
+    assert out.get("metric_bundle_id") == ems.POSTHOG_EXECUTIVE_METRIC_BUNDLE_ID
+    mf = out.get("metric_field_ids") or {}
+    assert mf.get("wqtu_7d_distinct_persons") == (
+        "posthog_hogql_wqtu_timer_completed_ge3_trailing_7d_fixed"
+    )
+    assert mf.get("distinct_persons_application_installed") == (
+        "posthog_hogql_distinct_persons_event_application_installed"
+    )
+
+
 def test_posthog_section_includes_wqtu_7d_from_queries(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import executive_metrics_snapshot as ems
 

--- a/scripts/tests/test_real_store_downloads.py
+++ b/scripts/tests/test_real_store_downloads.py
@@ -1,0 +1,50 @@
+"""Tests for Play review list pagination helper."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from real_store_downloads import (  # noqa: E402
+    ANDROID_REVIEW_COUNT_METRIC_ID,
+    IOS_REVIEW_COUNT_METRIC_ID,
+    _fetch_all_play_reviews_list,
+)
+
+
+def test_review_metric_ids_are_stable_tokens() -> None:
+    assert "google_play" in ANDROID_REVIEW_COUNT_METRIC_ID
+    assert "app_store_connect" in IOS_REVIEW_COUNT_METRIC_ID
+
+
+def test_fetch_all_play_reviews_list_paginates_until_no_token() -> None:
+    service = MagicMock()
+    list_resource = service.reviews.return_value.list
+    list_resource.return_value.execute.side_effect = [
+        {
+            "reviews": [{"reviewId": "a"}],
+            "tokenPagination": {"nextPageToken": "t1"},
+        },
+        {
+            "reviews": [{"reviewId": "b"}, {"reviewId": "c"}],
+            "tokenPagination": {},
+        },
+    ]
+
+    out = _fetch_all_play_reviews_list(service, "com.example.app")
+
+    assert len(out) == 3
+    assert list_resource.call_count == 2
+    first_kw = list_resource.call_args_list[0].kwargs
+    assert first_kw == {"packageName": "com.example.app", "maxResults": 100}
+    second_kw = list_resource.call_args_list[1].kwargs
+    assert second_kw == {
+        "packageName": "com.example.app",
+        "maxResults": 100,
+        "token": "t1",
+    }

--- a/scripts/tests/test_repo_hygiene_contracts.py
+++ b/scripts/tests/test_repo_hygiene_contracts.py
@@ -13,6 +13,18 @@ FEATURE_TEMPLATE = ROOT / ".github/ISSUE_TEMPLATE/feature_request.md"
 MAIN_WORKFLOW = ROOT / ".github/workflows/main.yml"
 
 
+def test_operational_reliability_contract_doc_exists() -> None:
+    path = ROOT / "docs" / "OPERATIONAL_RELIABILITY.md"
+    text = path.read_text(encoding="utf-8")
+    assert path.is_file()
+    for marker in (
+        "Ground truth vs proxy",
+        "Contradiction protocol",
+        "review_count_metric_id",
+    ):
+        assert marker in text, f"{path} must document {marker}"
+
+
 def test_instruction_docs_do_not_claim_unwired_memory_backends() -> None:
     for relative_path in ("CLAUDE.md", "AGENTS.md"):
         contents = (ROOT / relative_path).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Codifies operational trust (docs + Cursor rule), labels store/PostHog/Crashlytics metrics with stable IDs, Play reviews pagination + semantics, and exact fatal crash COUNT(*) in BQ.

## Evidence
- Commit: `e276772f6` (also on local `hotfix/emergency-both-platforms`)
- Tests: `uv run pytest scripts/tests/test_check_crashlytics.py scripts/tests/test_real_store_downloads.py scripts/tests/test_executive_metrics_snapshot.py scripts/tests/test_repo_hygiene_contracts.py`

## Note
Direct push to `hotfix/emergency-both-platforms` was rejected by repo rules; this PR is from `chore/operational-reliability-metrics`.

Made with [Cursor](https://cursor.com)