### PR TITLE
feat(metrics): executive revenue proxies + optional iOS sales ledger

### DIFF
--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -39,6 +39,8 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APP_STORE_CONNECT_KEY_B64: ${{ secrets.APP_STORE_CONNECT_KEY_B64 }}
+          APPSTORE_CONNECT_VENDOR_NUMBER: ${{ secrets.APPSTORE_CONNECT_VENDOR_NUMBER }}
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new

--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -40,7 +40,7 @@ jobs:
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           APP_STORE_CONNECT_KEY_B64: ${{ secrets.APP_STORE_CONNECT_KEY_B64 }}
-          APPSTORE_CONNECT_VENDOR_NUMBER: ${{ secrets.APPSTORE_CONNECT_VENDOR_NUMBER }}
+          APPSTORE_VENDOR_NUMBER: ${{ secrets.APPSTORE_VENDOR_NUMBER }}
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new

--- a/marketing/data/README.md
+++ b/marketing/data/README.md
@@ -2,7 +2,7 @@
 
 ## `executive_metrics.json`
 
-**What it is:** A JSON bundle of PostHog scalars (product), Play / App Store Connect snippets (when APIs succeed), optional **ledger** iOS daily sales rollup (`ledger_revenue.ios_sales_reports_daily` when `APPSTORE_CONNECT_VENDOR_NUMBER` is set), paywall funnel proxies (`paywall_viewed`, conversion vs viewers, UTM paid pageviews), and Crashlytics BigQuery summary (when the export has data).
+**What it is:** A JSON bundle of PostHog scalars (product), Play / App Store Connect snippets (when APIs succeed), optional **ledger** iOS daily sales rollup (`ledger_revenue.ios_sales_reports_daily` when `APPSTORE_VENDOR_NUMBER` is set), paywall funnel proxies (`paywall_viewed`, conversion vs viewers, UTM paid pageviews), and Crashlytics BigQuery summary (when the export has data).
 
 **Do you need to do anything?**
 
@@ -36,6 +36,6 @@
 
 **iOS sales ledger (optional)**
 
-- Set **`APPSTORE_CONNECT_VENDOR_NUMBER`** (same value as App Store Connect → Payments and Financial Reports → vendor number) alongside **`APPSTORE_KEY_ID`**, **`APPSTORE_ISSUER_ID`**, and **`APPSTORE_PRIVATE_KEY`** (or **`APP_STORE_CONNECT_KEY_B64`**). The snapshot then calls Sales Reports and sums TSV columns for the trailing window. Android Play earnings are still **not** automated here—use Play financial exports.
+- Set **`APPSTORE_VENDOR_NUMBER`** (same value as App Store Connect → Payments and Financial Reports → vendor number) alongside **`APPSTORE_KEY_ID`**, **`APPSTORE_ISSUER_ID`**, and **`APPSTORE_PRIVATE_KEY`** (or **`APP_STORE_CONNECT_KEY_B64`**). The legacy local alias **`APPSTORE_CONNECT_VENDOR_NUMBER`** is also accepted. The snapshot then calls Sales Reports and sums TSV columns for the trailing window. Android Play earnings are still **not** automated here—use Play financial exports.
 
 See also `docs/OPERATIONAL_RELIABILITY.md` and `docs/OBSERVABILITY.md`.

--- a/marketing/data/README.md
+++ b/marketing/data/README.md
@@ -2,7 +2,7 @@
 
 ## `executive_metrics.json`
 
-**What it is:** A JSON bundle of PostHog scalars (product), Play / App Store Connect snippets (when APIs succeed), and Crashlytics BigQuery summary (when the export has data).
+**What it is:** A JSON bundle of PostHog scalars (product), Play / App Store Connect snippets (when APIs succeed), optional **ledger** iOS daily sales rollup (`ledger_revenue.ios_sales_reports_daily` when `APPSTORE_CONNECT_VENDOR_NUMBER` is set), paywall funnel proxies (`paywall_viewed`, conversion vs viewers, UTM paid pageviews), and Crashlytics BigQuery summary (when the export has data).
 
 **Do you need to do anything?**
 
@@ -33,5 +33,9 @@
 
 - **Play:** use `GOOGLE_PLAY_JSON_KEY` (raw JSON from the secret) or `GOOGLE_PLAY_JSON_KEY_PATH` (path to a file). If the path is wrong, the snapshot now fails with a clear “not a file” error instead of a JSON parse error.
 - **Crashlytics BigQuery:** prefer `CRASHLYTICS_SERVICE_ACCOUNT_JSON` (same pattern as CI). If you use `GOOGLE_APPLICATION_CREDENTIALS`, the file must exist or the snapshot reports an explicit missing-file error.
+
+**iOS sales ledger (optional)**
+
+- Set **`APPSTORE_CONNECT_VENDOR_NUMBER`** (same value as App Store Connect → Payments and Financial Reports → vendor number) alongside **`APPSTORE_KEY_ID`**, **`APPSTORE_ISSUER_ID`**, and **`APPSTORE_PRIVATE_KEY`** (or **`APP_STORE_CONNECT_KEY_B64`**). The snapshot then calls Sales Reports and sums TSV columns for the trailing window. Android Play earnings are still **not** automated here—use Play financial exports.
 
 See also `docs/OPERATIONAL_RELIABILITY.md` and `docs/OBSERVABILITY.md`.

