### PR TITLE
fix(metrics): executive snapshot ASC import + credential errors + JSON refresh

### DIFF
--- a/marketing/data/README.md
+++ b/marketing/data/README.md
@@ -23,4 +23,15 @@
 
   `POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS` = comma-separated UUIDs in **`.env`** (local) and as repository secret **`POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS`** for **`Executive metrics snapshot`** (`.github/workflows/executive-metrics.yml` passes it into the script).
 
+**Finding person IDs to exclude (PostHog UI)**
+
+1. PostHog → **Persons** (or open a person from **Activity** / an event stream).
+2. Copy the **Person distinct ID** (UUID format) for each device or profile you want out of executive counts.
+3. Paste comma-separated into `POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS`. This is the only supported way to drop *your* devices from WQTU/install scalars; the script does not auto-detect names or “bot vs human.”
+
+**Local Play / Crashlytics keys**
+
+- **Play:** use `GOOGLE_PLAY_JSON_KEY` (raw JSON from the secret) or `GOOGLE_PLAY_JSON_KEY_PATH` (path to a file). If the path is wrong, the snapshot now fails with a clear “not a file” error instead of a JSON parse error.
+- **Crashlytics BigQuery:** prefer `CRASHLYTICS_SERVICE_ACCOUNT_JSON` (same pattern as CI). If you use `GOOGLE_APPLICATION_CREDENTIALS`, the file must exist or the snapshot reports an explicit missing-file error.
+
 See also `docs/OPERATIONAL_RELIABILITY.md` and `docs/OBSERVABILITY.md`.

