### PR TITLE
fix(ci): repair android production retry workflow yaml

### DIFF
--- a/.github/workflows/android-production-retry.yml
+++ b/.github/workflows/android-production-retry.yml
@@ -51,24 +51,24 @@ jobs:
           export EXPECTED_VERSION
 
           python3 <<'PY'
-import os
+          import os
 
-from scripts.verify_play_public_listing import build_store_url, verify_public_listing
+          from scripts.verify_play_public_listing import build_store_url, verify_public_listing
 
-expected_version = os.environ["EXPECTED_VERSION"].strip()
-result = verify_public_listing(
-    build_store_url("com.iganapolsky.randomtimer", "US"),
-    expected_version=expected_version,
-)
-should_retry = not result.passed
-reason = "play_public_current" if result.passed else f"play_public_{result.status.lower()}"
+          expected_version = os.environ["EXPECTED_VERSION"].strip()
+          result = verify_public_listing(
+              build_store_url("com.iganapolsky.randomtimer", "US"),
+              expected_version=expected_version,
+          )
+          should_retry = not result.passed
+          reason = "play_public_current" if result.passed else f"play_public_{result.status.lower()}"
 
-with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-    fh.write(f"should_retry={'true' if should_retry else 'false'}\n")
-    fh.write(f"reason={reason}\n")
-    fh.write(f"expected_version={expected_version}\n")
-    fh.write(f"public_status={result.status}\n")
-PY
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"should_retry={'true' if should_retry else 'false'}\n")
+              fh.write(f"reason={reason}\n")
+              fh.write(f"expected_version={expected_version}\n")
+              fh.write(f"public_status={result.status}\n")
+          PY
 
   dispatch-production-retry:
     needs: [gate]

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -119,6 +119,8 @@ def check_android_retry_contract(repo_root: Path, errors: list[str]) -> None:
         errors=errors,
         label=label,
     )
+    _assert_contains(source, "python3 <<'PY'\n          import os", errors=errors, label=label)
+    _assert_contains(source, '\n          PY\n', errors=errors, label=label)
     _assert_contains(source, 'build_store_url("com.iganapolsky.randomtimer", "US")', errors=errors, label=label)
     _assert_contains(source, "play_public_current", errors=errors, label=label)
     _assert_contains(source, "play_public_", errors=errors, label=label)

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -221,7 +221,9 @@ def test_android_production_retry_uses_public_storefront_truth_instead_of_issue_
     assert "actions/setup-python@v6.2.0" in source
     assert "python -m pip install --upgrade pip requests==2.32.5" in source
     assert "scripts/source_versions.py --format value --key ANDROID_VERSION_NAME" in source
+    assert "python3 <<'PY'\n          import os" in source
     assert "from scripts.verify_play_public_listing import build_store_url, verify_public_listing" in source
+    assert "\n          PY\n" in source
     assert 'build_store_url("com.iganapolsky.randomtimer", "US")' in source
     assert "play_public_current" in source
     assert "play_public_" in source


### PR DESCRIPTION
## What
- fix the android production retry workflow so the embedded Python heredoc is valid YAML block content
- keep the storefront-truth release logic intact
- add regression assertions so the workflow cannot silently slip back into a zero-job invalid state

## Proof
- `python3 - <<'PY' ... yaml.safe_load(...)`
- `uv run pytest -q scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_regression_guards.py`
- `python3 scripts/regression_guards.py --mode ci`

## Result
- pushes stop creating zero-job failed `android-production-retry.yml` workflow runs caused by invalid YAML