### PR TITLE
fix(ci): add iOS device regression gates

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, main]
     paths:
       - 'native-android/**'
+      - 'native-ios/**'
       - '.maestro/**'
       - 'scripts/device-tests/**'
       - '.github/workflows/device-tests.yml'
@@ -80,3 +81,107 @@ jobs:
           path: |
             native-android/app/build/reports/androidTests/connected
             native-android/app/build/outputs/androidTest-results/connected
+
+  ios-device-tests:
+    name: iOS Simulator + Maestro + Agent Device
+    runs-on: macos-15
+    timeout-minutes: 35
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create dummy GoogleService-Info.plist for CI
+        working-directory: native-ios
+        run: |
+          mkdir -p RandomTimer
+          {
+            printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+            printf '%s\n' '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+            printf '%s\n' '<plist version="1.0">'
+            printf '%s\n' '<dict>'
+            printf '%s\n' '  <key>CLIENT_ID</key>'
+            printf '%s\n' '  <string>000000000000-ci-placeholder.apps.googleusercontent.com</string>'
+            printf '%s\n' '  <key>REVERSED_CLIENT_ID</key>'
+            printf '%s\n' '  <string>com.googleusercontent.apps.000000000000-ci-placeholder</string>'
+            printf '%s\n' '  <key>API_KEY</key>'
+            printf '%s\n' '  <string>AIzaSyCiPlaceholderOnlyNotReal0000000</string>'
+            printf '%s\n' '  <key>GCM_SENDER_ID</key>'
+            printf '%s\n' '  <string>000000000000</string>'
+            printf '%s\n' '  <key>PLIST_VERSION</key>'
+            printf '%s\n' '  <string>1</string>'
+            printf '%s\n' '  <key>BUNDLE_ID</key>'
+            printf '%s\n' '  <string>com.igorganapolsky.randomtimer</string>'
+            printf '%s\n' '  <key>PROJECT_ID</key>'
+            printf '%s\n' '  <string>random-timer-ci-placeholder</string>'
+            printf '%s\n' '  <key>STORAGE_BUCKET</key>'
+            printf '%s\n' '  <string>random-timer-ci-placeholder.appspot.com</string>'
+            printf '%s\n' '  <key>IS_ADS_ENABLED</key>'
+            printf '%s\n' '  <false/>'
+            printf '%s\n' '  <key>IS_ANALYTICS_ENABLED</key>'
+            printf '%s\n' '  <false/>'
+            printf '%s\n' '  <key>IS_APPINVITE_ENABLED</key>'
+            printf '%s\n' '  <true/>'
+            printf '%s\n' '  <key>IS_GCM_ENABLED</key>'
+            printf '%s\n' '  <true/>'
+            printf '%s\n' '  <key>IS_SIGNIN_ENABLED</key>'
+            printf '%s\n' '  <true/>'
+            printf '%s\n' '  <key>GOOGLE_APP_ID</key>'
+            printf '%s\n' '  <string>1:000000000000:ios:0000000000000000000000</string>'
+            printf '%s\n' '</dict>'
+            printf '%s\n' '</plist>'
+          } > RandomTimer/GoogleService-Info.plist
+
+      - name: Select Xcode
+        working-directory: native-ios
+        run: |
+          XCODE_PATH=""
+          while IFS= read -r candidate; do
+            if DEVELOPER_DIR="${candidate}/Contents/Developer" xcodebuild -showsdks 2>/dev/null | grep -q 'iphonesimulator' \
+              && DEVELOPER_DIR="${candidate}/Contents/Developer" xcrun simctl list devices available 2>/dev/null | grep -q 'iPhone'; then
+              XCODE_PATH="${candidate}"
+              break
+            fi
+          done < <(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V -r)
+
+          if [ -z "${XCODE_PATH}" ]; then
+            echo "No Xcode installation with iOS Simulator SDK found."
+            ls -d /Applications/Xcode*.app 2>/dev/null || true
+            exit 1
+          fi
+
+          sudo xcode-select -s "${XCODE_PATH}/Contents/Developer"
+          xcodebuild -version
+
+      - name: Resolve simulator destination
+        id: sim
+        working-directory: native-ios
+        run: |
+          SIM_ID=$(xcodebuild -project RandomTimer.xcodeproj -scheme RandomTimer -showdestinations 2>/dev/null | \
+            grep 'platform:iOS Simulator' | \
+            grep -i 'iPhone' | \
+            grep -v 'Any iOS Simulator Device' | \
+            sed -nE 's/.*id:([0-9A-Fa-f-]{36}).*/\1/p' | \
+            head -n 1)
+          if [ -z "${SIM_ID}" ]; then
+            echo "No valid iOS Simulator destination found for RandomTimer."
+            xcodebuild -project RandomTimer.xcodeproj -scheme RandomTimer -showdestinations
+            exit 1
+          fi
+          echo "sim_id=${SIM_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Run iOS UI smoke tests on simulator
+        env:
+          SIMULATOR_UDID: ${{ steps.sim.outputs.sim_id }}
+        run: bash scripts/device-tests/ci-maestro-ios.sh
+
+      - name: Upload iOS device test artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-device-test-artifacts
+          path: |
+            native-ios/build/maestro
+            native-ios/build/agent-device
+            native-ios/build/device-tests-ios
+            ~/.maestro/tests
+          if-no-files-found: warn

