### PR TITLE
fix(release): verify internal build visibility

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -287,7 +287,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          TESTFLIGHT_GROUPS: ${{ secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
+          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
           TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}
           TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ secrets.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS || 'false' }}
         run: fastlane beta
@@ -302,6 +302,22 @@ jobs:
           set -euo pipefail
           VERSION="$(python scripts/source_versions.py --repo-root . --format json | python -c 'import json,sys; print(json.load(sys.stdin)["ios"]["version_name"])')"
           python scripts/verify_release.py --platform ios --version "$VERSION" --ios-scope testflight --wait --timeout 900 --poll-interval 60
+
+      - name: Ensure TestFlight internal distribution visibility
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY_PATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
+          TESTFLIGHT_INTERNAL_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
+          TESTFLIGHT_REQUIRED_TESTERS: ${{ vars.TESTFLIGHT_INTERNAL_TESTERS || secrets.FIREBASE_REQUIRED_TESTER_EMAIL || '' }}
+        run: |
+          set -euo pipefail
+          VERSION="$(python scripts/source_versions.py --repo-root . --format json | python -c 'import json,sys; print(json.load(sys.stdin)["ios"]["version_name"])')"
+          python scripts/ensure_internal_distribution.py \
+            --platform ios \
+            --ios-version "$VERSION" \
+            --ios-groups "$TESTFLIGHT_INTERNAL_GROUPS" \
+            --ios-required-testers "$TESTFLIGHT_REQUIRED_TESTERS"
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v7
@@ -367,6 +383,14 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Firebase verification Python dependencies
+        run: python -m pip install google-auth requests
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.300.0
@@ -525,6 +549,12 @@ jobs:
             echo "⚠️ Neither FIREBASE_INTERNAL_GROUPS nor FIREBASE_INTERNAL_TESTERS set — defaulting groups to 'internal-testers'"
             echo "FIREBASE_INTERNAL_GROUPS=internal-testers" >> "$GITHUB_ENV"
           fi
+          if [ -n "${FIREBASE_INTERNAL_GROUPS:-}" ]; then
+            echo "FIREBASE_INTERNAL_GROUPS=${FIREBASE_INTERNAL_GROUPS}" >> "$GITHUB_ENV"
+          fi
+          if [ -n "${FIREBASE_INTERNAL_TESTERS:-}" ]; then
+            echo "FIREBASE_INTERNAL_TESTERS=${FIREBASE_INTERNAL_TESTERS}" >> "$GITHUB_ENV"
+          fi
           if ! [[ "$FIREBASE_ANDROID_APP_ID" =~ ^1:[0-9]+:android:[a-fA-F0-9]+$ ]]; then
             echo "❌ FIREBASE_ANDROID_APP_ID must match 1:PROJECT_NUMBER:android:APP_ID (e.g. 1:712918404489:android:5fb1dfde1d712f53e7a558)"
             exit 1
@@ -574,11 +604,31 @@ jobs:
         with:
           appId: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-          testers: ${{ vars.FIREBASE_INTERNAL_TESTERS }}
+          testers: ${{ env.FIREBASE_INTERNAL_TESTERS }}
+          groups: ${{ env.FIREBASE_INTERNAL_GROUPS }}
           file: native-android/app/build/outputs/apk/release/app-release.apk
           releaseNotes: |
             Internal build from ${{ needs.gate.outputs.sha || github.sha }}
             Ref: ${{ needs.gate.outputs.ref }}
