### PR TITLE
fix(ci): allow direct Firebase tester signoff with empty group

### DIFF
--- a/scripts/ensure_internal_distribution.py
+++ b/scripts/ensure_internal_distribution.py
@@ -315,14 +315,23 @@ class FirebaseInternalDistributor:
                 )
 
             group_summaries: list[str] = []
+            group_warnings: list[str] = []
             for alias in group_aliases:
                 group = self._get_group(alias)
                 tester_count = int(group.get("testerCount", 0))
                 release_count = int(group.get("releaseCount", 0))
                 if tester_count <= 0:
-                    return _error(f"Firebase group '{alias}' has no testers")
+                    message = f"Firebase group '{alias}' has no testers"
+                    if direct_tester_emails:
+                        group_warnings.append(message)
+                        continue
+                    return _error(message)
                 if release_count <= 0:
-                    return _error(f"Firebase group '{alias}' has no accessible releases")
+                    message = f"Firebase group '{alias}' has no accessible releases"
+                    if direct_tester_emails:
+                        group_warnings.append(message)
+                        continue
+                    return _error(message)
                 group_summaries.append(f"{alias}(testers={tester_count}, releases={release_count})")
 
             direct_summary = (
@@ -342,6 +351,7 @@ class FirebaseInternalDistributor:
                     f"Firebase release {release.get('displayVersion', '?')} ({release.get('buildVersion', '?')}) "
                     f"is distributed. Firebase distribute API accepted the release; {direct_summary}. "
                     f"Groups verified: {', '.join(group_summaries) if group_summaries else 'none'}"
+                    f"{'; group warnings: ' + '; '.join(group_warnings) if group_warnings else ''}"
                     f"{propagation_summary}."
                 ),
             }

--- a/scripts/tests/test_ensure_internal_distribution.py
+++ b/scripts/tests/test_ensure_internal_distribution.py
@@ -115,6 +115,13 @@ class _FakeRequestsWithoutProjectTesters(_FakeRequests):
         return super().request(method, url, headers=headers, params=params, json=json, timeout=timeout)
 
 
+class _FakeRequestsWithEmptyGroup(_FakeRequests):
+    def request(self, method, url, headers=None, params=None, json=None, timeout=None):
+        if url.endswith("/groups/internal-testers"):
+            return _FakeResponse({"name": "projects/712918404489/groups/internal-testers", "testerCount": 0, "releaseCount": 4})
+        return super().request(method, url, headers=headers, params=params, json=json, timeout=timeout)
+
+
 def _firebase_verifier(fake_requests):
     verifier = eid.FirebaseInternalDistributor(
         app_id="1:712918404489:android:abc",
@@ -157,6 +164,15 @@ def test_firebase_internal_distribution_allows_project_tester_list_propagation_d
     assert result["passed"] is True
     assert result["status"] == "VISIBLE"
     assert "project tester list pending" in result["details"]
+    assert "direct tester distribution accepted for 1 tester" in result["details"]
+
+
+def test_firebase_internal_distribution_allows_empty_group_when_direct_tester_delivery_succeeded():
+    result = _ensure_firebase(_FakeRequestsWithEmptyGroup())
+
+    assert result["passed"] is True
+    assert result["status"] == "VISIBLE"
+    assert "group warnings: Firebase group 'internal-testers' has no testers" in result["details"]
     assert "direct tester distribution accepted for 1 tester" in result["details"]
 
 


### PR DESCRIPTION
## Summary\n- Treat successful direct Firebase tester distribution as sufficient signoff proof when the optional Firebase group alias exists but currently has zero testers.\n- Keep failing when no direct tester target exists and the group is empty.\n- Add regression coverage for the exact internal-distribution failure from run 24269311355.\n\n## Evidence\n- Firebase run 24269311355 uploaded release 1.3.19 (586), distributed to direct testers, then failed read-back only because group internal-testers had 0 testers.\n- uv run pytest -q scripts/tests/test_ensure_internal_distribution.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_workflow_security_contracts.py -> 42 passed\n- python3 scripts/regression_guards.py --mode ci -> regression_guards: ok\n- git diff --check -> clean