### PR TITLE
fix(ios): add hidden Pro unlock long-press parity with Android

### DIFF
--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -44,12 +44,14 @@ struct TimerSetupScreen: View {
                             Spacer()
 
                             if !proManager.isPro {
-                                Text(hasCompletedFirstTimer ? "PRO: 1H \u{1F512}" : "PRO: 1H")
+                                Text("PRO: 1H \u{1F512}")
                                     .font(.caption2)
                                     .foregroundColor(.accentPrimary)
                                     .onTapGesture {
-                                        guard hasCompletedFirstTimer else { return }
                                         presentPaywall(entryPoint: .rangeGate)
+                                    }
+                                    .onLongPressGesture {
+                                        proManager.unlockProForDebug()
                                     }
                             } else {
                                 Button {


### PR DESCRIPTION
## Summary
- iOS was missing the secret debug Pro unlock that Android has
- Long-press on "PRO: 1H" now calls `unlockProForDebug()`
- Lock emoji always visible (was hidden before first timer completion)
- Tap always shows paywall (was no-op before first timer)

## Test plan
- [ ] CI passes
- [ ] TestFlight: long-press PRO: 1H unlocks Pro features

🤖 Generated with [Claude Code](https://claude.com/claude-code)