### PR TITLE
fix(ios): restore Pro lock icons in TestFlight hotfix

### DIFF
--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -44,11 +44,10 @@ struct TimerSetupScreen: View {
                             Spacer()
 
                             if !proManager.isPro {
-                                Text(hasCompletedFirstTimer ? "PRO: 1H \u{1F512}" : "PRO: 1H")
+                                Text("PRO: 1H \u{1F512}")
                                     .font(.caption2)
                                     .foregroundColor(.accentPrimary)
                                     .onTapGesture {
-                                        guard hasCompletedFirstTimer else { return }
                                         presentPaywall(entryPoint: .rangeGate)
                                     }
                             } else {

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -167,14 +167,11 @@ struct TimerSetupScreen: View {
                                     }
 
                                     Button {
-                                        guard hasCompletedFirstTimer else { return }
                                         presentPaywall(entryPoint: .soundGate, feature: "voice_callouts")
                                     } label: {
                                         HStack(spacing: 4) {
                                             Text("PRO")
-                                            if hasCompletedFirstTimer {
-                                                Image(systemName: "lock.fill")
-                                            }
+                                            Image(systemName: "lock.fill")
                                         }
                                         .font(.caption2.weight(.bold))
                                         .padding(.horizontal, 8)
@@ -316,14 +313,11 @@ struct TimerSetupScreen: View {
                                     .labelsHidden()
                                 } else {
                                     Button {
-                                        guard hasCompletedFirstTimer else { return }
                                         presentPaywall(entryPoint: .soundGate)
                                     } label: {
                                         HStack(spacing: 4) {
                                             Text("PRO")
-                                            if hasCompletedFirstTimer {
-                                                Image(systemName: "lock.fill")
-                                            }
+                                            Image(systemName: "lock.fill")
                                         }
                                         .font(.caption2.weight(.bold))
                                         .padding(.horizontal, 8)
@@ -423,7 +417,6 @@ struct TimerSetupScreen: View {
                                         .foregroundColor(.textMuted)
 
                                     Button("Unlock Pro") {
-                                        guard hasCompletedFirstTimer else { return }
                                         presentPaywall(entryPoint: .soundGate)
                                     }
                                     .font(.caption2.weight(.semibold))

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -340,9 +340,15 @@ struct TimerSetupScreen: View {
                         .foregroundColor(proManager.isPro ? .textPrimary : .textMuted)
 
                     if !proManager.isPro {
-                        Image(systemName: "lock.fill")
-                            .font(.caption2)
-                            .foregroundColor(.textMuted)
+                        Button {
+                            presentPaywall(entryPoint: .soundGate)
+                        } label: {
+                            Image(systemName: "lock.fill")
+                                .font(.caption2)
+                                .foregroundColor(.textMuted)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Unlock Sound Arsenal")
                     }
 
                     Spacer()

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -297,4 +297,5 @@ def test_setup_screen_pro_range_toggle_and_voice_gating_are_present_on_both_plat
     assert "timerManager.updateConfig(newConfig.clamped(isPro: proManager.isPro))" in ios_setup
     assert 'Text("PRO: 1H \\u{1F512}")' in ios_setup
     assert 'guard hasCompletedFirstTimer else { return }' not in ios_setup
+    assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     assert 'Text("PREVIEW")' in ios_setup

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -295,5 +295,6 @@ def test_setup_screen_pro_range_toggle_and_voice_gating_are_present_on_both_plat
     assert 'Text(config.useExtendedRange ? "1H" : "5m")' in ios_setup
     assert "config.useExtendedRange ? proManager.maxSecondsLimit : 300" in ios_setup
     assert "timerManager.updateConfig(newConfig.clamped(isPro: proManager.isPro))" in ios_setup
-    assert 'Text(hasCompletedFirstTimer ? "PRO: 1H' in ios_setup
+    assert 'Text("PRO: 1H \\u{1F512}")' in ios_setup
+    assert 'guard hasCompletedFirstTimer else { return }' not in ios_setup
     assert 'Text("PREVIEW")' in ios_setup


### PR DESCRIPTION
## Summary
- backport the iOS lock-icon restoration onto the hotfix release line
- always show the Pro range lock badge and allow paywall taps before first timer completion
- tighten the iOS parity test so this regression is caught on the release branch

## Verification
- `pytest -q scripts/tests/test_mobile_feature_parity.py` -> `17 passed`
- verified `TimerSetupScreen.swift` now shows `Text("PRO: 1H \u{1F512}")`
- verified the range gate no longer contains `guard hasCompletedFirstTimer else { return }`