+
+      - name: Verify Firebase distribution read-back
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_INTERNAL_GROUPS: ${{ env.FIREBASE_INTERNAL_GROUPS }}
+          FIREBASE_INTERNAL_TESTERS: ${{ env.FIREBASE_INTERNAL_TESTERS }}
+          FIREBASE_REQUIRED_TESTER_EMAIL: ${{ secrets.FIREBASE_REQUIRED_TESTER_EMAIL }}
+        run: |
+          set -euo pipefail
+          VERSION="$(python scripts/source_versions.py --repo-root . --format json | python -c 'import json,sys; print(json.load(sys.stdin)["android"]["version_name"])')"
+          python scripts/ensure_internal_distribution.py \
+            --platform firebase \
+            --firebase-app-id "$FIREBASE_ANDROID_APP_ID" \
+            --firebase-build-version "${{ github.run_number }}" \
+            --firebase-display-version "$VERSION" \
+            --firebase-group-aliases "$FIREBASE_INTERNAL_GROUPS" \
+            --firebase-tester-emails "$FIREBASE_INTERNAL_TESTERS" \
+            --firebase-required-testers "${FIREBASE_REQUIRED_TESTER_EMAIL:-$FIREBASE_INTERNAL_TESTERS}"
 
       - name: Upload Android APK artifact
         uses: actions/upload-artifact@v7

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -24,13 +24,14 @@ platform :ios do
       api_key: api_key
     }
 
+    group_names = ENV.fetch("TESTFLIGHT_GROUPS", "").split(",").map(&:strip).reject(&:empty?)
+    options[:groups] = group_names unless group_names.empty?
+
     distribute_external = ENV.fetch("TESTFLIGHT_DISTRIBUTE_EXTERNAL", "false") == "true"
     return options unless distribute_external
 
-    group_names = ENV.fetch("TESTFLIGHT_GROUPS", "").split(",").map(&:strip).reject(&:empty?)
     UI.user_error!("TESTFLIGHT_GROUPS required when TESTFLIGHT_DISTRIBUTE_EXTERNAL=true") if group_names.empty?
 
-    options[:groups] = group_names
     options[:distribute_external] = true
     options[:notify_external_testers] = ENV.fetch("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS", "false") == "true"
     options[:changelog] = ENV.fetch("TESTFLIGHT_CHANGELOG", "Internal build from #{ENV.fetch('GITHUB_SHA', 'local')[0..7]}")

