### PR TITLE
fix(ui): align setup spacing and voice layout parity

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -1,13 +1,13 @@
 package com.iganapolsky.randomtimer.ui
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollAction
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.MainActivity
 import org.junit.Rule

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -1,8 +1,10 @@
 package com.iganapolsky.randomtimer.ui
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -41,16 +43,9 @@ class TimerSetupSmokeTest {
 
     @Test
     fun soundArsenalLockOpensPaywallForFreeUsers() {
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule
-                .onAllNodesWithText("Preview Sounds")
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-
         composeRule
-            .onNodeWithText("Preview Sounds")
-            .performScrollTo()
+            .onNode(hasScrollAction())
+            .performScrollToNode(hasContentDescription("Unlock Sound Arsenal"))
 
         composeRule
             .onNodeWithContentDescription("Unlock Sound Arsenal", useUnmergedTree = true)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -503,14 +503,26 @@ fun TimerSetupScreen(
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically,
+                                    verticalAlignment = Alignment.Top,
                                 ) {
-                                    Text(
-                                        text = "\uD83D\uDCE2 Voice Callouts",
-                                        style = MaterialTheme.typography.labelMedium,
-                                        fontWeight = FontWeight.SemiBold,
-                                        color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
-                                    )
+                                    Column(
+                                        modifier = Modifier.weight(1f),
+                                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                                    ) {
+                                        Text(
+                                            text = "\uD83D\uDCE2 Voice Callouts",
+                                            style = MaterialTheme.typography.labelMedium,
+                                            fontWeight = FontWeight.SemiBold,
+                                            color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
+                                        )
+                                        Text(
+                                            text = "Time checks and command cues that keep you sharp under pressure",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = TimerColors.TextMuted,
+                                        )
+                                    }
+
+                                    Spacer(modifier = Modifier.width(12.dp))
 
                                     if (isPro) {
                                         Switch(
@@ -523,88 +535,92 @@ fun TimerSetupScreen(
                                                 ),
                                         )
                                     } else {
-                                        Surface(
-                                            onClick = {
-                                                onFeatureGateHit("voice_callouts")
-                                                onUpgradeTap()
-                                            },
-                                            shape = RoundedCornerShape(4.dp),
-                                            color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
+                                        Row(
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                            verticalAlignment = Alignment.CenterVertically,
                                         ) {
-                                            Row(
-                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                                verticalAlignment = Alignment.CenterVertically,
+                                            Surface(
+                                                onClick = {
+                                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                    onCommandCuePreview(config.voiceGender)
+                                                },
+                                                shape = RoundedCornerShape(4.dp),
+                                                color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
                                             ) {
                                                 Text(
-                                                    text = "PRO ",
+                                                    text = "PREVIEW",
                                                     style = MaterialTheme.typography.labelSmall,
                                                     fontWeight = FontWeight.Bold,
                                                     color = TimerColors.AccentPrimary,
+                                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                                                 )
-                                                Text(
-                                                    text = "\uD83D\uDD12",
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = TimerColors.AccentPrimary,
-                                                )
+                                            }
+                                            Surface(
+                                                onClick = {
+                                                    onFeatureGateHit("voice_callouts")
+                                                    onUpgradeTap()
+                                                },
+                                                shape = RoundedCornerShape(4.dp),
+                                                color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
+                                            ) {
+                                                Row(
+                                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                ) {
+                                                    Text(
+                                                        text = "PRO ",
+                                                        style = MaterialTheme.typography.labelSmall,
+                                                        fontWeight = FontWeight.Bold,
+                                                        color = TimerColors.AccentPrimary,
+                                                    )
+                                                    Text(
+                                                        text = "\uD83D\uDD12",
+                                                        style = MaterialTheme.typography.labelSmall,
+                                                        color = TimerColors.AccentPrimary,
+                                                    )
+                                                }
                                             }
                                         }
                                     }
                                 }
 
-                                // Male/Female chips + Preview — always visible, right below the title
-                                Row(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .padding(top = 8.dp),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    VoiceGender.entries.forEach { gender ->
-                                        FilterChip(
-                                            selected = config.voiceGender == gender,
-                                            onClick = {
-                                                updateConfig(voiceGender = gender)
-                                                onVoiceGenderSelected(gender)
-                                            },
-                                            label = {
-                                                Text(
-                                                    if (gender == VoiceGender.MALE) {
-                                                        "Male"
-                                                    } else {
-                                                        "Female"
-                                                    },
-                                                )
-                                            },
-                                            colors =
-                                                FilterChipDefaults.filterChipColors(
-                                                    selectedContainerColor = TimerColors.AccentPrimary.copy(alpha = 0.2f),
-                                                    selectedLabelColor = TimerColors.AccentPrimary,
-                                                ),
-                                            border =
-                                                FilterChipDefaults.filterChipBorder(
-                                                    selectedBorderColor = TimerColors.AccentPrimary,
-                                                    enabled = true,
-                                                    selected = config.voiceGender == gender,
-                                                ),
-                                        )
-                                    }
-
-                                    if (!isPro) {
-                                        Surface(
-                                            onClick = {
-                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                onCommandCuePreview(config.voiceGender)
-                                            },
-                                            shape = RoundedCornerShape(4.dp),
-                                            color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
-                                        ) {
-                                            Text(
-                                                text = "PREVIEW",
-                                                style = MaterialTheme.typography.labelSmall,
-                                                fontWeight = FontWeight.Bold,
-                                                color = TimerColors.AccentPrimary,
-                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                if (config.voiceEnabled || !isPro) {
+                                    Row(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .padding(top = 8.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        VoiceGender.entries.forEach { gender ->
+                                            FilterChip(
+                                                selected = config.voiceGender == gender,
+                                                onClick = {
+                                                    updateConfig(voiceGender = gender)
+                                                    onVoiceGenderSelected(gender)
+                                                },
+                                                label = {
+                                                    Text(
+                                                        text =
+                                                            if (gender == VoiceGender.MALE) {
+                                                                "Male"
+                                                            } else {
+                                                                "Female"
+                                                            },
+                                                    )
+                                                },
+                                                colors =
+                                                    FilterChipDefaults.filterChipColors(
+                                                        selectedContainerColor = TimerColors.AccentPrimary.copy(alpha = 0.2f),
+                                                        selectedLabelColor = TimerColors.AccentPrimary,
+                                                    ),
+                                                border =
+                                                    FilterChipDefaults.filterChipBorder(
+                                                        selectedBorderColor = TimerColors.AccentPrimary,
+                                                        enabled = true,
+                                                        selected = config.voiceGender == gender,
+                                                    ),
                                             )
                                         }
                                     }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -35,11 +35,19 @@ struct TimerSetupScreen: View {
                 // 1. Timer Range Card
                 GlassCard {
                     VStack(alignment: .leading) {
-                        HStack {
-                            Label("Timer Range", systemImage: "timer")
-                                .font(.headline)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.textPrimary)
+                        HStack(alignment: .top) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Label("Timer Range", systemImage: "timer")
+                                    .font(.headline)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.textPrimary)
+
+                                Text(
+                                    "Each timer picks a random duration in your range \u{2014} stay ready for anything."
+                                )
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
 
                             Spacer()
 
@@ -88,10 +96,6 @@ struct TimerSetupScreen: View {
                             }
                         }
 
-                        Text("Each timer picks a random duration in your range \u{2014} stay ready for anything.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
                         Spacer().frame(height: 16)
 
                         TimeRangeSliders(
@@ -131,7 +135,7 @@ struct TimerSetupScreen: View {
                         Spacer().frame(height: 20)
 
                         // Voice Callouts (Pro Feature)
-                        HStack {
+                        HStack(alignment: .top) {
                             VStack(alignment: .leading, spacing: 4) {
                                 Label("Voice Callouts", systemImage: "waveform")
                                     .font(.subheadline)

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -108,9 +108,12 @@ def test_voice_callouts_present_on_both_platforms():
 
     assert "Voice Callouts" in android_setup or "AI Voice Callouts" in android_setup
     assert "Voice Callouts" in ios_setup or "AI Voice Callouts" in ios_setup
+    assert "Time checks and command cues that keep you sharp under pressure" in android_setup
     assert "Time checks and command cues that keep you sharp under pressure" in ios_setup
     assert "VoiceGender.entries.forEach" in android_setup
     assert 'text = "PREVIEW"' in android_setup
+    assert 'if (config.voiceEnabled || !isPro)' in android_setup
+    assert android_setup.index('text = "PREVIEW"') < android_setup.index("VoiceGender.entries.forEach")
     assert 'if (gender == VoiceGender.MALE)' in android_setup
 
     assert "voiceEnabled" in android_timer_config

--- a/scripts/tests/test_voice_regression_contracts.py
+++ b/scripts/tests/test_voice_regression_contracts.py
@@ -120,12 +120,13 @@ def test_android_free_preview_keeps_voice_selector_visible() -> None:
     setup = _read(ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt")
 
     assert 'text = "PREVIEW"' in setup
-    assert "Male/Female chips + Preview" in setup
+    assert "Time checks and command cues that keep you sharp under pressure" in setup
     assert "VoiceGender.entries.forEach" in setup
     assert "VoiceGender.MALE" in setup
-    assert "if (!isPro) {" in setup
+    assert "if (config.voiceEnabled || !isPro)" in setup
     assert "onCommandCuePreview(config.voiceGender)" in setup
     assert "if (config.voiceEnabled) {" not in setup
+    assert setup.index('text = "PREVIEW"') < setup.index("VoiceGender.entries.forEach")
 
 
 def test_preview_calls_thread_selected_gender_on_both_platforms() -> None:


### PR DESCRIPTION
## Summary\n- normalize Timer Range supporting-text spacing on iOS\n- move Android voice preview into the header action area and keep gender chips on their own row\n- align Android voice chip visibility with iOS when voice is off for Pro users\n\n## Verification\n- uv run pytest -q scripts/tests/test_mobile_feature_parity.py\n- cd native-android && ./gradlew compileDebugKotlin compileDebugAndroidTestKotlin -PenableFirebasePlugins=false --no-daemon\n- cd native-ios && xcodebuild -scheme RandomTimer -project RandomTimer.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16' build CODE_SIGNING_ALLOWED=NO