### PR TITLE
fix(android): normalize Sound Arsenal lock chip

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -840,23 +840,32 @@ fun TimerSetupScreen(
                             )
 
                             if (!isPro) {
-                                IconButton(
+                                Surface(
                                     onClick = {
                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         onFeatureGateHit("pro_sounds")
                                         onUpgradeTap()
                                     },
-                                    modifier =
-                                        Modifier
-                                            .size(28.dp)
-                                            .semantics { contentDescription = "Unlock Sound Arsenal" },
+                                    shape = RoundedCornerShape(4.dp),
+                                    color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
+                                    modifier = Modifier.semantics { contentDescription = "Unlock Sound Arsenal" },
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Filled.Lock,
-                                        contentDescription = null,
-                                        tint = TimerColors.TextMuted,
-                                        modifier = Modifier.size(14.dp),
-                                    )
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            text = "PRO ",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            fontWeight = FontWeight.Bold,
+                                            color = TimerColors.AccentPrimary,
+                                        )
+                                        Text(
+                                            text = "\uD83D\uDD12",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = TimerColors.AccentPrimary,
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -168,13 +168,17 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     android_pro_manager = _read(ANDROID_PRO_MANAGER)
     ios_setup = _read(IOS_SETUP)
     ios_paywall = _read(IOS_PAYWALL)
+    sound_arsenal_section = android_setup.split("// 3. Sound Arsenal", 1)[1].split("val actionLabel", 1)[0]
 
     assert "TACTICAL EXPANSION" not in android_setup
     assert "TACTICAL EXPANSION" not in ios_setup
     assert "Preview Sounds" in android_setup
     assert "Preview Sounds" in ios_setup
     assert 'contentDescription = "Unlock Sound Arsenal"' in android_setup
-    assert "Icons.Filled.Lock" in android_setup
+    assert 'text = "PRO "' in sound_arsenal_section
+    assert 'text = "\\uD83D\\uDD12"' in sound_arsenal_section
+    assert "Surface(" in sound_arsenal_section
+    assert "IconButton(" not in sound_arsenal_section
     assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     for expected in (
         "Train up to 60-minute sessions",


### PR DESCRIPTION
## Summary\n- make the Android Sound Arsenal gate use the same PRO + lock chip as the other premium gates\n- keep the existing tap target and paywall wiring\n- add a parity assertion so this section cannot drift back to a lone icon\n\n## Verification\n- uv run pytest -q scripts/tests/test_mobile_feature_parity.py\n- ./gradlew compileDebugKotlin compileDebugAndroidTestKotlin -PenableFirebasePlugins=false --no-daemon\n- python3 scripts/regression_guards.py --mode ci