--- a/scripts/ensure_internal_distribution.py
+++ b/scripts/ensure_internal_distribution.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Ensure internal TestFlight/Firebase builds are actually visible to testers."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from asc_client import ASCClient, AscClientError
+from pem_env import load_google_play_service_account_dict
+from repo_dotenv import load_repo_dotenv
+
+load_repo_dotenv(Path(__file__).resolve().parent.parent)
+
+IOS_BUNDLE_ID = "com.igorganapolsky.randomtimer"
+FIREBASE_SCOPE = ("https://www.googleapis.com/auth/cloud-platform",)
+
+
+def _csv(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _error(details: str) -> dict[str, Any]:
+    return {"passed": False, "status": "ERROR", "details": details}
+
+
+class TestFlightInternalDistributor:
+    def __init__(self, bundle_id: str = IOS_BUNDLE_ID, client: ASCClient | None = None):
+        self.bundle_id = bundle_id
+        self.client = client or ASCClient.from_env()
+
+    def _get_app_id(self) -> str:
+        apps = self.client.get("/apps", params={"filter[bundleId]": self.bundle_id}).get("data", [])
+        if not apps:
+            raise RuntimeError(f"No App Store Connect app found for bundle id '{self.bundle_id}'")
+        return apps[0]["id"]
+
+    def _groups_for_app(self, app_id: str) -> dict[str, dict[str, Any]]:
+        groups = self.client.get_all(f"/apps/{app_id}/betaGroups", params={"limit": "200"})
+        return {group["attributes"]["name"]: group for group in groups}
+
+    def _latest_build_for_version(self, app_id: str, marketing_version: str) -> dict[str, Any]:
+        payload = self.client.get(
+            "/builds",
+            params={
+                "filter[app]": app_id,
+                "include": "preReleaseVersion",
+                "sort": "-uploadedDate",
+                "limit": 50,
+                "fields[builds]": "version,processingState,uploadedDate,preReleaseVersion",
+                "fields[preReleaseVersions]": "version",
+            },
+        )
+        pre_release_versions = {
+            item["id"]: item.get("attributes", {}).get("version")
+            for item in payload.get("included", [])
+            if item.get("type") == "preReleaseVersions"
+        }
+        for build in payload.get("data", []):
+            pre_rel = (
+                build.get("relationships", {})
+                .get("preReleaseVersion", {})
+                .get("data")
+            )
+            pre_rel_id = pre_rel.get("id") if isinstance(pre_rel, dict) else None
+            if pre_release_versions.get(pre_rel_id) == marketing_version:
+                return build
+        raise RuntimeError(f"No TestFlight build found for marketing version {marketing_version}")
+
+    def _ensure_build_in_group(self, group_id: str, build_id: str) -> None:
+        try:
+            self.client.request(
+                "POST",
+                f"/betaGroups/{group_id}/relationships/builds",
+                payload={"data": [{"type": "builds", "id": build_id}]},
+            )
+        except AscClientError as exc:
+            if "HTTP 409" not in str(exc):
+                raise
+
+    def _group_build_ids(self, group_id: str) -> set[str]:
+        builds = self.client.get_all(f"/betaGroups/{group_id}/builds", params={"limit": "200"})
+        return {build["id"] for build in builds}
+
+    def _group_tester_emails(self, group_id: str) -> set[str]:
+        testers = self.client.get_all(f"/betaGroups/{group_id}/betaTesters", params={"limit": "200"})
+        return {
+            (tester.get("attributes", {}).get("email") or "").strip().lower()
+            for tester in testers
+            if tester.get("attributes", {}).get("email")
+        }
+
+    def ensure(self, *, marketing_version: str, groups: list[str], required_testers: list[str]) -> dict[str, Any]:
+        try:
+            app_id = self._get_app_id()
+            build = self._latest_build_for_version(app_id, marketing_version)
+            build_id = build["id"]
+            attrs = build.get("attributes", {})
+            build_number = str(attrs.get("version", "?"))
+            processing_state = attrs.get("processingState", "UNKNOWN")
+            app_groups = self._groups_for_app(app_id)
+
+            missing_groups: list[str] = []
+            missing_tester_details: list[str] = []
+            verified_groups: list[str] = []
+
+            for group_name in groups:
+                group = app_groups.get(group_name)
+                if not group:
+                    missing_groups.append(group_name)
+                    continue
+                group_id = group["id"]
+                is_internal_group = bool(group.get("attributes", {}).get("isInternalGroup"))
+                if not is_internal_group:
+                    self._ensure_build_in_group(group_id, build_id)
+                if build_id not in self._group_build_ids(group_id):
+                    return _error(
+                        f"Build {build_number} for {marketing_version} is missing from TestFlight group '{group_name}'"
+                    )
+                testers = self._group_tester_emails(group_id)
+                missing = [email for email in required_testers if email.lower() not in testers]
+                if missing:
+                    missing_tester_details.append(f"{group_name}: {', '.join(missing)}")
+                verified_groups.append(group_name)
+
+            if missing_groups:
+                return _error("Missing TestFlight groups: " + ", ".join(missing_groups))
+            if missing_tester_details:
+                return _error(
+                    "Required internal TestFlight testers missing from group membership: "
+                    + "; ".join(missing_tester_details)
+                )
+            if processing_state != "VALID":
+                return _error(
+                    f"Latest TestFlight build {build_number} for {marketing_version} is not VALID (processingState={processing_state})"
+                )
+
+            return {
+                "passed": True,
+                "status": "VISIBLE",
+                "details": (
+                    f"TestFlight {marketing_version} build {build_number} is attached to groups "
+                    f"{', '.join(verified_groups)} and required tester membership is present."
+                ),
+            }
+        except Exception as exc:
+            return _error(f"TestFlight internal distribution check failed: {exc}")
+
+
+class FirebaseInternalDistributor:
+    def __init__(
+        self,
+        *,
+        app_id: str,
+        service_account_key: str | None = None,
+        requests_module: Any | None = None,
+    ):
+        self.app_id = app_id
+        self.project_number = self._project_number_from_app_id(app_id)
+        self._service_account_key = (
+            service_account_key
+            or os.environ.get("FIREBASE_SERVICE_ACCOUNT_JSON", "")
+            or os.environ.get("GOOGLE_PLAY_JSON_KEY", "")
+        )
+        self._requests = requests_module
+        self._token: str | None = None
+
+    @staticmethod
+    def _project_number_from_app_id(app_id: str) -> str:
+        parts = app_id.split(":")
+        if len(parts) < 2 or not parts[1].isdigit():
+            raise RuntimeError(f"Could not parse project number from Firebase app id '{app_id}'")
+        return parts[1]
+
+    def _get_token(self) -> str:
+        if self._token:
+            return self._token
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2 import service_account
+        except ImportError as exc:
+            raise RuntimeError(
+                "Missing google-auth dependencies. Install: pip install google-auth requests"
+            ) from exc
+
+        info = load_google_play_service_account_dict(self._service_account_key)
+        credentials = service_account.Credentials.from_service_account_info(
+            info,
+            scopes=list(FIREBASE_SCOPE),
+        )
+        credentials.refresh(Request())
+        self._token = credentials.token
+        return self._token
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        requests_module = self._requests
+        if requests_module is None:
+            try:
+                import requests as requests_module  # type: ignore
+            except ImportError as exc:
+                raise RuntimeError("Missing requests. Install: pip install requests") from exc
+
+        response = requests_module.request(
+            method.upper(),
+            f"https://firebaseappdistribution.googleapis.com{path}",
+            headers={
+                "Authorization": f"Bearer {self._get_token()}",
+                "Content-Type": "application/json",
+            },
+            params=params or {},
+            json=payload,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(f"{method.upper()} {path} failed: HTTP {response.status_code} {response.text[:1000]}")
+        return response.json() if getattr(response, "text", "") else {}
+
+    def _list_releases(self) -> list[dict[str, Any]]:
+        payload = self._request(
+            "GET",
+            f"/v1/projects/{self.project_number}/apps/{quote(self.app_id, safe=':')}/releases",
+            params={"pageSize": 50},
+        )
+        return payload.get("releases", [])
+
+    def _find_release(self, *, build_version: str | None, display_version: str | None) -> dict[str, Any]:
+        releases = self._list_releases()
+        if build_version:
+            releases = [release for release in releases if str(release.get("buildVersion", "")) == str(build_version)]
+        if display_version:
+            releases = [release for release in releases if str(release.get("displayVersion", "")) == str(display_version)]
+        if not releases:
+            raise RuntimeError(
+                f"No Firebase release found for app {self.app_id}"
+                + (f" buildVersion={build_version}" if build_version else "")
+                + (f" displayVersion={display_version}" if display_version else "")
+            )
+        return max(releases, key=lambda release: release.get("createTime", ""))
+
+    def _distribute_release(self, release_name: str, *, tester_emails: list[str], group_aliases: list[str]) -> None:
+        if not tester_emails and not group_aliases:
+            return
+        self._request(
+            "POST",
+            f"/v1/{quote(release_name, safe='/:')}:distribute",
+            payload={"testerEmails": tester_emails, "groupAliases": group_aliases},
+        )
+
+    def _list_testers(self) -> list[dict[str, Any]]:
+        payload = self._request(
+            "GET",
+            f"/v1/projects/{self.project_number}/testers",
+            params={"pageSize": 200},
+        )
+        return payload.get("testers", [])
+
+    def _get_group(self, alias: str) -> dict[str, Any]:
+        return self._request("GET", f"/v1/projects/{self.project_number}/groups/{quote(alias, safe='')}")
+
+    def ensure(
+        self,
+        *,
+        build_version: str | None,
+        display_version: str | None,
+        group_aliases: list[str],
+        tester_emails: list[str],
+        required_testers: list[str],
+    ) -> dict[str, Any]:
+        try:
+            release = self._find_release(build_version=build_version, display_version=display_version)
+            self._distribute_release(
+                release["name"],
+                tester_emails=tester_emails,
+                group_aliases=group_aliases,
+            )
+
+            project_testers = {
+                (tester.get("email") or "").strip().lower()
+                for tester in self._list_testers()
+                if tester.get("email")
+            }
+            missing_testers = [email for email in required_testers if email.lower() not in project_testers]
+            if missing_testers:
+                return _error("Required Firebase testers missing from project tester list: " + ", ".join(missing_testers))
+
+            group_summaries: list[str] = []
+            for alias in group_aliases:
+                group = self._get_group(alias)
+                tester_count = int(group.get("testerCount", 0))
+                release_count = int(group.get("releaseCount", 0))
+                if tester_count <= 0:
+                    return _error(f"Firebase group '{alias}' has no testers")
+                if release_count <= 0:
+                    return _error(f"Firebase group '{alias}' has no accessible releases")
+                group_summaries.append(f"{alias}(testers={tester_count}, releases={release_count})")
+
+            return {
+                "passed": True,
+                "status": "VISIBLE",
+                "details": (
+                    f"Firebase release {release.get('displayVersion', '?')} ({release.get('buildVersion', '?')}) "
+                    f"is distributed. Required testers exist and groups verified: "
+                    f"{', '.join(group_summaries) if group_summaries else 'direct tester distribution'}."
+                ),
+            }
+        except Exception as exc:
+            return _error(f"Firebase internal distribution check failed: {exc}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ensure internal TestFlight/Firebase visibility before signoff.")
+    parser.add_argument("--platform", choices=["ios", "firebase", "both"], required=True)
+    parser.add_argument("--ios-version", default="")
+    parser.add_argument("--ios-groups", default="")
+    parser.add_argument("--ios-required-testers", default="")
+    parser.add_argument("--firebase-app-id", default=os.environ.get("FIREBASE_ANDROID_APP_ID", ""))
+    parser.add_argument("--firebase-build-version", default="")
+    parser.add_argument("--firebase-display-version", default="")
+    parser.add_argument("--firebase-group-aliases", default="")
+    parser.add_argument("--firebase-tester-emails", default="")
+    parser.add_argument("--firebase-required-testers", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    results: list[dict[str, Any]] = []
+
+    if args.platform in {"ios", "both"}:
+        if not args.ios_version:
+            print("❌ --ios-version is required for iOS checks", file=sys.stderr)
+            return 2
+        results.append(
+            {"platform": "iOS", **TestFlightInternalDistributor().ensure(
+                marketing_version=args.ios_version,
+                groups=_csv(args.ios_groups),
+                required_testers=[email.lower() for email in _csv(args.ios_required_testers)],
+            )}
+        )
+
+    if args.platform in {"firebase", "both"}:
+        if not args.firebase_app_id:
+            print("❌ --firebase-app-id is required for Firebase checks", file=sys.stderr)
+            return 2
+        results.append(
+            {"platform": "Firebase", **FirebaseInternalDistributor(app_id=args.firebase_app_id).ensure(
+                build_version=args.firebase_build_version or None,
+                display_version=args.firebase_display_version or None,
+                group_aliases=_csv(args.firebase_group_aliases),
+                tester_emails=[email.lower() for email in _csv(args.firebase_tester_emails)],
+                required_testers=[email.lower() for email in _csv(args.firebase_required_testers or args.firebase_tester_emails)],
+            )}
+        )
+
+    all_passed = True
+    for result in results:
+        icon = "✅" if result["passed"] else "❌"
+        print(f"{icon} {result['platform']}: {result['status']} — {result['details']}")
+        all_passed = all_passed and result["passed"]
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_ensure_internal_distribution.py
+++ b/scripts/tests/test_ensure_internal_distribution.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from scripts import ensure_internal_distribution as eid
+
+
+class _FakeASCClient:
+    def __init__(self):
+        self.posts = []
+
+    def get(self, path, params=None):
+        if path == "/apps":
+            return {"data": [{"id": "app-1"}]}
+        if path == "/builds":
+            return {
+                "data": [
+                    {
+                        "id": "build-453",
+                        "attributes": {"version": "453", "processingState": "VALID"},
+                        "relationships": {"preReleaseVersion": {"data": {"id": "prv-1"}}},
+                    }
+                ],
+                "included": [{"id": "prv-1", "type": "preReleaseVersions", "attributes": {"version": "1.3.18"}}],
+            }
+        raise AssertionError(path)
+
+    def get_all(self, path, params=None):
+        if path == "/apps/app-1/betaGroups":
+            return [{"id": "group-1", "attributes": {"name": "Internal Testers", "isInternalGroup": True}}]
+        if path == "/betaGroups/group-1/builds":
+            return [{"id": "build-453"}]
+        if path == "/betaGroups/group-1/betaTesters":
+            return [{"attributes": {"email": "iganapolsky@gmail.com"}}]
+        raise AssertionError(path)
+
+    def request(self, method, path, payload=None, params=None):
+        self.posts.append((method, path, payload))
+        return {}
+
+
+def test_ios_internal_distribution_ensures_build_visibility():
+    client = _FakeASCClient()
+    verifier = eid.TestFlightInternalDistributor(client=client)
+    result = verifier.ensure(
+        marketing_version="1.3.18",
+        groups=["Internal Testers"],
+        required_testers=["iganapolsky@gmail.com"],
+    )
+
+    assert result["passed"] is True
+    assert result["status"] == "VISIBLE"
+    assert "build 453" in result["details"]
+    assert client.posts == []
+
+
+def test_ios_internal_distribution_fails_when_required_tester_missing():
+    class _MissingTesterClient(_FakeASCClient):
+        def get_all(self, path, params=None):
+            if path == "/betaGroups/group-1/betaTesters":
+                return [{"attributes": {"email": "other@example.com"}}]
+            return super().get_all(path, params)
+
+    verifier = eid.TestFlightInternalDistributor(client=_MissingTesterClient())
+    result = verifier.ensure(
+        marketing_version="1.3.18",
+        groups=["Internal Testers"],
+        required_testers=["iganapolsky@gmail.com"],
+    )
+
+    assert result["passed"] is False
+    assert "Required internal TestFlight testers missing" in result["details"]
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+        self.text = "{}"
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequests:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, headers=None, params=None, json=None, timeout=None):
+        self.calls.append((method, url, params, json))
+        if url.endswith("/releases"):
+            return _FakeResponse(
+                {
+                    "releases": [
+                        {
+                            "name": "projects/712918404489/apps/1:712918404489:android:abc/releases/rel-1",
+                            "displayVersion": "1.3.18",
+                            "buildVersion": "557",
+                            "createTime": "2026-04-09T12:00:00Z",
+                        }
+                    ]
+                }
+            )
+        if url.endswith(":distribute"):
+            return _FakeResponse({})
+        if url.endswith("/testers"):
+            return _FakeResponse({"testers": [{"email": "iganapolsky@gmail.com"}]})
+        if url.endswith("/groups/internal-testers"):
+            return _FakeResponse({"name": "projects/712918404489/groups/internal-testers", "testerCount": 1, "releaseCount": 4})
+        raise AssertionError(url)
+
+
+def test_firebase_internal_distribution_distributes_and_verifies():
+    fake_requests = _FakeRequests()
+    verifier = eid.FirebaseInternalDistributor(
+        app_id="1:712918404489:android:abc",
+        service_account_key="{}",
+        requests_module=fake_requests,
+    )
+    verifier._get_token = lambda: "token"
+    result = verifier.ensure(
+        build_version="557",
+        display_version="1.3.18",
+        group_aliases=["internal-testers"],
+        tester_emails=["iganapolsky@gmail.com"],
+        required_testers=["iganapolsky@gmail.com"],
+    )
+
+    assert result["passed"] is True
+    assert result["status"] == "VISIBLE"
+    assert "internal-testers" in result["details"]
+    assert any(call[1].endswith(":distribute") for call in fake_requests.calls)
+
+
+def test_firebase_internal_distribution_fails_when_required_tester_missing():
+    class _MissingTesterRequests(_FakeRequests):
+        def request(self, method, url, headers=None, params=None, json=None, timeout=None):
+            if url.endswith("/testers"):
+                return _FakeResponse({"testers": []})
+            return super().request(method, url, headers=headers, params=params, json=json, timeout=timeout)
+
+    fake_requests = _MissingTesterRequests()
+    verifier = eid.FirebaseInternalDistributor(
+        app_id="1:712918404489:android:abc",
+        service_account_key="{}",
+        requests_module=fake_requests,
+    )
+    verifier._get_token = lambda: "token"
+    result = verifier.ensure(
+        build_version="557",
+        display_version="1.3.18",
+        group_aliases=["internal-testers"],
+        tester_emails=["iganapolsky@gmail.com"],
+        required_testers=["iganapolsky@gmail.com"],
+    )
+
+    assert result["passed"] is False
+    assert "Required Firebase testers missing" in result["details"]

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -43,7 +43,10 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
         "Guard iOS version lineage against ASC"
     )
     assert "Internal Testers" in source
+    assert "TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}" in source
     assert "TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ secrets.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}" in source
+    assert "Ensure TestFlight internal distribution visibility" in source
+    assert "scripts/ensure_internal_distribution.py" in source
     assert "ios-testflight-signoff:" in source
     assert "environment: testflight-signoff" in source
     assert "environment: internal-play" in source
@@ -100,6 +103,8 @@ def test_internal_distribution_workflow_supports_targeted_reruns_and_firebase_de
     assert "FIREBASE_SERVICE_ACCOUNT_JSON" in source
     assert "FIREBASE_ANDROID_APP_ID" in source
     assert "android-apk-firebase-internal" in source or "app-release.apk" in source
+    assert "groups: ${{ env.FIREBASE_INTERNAL_GROUPS }}" in source
+    assert "Verify Firebase distribution read-back" in source
     firebase_section = source.split("- name: Distribute to Firebase", 1)[1].split(
         "- name: Upload Android APK artifact", 1
     )[0]

--- a/scripts/tests/test_ios_fastlane_contracts.py
+++ b/scripts/tests/test_ios_fastlane_contracts.py
@@ -5,12 +5,12 @@ ROOT = Path(__file__).resolve().parents[2]
 FASTFILE = ROOT / "native-ios/fastlane/Fastfile"
 
 
-def test_ios_beta_lane_only_assigns_testflight_groups_for_external_distribution():
+def test_ios_beta_lane_keeps_testflight_groups_for_internal_and_external_distribution():
     source = FASTFILE.read_text(encoding="utf-8")
 
     assert "TESTFLIGHT_GROUPS" in source
+    assert "options[:groups] = group_names unless group_names.empty?" in source
     assert 'return options unless distribute_external' in source
-    assert "options[:groups]" in source
     assert "options[:distribute_external] = true" in source
     assert 'TESTFLIGHT_GROUPS required when TESTFLIGHT_DISTRIBUTE_EXTERNAL=true' in source
 


### PR DESCRIPTION
## Summary
- verify internal TestFlight build visibility against actual tester group membership
- re-distribute and verify Firebase internal visibility after APK upload
- keep workflow/tests aligned so upload success is not confused with tester access

## Verification
- uv run pytest -q scripts/tests/test_ensure_internal_distribution.py scripts/tests/test_ios_fastlane_contracts.py scripts/tests/test_growth_workflow_contracts.py
- python3 scripts/regression_guards.py --mode ci
- live ASC read-back: TestFlight 1.3.18 build 454 visible to Internal Testers and iganapolsky@gmail.com
