### PR TITLE
fix(android): restore Sound Arsenal lock parity

### DIFF
--- a/.maestro/regression-pro-locks-visible-android.yaml
+++ b/.maestro/regression-pro-locks-visible-android.yaml
@@ -15,5 +15,5 @@ appId: com.iganapolsky.randomtimer
 - scrollUntilVisible:
     element: "Sound Arsenal"
     direction: DOWN
-- assertVisible: "Sound Arsenal"
+- assertVisible: "Unlock Sound Arsenal"
 - takeScreenshot: evidence/android-pro-locks-visible

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -1,6 +1,8 @@
 package com.iganapolsky.randomtimer.ui
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -34,6 +36,36 @@ class TimerSetupSmokeTest {
 
         composeRule
             .onNodeWithContentDescription("Maximum time slider")
+            .assertExists()
+    }
+
+    @Test
+    fun soundArsenalLockOpensPaywallForFreeUsers() {
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule
+                .onAllNodesWithText("Preview Sounds")
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+
+        composeRule
+            .onNodeWithText("Preview Sounds")
+            .performScrollTo()
+
+        composeRule
+            .onNodeWithContentDescription("Unlock Sound Arsenal", useUnmergedTree = true)
+            .assertExists()
+            .performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule
+                .onAllNodesWithText("Unlock Full Training Mode")
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+
+        composeRule
+            .onNodeWithText("Unlock Full Training Mode")
             .assertExists()
     }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Card
@@ -810,32 +811,55 @@ fun TimerSetupScreen(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(
-                            text = "Sound Arsenal",
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
-                            modifier =
-                                Modifier.pointerInput(Unit) {
-                                    detectTapGestures(
-                                        onTap = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            if (isCompactHeight) {
-                                                showArsenalSheet = true
-                                            } else {
-                                                showArsenal = !showArsenal
-                                            }
-                                        },
-                                        onPress = {
-                                            val released = withTimeoutOrNull(8000L) { tryAwaitRelease() }
-                                            if (released == null) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = "Sound Arsenal",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
+                                modifier =
+                                    Modifier.pointerInput(Unit) {
+                                        detectTapGestures(
+                                            onTap = {
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                onSecretUnlock()
-                                            }
-                                        },
+                                                if (isCompactHeight) {
+                                                    showArsenalSheet = true
+                                                } else {
+                                                    showArsenal = !showArsenal
+                                                }
+                                            },
+                                            onPress = {
+                                                val released = withTimeoutOrNull(8000L) { tryAwaitRelease() }
+                                                if (released == null) {
+                                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                    onSecretUnlock()
+                                                }
+                                            },
+                                        )
+                                    },
+                            )
+
+                            if (!isPro) {
+                                IconButton(
+                                    onClick = {
+                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        onFeatureGateHit("pro_sounds")
+                                        onUpgradeTap()
+                                    },
+                                    modifier =
+                                        Modifier
+                                            .size(28.dp)
+                                            .semantics { contentDescription = "Unlock Sound Arsenal" },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Filled.Lock,
+                                        contentDescription = null,
+                                        tint = TimerColors.TextMuted,
+                                        modifier = Modifier.size(14.dp),
                                     )
-                                },
-                        )
+                                }
+                            }
+                        }
 
                         val actionLabel =
                             when {

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -173,6 +173,8 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert "TACTICAL EXPANSION" not in ios_setup
     assert "Preview Sounds" in android_setup
     assert "Preview Sounds" in ios_setup
+    assert 'contentDescription = "Unlock Sound Arsenal"' in android_setup
+    assert "Icons.Filled.Lock" in android_setup
     assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     for expected in (
         "Train up to 60-minute sessions",


### PR DESCRIPTION
## What
- add a real Android Sound Arsenal lock icon/button for free users
- keep the Android paywall path explicit via `Unlock Sound Arsenal`
- strengthen parity and Android UI tests so this cannot regress silently

## Proof
- `uv run pytest -q scripts/tests/test_mobile_feature_parity.py`
- `python3 scripts/regression_guards.py --mode ci`
- `cd native-android && ./gradlew compileDebugAndroidTestKotlin -PenableFirebasePlugins=false --no-daemon`