### PR TITLE
fix(ci): skip ElevenLabs smoke when API returns payment_issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
           if [ "$status" -eq 0 ]; then
             exit 0
           fi
-          if printf '%s\n' "$output" | grep -q "quota_exceeded"; then
-            echo "Live ElevenLabs smoke skipped because the account has no remaining credits."
+          if printf '%s\n' "$output" | grep -qE "quota_exceeded|payment_issue"; then
+            echo "Live ElevenLabs smoke skipped (quota or billing: payment_issue / no credits)."
             exit 0
           fi
           exit "$status"

--- a/scripts/tests/test_voice_regression_contracts.py
+++ b/scripts/tests/test_voice_regression_contracts.py
@@ -188,8 +188,8 @@ def test_ci_runs_static_and_live_voice_regression_guards() -> None:
     assert "Decide live smoke execution" in workflow
     assert 'steps.gate.outputs.run_live_smoke == \'true\'' in workflow
     assert "Record controlled skip" in workflow
-    assert 'grep -q "quota_exceeded"' in workflow
-    assert "no remaining credits" in workflow
+    assert 'grep -qE "quota_exceeded|payment_issue"' in workflow
+    assert "payment_issue" in workflow
     assert "content/pro_audio/voice_personas.json" in verify_script
     assert "/v1/text-to-speech/" in verify_script
     assert "verifiedProbes" in verify_script


### PR DESCRIPTION
ElevenLabs returned HTTP 401 with `payment_issue` (failed/incomplete invoice), which blocked all PRs including docs-only changes. Mirror the existing `quota_exceeded` escape hatch so CI stays green until billing is fixed; contract test updated.

Made with [Cursor](https://cursor.com)