--- a/marketing/data/executive_metrics.json
+++ b/marketing/data/executive_metrics.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-10T17:50:23+00:00",
+  "generated_at": "2026-04-10T20:20:59+00:00",
   "source": "executive_metrics_snapshot",
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "definitions": {
@@ -7,6 +7,9 @@
     "reviews_store": "Play: reviews.list is comment-bearing reviews touched in the last 7 days only (per Google); star-only ratings omitted; can read 0 while the public listing shows reviews; pagination max 100/page. App Store: customerReviews first page only (limit 50, newest first), not lifetime total. Use review_count_metric_id under store_apis.android / store_apis.ios when present.",
     "reviews_in_app": "PostHog review_prompt_requested / write_review_tapped (not published star count).",
     "paid_posthog": "In-app telemetry: paywall_purchase_success / paywall_purchase_result (not Play/App Store revenue). Compare posthog.events_paywall_purchase_success_ios vs _android (properties.platform). Ledger: App Store Connect + Google Play billing.",
+    "paywall_revenue_event_properties": "Sum of coalesce(properties.revenue, properties.price) on paywall_purchase_success within pragmatic_live + window_days. Semantics depend on client instrumentation (currency, tax); not store ledger.",
+    "ledger_revenue_ios_sales_reports": "App Store Connect GET /v1/salesReports (SALES, DAILY, SUMMARY, 1_0) aggregated TSV columns when APPSTORE_CONNECT_VENDOR_NUMBER is set. Filtered to Apple Identifier 6758355312 when the report includes that column.",
+    "marketing_utm_signal": "Distinct persons with $pageview and utm_medium in (cpc, ppc, paid) \u2014 coarse paid-traffic proxy; not ad network attribution.",
     "posthog_executive": "HogQL scalars use audience_sql (PRAGMATIC_LIVE) and window_days except wqtu_7d_distinct_persons (fixed 7d). Filters exclude non\u2013store-production distribution_channel (testflight, non_play_install, dev, emulator, etc.), is_internal, debug/sim events; legacy events without distribution_channel stay included as 'legacy'. Optional POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS env. See posthog.metric_field_ids and posthog.audience_note.",
     "crashes": "Crashlytics BigQuery streaming export; posthog_exception_events is separate. crashlytics_bigquery.fatal_events_in_window is COUNT(*) of fatal rows in the lookback hours. fatal_events sums crash_count only within parsed top_fatal_issues (up to 10 rows displayed from top 20 SQL groups) \u2014 see metric_field_ids.",
     "uninstalls": "Not available on iOS; Android uninstall metrics require Play reporting APIs (not in this script yet).",
@@ -24,34 +27,38 @@
     "exclude_person_ids_configured": true,
     "window_days": 30,
     "errors": [],
-    "distinct_persons_application_installed": 464,
-    "distinct_persons_first_open": 439,
-    "timer_started_events": 1479,
+    "distinct_persons_application_installed": 469,
+    "distinct_persons_first_open": 444,
+    "timer_started_events": 1502,
     "timer_completed_events": 290,
-    "distinct_persons_timer_started": 383,
+    "distinct_persons_timer_started": 388,
     "distinct_persons_timer_completed": 47,
     "distinct_persons_timer_started_and_completed": 47,
     "wqtu_distinct_persons": 10,
     "wqtu_7d_distinct_persons": 8,
-    "timer_abandon_rate_event_level_pct": 80.39,
+    "timer_abandon_rate_event_level_pct": 80.69,
     "distinct_persons_paywall_purchase_success": 1,
     "events_paywall_purchase_success": 1,
     "distinct_persons_paywall_purchase_success_ios": 1,
     "distinct_persons_paywall_purchase_success_android": 0,
     "events_paywall_purchase_success_ios": 1,
     "events_paywall_purchase_success_android": 0,
+    "paywall_revenue_sum_event_properties": 0.0,
+    "paywall_viewed_distinct_persons": 345,
+    "paywall_purchaser_conversion_from_viewed_pct": 0.29,
+    "distinct_persons_pageview_utm_cpc_ppc_paid": 0,
     "in_app_review_prompt_events": 12,
     "in_app_review_prompt_distinct_persons": 12,
     "top_screens_by_distinct_persons": [
       [
         "Timer Setup",
-        462,
-        2810
+        466,
+        2842
       ],
       [
         "Active Timer",
-        378,
-        1896
+        383,
+        1928
       ]
     ],
     "posthog_exception_events": 0,
@@ -76,13 +83,26 @@
       "in_app_review_prompt_events": "posthog_hogql_count_events_review_prompt_requested",
       "in_app_review_prompt_distinct_persons": "posthog_hogql_distinct_persons_event_review_prompt_requested",
       "top_screens_by_distinct_persons": "posthog_hogql_top_screens_by_distinct_persons_limit_12_order_desc",
-      "posthog_exception_events": "posthog_hogql_count_events_dollar_exception"
+      "posthog_exception_events": "posthog_hogql_count_events_dollar_exception",
+      "paywall_revenue_sum_event_properties": "posthog_hogql_sum_coalesce_revenue_price_paywall_purchase_success",
+      "paywall_viewed_distinct_persons": "posthog_hogql_distinct_persons_paywall_viewed",
+      "paywall_purchaser_conversion_from_viewed_pct": "posthog_derived_distinct_purchasers_over_distinct_paywall_viewers_pct",
+      "distinct_persons_pageview_utm_cpc_ppc_paid": "posthog_hogql_distinct_persons_pageview_utm_medium_cpc_ppc_paid"
     }
   },
   "store_apis": {
     "android": {
-      "status": "error",
-      "reason": "credential error: Google Play key path is not a file (check GOOGLE_PLAY_JSON_KEY_PATH): <redacted>"
+      "status": "ok",
+      "review_count": 0,
+      "review_count_metric_id": "google_play_androidpublisher_reviews_list_7d_commented_paginated",
+      "production_release": {
+        "version_codes": [
+          "1775653001"
+        ],
+        "status": "completed",
+        "name": "v1775653001"
+      },
+      "note": "Play reviews.list: comment-bearing reviews created or modified in the last 7 days only; star-only ratings are excluded. Not equal to public Play review totals. No per-app download count in this API."
     },
     "ios": {
       "status": "ok",
@@ -123,9 +143,42 @@
       "note": "App Store Connect Sales reports require async report generation. customerReviews count is the first page only (limit 50, newest first), not total lifetime App Store reviews. Version state is live from the API."
     }
   },
+  "ledger_revenue": {
+    "ios_sales_reports_daily": {
+      "status": "skipped",
+      "reason": "APPSTORE_CONNECT_VENDOR_NUMBER not set",
+      "metric_bundle_id": "asc_sales_daily_summary_tsv_v1"
+    },
+    "android_play_billing": {
+      "status": "skipped",
+      "reason": "Play Console earnings not wired in executive snapshot (use Play financial exports)."
+    }
+  },
   "crashlytics_bigquery": {
-    "status": "error",
-    "reason": "GOOGLE_APPLICATION_CREDENTIALS points to a missing file (<redacted>). Set CRASHLYTICS_SERVICE_ACCOUNT_JSON or fix the path.",
-    "source": "crashlytics"
+    "status": "ok",
+    "source": "crashlytics_bigquery",
+    "metric_bundle_id": "crashlytics_bq_streaming_fatal_window_v1",
+    "metric_field_ids": {
+      "fatal_events": "crashlytics_bq_sum_crash_count_in_top_20_issue_groups_only_not_total_window",
+      "fatal_events_in_window": "crashlytics_bq_count_star_all_fatal_rows_in_lookback_window",
+      "top_fatal_issues": "crashlytics_bq_fatal_groups_limited_20_order_by_crash_count_desc",
+      "crash_free_pct": "crashlytics_bq_session_crash_free_rate_by_installation_uuid",
+      "total_users": "crashlytics_bq_distinct_installation_uuids_in_window",
+      "crash_free_users": "crashlytics_bq_installation_uuids_without_fatal_in_window",
+      "affected_users": "crashlytics_bq_total_users_minus_crash_free_users"
+    },
+    "project_id": "random-timer-dist-new",
+    "dataset": "firebase_crashlytics",
+    "package": "com.iganapolsky.randomtimer",
+    "hours": 168,
+    "table_id": null,
+    "fatal_events": 0,
+    "fatal_events_in_window": 0,
+    "affected_users": 0,
+    "total_users": 0,
+    "crash_free_users": 0,
+    "crash_free_pct": null,
+    "top_fatal_issues": [],
+    "reason": "BigQuery dataset exists but no tables yet"
   }
 }

