### PR TITLE
fix(ci): auto-run internal builds on develop merges

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -2,7 +2,7 @@ name: Internal Distribution
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   workflow_dispatch:
     inputs:
       ref:
@@ -79,8 +79,8 @@ jobs:
           TARGET="${INPUT_TARGET:-all}"
 
           if [[ "$EVENT_NAME" == "push" ]]; then
-            if [[ "$GITHUB_REF_NAME_VALUE" != "main" ]]; then
-              echo "Automatic internal distribution is only allowed on pushes to main."
+            if [[ "$GITHUB_REF_NAME_VALUE" != "main" && "$GITHUB_REF_NAME_VALUE" != "develop" ]]; then
+              echo "Automatic internal distribution is only allowed on pushes to develop or main."
               {
                 echo "should_run=false"
                 echo "ref="
@@ -97,7 +97,11 @@ jobs:
             SHA="${GITHUB_SHA_VALUE}"
             TARGET="all"
             SHOULD_RUN="true"
-            REASON="auto_push_main"
+            if [[ "$GITHUB_REF_NAME_VALUE" == "develop" ]]; then
+              REASON="auto_push_develop"
+            else
+              REASON="auto_push_main"
+            fi
           elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             # Budget ack check removed — REQUIRED_BUDGET_ACK was never defined,
             # causing unbound variable crash with set -u.

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -855,28 +855,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Read Android changelog if it exists
-          CHANGELOG_FILE="native-android/fastlane/metadata/android/en-US/changelogs/${{ steps.version.outputs.version_code }}.txt"
-          NOTES=""
-          if [ -f "$CHANGELOG_FILE" ]; then
-            NOTES=$(cat "$CHANGELOG_FILE")
-          fi
-
-          # Read iOS release notes if available
-          IOS_NOTES_FILE="native-ios/fastlane/metadata/en-US/release_notes.txt"
-          if [ -f "$IOS_NOTES_FILE" ]; then
-            IOS_NOTES=$(cat "$IOS_NOTES_FILE")
-            if [ -n "$IOS_NOTES" ]; then
-              NOTES="${NOTES}
-
-          ### iOS
-          ${IOS_NOTES}"
-            fi
-          fi
-
-          if [ -z "$NOTES" ]; then
-            NOTES="Release ${{ steps.version.outputs.tag }}"
-          fi
+          NOTES=$(python3 scripts/release_notes.py \
+            --repo-root . \
+            --version "${{ steps.version.outputs.version_name }}" \
+            --print-body)
 
           NOTES="${NOTES}
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -42,6 +42,25 @@ Version bumps happen on `develop` first, then release branches are cut from `dev
 - **`versionCode`**: Auto-incremented by bump script. Integer, monotonically increasing for Play Store.
 - **`CURRENT_PROJECT_VERSION`**: Auto-incremented by fastlane `beta` lane during TestFlight upload. Does NOT need to match Android's versionCode.
 
+## Release Notes Strategy
+
+This repo uses a versioned release-note manifest:
+
+- `release-notes/X.Y.Z.md`
+
+Why this strategy:
+
+- Random Timer is a single consumer app, not a multi-package library monorepo.
+- `.changeset/` package fragments are overkill here.
+- A single versioned note file gives us one canonical customer-facing summary for GitHub Releases while Android and iOS keep their required store-specific metadata files.
+
+Enforcement:
+
+- `scripts/bump-version.sh` creates `release-notes/X.Y.Z.md`
+- `scripts/validate_release_branch.py` blocks `release/vX.Y.Z` and `hotfix/vX.Y.Z` promotion without a filled `release-notes/X.Y.Z.md`
+- `scripts/preflight-release.sh` rejects placeholder text in the versioned release note, Android changelog, and iOS `release_notes.txt`
+- `native-release.yml` uses `release-notes/X.Y.Z.md` as the canonical GitHub Release body
+
 ## Step-by-Step Release Process
 
 ### 1. Bump Version on `develop`

--- a/release-notes/1.3.18.md
+++ b/release-notes/1.3.18.md
@@ -1,0 +1,13 @@
+# Release 1.3.18
+
+## Summary
+Operational hardening release that restores upgrade-path parity across iOS and Android and tightens internal release verification.
+
+## Customer-visible changes
+- Restored missing Pro lock indicators and upgrade entry points in timer setup flows.
+- Simplified the active timer ring so it keeps the two meaningful markers only.
+- Improved upgrade prompt consistency around Sound Arsenal on Android.
+
+## Release operations
+- Added stronger parity checks across iOS and Android.
+- Tightened internal distribution and release verification for TestFlight, Firebase, and Play.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,13 @@
+# Versioned Release Notes
+
+Each store release must have one canonical customer-facing note file:
+
+- `release-notes/X.Y.Z.md`
+
+Rules:
+
+- The filename must match the app semantic version.
+- The file must be committed before a `release/vX.Y.Z` or `hotfix/vX.Y.Z` branch can promote to `main`.
+- Placeholder text such as `TODO` or `TBD` is rejected by CI.
+
+This repo uses versioned release notes instead of `.changeset/` package fragments because Random Timer is a single consumer app, not a multi-package library monorepo.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,7 +14,8 @@
 #   3. Sets Android versionName to <new_version>
 #   4. Sets iOS MARKETING_VERSION to <new_version> (all build configs)
 #   5. Creates Android changelog placeholder for new versionCode
-#   6. Prints summary of all changes
+#   6. Creates versioned release notes placeholder
+#   7. Prints summary of all changes
 
 set -euo pipefail
 
@@ -70,6 +71,7 @@ fi
 GRADLE_FILE="$PROJECT_ROOT/native-android/app/build.gradle.kts"
 PBXPROJ="$PROJECT_ROOT/native-ios/RandomTimer.xcodeproj/project.pbxproj"
 ANDROID_CHANGELOGS="$PROJECT_ROOT/native-android/fastlane/metadata/android/en-US/changelogs"
+VERSIONED_RELEASE_NOTES_DIR="$PROJECT_ROOT/release-notes"
 
 # ── Read current versions ────────────────────────────────────────────────────
 
@@ -181,6 +183,29 @@ else
   echo -e "${CYAN}▸${RESET} Changelog ${NEW_VERSION_CODE}.txt already exists, skipping"
 fi
 
+# ── Versioned release notes placeholder ──────────────────────────────────────
+
+mkdir -p "$VERSIONED_RELEASE_NOTES_DIR"
+VERSIONED_RELEASE_NOTES_FILE="$VERSIONED_RELEASE_NOTES_DIR/${NEW_VERSION}.md"
+if [[ ! -f "$VERSIONED_RELEASE_NOTES_FILE" ]]; then
+  cat > "$VERSIONED_RELEASE_NOTES_FILE" <<EOF
+# Release ${NEW_VERSION}
+
+## Summary
+TODO: replace with a customer-facing summary for ${NEW_VERSION}.
+
+## Customer-visible changes
+- TODO: add the first notable change.
+- TODO: add the second notable change.
+
+## Release operations
+- TODO: note any release-hardening or operational improvements worth tracking.
+EOF
+  echo -e "${GREEN}✓${RESET} Created release notes placeholder: release-notes/${NEW_VERSION}.md"
+else
+  echo -e "${CYAN}▸${RESET} release-notes/${NEW_VERSION}.md already exists, skipping"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""
@@ -190,9 +215,11 @@ echo "Files modified:"
 echo "  - native-android/app/build.gradle.kts"
 echo "  - native-ios/RandomTimer.xcodeproj/project.pbxproj"
 echo "  - native-android/fastlane/metadata/android/en-US/changelogs/${NEW_VERSION_CODE}.txt"
+echo "  - release-notes/${NEW_VERSION}.md"
 echo ""
 echo "Next steps:"
 echo "  1. Update changelogs/${NEW_VERSION_CODE}.txt with actual release notes"
 echo "  2. Update native-ios/fastlane/metadata/en-US/release_notes.txt"
-echo "  3. git add -A && git commit -m \"chore: bump version to ${NEW_VERSION}\""
-echo "  4. Cut release/v${NEW_VERSION} from develop, PR release/v${NEW_VERSION} → main, then trigger native-release workflow"
+echo "  3. Update release-notes/${NEW_VERSION}.md with the canonical GitHub/customer release notes"
+echo "  4. git add -A && git commit -m \"chore: bump version to ${NEW_VERSION}\""
+echo "  5. Cut release/v${NEW_VERSION} from develop, PR release/v${NEW_VERSION} → main, then trigger native-release workflow"

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -69,6 +69,18 @@ check_file_nonempty() {
   return 0
 }
 
+check_file_meaningful() {
+  local path="$1" label="$2"
+  if ! check_file_nonempty "$path" "$label"; then
+    return 1
+  fi
+  if grep -Eiq 'TODO|TBD|REPLACE_THIS_PLACEHOLDER|<fill' "$path"; then
+    err "$label still contains placeholder text: $path"
+    return 1
+  fi
+  return 0
+}
+
 check_dir_has_files() {
   local dir="$1" pattern="$2" label="$3" min="${4:-1}"
   local count
@@ -133,6 +145,13 @@ if [[ -n "$ANDROID_VERSION_NAME" && -n "$IOS_VERSION_NAME" ]]; then
   fi
 fi
 
+RELEASE_NOTES_VERSION="${ANDROID_VERSION_NAME:-$IOS_VERSION_NAME}"
+if [[ -n "$RELEASE_NOTES_VERSION" ]]; then
+  RELEASE_NOTES_FILE="$PROJECT_ROOT/release-notes/${RELEASE_NOTES_VERSION}.md"
+else
+  RELEASE_NOTES_FILE=""
+fi
+
 # ══════════════════════════════════════════════════════════════════════════════
 # LAYER 1 — Metadata & File Checks
 # ══════════════════════════════════════════════════════════════════════════════
@@ -146,6 +165,16 @@ if check_file_nonempty "$PRIVACY_FILE" "PRIVACY_POLICY.md"; then
   info "PRIVACY_POLICY.md present ($(wc -l < "$PRIVACY_FILE" | tr -d ' ') lines)"
 else
   err "PRIVACY_POLICY.md must exist at project root"
+fi
+
+header "Versioned Release Notes"
+
+if [[ -n "$RELEASE_NOTES_FILE" ]]; then
+  if check_file_meaningful "$RELEASE_NOTES_FILE" "Versioned release notes"; then
+    info "Release notes manifest present: $(basename "$RELEASE_NOTES_FILE")"
+  fi
+else
+  warn "Could not resolve semantic version — skipping versioned release notes check"
 fi
 
 # ── Android Metadata ─────────────────────────────────────────────────────────
@@ -164,10 +193,10 @@ if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
   if [[ -n "$ANDROID_VERSION_CODE" ]]; then
     CHANGELOG="$ANDROID_META/changelogs/${ANDROID_VERSION_CODE}.txt"
     if [[ -f "$CHANGELOG" ]]; then
-      check_file_nonempty "$CHANGELOG" "Android changelog (versionCode $ANDROID_VERSION_CODE)"
+      check_file_meaningful "$CHANGELOG" "Android changelog (versionCode $ANDROID_VERSION_CODE)"
       info "Changelog $ANDROID_VERSION_CODE.txt present"
     elif [[ -f "$ANDROID_META/changelogs/default.txt" ]]; then
-      check_file_nonempty "$ANDROID_META/changelogs/default.txt" "Android fallback changelog (default.txt)"
+      check_file_meaningful "$ANDROID_META/changelogs/default.txt" "Android fallback changelog (default.txt)"
       info "Fallback changelog default.txt present"
     else
       err "Android changelog missing (expected ${ANDROID_VERSION_CODE}.txt or default.txt in $ANDROID_META/changelogs/)"
@@ -221,9 +250,10 @@ if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
   IOS_META="$PROJECT_ROOT/native-ios/fastlane/metadata/en-US"
 
   # Required text files
-  for f in name.txt subtitle.txt description.txt keywords.txt release_notes.txt; do
+  for f in name.txt subtitle.txt description.txt keywords.txt; do
     check_file_nonempty "$IOS_META/$f" "iOS $f"
   done
+  check_file_meaningful "$IOS_META/release_notes.txt" "iOS release_notes.txt"
 
   # Privacy URL (required by App Store)
   if check_file_nonempty "$IOS_META/privacy_url.txt" "iOS privacy_url.txt"; then

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Helpers for versioned release notes."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+PLACEHOLDER_MARKERS = (
+    "TODO:",
+    "TBD",
+    "REPLACE_THIS_PLACEHOLDER",
+    "<fill",
+)
+
+
+class ReleaseNotesError(RuntimeError):
+    """Raised when versioned release notes are missing or incomplete."""
+
+
+def release_notes_path(repo_root: Path, version: str) -> Path:
+    return repo_root / "release-notes" / f"{version}.md"
+
+
+def is_placeholder_release_notes(text: str) -> bool:
+    normalized = text.strip()
+    if not normalized:
+        return True
+
+    upper = normalized.upper()
+    return any(marker in normalized for marker in PLACEHOLDER_MARKERS) or "TODO" in upper or "TBD" in upper
+
+
+def read_and_validate_release_notes(repo_root: Path, version: str) -> tuple[Path, str]:
+    path = release_notes_path(repo_root, version)
+    if not path.is_file():
+        raise ReleaseNotesError(
+            f"Versioned release notes missing: expected {path.relative_to(repo_root)} for release {version}"
+        )
+
+    text = path.read_text(encoding="utf-8").strip()
+    if is_placeholder_release_notes(text):
+        raise ReleaseNotesError(
+            f"Versioned release notes still contain placeholder content: {path.relative_to(repo_root)}"
+        )
+
+    return path, text
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate or print versioned release notes.")
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument("--version", required=True, help="Semantic version, e.g. 1.3.18")
+    parser.add_argument(
+        "--print-body",
+        action="store_true",
+        help="Print the validated release note body to stdout instead of a status line.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+
+    try:
+        path, text = read_and_validate_release_notes(repo_root=repo_root, version=args.version)
+    except ReleaseNotesError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+    if args.print_body:
+        sys.stdout.write(text)
+        if not text.endswith("\n"):
+            sys.stdout.write("\n")
+        return 0
+
+    print(f"[OK] Release notes ready: {path.relative_to(repo_root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -220,6 +220,7 @@ def test_native_release_workflow_creates_annotated_release_from_exact_sha():
 
     tag_block = source.split("tag-release:", 1)[1].split("sync-main:", 1)[0]
     assert "scripts/source_versions.py --repo-root . --format json" in tag_block
+    assert "scripts/release_notes.py" in tag_block
     assert 'git tag -a "${{ steps.version.outputs.tag }}" "${GITHUB_SHA}"' in tag_block
     assert '--verify-tag \\' in tag_block
     assert '--target "${GITHUB_SHA}" \\' in tag_block

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -115,14 +115,15 @@ def test_internal_distribution_workflow_supports_targeted_reruns_and_firebase_de
     assert "1:712918404489:android:5fb1dfde1d712f53e7a558" in source
 
 
-def test_internal_distribution_runs_automatically_on_main_push_for_internal_signoff_builds():
+def test_internal_distribution_runs_automatically_on_develop_and_main_push_for_internal_signoff_builds():
     source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
 
     assert "push:" in source
-    assert "branches: [main]" in source
+    assert "branches: [develop, main]" in source
     assert "github.event_name == 'workflow_dispatch' || github.event_name == 'push'" in source
-    assert 'Automatic internal distribution is only allowed on pushes to main.' in source
+    assert 'Automatic internal distribution is only allowed on pushes to develop or main.' in source
     assert 'TARGET="all"' in source
+    assert 'REASON="auto_push_develop"' in source
     assert 'REASON="auto_push_main"' in source
 
 

--- a/scripts/tests/test_validate_release_branch.py
+++ b/scripts/tests/test_validate_release_branch.py
@@ -22,12 +22,23 @@ def _write_version_files(repo_root, android_version: str, ios_version: str) -> N
     )
 
 
+def _write_release_notes(repo_root, version: str, body: str | None = None) -> None:
+    notes_file = repo_root / "release-notes" / f"{version}.md"
+    notes_file.parent.mkdir(parents=True, exist_ok=True)
+    notes_file.write_text(
+        body or f"# Release {version}\n\n## Summary\nShipped fixes.\n",
+        encoding="utf-8",
+    )
+
+
 def test_validate_release_branch_passes_when_versions_match(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.3")
+    _write_release_notes(tmp_path, version="1.2.3")
     result = validate_release_branch(repo_root=tmp_path, head_ref="release/v1.2.3")
     assert result["expected_version"] == "1.2.3"
     assert result["android_version"] == "1.2.3"
     assert result["ios_version"] == "1.2.3"
+    assert result["release_notes_path"] == "release-notes/1.2.3.md"
 
 
 def test_validate_release_branch_rejects_invalid_branch_name(tmp_path):
@@ -38,18 +49,21 @@ def test_validate_release_branch_rejects_invalid_branch_name(tmp_path):
 
 def test_validate_release_branch_rejects_platform_version_mismatch(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.4")
+    _write_release_notes(tmp_path, version="1.2.3")
     with pytest.raises(ValidationError, match="Version mismatch"):
         validate_release_branch(repo_root=tmp_path, head_ref="release/v1.2.3")
 
 
 def test_validate_release_branch_rejects_branch_version_mismatch(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.3")
+    _write_release_notes(tmp_path, version="1.2.3")
     with pytest.raises(ValidationError, match="branch expects 1.2.4"):
         validate_release_branch(repo_root=tmp_path, head_ref="release/v1.2.4")
 
 
 def test_validate_hotfix_branch_passes_when_versions_match(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.4")
+    _write_release_notes(tmp_path, version="1.2.4")
     result = validate_release_branch(repo_root=tmp_path, head_ref="hotfix/v1.2.4")
     assert result["expected_version"] == "1.2.4"
     assert result["android_version"] == "1.2.4"
@@ -58,12 +72,14 @@ def test_validate_hotfix_branch_passes_when_versions_match(tmp_path):
 
 def test_validate_hotfix_branch_rejects_platform_version_mismatch(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.5")
+    _write_release_notes(tmp_path, version="1.2.4")
     with pytest.raises(ValidationError, match="Version mismatch"):
         validate_release_branch(repo_root=tmp_path, head_ref="hotfix/v1.2.4")
 
 
 def test_validate_hotfix_branch_rejects_branch_version_mismatch(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.4")
+    _write_release_notes(tmp_path, version="1.2.4")
     with pytest.raises(ValidationError, match="branch expects 1.2.5"):
         validate_release_branch(repo_root=tmp_path, head_ref="hotfix/v1.2.5")
 
@@ -72,3 +88,16 @@ def test_validate_release_branch_rejects_bare_hotfix_prefix(tmp_path):
     _write_version_files(tmp_path, android_version="1.2.4", ios_version="1.2.4")
     with pytest.raises(ValidationError, match="release/vX.Y.Z or hotfix/vX.Y.Z"):
         validate_release_branch(repo_root=tmp_path, head_ref="hotfix")
+
+
+def test_validate_release_branch_rejects_missing_versioned_release_notes(tmp_path):
+    _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.3")
+    with pytest.raises(ValidationError, match="Versioned release notes missing"):
+        validate_release_branch(repo_root=tmp_path, head_ref="release/v1.2.3")
+
+
+def test_validate_release_branch_rejects_placeholder_versioned_release_notes(tmp_path):
+    _write_version_files(tmp_path, android_version="1.2.3", ios_version="1.2.3")
+    _write_release_notes(tmp_path, version="1.2.3", body="# Release 1.2.3\n\nTODO: fill this in.\n")
+    with pytest.raises(ValidationError, match="placeholder"):
+        validate_release_branch(repo_root=tmp_path, head_ref="release/v1.2.3")

--- a/scripts/validate_release_branch.py
+++ b/scripts/validate_release_branch.py
@@ -15,8 +15,10 @@ import sys
 from pathlib import Path
 
 try:
+    from scripts.release_notes import ReleaseNotesError, read_and_validate_release_notes
     from scripts.source_versions import VersionParseError, read_source_versions
 except ModuleNotFoundError:
+    from release_notes import ReleaseNotesError, read_and_validate_release_notes
     from source_versions import VersionParseError, read_source_versions
 
 
@@ -50,11 +52,17 @@ def validate_release_branch(repo_root: Path, head_ref: str) -> dict:
             f"Release branch mismatch: branch expects {expected_version}, app versions are {android_version}"
         )
 
+    try:
+        release_notes_path, _ = read_and_validate_release_notes(repo_root=repo_root, version=expected_version)
+    except ReleaseNotesError as exc:
+        raise ValidationError(str(exc)) from exc
+
     return {
         "head_ref": head_ref,
         "expected_version": expected_version,
         "android_version": android_version,
         "ios_version": ios_version,
+        "release_notes_path": str(release_notes_path.relative_to(repo_root)),
     }
 
 
@@ -80,6 +88,7 @@ def main() -> int:
     print(f"  version:  {result['expected_version']}")
     print(f"  android:  {result['android_version']}")
     print(f"  ios:      {result['ios_version']}")
+    print(f"  notes:    {result['release_notes_path']}")
     return 0
 
 


### PR DESCRIPTION
## Summary\n- auto-run Internal Distribution on pushes to develop as well as main\n- keep the exact merge SHA as the distribution ref\n- update the workflow contract test so this cannot silently regress\n\n## Verification\n- uv run pytest -q scripts/tests/test_growth_workflow_contracts.py\n- python3 scripts/regression_guards.py --mode ci