### PR TITLE
ci(growth): GitHub-side Zernio controls for Daily Growth Publishing

### DIFF
--- a/.github/workflows/daily-growth-publishing.yml
+++ b/.github/workflows/daily-growth-publishing.yml
@@ -2,8 +2,20 @@ name: Daily Growth Publishing
 
 on:
   schedule:
+    # Runs on the repo default branch (develop): no laptop required.
     - cron: '15 13 * * *' # Daily at 13:15 UTC
   workflow_dispatch:
+    inputs:
+      zernio_auto_publish:
+        description: >
+          Zernio fan-out. secret = use repo secret ZERNIO_AUTO_PUBLISH; 0 = dry-run; 1 = live publish.
+        type: choice
+        required: false
+        default: secret
+        options:
+          - secret
+          - "0"
+          - "1"
 
 permissions:
   contents: write
@@ -77,7 +89,7 @@ jobs:
           ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
           ZERNIO_TOKEN: ${{ secrets.ZERNIO_API_KEY }}
           ZERNIO_PUBLISH_ACCOUNTS: ${{ secrets.ZERNIO_PUBLISH_ACCOUNTS }}
-          ZERNIO_AUTO_PUBLISH: ${{ secrets.ZERNIO_AUTO_PUBLISH }}
+          ZERNIO_AUTO_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.zernio_auto_publish == '0' || github.event.inputs.zernio_auto_publish == '1') && github.event.inputs.zernio_auto_publish || secrets.ZERNIO_AUTO_PUBLISH }}
         run: python scripts/zernio_orchestrate.py sync-latest --repo-root . --output-root marketing
 
       - name: Commit generated assets
@@ -126,6 +138,7 @@ jobs:
             marketing/data/publish_ab_pilot_report.md
             marketing/data/bot_traffic_summary.json
             marketing/data/bot_traffic_summary.md
+            marketing/data/zernio_orchestration.jsonl
             marketing/keywords/keyword_backlog.json
             marketing/keywords/keyword_backlog.csv
             marketing/keywords/keyword_backlog.md


### PR DESCRIPTION
Runs entirely on GitHub Actions (default branch `develop`); no local machine required for the daily schedule.

**Changes**
- **workflow_dispatch** input `zernio_auto_publish`: `secret` (use repo secret `ZERNIO_AUTO_PUBLISH`), `0` dry-run, or `1` live publish for that manual run only.
- Scheduled runs keep using **`ZERNIO_AUTO_PUBLISH`** secret only.
- Upload **`marketing/data/zernio_orchestration.jsonl`** as part of `growth-daily-artifacts`.

**Evidence**
- `gh secret list` shows `ZERNIO_API_KEY`, `ZERNIO_AUTO_PUBLISH`, `ZERNIO_PUBLISH_ACCOUNTS` present.
- `python3 -m pytest scripts/tests/test_workflow_yaml_syntax.py scripts/tests/test_growth_workflow_contracts.py -q` — 31 passed locally.

To go live on the cron job, set repository secret `ZERNIO_AUTO_PUBLISH` to `1` in GitHub Settings → Secrets. To test live once without changing the secret, run **Daily Growth Publishing** manually and choose `1`.

Made with [Cursor](https://cursor.com)