### PR TITLE
fix(ops): auto-close stale weekly issue reports

### DIFF
--- a/.github/workflows/weekly-shared.yml
+++ b/.github/workflows/weekly-shared.yml
@@ -171,6 +171,26 @@ jobs:
           path: ${{ inputs.wiki_path }}
           token: ${{ github.token }}
 
+      - name: Close stale automated report issues
+        if: inputs.issue_title != '' && inputs.issue_content_path != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ inputs.issue_title }}
+        run: |
+          set -euo pipefail
+          gh issue list \
+            --state open \
+            --search "\"${ISSUE_TITLE}\" in:title" \
+            --limit 100 \
+            --json number,title \
+            --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' \
+            | while read -r issue_number; do
+                if [ -n "$issue_number" ]; then
+                  gh issue close "$issue_number" \
+                    --comment "Closing previous automated report issue before publishing refreshed weekly output."
+                fi
+              done
+
       - name: Create issue from report
         if: inputs.issue_title != '' && inputs.issue_content_path != ''
         uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4

--- a/.github/workflows/weekly-shared.yml
+++ b/.github/workflows/weekly-shared.yml
@@ -183,7 +183,7 @@ jobs:
             --search "\"${ISSUE_TITLE}\" in:title" \
             --limit 100 \
             --json number,title \
-            --jq '.[] | select(.title == env.ISSUE_TITLE) | .number' \
+            | jq -r --arg issue_title "$ISSUE_TITLE" '.[] | select(.title == $issue_title) | .number' \
             | while read -r issue_number; do
                 if [ -n "$issue_number" ]; then
                   gh issue close "$issue_number" \

--- a/.github/workflows/wqtu-health.yml
+++ b/.github/workflows/wqtu-health.yml
@@ -87,6 +87,19 @@ jobs:
           READY="${{ steps.gate.outputs.ready }}"
           ERRORS="${{ steps.gate.outputs.error_count }}"
 
+          gh issue list \
+            --state open \
+            --search '"⚠️ WQTU Alert:" in:title' \
+            --limit 100 \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("⚠️ WQTU Alert:")) | .number' \
+            | while read -r issue_number; do
+                if [ -n "$issue_number" ]; then
+                  gh issue close "$issue_number" \
+                    --comment "Closing previous weekly WQTU alert before publishing refreshed weekly output."
+                fi
+              done
+
           gh issue create \
             --title "⚠️ WQTU Alert: ${WQTU} qualified users this week" \
             --label "priority:high,analytics" \

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -294,7 +294,8 @@ def test_weekly_shared_workflow_closes_prior_report_issue_before_creating_next_o
 
     assert "Close stale automated report issues" in source
     assert '--search "\\"${ISSUE_TITLE}\\" in:title"' in source
-    assert "select(.title == env.ISSUE_TITLE)" in source
+    assert 'jq -r --arg issue_title "$ISSUE_TITLE"' in source
+    assert "select(.title == $issue_title)" in source
     assert "Closing previous automated report issue before publishing refreshed weekly output." in source
 
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -14,6 +14,8 @@ NORTH_STAR_OPS_WORKFLOW = ROOT / ".github/workflows/north-star-ops.yml"
 WEEKLY_EXPERIMENT_WORKFLOW = ROOT / ".github/workflows/weekly-north-star-experiment.yml"
 WORKFLOW_CONTRACT = ROOT / "docs/workflow.md"
 DEVICE_TESTS_WORKFLOW = ROOT / ".github/workflows/device-tests.yml"
+WEEKLY_SHARED_WORKFLOW = ROOT / ".github/workflows/weekly-shared.yml"
+WQTU_HEALTH_WORKFLOW = ROOT / ".github/workflows/wqtu-health.yml"
 
 
 def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():
@@ -285,6 +287,23 @@ def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
     assert "scripts/device-tests/ci-maestro-ios.sh" in source
     assert "agent-device" in source
     assert "regression-sound-arsenal-paywall-ios.yaml" in ios_script
+
+
+def test_weekly_shared_workflow_closes_prior_report_issue_before_creating_next_one():
+    source = WEEKLY_SHARED_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Close stale automated report issues" in source
+    assert '--search "\\"${ISSUE_TITLE}\\" in:title"' in source
+    assert "select(.title == env.ISSUE_TITLE)" in source
+    assert "Closing previous automated report issue before publishing refreshed weekly output." in source
+
+
+def test_wqtu_health_workflow_closes_prior_alert_issue_before_creating_next_one():
+    source = WQTU_HEALTH_WORKFLOW.read_text(encoding="utf-8")
+
+    assert '"⚠️ WQTU Alert:" in:title' in source
+    assert 'select(.title | startswith("⚠️ WQTU Alert:"))' in source
+    assert "Closing previous weekly WQTU alert before publishing refreshed weekly output." in source
 
 
 def test_dead_play_precondition_stub_is_removed():


### PR DESCRIPTION
## What
- close older open weekly report issues before creating the refreshed report
- close older open `⚠️ WQTU Alert:` issues before creating the new weekly alert
- lock the behavior with workflow contract tests

## Proof
- `uv run pytest -q scripts/tests/test_growth_workflow_contracts.py`
- `python3 scripts/regression_guards.py --mode ci`

## Result
- stale weekly report issues no longer accumulate as open issue clutter