--- a/marketing/data/executive_metrics.json
+++ b/marketing/data/executive_metrics.json
@@ -8,7 +8,7 @@
     "reviews_in_app": "PostHog review_prompt_requested / write_review_tapped (not published star count).",
     "paid_posthog": "In-app telemetry: paywall_purchase_success / paywall_purchase_result (not Play/App Store revenue). Compare posthog.events_paywall_purchase_success_ios vs _android (properties.platform). Ledger: App Store Connect + Google Play billing.",
     "paywall_revenue_event_properties": "Sum of coalesce(properties.revenue, properties.price) on paywall_purchase_success within pragmatic_live + window_days. Semantics depend on client instrumentation (currency, tax); not store ledger.",
-    "ledger_revenue_ios_sales_reports": "App Store Connect GET /v1/salesReports (SALES, DAILY, SUMMARY, 1_0) aggregated TSV columns when APPSTORE_CONNECT_VENDOR_NUMBER is set. Filtered to Apple Identifier 6758355312 when the report includes that column.",
+    "ledger_revenue_ios_sales_reports": "App Store Connect GET /v1/salesReports (SALES, DAILY, SUMMARY, 1_0) aggregated TSV columns when APPSTORE_VENDOR_NUMBER is set. Filtered to Apple Identifier 6758355312 when the report includes that column.",
     "marketing_utm_signal": "Distinct persons with $pageview and utm_medium in (cpc, ppc, paid) \u2014 coarse paid-traffic proxy; not ad network attribution.",
     "posthog_executive": "HogQL scalars use audience_sql (PRAGMATIC_LIVE) and window_days except wqtu_7d_distinct_persons (fixed 7d). Filters exclude non\u2013store-production distribution_channel (testflight, non_play_install, dev, emulator, etc.), is_internal, debug/sim events; legacy events without distribution_channel stay included as 'legacy'. Optional POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS env. See posthog.metric_field_ids and posthog.audience_note.",
     "crashes": "Crashlytics BigQuery streaming export; posthog_exception_events is separate. crashlytics_bigquery.fatal_events_in_window is COUNT(*) of fatal rows in the lookback hours. fatal_events sums crash_count only within parsed top_fatal_issues (up to 10 rows displayed from top 20 SQL groups) \u2014 see metric_field_ids.",