--- a/marketing/data/executive_metrics.json
+++ b/marketing/data/executive_metrics.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-04-08T13:31:23+00:00",
+  "generated_at": "2026-04-09T18:47:45+00:00",
   "source": "executive_metrics_snapshot",
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "definitions": {
     "install_proxy_posthog": "Distinct persons with event Application Installed (not store units).",
     "reviews_store": "Play: reviews.list is comment-bearing reviews touched in the last 7 days only (per Google); star-only ratings omitted; can read 0 while the public listing shows reviews; pagination max 100/page. App Store: customerReviews first page only (limit 50, newest first), not lifetime total. Use review_count_metric_id under store_apis.android / store_apis.ios when present.",
     "reviews_in_app": "PostHog review_prompt_requested / write_review_tapped (not published star count).",
-    "paid_posthog": "paywall_purchase_success and paywall_purchase_result in PostHog; use Store/RevenueCat for ledger truth.",
+    "paid_posthog": "In-app telemetry: paywall_purchase_success / paywall_purchase_result (not Play/App Store revenue). Compare posthog.events_paywall_purchase_success_ios vs _android (properties.platform). Ledger: App Store Connect + Google Play billing.",
     "posthog_executive": "HogQL scalars use audience_sql (PRAGMATIC_LIVE) and window_days except wqtu_7d_distinct_persons (fixed 7d). Filters exclude non\u2013store-production distribution_channel (testflight, non_play_install, dev, emulator, etc.), is_internal, debug/sim events; legacy events without distribution_channel stay included as 'legacy'. Optional POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS env. See posthog.metric_field_ids and posthog.audience_note.",
     "crashes": "Crashlytics BigQuery streaming export; posthog_exception_events is separate. crashlytics_bigquery.fatal_events_in_window is COUNT(*) of fatal rows in the lookback hours. fatal_events sums crash_count only within parsed top_fatal_issues (up to 10 rows displayed from top 20 SQL groups) \u2014 see metric_field_ids.",
     "uninstalls": "Not available on iOS; Android uninstall metrics require Play reporting APIs (not in this script yet).",
@@ -24,30 +24,34 @@
     "exclude_person_ids_configured": true,
     "window_days": 30,
     "errors": [],
-    "distinct_persons_application_installed": 414,
-    "distinct_persons_first_open": 389,
-    "timer_started_events": 1373,
-    "timer_completed_events": 293,
-    "distinct_persons_timer_started": 355,
-    "distinct_persons_timer_completed": 47,
-    "distinct_persons_timer_started_and_completed": 47,
-    "wqtu_distinct_persons": 11,
-    "wqtu_7d_distinct_persons": 6,
-    "timer_abandon_rate_event_level_pct": 78.66,
+    "distinct_persons_application_installed": 447,
+    "distinct_persons_first_open": 422,
+    "timer_started_events": 1442,
+    "timer_completed_events": 296,
+    "distinct_persons_timer_started": 383,
+    "distinct_persons_timer_completed": 54,
+    "distinct_persons_timer_started_and_completed": 54,
+    "wqtu_distinct_persons": 10,
+    "wqtu_7d_distinct_persons": 8,
+    "timer_abandon_rate_event_level_pct": 79.47,
     "distinct_persons_paywall_purchase_success": 1,
     "events_paywall_purchase_success": 1,
-    "in_app_review_prompt_events": 10,
-    "in_app_review_prompt_distinct_persons": 10,
+    "distinct_persons_paywall_purchase_success_ios": 1,
+    "distinct_persons_paywall_purchase_success_android": 0,
+    "events_paywall_purchase_success_ios": 1,
+    "events_paywall_purchase_success_android": 0,
+    "in_app_review_prompt_events": 13,
+    "in_app_review_prompt_distinct_persons": 13,
     "top_screens_by_distinct_persons": [
       [
         "Timer Setup",
-        428,
-        2566
+        460,
+        2738
       ],
       [
         "Active Timer",
-        352,
-        1712
+        379,
+        1840
       ]
     ],
     "posthog_exception_events": 0,
@@ -65,6 +69,10 @@
       "timer_abandon_rate_event_level_pct": "posthog_derived_event_level_started_minus_completed_over_started_pct",
       "distinct_persons_paywall_purchase_success": "posthog_hogql_distinct_persons_event_paywall_purchase_success",
       "events_paywall_purchase_success": "posthog_hogql_count_events_paywall_purchase_success",
+      "distinct_persons_paywall_purchase_success_ios": "posthog_hogql_distinct_persons_event_paywall_purchase_success_ios",
+      "distinct_persons_paywall_purchase_success_android": "posthog_hogql_distinct_persons_event_paywall_purchase_success_android",
+      "events_paywall_purchase_success_ios": "posthog_hogql_count_events_paywall_purchase_success_ios",
+      "events_paywall_purchase_success_android": "posthog_hogql_count_events_paywall_purchase_success_android",
       "in_app_review_prompt_events": "posthog_hogql_count_events_review_prompt_requested",
       "in_app_review_prompt_distinct_persons": "posthog_hogql_distinct_persons_event_review_prompt_requested",
       "top_screens_by_distinct_persons": "posthog_hogql_top_screens_by_distinct_persons_limit_12_order_desc",
@@ -78,50 +86,16 @@
       "review_count_metric_id": "google_play_androidpublisher_reviews_list_7d_commented_paginated",
       "production_release": {
         "version_codes": [
-          "1775593228"
+          "1775653001"
         ],
         "status": "completed",
-        "name": "v1775593228"
+        "name": "v1775653001"
       },
       "note": "Play reviews.list: comment-bearing reviews created or modified in the last 7 days only; star-only ratings are excluded. Not equal to public Play review totals. No per-app download count in this API."
     },
     "ios": {
-      "status": "ok",
-      "app_name": "Random Tactical Timer",
-      "bundle_id": "com.igorganapolsky.randomtimer",
-      "sku": "randomtimer2026",
-      "versions": [
-        {
-          "version": "1.3.17",
-          "state": "READY_FOR_SALE",
-          "created": "2026-04-06T09:08:34-07:00"
-        },
-        {
-          "version": "1.3.16",
-          "state": "READY_FOR_SALE",
-          "created": "2026-04-02T13:16:21-07:00"
-        },
-        {
-          "version": "1.3.15",
-          "state": "READY_FOR_SALE",
-          "created": "2026-02-24T11:12:51-08:00"
-        },
-        {
-          "version": "1.2.0",
-          "state": "READY_FOR_SALE",
-          "created": "2026-02-18T15:22:27-08:00"
-        },
-        {
-          "version": "1.1.1",
-          "state": "READY_FOR_SALE",
-          "created": "2026-01-27T13:25:27-08:00"
-        }
-      ],
-      "review_count": 0,
-      "review_count_metric_id": "app_store_connect_customer_reviews_sort_created_desc_limit_50",
-      "review_count_request_limit": 50,
-      "reviews": [],
-      "note": "App Store Connect Sales reports require async report generation. customerReviews count is the first page only (limit 50, newest first), not total lifetime App Store reviews. Version state is live from the API."
+      "status": "skipped",
+      "reason": "asc_client not importable"
     }
   },
   "crashlytics_bigquery": {

--- a/scripts/check_crashlytics.py
+++ b/scripts/check_crashlytics.py
@@ -50,6 +50,15 @@ def get_credentials():
             scopes=SCOPES,
         )
 