--- a/.maestro/regression-pro-locks-visible-ios.yaml
+++ b/.maestro/regression-pro-locks-visible-ios.yaml
@@ -5,15 +5,16 @@ appId: com.igorganapolsky.randomtimer
 - launchApp:
     clearState: true
 # Timer Range - PRO: 1H lock must be visible
-- assertVisible: "PRO: 1H"
+- assertVisible:
+    text: ".*PRO: 1H.*"
 # Voice Callouts - PRO lock must be visible
 - scrollUntilVisible:
     element: "Voice Callouts"
     direction: DOWN
 - assertVisible: "PRO"
-# Round Selection - PRO lock must be visible
+# Sound Arsenal lock must be visible to free users
 - scrollUntilVisible:
-    element: "Round Selection"
+    element: "SOUND ARSENAL"
     direction: DOWN
-- assertVisible: "PRO"
+- assertVisible: "Unlock Sound Arsenal"
 - takeScreenshot: evidence/ios-pro-locks-visible

--- a/.maestro/regression-sound-arsenal-paywall-ios.yaml
+++ b/.maestro/regression-sound-arsenal-paywall-ios.yaml
@@ -1,0 +1,11 @@
+appId: com.igorganapolsky.randomtimer
+---
+# Regression test: tapping the Sound Arsenal header lock must open the paywall on iOS
+- launchApp:
+    clearState: true
+- scrollUntilVisible:
+    element: "SOUND ARSENAL"
+    direction: DOWN
+- tapOn: "Unlock Sound Arsenal"
+- assertVisible: "Unlock Full Training Mode"
+- takeScreenshot: evidence/ios-sound-arsenal-paywall

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -343,9 +343,15 @@ struct TimerSetupScreen: View {
                         .foregroundColor(proManager.isPro ? .textPrimary : .textMuted)
 
                     if !proManager.isPro {
-                        Image(systemName: "lock.fill")
-                            .font(.caption2)
-                            .foregroundColor(.textMuted)
+                        Button {
+                            presentPaywall(entryPoint: .soundGate)
+                        } label: {
+                            Image(systemName: "lock.fill")
+                                .font(.caption2)
+                                .foregroundColor(.textMuted)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Unlock Sound Arsenal")
                     }
 
                     Spacer()

--- a/scripts/device-tests/ci-maestro-ios.sh
+++ b/scripts/device-tests/ci-maestro-ios.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ci-maestro-ios.sh — Run iOS simulator smoke/regression verification in CI.
+# Called by .github/workflows/device-tests.yml
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+NATIVE_IOS_DIR="$PROJECT_ROOT/native-ios"
+SIMULATOR_UDID="${SIMULATOR_UDID:?SIMULATOR_UDID is required}"
+BUNDLE_ID="com.igorganapolsky.randomtimer"
+DERIVED_DATA_PATH="$NATIVE_IOS_DIR/build/device-tests-ios"
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug-iphonesimulator/RandomTimer.app"
+MAESTRO_ARTIFACT_DIR="$NATIVE_IOS_DIR/build/maestro"
+AGENT_DEVICE_ARTIFACT_DIR="$NATIVE_IOS_DIR/build/agent-device"
+
+mkdir -p "$MAESTRO_ARTIFACT_DIR" "$AGENT_DEVICE_ARTIFACT_DIR"
+
+if ! command -v maestro >/dev/null 2>&1; then
+  curl -Ls "https://get.maestro.mobile.dev" | bash
+fi
+export PATH="$HOME/.maestro/bin:$PATH"
+export MAESTRO_DRIVER_STARTUP_TIMEOUT=120000
+export MAESTRO_DISABLE_ANALYTICS=true
+
+xcrun simctl shutdown "$SIMULATOR_UDID" 2>/dev/null || true
+xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
+xcrun simctl bootstatus "$SIMULATOR_UDID" -b
+
+cd "$NATIVE_IOS_DIR"
+rm -rf "$DERIVED_DATA_PATH"
+xcodebuild build \
+  -project RandomTimer.xcodeproj \
+  -scheme RandomTimer \
+  -destination "platform=iOS Simulator,id=${SIMULATOR_UDID}" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  -quiet \
+  CODE_SIGNING_ALLOWED=NO \
+  'OTHER_SWIFT_FLAGS=$(inherited) -D RT_SKIP_FIREBASE_FOR_CI'
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "Built app not found at $APP_PATH"
+  exit 1
+fi
+
+xcrun simctl uninstall "$SIMULATOR_UDID" "$BUNDLE_ID" 2>/dev/null || true
+xcrun simctl install "$SIMULATOR_UDID" "$APP_PATH"
+
+maestro test -p ios --device "$SIMULATOR_UDID" "$PROJECT_ROOT/.maestro/ios-smoke-test.yaml" \
+  | tee "$MAESTRO_ARTIFACT_DIR/ios-smoke.log"
+maestro test -p ios --device "$SIMULATOR_UDID" "$PROJECT_ROOT/.maestro/regression-pro-locks-visible-ios.yaml" \
+  | tee "$MAESTRO_ARTIFACT_DIR/pro-locks.log"
+maestro test -p ios --device "$SIMULATOR_UDID" "$PROJECT_ROOT/.maestro/regression-sound-arsenal-paywall-ios.yaml" \
+  | tee "$MAESTRO_ARTIFACT_DIR/sound-arsenal-paywall.log"
+
+npx -y agent-device install "$BUNDLE_ID" "$APP_PATH" --platform ios --udid "$SIMULATOR_UDID"
+npx -y agent-device open "$BUNDLE_ID" --platform ios --udid "$SIMULATOR_UDID" --relaunch
+npx -y agent-device snapshot -i --platform ios --udid "$SIMULATOR_UDID" \
+  > "$AGENT_DEVICE_ARTIFACT_DIR/interactive-snapshot.txt"
+grep -q "Random Tactical Timer" "$AGENT_DEVICE_ARTIFACT_DIR/interactive-snapshot.txt"
+npx -y agent-device screenshot "$AGENT_DEVICE_ARTIFACT_DIR/home.png" --platform ios --udid "$SIMULATOR_UDID"
+npx -y agent-device close "$BUNDLE_ID" --platform ios --udid "$SIMULATOR_UDID"

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -13,6 +13,7 @@ NORTH_STAR_GUARDRAIL_WORKFLOW = ROOT / ".github/workflows/north-star-guardrail.y
 NORTH_STAR_OPS_WORKFLOW = ROOT / ".github/workflows/north-star-ops.yml"
 WEEKLY_EXPERIMENT_WORKFLOW = ROOT / ".github/workflows/weekly-north-star-experiment.yml"
 WORKFLOW_CONTRACT = ROOT / "docs/workflow.md"
+DEVICE_TESTS_WORKFLOW = ROOT / ".github/workflows/device-tests.yml"
 
 
 def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():
@@ -273,6 +274,17 @@ def test_workflow_contract_exists_and_points_at_canonical_proof_commands():
     assert "maestro test .maestro/ios-smoke-test.yaml" in source
     assert "scripts/tests" in source
     assert "tests/python" not in source
+
+
+def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
+    source = DEVICE_TESTS_WORKFLOW.read_text(encoding="utf-8")
+    ios_script = (ROOT / "scripts/device-tests/ci-maestro-ios.sh").read_text(encoding="utf-8")
+
+    assert "native-ios/**" in source
+    assert "iOS Simulator + Maestro + Agent Device" in source
+    assert "scripts/device-tests/ci-maestro-ios.sh" in source
+    assert "agent-device" in source
+    assert "regression-sound-arsenal-paywall-ios.yaml" in ios_script
 
 
 def test_dead_play_precondition_stub_is_removed():

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -173,6 +173,7 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert "TACTICAL EXPANSION" not in ios_setup
     assert "Preview Sounds" in android_setup
     assert "Preview Sounds" in ios_setup
+    assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     for expected in (
         "Train up to 60-minute sessions",
         "Get voice callouts during training",


### PR DESCRIPTION
## What
- add an iOS simulator device-tests job to CI with Maestro and agent-device
- add iOS Maestro regressions for visible Pro locks and Sound Arsenal paywall tap
- assert the new iOS gate in workflow contract tests
- keep the Sound Arsenal lock tappable on the develop line

## Proof
- `maestro test --device 6683CC23-EBF9-4BB7-9F34-D56C4F18F455 .maestro/regression-pro-locks-visible-ios.yaml`
- `maestro test --device 6683CC23-EBF9-4BB7-9F34-D56C4F18F455 .maestro/regression-sound-arsenal-paywall-ios.yaml`
- `SIMULATOR_UDID=6683CC23-EBF9-4BB7-9F34-D56C4F18F455 bash scripts/device-tests/ci-maestro-ios.sh`
- `uv run pytest -q scripts/tests/test_mobile_feature_parity.py scripts/tests/test_growth_workflow_contracts.py`
- `python3 scripts/regression_guards.py --mode ci`

## Artifacts
- `native-ios/build/maestro/ios-smoke.log`
- `native-ios/build/maestro/pro-locks.log`
- `native-ios/build/maestro/sound-arsenal-paywall.log`
- `native-ios/build/agent-device/interactive-snapshot.txt`
- `native-ios/build/agent-device/home.png`