@@ -146,7 +146,7 @@
   "ledger_revenue": {
     "ios_sales_reports_daily": {
       "status": "skipped",
-      "reason": "APPSTORE_CONNECT_VENDOR_NUMBER not set",
+      "reason": "APPSTORE_VENDOR_NUMBER not set",
       "metric_bundle_id": "asc_sales_daily_summary_tsv_v1"
     },
     "android_play_billing": {

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -24,7 +24,7 @@ SCRIPTS = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPTS.parent
 sys.path.insert(0, str(SCRIPTS))
 
-from repo_dotenv import load_repo_dotenv
+from repo_dotenv import load_repo_dotenv  # noqa: E402
 
 # distribution_channel set by iOS/Android SDKs; legacy events omit it (treated as legacy).
 _DISTRIBUTION_EXCLUDE = (
@@ -397,7 +397,7 @@ def run(
             ),
             "ledger_revenue_ios_sales_reports": (
                 "App Store Connect GET /v1/salesReports (SALES, DAILY, SUMMARY, 1_0) aggregated TSV "
-                "columns when APPSTORE_CONNECT_VENDOR_NUMBER is set. Filtered to Apple Identifier "
+                "columns when APPSTORE_VENDOR_NUMBER is set. Filtered to Apple Identifier "
                 "6758355312 when the report includes that column."
             ),
             "marketing_utm_signal": (

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -109,6 +109,16 @@ POSTHOG_EXECUTIVE_METRIC_FIELD_IDS: Dict[str, str] = {
         "posthog_hogql_top_screens_by_distinct_persons_limit_12_order_desc"
     ),
     "posthog_exception_events": "posthog_hogql_count_events_dollar_exception",
+    "paywall_revenue_sum_event_properties": (
+        "posthog_hogql_sum_coalesce_revenue_price_paywall_purchase_success"
+    ),
+    "paywall_viewed_distinct_persons": "posthog_hogql_distinct_persons_paywall_viewed",
+    "paywall_purchaser_conversion_from_viewed_pct": (
+        "posthog_derived_distinct_purchasers_over_distinct_paywall_viewers_pct"
+    ),
+    "distinct_persons_pageview_utm_cpc_ppc_paid": (
+        "posthog_hogql_distinct_persons_pageview_utm_medium_cpc_ppc_paid"
+    ),
 }
 
 
@@ -159,6 +169,18 @@ def _posthog_section(project_id: str, api_key: str, days: int) -> Dict[str, Any]
             return None
         try:
             return int(row[0] or 0)
+        except (TypeError, ValueError):
+            return None
+
+    def scalar_float(sql: str) -> Optional[float]:
+        data = posthog_query(sql, api_key, project_id, errors)
+        if not data or not data.get("results"):
+            return None
+        row = data["results"][0]
+        if not row:
+            return None
+        try:
+            return float(row[0] or 0.0)
         except (TypeError, ValueError):
             return None
 
@@ -240,6 +262,26 @@ def _posthog_section(project_id: str, api_key: str, days: int) -> Dict[str, Any]
         f"SELECT count() FROM events WHERE event = 'paywall_purchase_success' "
         f"AND timestamp > now() - interval {win} AND {f} {pf_android}"
     )
+    out["paywall_revenue_sum_event_properties"] = scalar_float(
+        f"SELECT sum(toFloatOrZero(coalesce(toString(properties.revenue), toString(properties.price), '0'))) "
+        f"FROM events WHERE event = 'paywall_purchase_success' "
+        f"AND timestamp > now() - interval {win} AND {f}"
+    )
+    viewed_d = scalar(
+        f"SELECT count(DISTINCT person_id) FROM events WHERE event = 'paywall_viewed' "
+        f"AND timestamp > now() - interval {win} AND {f}"
+    )
+    out["paywall_viewed_distinct_persons"] = viewed_d
+    purchasers_d = out.get("distinct_persons_paywall_purchase_success")
+    if viewed_d and viewed_d > 0 and purchasers_d is not None:
+        out["paywall_purchaser_conversion_from_viewed_pct"] = round(
+            purchasers_d / viewed_d * 100, 2
+        )
+    out["distinct_persons_pageview_utm_cpc_ppc_paid"] = scalar(
+        f"SELECT count(DISTINCT person_id) FROM events WHERE event = '$pageview' "
+        f"AND timestamp > now() - interval {win} AND {f} AND "
+        f"lower(coalesce(toString(properties.utm_medium), '')) IN ('cpc', 'ppc', 'paid')"
+    )
     q_reviews = posthog_query(
         f"SELECT count(), count(DISTINCT person_id) FROM events WHERE event = 'review_prompt_requested' "
         f"AND timestamp > now() - interval {win} AND {f}",
@@ -314,6 +356,21 @@ def run(
     except Exception as exc:
         crashlytics = {"status": "error", "reason": str(exc), "source": "crashlytics"}
 
+    try:
+        from store_sales_ledger import fetch_ios_sales_daily_summary
+
+        ios_ledger = fetch_ios_sales_daily_summary(days)
+    except Exception as exc:
+        ios_ledger = {"status": "error", "reason": str(exc), "metric_bundle_id": "asc_sales_daily_summary_tsv_v1"}
+
+    ledger_revenue: Dict[str, Any] = {
+        "ios_sales_reports_daily": ios_ledger,
+        "android_play_billing": {
+            "status": "skipped",
+            "reason": "Play Console earnings not wired in executive snapshot (use Play financial exports).",
+        },
+    }
+
     payload: Dict[str, Any] = {
         "generated_at": generated_at,
         "source": "executive_metrics_snapshot",
@@ -332,6 +389,20 @@ def run(
                 "In-app telemetry: paywall_purchase_success / paywall_purchase_result (not Play/App Store "
                 "revenue). Compare posthog.events_paywall_purchase_success_ios vs _android "
                 "(properties.platform). Ledger: App Store Connect + Google Play billing."
+            ),
+            "paywall_revenue_event_properties": (
+                "Sum of coalesce(properties.revenue, properties.price) on paywall_purchase_success "
+                "within pragmatic_live + window_days. Semantics depend on client instrumentation "
+                "(currency, tax); not store ledger."
+            ),
+            "ledger_revenue_ios_sales_reports": (
+                "App Store Connect GET /v1/salesReports (SALES, DAILY, SUMMARY, 1_0) aggregated TSV "
+                "columns when APPSTORE_CONNECT_VENDOR_NUMBER is set. Filtered to Apple Identifier "
+                "6758355312 when the report includes that column."
+            ),
+            "marketing_utm_signal": (
+                "Distinct persons with $pageview and utm_medium in (cpc, ppc, paid) — coarse paid-traffic "
+                "proxy; not ad network attribution."
             ),
             "posthog_executive": (
                 "HogQL scalars use audience_sql (PRAGMATIC_LIVE) and window_days except "
@@ -354,6 +425,7 @@ def run(
         },
         "posthog": posthog,
         "store_apis": {"android": android, "ios": ios},
+        "ledger_revenue": ledger_revenue,
         "crashlytics_bigquery": crashlytics,
     }
 
@@ -400,6 +472,15 @@ def main() -> int:
             f"wqtu_{ph.get('window_days')}d={ph.get('wqtu_distinct_persons')} "
             f"wqtu_7d={ph.get('wqtu_7d_distinct_persons')}"
         )
+        print(
+            f"    revenue(proxy): sum_event_props={ph.get('paywall_revenue_sum_event_properties')} "
+            f"paywall_viewers={ph.get('paywall_viewed_distinct_persons')} "
+            f"conversion_vs_viewed_pct={ph.get('paywall_purchaser_conversion_from_viewed_pct')} "
+            f"utm_paid_viewers={ph.get('distinct_persons_pageview_utm_cpc_ppc_paid')}"
+        )
+    lr = payload.get("ledger_revenue") or {}
+    ios_l = (lr.get("ios_sales_reports_daily") or {}).get("status")
+    print(f"  Ledger iOS sales API: {ios_l}")
     st = payload.get("store_apis") or {}
     print(f"  Android API: {(st.get('android') or {}).get('status')}")
     print(f"  iOS API: {(st.get('ios') or {}).get('status')}")

--- a/scripts/posthog_dashboard.py
+++ b/scripts/posthog_dashboard.py
@@ -325,7 +325,7 @@ def _revenue_section(
     )
 
     purchase_revenue = _scalar_float(
-        f"SELECT sum(toFloat64OrZero(toString(coalesce(properties.revenue, properties.price, '0')))) "
+        f"SELECT sum(toFloatOrZero(coalesce(toString(properties.revenue), toString(properties.price), '0'))) "
         f"FROM events "
         f"WHERE event = 'paywall_purchase_success' "
         f"AND timestamp > now() - interval {win} AND {f}",

--- a/scripts/store_sales_ledger.py
+++ b/scripts/store_sales_ledger.py
@@ -2,7 +2,8 @@
 """Optional store ledger snippets for executive_metrics (not PostHog proxies).
 
 - iOS: App Store Connect Sales Reports API (daily SALES SUMMARY), when
-  APPSTORE_CONNECT_VENDOR_NUMBER is set alongside standard ASC auth env vars.
+  APPSTORE_VENDOR_NUMBER is set alongside standard ASC auth env vars.
+  APPSTORE_CONNECT_VENDOR_NUMBER is accepted as a legacy alias for local runs.
   Aggregates numeric columns across downloaded TSV reports for the lookback window.
 
 Does not print secrets. See docs/OPERATIONAL_RELIABILITY.md for proxy vs ledger rules.
@@ -29,6 +30,8 @@ for _p in (_SCRIPTS, _SCRIPTS / "asc"):
 IOS_APP_ID = "6758355312"
 
 ASC_SALES_METRIC_BUNDLE_ID = "asc_sales_daily_summary_tsv_v1"
+ASC_VENDOR_ENV = "APPSTORE_VENDOR_NUMBER"
+ASC_LEGACY_VENDOR_ENV = "APPSTORE_CONNECT_VENDOR_NUMBER"
 
 
 def _norm_header(h: str) -> str:
@@ -68,6 +71,16 @@ def _find_col(header: list[str], *candidates: str) -> int | None:
     return None
 
 
+def _vendor_number_from_env() -> tuple[str, str | None]:
+    vendor = (os.environ.get(ASC_VENDOR_ENV) or "").strip()
+    if vendor:
+        return vendor, ASC_VENDOR_ENV
+    legacy_vendor = (os.environ.get(ASC_LEGACY_VENDOR_ENV) or "").strip()
+    if legacy_vendor:
+        return legacy_vendor, ASC_LEGACY_VENDOR_ENV
+    return "", None
+
+
 def _float_cell(val: str) -> float:
     try:
         return float((val or "").replace(",", "").strip() or 0.0)
@@ -84,11 +97,11 @@ def _int_cell(val: str) -> int:
 
 def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
     """Sum units and money columns from ASC daily SALES SUMMARY reports."""
-    vendor = (os.environ.get("APPSTORE_CONNECT_VENDOR_NUMBER") or "").strip()
+    vendor, vendor_env = _vendor_number_from_env()
     if not vendor:
         return {
             "status": "skipped",
-            "reason": "APPSTORE_CONNECT_VENDOR_NUMBER not set",
+            "reason": f"{ASC_VENDOR_ENV} not set",
             "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
         }
 
@@ -212,6 +225,7 @@ def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
         "status": status,
         "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
         "vendor_configured": True,
+        "vendor_env": vendor_env,
         "window_days_requested": days,
         "days_with_nonzero_rows": days_with_data,
         "sum_units": sum_units,

--- a/scripts/store_sales_ledger.py
+++ b/scripts/store_sales_ledger.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Optional store ledger snippets for executive_metrics (not PostHog proxies).
+
+- iOS: App Store Connect Sales Reports API (daily SALES SUMMARY), when
+  APPSTORE_CONNECT_VENDOR_NUMBER is set alongside standard ASC auth env vars.
+  Aggregates numeric columns across downloaded TSV reports for the lookback window.
+
+Does not print secrets. See docs/OPERATIONAL_RELIABILITY.md for proxy vs ledger rules.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import gzip
+import io
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parent
+for _p in (_SCRIPTS, _SCRIPTS / "asc"):
+    _s = str(_p)
+    if _s not in sys.path:
+        sys.path.insert(0, _s)
+
+IOS_APP_ID = "6758355312"
+
+ASC_SALES_METRIC_BUNDLE_ID = "asc_sales_daily_summary_tsv_v1"
+
+
+def _norm_header(h: str) -> str:
+    return re.sub(r"\s+", " ", (h or "").strip().lower())
+
+
+def _parse_sales_tsv_rows(text: str) -> tuple[list[str], list[list[str]]]:
+    """Apple sales files are typically tab-separated with a header row."""
+    sample = text[:4096]
+    delim = "\t" if sample.count("\t") >= sample.count(",") else ","
+    reader = csv.reader(io.StringIO(text), delimiter=delim)
+    rows = list(reader)
+    if not rows:
+        return [], []
+    header = [_norm_header(c) for c in rows[0]]
+    data = [r for r in rows[1:] if any((c or "").strip() for c in r)]
+    return header, data
+
+
+def _find_col(header: list[str], *candidates: str) -> int | None:
+    cand = {_norm_header(c) for c in candidates}
+    for i, h in enumerate(header):
+        if h in cand:
+            return i
+        for c in cand:
+            if c in h or h in c:
+                return i
+    return None
+
+
+def _float_cell(val: str) -> float:
+    try:
+        return float((val or "").replace(",", "").strip() or 0.0)
+    except ValueError:
+        return 0.0
+
+
+def _int_cell(val: str) -> int:
+    try:
+        return int(float((val or "").replace(",", "").strip() or 0))
+    except ValueError:
+        return 0
+
+
+def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
+    """Sum units and money columns from ASC daily SALES SUMMARY reports."""
+    vendor = (os.environ.get("APPSTORE_CONNECT_VENDOR_NUMBER") or "").strip()
+    if not vendor:
+        return {
+            "status": "skipped",
+            "reason": "APPSTORE_CONNECT_VENDOR_NUMBER not set",
+            "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
+        }
+
+    try:
+        import requests
+    except ImportError:
+        return {
+            "status": "skipped",
+            "reason": "requests not installed",
+            "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
+        }
+
+    try:
+        from asc_client import APP_STORE_CONNECT_API, ASCAuth
+    except ImportError:
+        return {
+            "status": "skipped",
+            "reason": "asc_client not importable",
+            "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
+        }
+
+    try:
+        auth = ASCAuth.from_env()
+    except Exception as exc:
+        return {
+            "status": "skipped",
+            "reason": str(exc),
+            "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
+        }
+
+    headers = {
+        "Authorization": f"Bearer {auth.jwt()}",
+        "Content-Type": "application/json",
+    }
+
+    today = dt.date.today()
+    sum_proceeds = 0.0
+    sum_customer = 0.0
+    sum_units = 0
+    days_with_data = 0
+    http_errors: list[str] = []
+    parse_errors: list[str] = []
+
+    for i in range(1, days + 1):
+        report_day = today - dt.timedelta(days=i)
+        report_date = report_day.isoformat()
+        params = {
+            "filter[reportType]": "SALES",
+            "filter[frequency]": "DAILY",
+            "filter[reportSubType]": "SUMMARY",
+            "filter[version]": "1_0",
+            "filter[vendorNumber]": vendor,
+            "filter[reportDate]": report_date,
+        }
+        try:
+            list_resp = requests.get(
+                f"{APP_STORE_CONNECT_API}/salesReports",
+                headers=headers,
+                params=params,
+                timeout=90,
+            )
+        except Exception as exc:
+            http_errors.append(f"{report_date}: request {exc}")
+            continue
+
+        if list_resp.status_code == 404:
+            continue
+        if list_resp.status_code >= 300:
+            http_errors.append(f"{report_date}: HTTP {list_resp.status_code}")
+            continue
+
+        try:
+            body = list_resp.json()
+        except Exception as exc:
+            http_errors.append(f"{report_date}: json {exc}")
+            continue
+
+        data = body.get("data") or []
+        if not data:
+            continue
+
+        attrs = (data[0] or {}).get("attributes") or {}
+        url = (attrs.get("url") or "").strip()
+        if not url:
+            continue
+
+        try:
+            blob_resp = requests.get(url, timeout=120)
+        except Exception as exc:
+            http_errors.append(f"{report_date}: download {exc}")
+            continue
+
+        if blob_resp.status_code >= 300:
+            http_errors.append(f"{report_date}: download HTTP {blob_resp.status_code}")
+            continue
+
+        raw = blob_resp.content
+        try:
+            text = gzip.decompress(raw).decode("utf-8-sig")
+        except OSError:
+            text = raw.decode("utf-8-sig", errors="replace")
+
+        try:
+            hdr, rows = _parse_sales_tsv_rows(text)
+            if not hdr:
+                parse_errors.append(f"{report_date}: empty header")
+                continue
+            idx_units = _find_col(hdr, "units", "quantity", "qty")
+            idx_proceeds = _find_col(
+                hdr,
+                "developer proceeds",
+                "proceeds",
+                "partner share",
+                "earnings",
+            )
+            idx_customer = _find_col(hdr, "customer price", "end customer price")
+            day_units = 0
+            day_proceeds = 0.0
+            day_customer = 0.0
+            app_col = _find_col(hdr, "apple identifier", "app apple id", "parent identifier")
+            for row in rows:
+                if app_col is not None and app_col < len(row):
+                    cell = (row[app_col] or "").strip()
+                    if cell and cell != IOS_APP_ID:
+                        continue
+                if idx_units is not None and idx_units < len(row):
+                    day_units += _int_cell(row[idx_units])
+                if idx_proceeds is not None and idx_proceeds < len(row):
+                    day_proceeds += _float_cell(row[idx_proceeds])
+                if idx_customer is not None and idx_customer < len(row):
+                    day_customer += _float_cell(row[idx_customer])
+            if day_units or day_proceeds or day_customer:
+                days_with_data += 1
+            sum_units += day_units
+            sum_proceeds += day_proceeds
+            sum_customer += day_customer
+        except Exception as exc:
+            parse_errors.append(f"{report_date}: {exc}")
+
+    note = (
+        "Ledger from App Store Connect salesReports (SALES, DAILY, SUMMARY, 1_0). "
+        "Sums TSV columns matching developer proceeds / customer price / units when present; "
+        f"filtered to Apple identifier {IOS_APP_ID} when a matching column exists. "
+        "Territory/tax timing per Apple reporting; not bank settlement."
+    )
+
+    out: dict[str, Any] = {
+        "status": "ok",
+        "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
+        "vendor_configured": True,
+        "window_days_requested": days,
+        "days_with_nonzero_rows": days_with_data,
+        "sum_units": sum_units,
+        "sum_developer_proceeds_or_partner_share": round(sum_proceeds, 4)
+        if sum_proceeds
+        else sum_proceeds,
+        "sum_customer_price": round(sum_customer, 4) if sum_customer else sum_customer,
+        "note": note,
+    }
+    if http_errors:
+        out["http_errors_sample"] = http_errors[:15]
+    if parse_errors:
+        out["parse_errors_sample"] = parse_errors[:15]
+    if days_with_data == 0 and not http_errors and not parse_errors:
+        out["note"] += " No report rows in window (or no sales yet)."
+    return out

--- a/scripts/store_sales_ledger.py
+++ b/scripts/store_sales_ledger.py
@@ -57,12 +57,13 @@ def _decode_sales_report_body(raw: bytes) -> str:
 
 
 def _find_col(header: list[str], *candidates: str) -> int | None:
-    cand = {_norm_header(c) for c in candidates}
+    cand = [_norm_header(c) for c in candidates]
     for i, h in enumerate(header):
         if h in cand:
             return i
+    for i, h in enumerate(header):
         for c in cand:
-            if c in h or h in c:
+            if c and h.startswith(f"{c} "):
                 return i
     return None
 

--- a/scripts/store_sales_ledger.py
+++ b/scripts/store_sales_ledger.py
@@ -48,6 +48,14 @@ def _parse_sales_tsv_rows(text: str) -> tuple[list[str], list[list[str]]]:
     return header, data
 
 
+def _decode_sales_report_body(raw: bytes) -> str:
+    """ASC salesReports returns gzip bytes on success, but keep TSV fallback tolerant."""
+    try:
+        return gzip.decompress(raw).decode("utf-8-sig")
+    except OSError:
+        return raw.decode("utf-8-sig", errors="replace")
+
+
 def _find_col(header: list[str], *candidates: str) -> int | None:
     cand = {_norm_header(c) for c in candidates}
     for i, h in enumerate(header):
@@ -110,11 +118,6 @@ def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
             "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
         }
 
-    headers = {
-        "Authorization": f"Bearer {auth.jwt()}",
-        "Content-Type": "application/json",
-    }
-
     today = dt.date.today()
     sum_proceeds = 0.0
     sum_customer = 0.0
@@ -135,6 +138,10 @@ def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
             "filter[reportDate]": report_date,
         }
         try:
+            headers = {
+                "Authorization": f"Bearer {auth.jwt()}",
+                "Accept": "application/a-gzip",
+            }
             list_resp = requests.get(
                 f"{APP_STORE_CONNECT_API}/salesReports",
                 headers=headers,
@@ -152,37 +159,7 @@ def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
             continue
 
         try:
-            body = list_resp.json()
-        except Exception as exc:
-            http_errors.append(f"{report_date}: json {exc}")
-            continue
-
-        data = body.get("data") or []
-        if not data:
-            continue
-
-        attrs = (data[0] or {}).get("attributes") or {}
-        url = (attrs.get("url") or "").strip()
-        if not url:
-            continue
-
-        try:
-            blob_resp = requests.get(url, timeout=120)
-        except Exception as exc:
-            http_errors.append(f"{report_date}: download {exc}")
-            continue
-
-        if blob_resp.status_code >= 300:
-            http_errors.append(f"{report_date}: download HTTP {blob_resp.status_code}")
-            continue
-
-        raw = blob_resp.content
-        try:
-            text = gzip.decompress(raw).decode("utf-8-sig")
-        except OSError:
-            text = raw.decode("utf-8-sig", errors="replace")
-
-        try:
+            text = _decode_sales_report_body(list_resp.content)
             hdr, rows = _parse_sales_tsv_rows(text)
             if not hdr:
                 parse_errors.append(f"{report_date}: empty header")
@@ -226,8 +203,12 @@ def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
         "Territory/tax timing per Apple reporting; not bank settlement."
     )
 
+    status = "ok"
+    if http_errors or parse_errors:
+        status = "partial" if days_with_data else "error"
+
     out: dict[str, Any] = {
-        "status": "ok",
+        "status": status,
         "metric_bundle_id": ASC_SALES_METRIC_BUNDLE_ID,
         "vendor_configured": True,
         "window_days_requested": days,
@@ -245,4 +226,8 @@ def fetch_ios_sales_daily_summary(days: int) -> dict[str, Any]:
         out["parse_errors_sample"] = parse_errors[:15]
     if days_with_data == 0 and not http_errors and not parse_errors:
         out["note"] += " No report rows in window (or no sales yet)."
+    elif status == "partial":
+        out["note"] += " Ledger collection partially succeeded; error samples are attached."
+    elif status == "error":
+        out["note"] += " Ledger collection failed for every non-empty requested report; error samples are attached."
     return out

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -40,6 +40,12 @@ def test_posthog_section_includes_metric_field_ids_when_ok(monkeypatch: pytest.M
             return {"results": [[0, 0]]}
         if "$screen" in query:
             return {"results": []}
+        if "paywall_viewed" in query and "count(DISTINCT person_id)" in query:
+            return {"results": [[5]]}
+        if "sum(toFloatOrZero(coalesce(toString(properties.revenue)" in query:
+            return {"results": [[19.99]]}
+        if "$pageview" in query and "utm_medium" in query:
+            return {"results": [[2]]}
         return {"results": [[0]]}
 
     monkeypatch.setattr(sds, "posthog_query", fake_posthog_query)
@@ -56,6 +62,12 @@ def test_posthog_section_includes_metric_field_ids_when_ok(monkeypatch: pytest.M
     )
     assert out.get("events_paywall_purchase_success_ios") == 0
     assert out.get("distinct_persons_paywall_purchase_success_android") == 0
+    assert out.get("paywall_revenue_sum_event_properties") == 19.99
+    assert out.get("paywall_viewed_distinct_persons") == 5
+    assert out.get("paywall_purchaser_conversion_from_viewed_pct") == 0.0
+    assert out.get("distinct_persons_pageview_utm_cpc_ppc_paid") == 2
+    mf2 = out.get("metric_field_ids") or {}
+    assert mf2.get("paywall_revenue_sum_event_properties")
 
 
 def test_pragmatic_live_excludes_non_store_distribution_channels() -> None:
@@ -111,6 +123,12 @@ def test_posthog_section_includes_wqtu_7d_from_queries(monkeypatch: pytest.Monke
             return {"results": [[1, 1]]}
         if "$screen" in query:
             return {"results": [["Timer Setup", 2, 3]]}
+        if "paywall_viewed" in query and "count(DISTINCT person_id)" in query:
+            return {"results": [[10]]}
+        if "sum(toFloatOrZero(coalesce(toString(properties.revenue)" in query:
+            return {"results": [[0.0]]}
+        if "$pageview" in query and "utm_medium" in query:
+            return {"results": [[0]]}
         return {"results": [[0]]}
 
     monkeypatch.setattr(sds, "posthog_query", fake_posthog_query)

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -62,9 +62,9 @@ def test_posthog_section_includes_metric_field_ids_when_ok(monkeypatch: pytest.M
     )
     assert out.get("events_paywall_purchase_success_ios") == 0
     assert out.get("distinct_persons_paywall_purchase_success_android") == 0
-    assert out.get("paywall_revenue_sum_event_properties") == 19.99
+    assert out.get("paywall_revenue_sum_event_properties") == pytest.approx(19.99)
     assert out.get("paywall_viewed_distinct_persons") == 5
-    assert out.get("paywall_purchaser_conversion_from_viewed_pct") == 0.0
+    assert out.get("paywall_purchaser_conversion_from_viewed_pct") == pytest.approx(0.0)
     assert out.get("distinct_persons_pageview_utm_cpc_ppc_paid") == 2
     mf2 = out.get("metric_field_ids") or {}
     assert mf2.get("paywall_revenue_sum_event_properties")

--- a/scripts/tests/test_store_sales_ledger.py
+++ b/scripts/tests/test_store_sales_ledger.py
@@ -24,6 +24,15 @@ def test_parse_sales_tsv_tab_separated_sums() -> None:
     assert len(rows) == 2
 
 
+def test_find_col_prefers_exact_match_and_rejects_ambiguous_substrings() -> None:
+    from scripts.store_sales_ledger import _find_col
+
+    assert _find_col(["gross proceeds", "developer proceeds"], "developer proceeds", "proceeds") == 1
+    assert _find_col(["developer proceeds usd"], "developer proceeds") == 0
+    assert _find_col(["gross proceeds"], "proceeds") is None
+    assert _find_col(["net units"], "units") is None
+
+
 def test_fetch_ios_sales_skipped_without_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import store_sales_ledger as ssl
 

--- a/scripts/tests/test_store_sales_ledger.py
+++ b/scripts/tests/test_store_sales_ledger.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-import os
+import gzip
+import sys
+import types
 
 import pytest
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes = b"") -> None:
+        self.status_code = status_code
+        self.content = content
 
 
 def test_parse_sales_tsv_tab_separated_sums() -> None:
@@ -41,3 +49,124 @@ def test_fetch_ios_sales_skipped_when_vendor_only_no_asc(
     monkeypatch.delenv("APPSTORE_PRIVATE_KEY_PATH", raising=False)
     out = ssl.fetch_ios_sales_daily_summary(1)
     assert out["status"] in {"skipped", "error"}
+
+
+def test_fetch_ios_sales_parses_direct_gzip_report_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import store_sales_ledger as ssl
+
+    auth_calls: list[str] = []
+
+    class FakeASCAuth:
+        @classmethod
+        def from_env(cls) -> types.SimpleNamespace:
+            return types.SimpleNamespace(jwt=lambda: auth_calls.append("jwt") or "token")
+
+    def fake_get(url: str, **kwargs: object) -> _FakeResponse:
+        assert url.endswith("/salesReports")
+        assert kwargs["headers"] == {
+            "Authorization": "Bearer token",
+            "Accept": "application/a-gzip",
+        }
+        body = (
+            "Units\tDeveloper Proceeds\tCustomer Price\tApple Identifier\n"
+            "2\t1.50\t3.00\t6758355312\n"
+            "9\t7.00\t8.00\t1111111111\n"
+        )
+        return _FakeResponse(200, gzip.compress(body.encode("utf-8")))
+
+    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setitem(
+        sys.modules,
+        "asc_client",
+        types.SimpleNamespace(
+            APP_STORE_CONNECT_API="https://api.appstoreconnect.apple.com/v1",
+            ASCAuth=FakeASCAuth,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "requests", types.SimpleNamespace(get=fake_get))
+
+    out = ssl.fetch_ios_sales_daily_summary(1)
+
+    assert out["status"] == "ok"
+    assert out["days_with_nonzero_rows"] == 1
+    assert out["sum_units"] == 2
+    assert out["sum_developer_proceeds_or_partner_share"] == 1.5
+    assert out["sum_customer_price"] == 3.0
+    assert auth_calls == ["jwt"]
+
+
+def test_fetch_ios_sales_all_failures_return_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import store_sales_ledger as ssl
+
+    class FakeASCAuth:
+        @classmethod
+        def from_env(cls) -> types.SimpleNamespace:
+            return types.SimpleNamespace(jwt=lambda: "token")
+
+    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setitem(
+        sys.modules,
+        "asc_client",
+        types.SimpleNamespace(
+            APP_STORE_CONNECT_API="https://api.appstoreconnect.apple.com/v1",
+            ASCAuth=FakeASCAuth,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        types.SimpleNamespace(get=lambda *_args, **_kwargs: _FakeResponse(500, b"error")),
+    )
+
+    out = ssl.fetch_ios_sales_daily_summary(2)
+
+    assert out["status"] == "error"
+    assert out["days_with_nonzero_rows"] == 0
+    assert len(out["http_errors_sample"]) == 2
+    assert all("HTTP 500" in err for err in out["http_errors_sample"])
+
+
+def test_fetch_ios_sales_some_failures_return_partial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import store_sales_ledger as ssl
+
+    class FakeASCAuth:
+        @classmethod
+        def from_env(cls) -> types.SimpleNamespace:
+            return types.SimpleNamespace(jwt=lambda: "token")
+
+    calls = 0
+
+    def fake_get(_url: str, **_kwargs: object) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            body = (
+                "Units\tDeveloper Proceeds\tCustomer Price\tApple Identifier\n"
+                "1\t0.75\t1.99\t6758355312\n"
+            )
+            return _FakeResponse(200, gzip.compress(body.encode("utf-8")))
+        return _FakeResponse(503, b"unavailable")
+
+    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setitem(
+        sys.modules,
+        "asc_client",
+        types.SimpleNamespace(
+            APP_STORE_CONNECT_API="https://api.appstoreconnect.apple.com/v1",
+            ASCAuth=FakeASCAuth,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "requests", types.SimpleNamespace(get=fake_get))
+
+    out = ssl.fetch_ios_sales_daily_summary(2)
+
+    assert out["status"] == "partial"
+    assert out["days_with_nonzero_rows"] == 1
+    assert out["sum_units"] == 1
+    assert out["http_errors_sample"] and "HTTP 503" in out["http_errors_sample"][0]

--- a/scripts/tests/test_store_sales_ledger.py
+++ b/scripts/tests/test_store_sales_ledger.py
@@ -92,8 +92,8 @@ def test_fetch_ios_sales_parses_direct_gzip_report_body(
     assert out["status"] == "ok"
     assert out["days_with_nonzero_rows"] == 1
     assert out["sum_units"] == 2
-    assert out["sum_developer_proceeds_or_partner_share"] == 1.5
-    assert out["sum_customer_price"] == 3.0
+    assert out["sum_developer_proceeds_or_partner_share"] == pytest.approx(1.5)
+    assert out["sum_customer_price"] == pytest.approx(3.0)
     assert auth_calls == ["jwt"]
 
 

--- a/scripts/tests/test_store_sales_ledger.py
+++ b/scripts/tests/test_store_sales_ledger.py
@@ -36,6 +36,7 @@ def test_find_col_prefers_exact_match_and_rejects_ambiguous_substrings() -> None
 def test_fetch_ios_sales_skipped_without_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import store_sales_ledger as ssl
 
+    monkeypatch.delenv("APPSTORE_VENDOR_NUMBER", raising=False)
     monkeypatch.delenv("APPSTORE_CONNECT_VENDOR_NUMBER", raising=False)
     out = ssl.fetch_ios_sales_daily_summary(7)
     assert out["status"] == "skipped"
@@ -47,7 +48,7 @@ def test_fetch_ios_sales_skipped_when_vendor_only_no_asc(
 ) -> None:
     from scripts import store_sales_ledger as ssl
 
-    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setenv("APPSTORE_VENDOR_NUMBER", "12345678")
     for k in (
         "APPSTORE_KEY_ID",
         "APPSTORE_ISSUER_ID",
@@ -85,7 +86,7 @@ def test_fetch_ios_sales_parses_direct_gzip_report_body(
         )
         return _FakeResponse(200, gzip.compress(body.encode("utf-8")))
 
-    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setenv("APPSTORE_VENDOR_NUMBER", "12345678")
     monkeypatch.setitem(
         sys.modules,
         "asc_client",
@@ -106,6 +107,20 @@ def test_fetch_ios_sales_parses_direct_gzip_report_body(
     assert auth_calls == ["jwt"]
 
 
+def test_fetch_ios_sales_accepts_legacy_connect_vendor_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import store_sales_ledger as ssl
+
+    monkeypatch.delenv("APPSTORE_VENDOR_NUMBER", raising=False)
+    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+
+    vendor, env_name = ssl._vendor_number_from_env()
+
+    assert vendor == "12345678"
+    assert env_name == "APPSTORE_CONNECT_VENDOR_NUMBER"
+
+
 def test_fetch_ios_sales_all_failures_return_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -116,7 +131,7 @@ def test_fetch_ios_sales_all_failures_return_error(
         def from_env(cls) -> types.SimpleNamespace:
             return types.SimpleNamespace(jwt=lambda: "token")
 
-    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setenv("APPSTORE_VENDOR_NUMBER", "12345678")
     monkeypatch.setitem(
         sys.modules,
         "asc_client",
@@ -162,7 +177,7 @@ def test_fetch_ios_sales_some_failures_return_partial(
             return _FakeResponse(200, gzip.compress(body.encode("utf-8")))
         return _FakeResponse(503, b"unavailable")
 
-    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    monkeypatch.setenv("APPSTORE_VENDOR_NUMBER", "12345678")
     monkeypatch.setitem(
         sys.modules,
         "asc_client",

--- a/scripts/tests/test_store_sales_ledger.py
+++ b/scripts/tests/test_store_sales_ledger.py
@@ -1,0 +1,43 @@
+"""Tests for App Store sales TSV parsing helpers."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def test_parse_sales_tsv_tab_separated_sums() -> None:
+    from scripts.store_sales_ledger import _parse_sales_tsv_rows
+
+    text = "Units\tDeveloper Proceeds\tApple Identifier\n2\t9.99\t6758355312\n1\t4.99\t6758355312\n"
+    hdr, rows = _parse_sales_tsv_rows(text)
+    assert "units" in hdr
+    assert len(rows) == 2
+
+
+def test_fetch_ios_sales_skipped_without_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import store_sales_ledger as ssl
+
+    monkeypatch.delenv("APPSTORE_CONNECT_VENDOR_NUMBER", raising=False)
+    out = ssl.fetch_ios_sales_daily_summary(7)
+    assert out["status"] == "skipped"
+    assert "VENDOR" in (out.get("reason") or "").upper()
+
+
+def test_fetch_ios_sales_skipped_when_vendor_only_no_asc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import store_sales_ledger as ssl
+
+    monkeypatch.setenv("APPSTORE_CONNECT_VENDOR_NUMBER", "12345678")
+    for k in (
+        "APPSTORE_KEY_ID",
+        "APPSTORE_ISSUER_ID",
+        "APPSTORE_PRIVATE_KEY",
+        "APP_STORE_CONNECT_KEY_B64",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.delenv("APPSTORE_PRIVATE_KEY_PATH", raising=False)
+    out = ssl.fetch_ios_sales_daily_summary(1)
+    assert out["status"] in {"skipped", "error"}

--- a/scripts/verify_elevenlabs_voices.py
+++ b/scripts/verify_elevenlabs_voices.py
@@ -26,6 +26,8 @@ SUPPORTED_VOICE_ENDPOINTS = {
     "DGzg6RaUqxGRTHSBjfgF": f"{API_BASE_URL}/v1/text-to-speech/DGzg6RaUqxGRTHSBjfgF?output_format={OUTPUT_FORMAT}",
     "AZnzlk1XvdvUeBnXmlld": f"{API_BASE_URL}/v1/text-to-speech/AZnzlk1XvdvUeBnXmlld?output_format={OUTPUT_FORMAT}",
     "sS5fXGlqomdGXa7mxBcy": f"{API_BASE_URL}/v1/text-to-speech/sS5fXGlqomdGXa7mxBcy?output_format={OUTPUT_FORMAT}",
+    "EXAVITQu4vr4xnSDxMaL": f"{API_BASE_URL}/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL?output_format={OUTPUT_FORMAT}",
+    "gE0owC0H9C8SzfDyIUtB": f"{API_BASE_URL}/v1/text-to-speech/gE0owC0H9C8SzfDyIUtB?output_format={OUTPUT_FORMAT}",
 }
 
 


### PR DESCRIPTION
### Summary
- **PostHog (executive snapshot):** paywall revenue sum from event properties (uses `toFloatOrZero` — PostHog no longer accepts `toFloat64OrZero`), paywall viewers, purchaser conversion vs viewers, coarse UTM paid pageview distinct persons.
- **Ledger:** `ledger_revenue.ios_sales_reports_daily` via App Store Connect Sales Reports API when `APPSTORE_CONNECT_VENDOR_NUMBER` is set; Android documented as skipped (Play financial exports).
- **CI:** `executive-metrics.yml` passes optional `APPSTORE_CONNECT_VENDOR_NUMBER` and `APP_STORE_CONNECT_KEY_B64`.
- **Docs:** `marketing/data/README.md` updated.
- **Also:** `posthog_dashboard.py` revenue HogQL aligned with PostHog.

### Evidence
- `python3 -m pytest scripts/tests/test_executive_metrics_snapshot.py scripts/tests/test_store_sales_ledger.py scripts/tests/test_workflow_yaml_syntax.py -q` — pass.
- Local `python3 scripts/executive_metrics_snapshot.py` regenerated `marketing/data/executive_metrics.json`.

### CEO follow-up
Add repo secret **`APPSTORE_CONNECT_VENDOR_NUMBER`** (and ensure ASC key secrets) to populate iOS ledger in CI artifacts.

Made with [Cursor](https://cursor.com)