### PR TITLE
fix(ci): require fresh store signoff and upgrade actions

### DIFF
--- a/.github/workflows/android-production-retry.yml
+++ b/.github/workflows/android-production-retry.yml
@@ -25,9 +25,9 @@ jobs:
       expected_version: ${{ steps.gate.outputs.expected_version }}
       public_status: ${{ steps.gate.outputs.public_status }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/android17-canary.yml
+++ b/.github/workflows/android17-canary.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             scripts/tests/test_voice_regression_contracts.py
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -53,7 +53,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.4
         id: avd-cache
         with:
           path: |

--- a/.github/workflows/domi-v3-human.yml
+++ b/.github/workflows/domi-v3-human.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
       - name: Generate Domi v3 samples with audio tags

--- a/.github/workflows/domi-voice-tuning.yml
+++ b/.github/workflows/domi-voice-tuning.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
       - name: Generate Domi tuning samples

--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -19,9 +19,9 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 
@@ -49,7 +49,7 @@ jobs:
             --crashlytics-hours "${{ inputs.crashlytics_hours }}" \
             --no-dotenv
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.0
         with:
           name: executive-metrics
           path: marketing/data/executive_metrics.json

--- a/.github/workflows/female-voice-samples.yml
+++ b/.github/workflows/female-voice-samples.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/fix-alarm-sound.yml
+++ b/.github/workflows/fix-alarm-sound.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
       - name: Generate alarm variants

--- a/.github/workflows/generate-female-voice-pack.yml
+++ b/.github/workflows/generate-female-voice-pack.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/generate-real-sounds.yml
+++ b/.github/workflows/generate-real-sounds.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -183,7 +183,7 @@ jobs:
           python-version: "3.11"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: "3.3"
           bundler-cache: true
@@ -337,13 +337,13 @@ jobs:
         run: bash scripts/preflight-release.sh --platform android --layer 1
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: "3.3"
           bundler-cache: true
@@ -508,7 +508,7 @@ jobs:
         run: bash scripts/preflight-release.sh --platform android --layer 1
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -63,7 +63,7 @@ jobs:
         run: bash scripts/preflight-release.sh --platform ios --layer 1
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: "3.2"
           bundler-cache: true

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -67,7 +67,7 @@ jobs:
         run: pip install pyjwt==2.11.0 cryptography==46.0.5 requests==2.32.5
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: "3.2"
           bundler-cache: true

--- a/.github/workflows/monthly-audio-pack.yml
+++ b/.github/workflows/monthly-audio-pack.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -57,7 +57,7 @@ jobs:
   release-intent-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Enforce release-branch intent (avoid accidental Android skip)
         env:
@@ -72,7 +72,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Read commit status proofs for release SHA
         env:
@@ -84,13 +84,22 @@ jobs:
             --platform "${{ inputs.platform }}" \
             --statuses-json /tmp/internal-signoff-status.json
 
-  ios-testflight:
+  require-production-signoff:
     needs: [release-intent-gate, require-internal-signoff]
+    runs-on: ubuntu-latest
+    environment: production-signoff
+    steps:
+      - name: Await fresh CEO production release approval
+        run: |
+          echo "Fresh production signoff approved for ${GITHUB_SHA}"
+
+  ios-testflight:
+    needs: [release-intent-gate, require-internal-signoff, require-production-signoff]
     if: ${{ inputs.platform == 'ios' || inputs.platform == 'both' }}
     runs-on: macos-26
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Write GoogleService-Info.plist from secret (Firebase)
         env:
@@ -127,12 +136,12 @@ jobs:
         run: bash scripts/preflight-release.sh --platform ios --layer 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: '3.2'
           bundler-cache: true
@@ -209,14 +218,14 @@ jobs:
         working-directory: native-ios
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: always()
         with:
           name: ios-ipa
           path: native-ios/RandomTimer.ipa
 
   android-release:
-    needs: [release-intent-gate, require-internal-signoff]
+    needs: [release-intent-gate, require-internal-signoff, require-production-signoff]
     if: ${{ inputs.platform == 'android' || inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     environment: production
@@ -229,7 +238,7 @@ jobs:
       precondition_blocked: ${{ steps.play_result.outputs.precondition_blocked }}
       version_code: ${{ steps.play_result.outputs.version_code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Fail fast on required Android release secrets
         env:
@@ -251,18 +260,18 @@ jobs:
         run: bash scripts/preflight-release.sh --platform android --layer 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v6.1.0
 
       - name: Create google-services.json
         env:
@@ -391,7 +400,7 @@ jobs:
           echo "play_result requested=$REQUESTED_TRACK effective=$EFFECTIVE_TRACK fallback_used=$FALLBACK_USED precondition_blocked=$PRECONDITION_BLOCKED version_code=$VERSION_CODE"
 
       - name: Upload Play upload result (if any)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: always()
         with:
           name: play-upload-result
@@ -399,7 +408,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Play upload error (if any)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: always()
         with:
           name: play-upload-error
@@ -407,7 +416,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: always()
         with:
           name: android-aab
@@ -429,10 +438,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 
@@ -564,7 +573,7 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Gate submit-for-review (no secrets)
         id: gate
@@ -589,7 +598,7 @@ jobs:
 
       - name: Setup Python
         if: steps.gate.outputs.enabled == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 
@@ -651,7 +660,7 @@ jobs:
 
       - name: Setup Ruby
         if: steps.gate.outputs.enabled == 'true'
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: '3.2'
           bundler-cache: true
@@ -748,7 +757,7 @@ jobs:
             --enforce
 
       - name: Upload readiness report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: ${{ steps.gate.outputs.enabled == 'true' && always() }}
         with:
           name: asc-ready-report
@@ -785,7 +794,7 @@ jobs:
             --require-appstore-submission
 
       - name: Upload version resolution report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: ${{ steps.gate.outputs.enabled == 'true' && always() }}
         with:
           name: asc-version-resolution
@@ -805,7 +814,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -890,7 +899,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/posthog-dashboard.yml
+++ b/.github/workflows/posthog-dashboard.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.12'
 
@@ -44,14 +44,14 @@ jobs:
             --json-stdout > posthog_dashboard_output.json
 
       - name: Upload dashboard JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: posthog-dashboard
           path: posthog_dashboard_output.json
           retention-days: 90
 
       - name: Upload marketing data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: posthog-dashboard-marketing
           path: marketing/data/posthog_dashboard.json

--- a/.github/workflows/regenerate-pro-sounds.yml
+++ b/.github/workflows/regenerate-pro-sounds.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/voice-ab-test.yml
+++ b/.github/workflows/voice-ab-test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/wqtu-health.yml
+++ b/.github/workflows/wqtu-health.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -12,7 +12,7 @@ This document is the **source of truth** for what is **implemented in code** ver
 |------------|-----|---------|--------|
 | **PostHog** (events, identify, funnels) | Yes | Yes | Initializes only when `POSTHOG_API_KEY` is non-empty at build/runtime wiring. |
 | **Session replay** | Yes (SDK config) | Yes (SDK config) | Masking + throttling in code. **Internal** builds / simulators excluded on iOS; Android excludes emulators / debug similarly. **PostHog project** must have session recording enabled if you want replays in the UI. |
-| **Firebase Crashlytics** | Yes | Yes | Requires real `GoogleService-Info.plist` / `google-services.json` in local and release pipelines (not committed). CI uses **placeholders**; iOS **unit tests on CI** skip `FirebaseApp.configure()` via `RT_SKIP_FIREBASE_FOR_CI`. |
+| **Firebase Crashlytics** | Yes | Yes | Release pipelines require real `GoogleService-Info.plist` / `google-services.json` (not committed). iOS debug/test builds can run without a local `GoogleService-Info.plist`; Firebase init is skipped when the plist is not bundled or when CI/test skip flags are set. |
 | **Firebase Performance** | **No** (SPM product not linked) | **Yes** (Gradle plugin + `firebase-perf` dependency) | iOS auto-instrumentation was removed to stabilize CI; can be re-added later with the same CI skip pattern if validated. |
 | **Firebase Remote Config** | **No** | **No** | Not referenced in app sources; use PostHog feature flags until/unless RC is added. |
 | **Firebase Cloud Messaging** | Not wired for product analytics | Not wired for product analytics | Listed only as a future option if you add push. |
@@ -47,7 +47,7 @@ Nothing below should be pasted into chat or committed to git. Use Xcode, Gradle 
 
 ### 2. Firebase (Crashlytics + Android Performance)
 
-- [ ] **iOS:** Download **`GoogleService-Info.plist`** from Firebase Console for `com.iganapolsky.randomtimer`, place at `native-ios/RandomTimer/GoogleService-Info.plist` (file is **gitignored**).
+- [ ] **iOS release / local Firebase validation:** Download **`GoogleService-Info.plist`** from Firebase Console for `com.iganapolsky.randomtimer`, place at `native-ios/RandomTimer/GoogleService-Info.plist` (file is **gitignored**). Debug/test builds can compile without it, but Firebase/Crashlytics will stay disabled until the real plist is present.
 - [ ] **Android:** **`google-services.json`** in `native-android/app/` for real builds (gitignored in normal dev; CI generates a dummy for builds/tests).
 - [ ] Firebase Console: ensure **Crashlytics** is enabled for the app; **Performance Monitoring** enabled for Android (already depends on Gradle setup).
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -75,7 +75,6 @@
 		PRIV001122334455AABB0002 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = PRIV001122334455AABB0001 /* PrivacyInfo.xcprivacy */; };
 		FCBFIR001122334455667788AA /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = FPDFIR00112233445566778801 /* FirebaseCrashlytics */; };
 		CRSVC00112233445566778802 /* CrashReportingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRSVC00112233445566778801 /* CrashReportingService.swift */; };
-		GSIPL00112233445566778802 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = GSIPL00112233445566778801 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -415,13 +414,14 @@
 		071F286DC49E27F1773FA883 /* RandomTimer */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1FC5C4B604AB7C83642F1A28 /* Build configuration list for PBXNativeTarget "RandomTimer" */;
-			buildPhases = (
-				4B3649502FCACD78DF51B7D7 /* Sources */,
-				PH00112233445566778899CC /* Frameworks */,
-				C860582E5E34407E753D7F99 /* Resources */,
-				C1D86135661BEED30B3D6574 /* Embed Foundation Extensions */,
-				CRSHEL00112233445566778801 /* Run Crashlytics */,
-			);
+				buildPhases = (
+					4B3649502FCACD78DF51B7D7 /* Sources */,
+					PH00112233445566778899CC /* Frameworks */,
+					C860582E5E34407E753D7F99 /* Resources */,
+					GSICOPY001122334455667788 /* Copy GoogleService-Info.plist if present */,
+					C1D86135661BEED30B3D6574 /* Embed Foundation Extensions */,
+					CRSHEL00112233445566778801 /* Run Crashlytics */,
+				);
 			buildRules = (
 			);
 			dependencies = (
@@ -525,16 +525,15 @@
 		C860582E5E34407E753D7F99 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				A1C100112233445566778899 /* Audio in Resources */,
-				56DF942937CE323893E2E4C6 /* alarm.mp3 in Resources */,
-				4E242D865279E0BFD5B9CF7B /* gentle-chime.mp3 in Resources */,
-				AABB001122334455DEADBEE0 /* Assets.xcassets in Resources */,
-				PRIV001122334455AABB0002 /* PrivacyInfo.xcprivacy in Resources */,
-				GSIPL00112233445566778802 /* GoogleService-Info.plist in Resources */,
-				3FFD4482489894E382E7B6E8 /* klaxon.mp3 in Resources */,
-				4FF9285AE33C37D3F7655511 /* whistle.mp3 in Resources */,
-				5B6F3408CC4B851C6428EAAA /* buzzer.mp3 in Resources */,
+				files = (
+					A1C100112233445566778899 /* Audio in Resources */,
+					56DF942937CE323893E2E4C6 /* alarm.mp3 in Resources */,
+					4E242D865279E0BFD5B9CF7B /* gentle-chime.mp3 in Resources */,
+					AABB001122334455DEADBEE0 /* Assets.xcassets in Resources */,
+					PRIV001122334455AABB0002 /* PrivacyInfo.xcprivacy in Resources */,
+					3FFD4482489894E382E7B6E8 /* klaxon.mp3 in Resources */,
+					4FF9285AE33C37D3F7655511 /* whistle.mp3 in Resources */,
+					5B6F3408CC4B851C6428EAAA /* buzzer.mp3 in Resources */,
 				997459C4BEB58C7A5CB1C72F /* gong.mp3 in Resources */,
 				2B75985921EFA190A6114447 /* airhorn.mp3 in Resources */,
 				1DB82123D1FB23AC92C566D7 /* drum_roll.mp3 in Resources */,
@@ -546,6 +545,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		GSICOPY001122334455667788 /* Copy GoogleService-Info.plist if present */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(PROJECT_DIR)/RandomTimer/GoogleService-Info.plist",
+			);
+			name = "Copy GoogleService-Info.plist if present";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SOURCE_PLIST=\"${PROJECT_DIR}/RandomTimer/GoogleService-Info.plist\"\nDEST_PLIST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\nif [ -f \"$SOURCE_PLIST\" ]; then\n  cp \"$SOURCE_PLIST\" \"$DEST_PLIST\"\n  echo \"Bundled GoogleService-Info.plist\"\nelse\n  rm -f \"$DEST_PLIST\"\n  echo \"GoogleService-Info.plist not present; continuing without bundled Firebase config\"\nfi\n";
+		};
 		CRSHEL00112233445566778801 /* Run Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -568,7 +587,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -f \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" ]; then\n  \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nfi\n";
+			shellScript = "if [ ! -f \"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\" ]; then\n  echo \"Skipping Crashlytics run script because GoogleService-Info.plist is not bundled\"\n  exit 0\nfi\nif [ -f \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" ]; then\n  \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
+++ b/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
@@ -1,8 +1,14 @@
 import FirebaseCore
+import OSLog
 import SwiftUI
 
 @main
 struct RandomTimerApp: App {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.igorganapolsky.randomtimer",
+        category: "App"
+    )
+
     // swiftlint:disable:next no_state_object
     @StateObject private var timerManager = TimerManager()
     @Environment(\.scenePhase) private var scenePhase
@@ -18,8 +24,20 @@ struct RandomTimerApp: App {
         #endif
     }
 
+    private static var hasBundledFirebaseConfig: Bool {
+        Bundle.main.url(forResource: "GoogleService-Info", withExtension: "plist") != nil
+    }
+
     init() {
         guard !Self.shouldSkipFirebaseForHostedTests else { return }
+        guard Self.hasBundledFirebaseConfig else {
+            #if DEBUG
+            Self.logger.warning("Skipping Firebase initialization because GoogleService-Info.plist is not bundled.")
+            return
+            #else
+            preconditionFailure("Missing bundled GoogleService-Info.plist in release build.")
+            #endif
+        }
         FirebaseApp.configure()
         CrashReportingService.shared.initialize()
         AnalyticsService.shared.initialize()
@@ -52,7 +70,6 @@ struct RandomTimerApp: App {
 }
 
 struct ContentView: View {
-    // swiftlint:disable:next no_environment_object
     @EnvironmentObject var timerManager: TimerManager
     @State private var didApplyUITestSeed: Bool = false
 

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -38,6 +38,12 @@ VOICE_GUARD_PATH_FRAGMENTS = (
     "scripts/tests/test_voice_regression_contracts.py",
 )
 
+IOS_FIREBASE_GUARD_PATH_FRAGMENTS = (
+    "native-ios/RandomTimer.xcodeproj/project.pbxproj",
+    "native-ios/RandomTimer/Sources/App/RandomTimerApp.swift",
+    "docs/OBSERVABILITY.md",
+)
+
 
 def _read(repo_root: Path, relative_path: str) -> str:
     return (repo_root / relative_path).read_text(encoding="utf-8")
@@ -74,8 +80,16 @@ def _matches_release_path(path: str) -> bool:
     return path in RELEASE_GUARD_PATHS
 
 
+def _matches_ios_firebase_path(path: str) -> bool:
+    return any(fragment in path for fragment in IOS_FIREBASE_GUARD_PATH_FRAGMENTS)
+
+
 def relevant_paths(paths: list[str]) -> list[str]:
-    return [path for path in _normalize_paths(paths) if _matches_release_path(path) or _matches_voice_path(path)]
+    return [
+        path
+        for path in _normalize_paths(paths)
+        if _matches_release_path(path) or _matches_voice_path(path) or _matches_ios_firebase_path(path)
+    ]
 
 
 def _assert_contains(source: str, needle: str, *, errors: list[str], label: str) -> None:
@@ -186,13 +200,64 @@ def check_voice_contract(repo_root: Path, errors: list[str]) -> None:
     _assert_contains(android_voice_manager, "runtimeVoiceCueForElapsedMark", errors=errors, label="AIVoiceCalloutManager.kt")
 
 
-def run_checks(repo_root: Path, *, include_voice: bool) -> list[str]:
+def check_ios_firebase_contract(repo_root: Path, errors: list[str]) -> None:
+    app_source = _read(repo_root, "native-ios/RandomTimer/Sources/App/RandomTimerApp.swift")
+    pbxproj = _read(repo_root, "native-ios/RandomTimer.xcodeproj/project.pbxproj")
+    observability = _read(repo_root, "docs/OBSERVABILITY.md")
+
+    _assert_contains(
+        app_source,
+        'Bundle.main.url(forResource: "GoogleService-Info", withExtension: "plist") != nil',
+        errors=errors,
+        label="RandomTimerApp.swift",
+    )
+    _assert_contains(
+        app_source,
+        "Skipping Firebase initialization because GoogleService-Info.plist is not bundled.",
+        errors=errors,
+        label="RandomTimerApp.swift",
+    )
+    _assert_contains(
+        app_source,
+        "Missing bundled GoogleService-Info.plist in release build.",
+        errors=errors,
+        label="RandomTimerApp.swift",
+    )
+    _assert_contains(
+        pbxproj,
+        "Copy GoogleService-Info.plist if present",
+        errors=errors,
+        label="project.pbxproj",
+    )
+    _assert_contains(
+        pbxproj,
+        "Skipping Crashlytics run script because GoogleService-Info.plist is not bundled",
+        errors=errors,
+        label="project.pbxproj",
+    )
+    _assert_not_contains(
+        pbxproj,
+        "GoogleService-Info.plist in Resources",
+        errors=errors,
+        label="project.pbxproj",
+    )
+    _assert_contains(
+        observability,
+        "iOS debug/test builds can run without a local `GoogleService-Info.plist`",
+        errors=errors,
+        label="docs/OBSERVABILITY.md",
+    )
+
+
+def run_checks(repo_root: Path, *, include_voice: bool, include_ios_firebase: bool) -> list[str]:
     errors: list[str] = []
     check_android_retry_contract(repo_root, errors)
     check_native_release_contract(repo_root, errors)
     check_play_public_listing_contract(repo_root, errors)
     if include_voice:
         check_voice_contract(repo_root, errors)
+    if include_ios_firebase:
+        check_ios_firebase_contract(repo_root, errors)
     return errors
 
 
@@ -211,12 +276,13 @@ def main() -> int:
     candidate_paths = _normalize_paths(args.paths) if args.paths is not None else _git_staged_paths(repo_root)
     matched_paths = relevant_paths(candidate_paths)
     include_voice = args.mode == "ci" or any(_matches_voice_path(path) for path in matched_paths)
+    include_ios_firebase = args.mode == "ci" or any(_matches_ios_firebase_path(path) for path in matched_paths)
 
     if args.mode == "staged" and not matched_paths:
-        print("regression_guards: skip (no staged voice/store regression paths)")
+        print("regression_guards: skip (no staged voice/store/iOS Firebase regression paths)")
         return 0
 
-    errors = run_checks(repo_root, include_voice=include_voice)
+    errors = run_checks(repo_root, include_voice=include_voice, include_ios_firebase=include_ios_firebase)
     if errors:
         print("regression_guards: FAILED")
         for error in errors:

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -91,8 +91,8 @@ def _assert_not_contains(source: str, needle: str, *, errors: list[str], label: 
 def check_android_retry_contract(repo_root: Path, errors: list[str]) -> None:
     source = _read(repo_root, ".github/workflows/android-production-retry.yml")
     label = ".github/workflows/android-production-retry.yml"
-    _assert_contains(source, "actions/checkout@v4", errors=errors, label=label)
-    _assert_contains(source, "actions/setup-python@v5", errors=errors, label=label)
+    _assert_contains(source, "actions/checkout@v6.0.2", errors=errors, label=label)
+    _assert_contains(source, "actions/setup-python@v6.2.0", errors=errors, label=label)
     _assert_contains(
         source,
         "scripts/source_versions.py --format value --key ANDROID_VERSION_NAME",
@@ -119,6 +119,9 @@ def check_android_retry_contract(repo_root: Path, errors: list[str]) -> None:
 def check_native_release_contract(repo_root: Path, errors: list[str]) -> None:
     source = _read(repo_root, ".github/workflows/native-release.yml")
     label = ".github/workflows/native-release.yml"
+    _assert_contains(source, "require-production-signoff:", errors=errors, label=label)
+    _assert_contains(source, "environment: production-signoff", errors=errors, label=label)
+    _assert_contains(source, "Await fresh CEO production release approval", errors=errors, label=label)
     _assert_contains(source, "Verify public Google Play listing (production only)", errors=errors, label=label)
     _assert_contains(source, "python scripts/verify_play_public_listing.py", errors=errors, label=label)
     _assert_contains(source, "--expected-version", errors=errors, label=label)

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -54,7 +54,7 @@ def test_internal_distribution_workflow_keeps_ruby_setup_pin_in_sync_with_native
     internal_source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
     release_source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
-    ruby_pin = "ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd"
+    ruby_pin = "ruby/setup-ruby@v1.300.0"
     assert ruby_pin in internal_source
     assert ruby_pin in release_source
 
@@ -144,6 +144,8 @@ def test_native_release_workflow_disables_hidden_play_fallback_and_verifies_requ
 
     assert 'PLAY_FALLBACK_TRACK: ""' in source
     assert "require-internal-signoff:" in source
+    assert "require-production-signoff:" in source
+    assert "environment: production-signoff" in source
     assert "internal_signoff_gate.py" in source
     assert "(inputs.platform == 'both' && needs.ios-testflight.result == 'success' && needs.android-release.result == 'success')" in source
     assert "(inputs.platform == 'ios' && needs.ios-testflight.result == 'success')" in source
@@ -183,7 +185,9 @@ def test_native_release_workflow_blocks_production_without_internal_signoff_proo
     assert "require-internal-signoff:" in source
     assert 'gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/status"' in source
     assert 'python scripts/internal_signoff_gate.py \\' in source
-    assert "needs: [release-intent-gate, require-internal-signoff]" in source
+    assert "require-production-signoff:" in source
+    assert "Await fresh CEO production release approval" in source
+    assert "needs: [release-intent-gate, require-internal-signoff, require-production-signoff]" in source
     assert "android-firebase-mirror:" not in source
 
 
@@ -210,8 +214,8 @@ def test_native_release_workflow_creates_annotated_release_from_exact_sha():
 def test_android_production_retry_uses_public_storefront_truth_instead_of_issue_title():
     source = ANDROID_PRODUCTION_RETRY_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "actions/checkout@v4" in source
-    assert "actions/setup-python@v5" in source
+    assert "actions/checkout@v6.0.2" in source
+    assert "actions/setup-python@v6.2.0" in source
     assert "python -m pip install --upgrade pip requests==2.32.5" in source
     assert "scripts/source_versions.py --format value --key ANDROID_VERSION_NAME" in source
     assert "from scripts.verify_play_public_listing import build_store_url, verify_public_listing" in source

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -295,5 +295,5 @@ def test_setup_screen_pro_range_toggle_and_voice_gating_are_present_on_both_plat
     assert 'Text(config.useExtendedRange ? "1H" : "5m")' in ios_setup
     assert "config.useExtendedRange ? proManager.maxSecondsLimit : 300" in ios_setup
     assert "timerManager.updateConfig(newConfig.clamped(isPro: proManager.isPro))" in ios_setup
-    assert 'Text(hasCompletedFirstTimer ? "PRO: 1H' in ios_setup
+    assert 'Text("PRO: 1H \\u{1F512}")' in ios_setup
     assert 'Text("PREVIEW")' in ios_setup

--- a/scripts/tests/test_regression_guards.py
+++ b/scripts/tests/test_regression_guards.py
@@ -16,12 +16,14 @@ def test_relevant_paths_detects_release_and_voice_regression_surfaces():
         [
             ".github/workflows/android-production-retry.yml",
             "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt",
+            "native-ios/RandomTimer.xcodeproj/project.pbxproj",
             "README.md",
         ]
     )
 
     assert ".github/workflows/android-production-retry.yml" in paths
     assert "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt" in paths
+    assert "native-ios/RandomTimer.xcodeproj/project.pbxproj" in paths
     assert "README.md" not in paths
 
 
@@ -30,7 +32,7 @@ def test_relevant_paths_skips_unrelated_files():
 
 
 def test_run_checks_passes_on_current_repo():
-    assert guards.run_checks(ROOT, include_voice=True) == []
+    assert guards.run_checks(ROOT, include_voice=True, include_ios_firebase=True) == []
 
 
 def test_cli_skips_unrelated_paths():
@@ -68,4 +70,3 @@ def test_pre_commit_invokes_regression_guards():
     source = (ROOT / "scripts" / "pre-commit").read_text(encoding="utf-8")
 
     assert "python3 scripts/regression_guards.py --mode staged" in source
-

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -27,7 +27,7 @@ def test_security_sensitive_workflows_pin_third_party_actions() -> None:
     expected_pins = {
         ".github/workflows/android17-canary.yml": "android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407",
         ".github/workflows/device-tests.yml": "reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7",
-        ".github/workflows/internal-distribution.yml": "ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd",
+        ".github/workflows/internal-distribution.yml": "ruby/setup-ruby@v1.300.0",
         ".github/workflows/internal-distribution.yml#firebase": "wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6",
         ".github/workflows/release.yml#expo": "expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e",
         ".github/workflows/release.yml#sbom": "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610",


### PR DESCRIPTION
## Summary
- require a fresh `production-signoff` approval before store release jobs
- add the matching GitHub environment config contract to release tests and regression guards
- upgrade deprecated GitHub Actions refs to current Node 24-ready versions

## Verification
- `python3 scripts/regression_guards.py --mode ci`
- `pytest -q scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_workflow_security_contracts.py`
- `git diff --check`