+    gac = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+    if gac:
+        expanded = os.path.expanduser(gac)
+        if not os.path.isfile(expanded):
+            raise RuntimeError(
+                "GOOGLE_APPLICATION_CREDENTIALS points to a missing file "
+                f"({expanded}). Set CRASHLYTICS_SERVICE_ACCOUNT_JSON or fix the path."
+            )
+
     creds, _ = google.auth.default(scopes=SCOPES)
     return creds
 

--- a/scripts/pem_env.py
+++ b/scripts/pem_env.py
@@ -83,8 +83,14 @@ def load_google_play_service_account_dict(key_material: str) -> Dict[str, Any]:
     expanded = os.path.expanduser(raw)
     if os.path.isfile(expanded):
         raw = Path(expanded).read_text(encoding="utf-8")
+    elif raw and not raw.lstrip().startswith("{"):
+        raise ValueError(
+            f"Google Play key path is not a file (check GOOGLE_PLAY_JSON_KEY_PATH): {expanded}"
+        )
     if raw.startswith("\ufeff"):
         raw = raw[1:]
+    if not raw.strip():
+        raise ValueError("Google Play key material is empty")
     info = json.loads(raw)
     if not isinstance(info, dict):
         raise ValueError("Google Play key must be a JSON object")

--- a/scripts/real_store_downloads.py
+++ b/scripts/real_store_downloads.py
@@ -29,7 +29,12 @@ ANDROID_PACKAGE = "com.iganapolsky.randomtimer"
 IOS_BUNDLE_ID = "com.igorganapolsky.randomtimer"
 IOS_APP_ID = "6758355312"
 
-sys.path.append(str(Path(__file__).parent.resolve()))
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_ASC_DIR = _SCRIPTS_DIR / "asc"
+for _p in (_SCRIPTS_DIR, _ASC_DIR):
+    _s = str(_p)
+    if _s not in sys.path:
+        sys.path.insert(0, _s)
 
 
 def _asc_get_with_retries(

--- a/scripts/tests/test_pem_env.py
+++ b/scripts/tests/test_pem_env.py
@@ -48,6 +48,11 @@ class PemEnvTests(unittest.TestCase):
         self.assertNotIn("\\n", fixed["private_key"])
         self.assertIn("\nLINE\n", fixed["private_key"])
 
+    def test_load_google_play_rejects_missing_path(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            load_google_play_service_account_dict("/nonexistent/path/google-play-ci-missing.json")
+        self.assertIn("not a file", str(ctx.exception).lower())
+
     def test_load_google_play_dict_from_minimal_json_string(self) -> None:
         inner = {
             "type": "service_account",


### PR DESCRIPTION
## Summary
- **real_store_downloads**: add `scripts/asc` to `sys.path` so App Store Connect client imports in CI (fixes `asc_client not importable` in executive snapshot).
- **pem_env**: if `GOOGLE_PLAY_JSON_KEY_PATH` is set but not a file, raise a clear error instead of JSON parse noise.
- **check_crashlytics**: if `GOOGLE_APPLICATION_CREDENTIALS` points to a missing file, fail with an explicit message (suggest `CRASHLYTICS_SERVICE_ACCOUNT_JSON`).
- **Tests**: missing Play key path raises `ValueError`.
- **marketing/data/README.md**: how to find PostHog person IDs for `POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS`; local key notes.
- **executive_metrics.json**: refreshed from successful workflow run 24207483094 (PostHog + Play + BQ).

## Evidence
- Local: `uv run pytest scripts/tests/test_pem_env.py scripts/tests/test_real_store_downloads.py` — pass.
- CI: Executive metrics snapshot run https://github.com/IgorGanapolsky/Random-Timer/actions/runs/24207483094 (success; iOS still skipped on **current** develop — this PR fixes the import for **next** runs).

Made with [Cursor](https://cursor.com)