### PR TITLE
fix(ci): harden workflow input handling

### DIFF
--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -42,12 +42,14 @@ jobs:
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new
+          POSTHOG_DAYS: ${{ inputs.posthog_days }}
+          CRASHLYTICS_HOURS: ${{ inputs.crashlytics_hours }}
         run: |
           set -euo pipefail
           python3 scripts/executive_metrics_snapshot.py \
             --repo-root . \
-            --days "${{ inputs.posthog_days }}" \
-            --crashlytics-hours "${{ inputs.crashlytics_hours }}" \
+            --days "$POSTHOG_DAYS" \
+            --crashlytics-hours "$CRASHLYTICS_HOURS" \
             --no-dotenv
 
       - uses: actions/upload-artifact@v7.0.0

--- a/.github/workflows/ios-remove-from-review.yml
+++ b/.github/workflows/ios-remove-from-review.yml
@@ -59,6 +59,7 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
+          IOS_VERSION: ${{ inputs.version }}
           WAIT_FOR_EDITABLE: ${{ inputs.wait }}
         run: |
           EXTRA_ARGS=()
@@ -66,7 +67,7 @@ jobs:
             EXTRA_ARGS+=(--wait)
           fi
           python scripts/asc/asc_remove_from_review.py \
-            --version "${{ inputs.version }}" \
+            --version "$IOS_VERSION" \
             "${EXTRA_ARGS[@]}" \
             --json-out /tmp/asc_remove_from_review.json
           cat /tmp/asc_remove_from_review.json

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -224,6 +224,7 @@ jobs:
           APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
           LOCALE: ${{ inputs.locale }}
           IOS_VERSION: ${{ steps.asc_version.outputs.selected_version }}
+          ATTACH_SUBSCRIPTIONS: ${{ inputs.attach_subscriptions }}
         run: |
           if ! echo "$LOCALE" | grep -Eq '^[A-Za-z]{2}(-[A-Za-z]{2})?$'; then
             echo "❌ Invalid locale input (expected e.g. en-US): $LOCALE"
@@ -234,7 +235,7 @@ jobs:
             exit 1
           fi
           EXTRA_FLAGS=""
-          if [[ "${{ inputs.attach_subscriptions }}" == "true" ]]; then
+          if [[ "$ATTACH_SUBSCRIPTIONS" == "true" ]]; then
             EXTRA_FLAGS="--skip-build-check"
           fi
           python scripts/asc/asc_verify_ready.py \

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -77,11 +77,12 @@ jobs:
       - name: Read commit status proofs for release SHA
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_PLATFORM: ${{ inputs.platform }}
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/status" > /tmp/internal-signoff-status.json
           python scripts/internal_signoff_gate.py \
-            --platform "${{ inputs.platform }}" \
+            --platform "$RELEASE_PLATFORM" \
             --statuses-json /tmp/internal-signoff-status.json
 
   require-production-signoff:
@@ -370,9 +371,11 @@ jobs:
       - name: Capture Play publish result outputs
         id: play_result
         if: always()
+        env:
+          ANDROID_TRACK_INPUT: ${{ inputs.android_track }}
         run: |
-          REQUESTED_TRACK="${{ inputs.android_track }}"
-          EFFECTIVE_TRACK="${{ inputs.android_track }}"
+          REQUESTED_TRACK="$ANDROID_TRACK_INPUT"
+          EFFECTIVE_TRACK="$ANDROID_TRACK_INPUT"
           FALLBACK_USED="false"
           PRECONDITION_BLOCKED="false"
           VERSION_CODE="${{ steps.build_meta.outputs.version_code }}"
@@ -386,7 +389,7 @@ jobs:
           fi
 
           if [ -z "$REQUESTED_TRACK" ] || [ "$REQUESTED_TRACK" = "null" ]; then
-            REQUESTED_TRACK="${{ inputs.android_track }}"
+            REQUESTED_TRACK="$ANDROID_TRACK_INPUT"
           fi
           if [ -z "$EFFECTIVE_TRACK" ] || [ "$EFFECTIVE_TRACK" = "null" ]; then
             EFFECTIVE_TRACK="$REQUESTED_TRACK"
@@ -476,15 +479,23 @@ jobs:
           PY
 
       - name: Debug workflow inputs (no secrets)
+        env:
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_ANDROID_TRACK: ${{ inputs.android_track }}
+          INPUT_SUBMIT_REVIEW: ${{ inputs.submit_review }}
+          EVENT_INPUT_PLATFORM: ${{ github.event.inputs.platform }}
+          EVENT_INPUT_ANDROID_TRACK: ${{ github.event.inputs.android_track }}
+          EVENT_INPUT_SUBMIT_REVIEW: ${{ github.event.inputs.submit_review }}
+          EVENT_INPUTS_JSON: ${{ toJSON(github.event.inputs) }}
         run: |
           echo "event_name=${{ github.event_name }}"
-          echo "inputs.platform=${{ inputs.platform }}"
-          echo "inputs.android_track=${{ inputs.android_track }}"
-          echo "inputs.submit_review=${{ inputs.submit_review }}"
-          echo "github.event.inputs.platform=${{ github.event.inputs.platform }}"
-          echo "github.event.inputs.android_track=${{ github.event.inputs.android_track }}"
-          echo "github.event.inputs.submit_review=${{ github.event.inputs.submit_review }}"
-          echo "github.event.inputs(json)=${{ toJSON(github.event.inputs) }}"
+          echo "inputs.platform=$INPUT_PLATFORM"
+          echo "inputs.android_track=$INPUT_ANDROID_TRACK"
+          echo "inputs.submit_review=$INPUT_SUBMIT_REVIEW"
+          echo "github.event.inputs.platform=$EVENT_INPUT_PLATFORM"
+          echo "github.event.inputs.android_track=$EVENT_INPUT_ANDROID_TRACK"
+          echo "github.event.inputs.submit_review=$EVENT_INPUT_SUBMIT_REVIEW"
+          echo "github.event.inputs(json)=$EVENT_INPUTS_JSON"
 
       - name: Determine platform flag
         id: platform
@@ -499,6 +510,8 @@ jobs:
 
       - name: Determine Android track (no secrets)
         id: android_track
+        env:
+          ANDROID_TRACK_INPUT: ${{ inputs.android_track }}
         run: |
           TRACK="${{ needs.android-release.outputs.effective_track }}"
           if [ -n "$TRACK" ] && [ "$TRACK" != "null" ]; then
@@ -507,7 +520,7 @@ jobs:
             TRACK=$(jq -r '.inputs.android_track // ""' "$GITHUB_EVENT_PATH")
           fi
           if [ -z "$TRACK" ] || [ "$TRACK" = "null" ]; then
-            TRACK="${{ inputs.android_track }}"
+            TRACK="$ANDROID_TRACK_INPUT"
           fi
           if [ -z "$TRACK" ] || [ "$TRACK" = "null" ]; then
             TRACK="production"

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -16,6 +16,28 @@ def test_pause_paid_campaigns_uses_environment_backed_reason() -> None:
     assert '--reason "$INPUT_REASON"' in contents
 
 
+def test_workflow_inputs_are_not_interpolated_inside_run_blocks() -> None:
+    offenders: list[str] = []
+
+    for path in sorted((REPO_ROOT / ".github/workflows").glob("*.yml")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        active_run_indent: int | None = None
+        for line_number, line in enumerate(lines, start=1):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+
+            if active_run_indent is not None:
+                if stripped and indent <= active_run_indent:
+                    active_run_indent = None
+                elif "${{ inputs." in line:
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}:{line_number}")
+
+            if stripped.startswith("run: |") or stripped.startswith("run: >"):
+                active_run_indent = indent
+
+    assert offenders == []
+
+
 def test_security_workflow_moves_permissions_to_jobs() -> None:
     contents = _read(".github/workflows/security.yml")
     assert "\npermissions:\n" not in contents.split("jobs:", 1)[0]


### PR DESCRIPTION
## Summary
- Move workflow_dispatch inputs out of shell run-block interpolation and into step env variables.
- Cover the release-blocking SonarCloud GitHub Actions injection findings in executive metrics and iOS review workflows.
- Add a workflow security contract that fails if `${{ inputs.* }}` is interpolated directly inside any run block.

## Local evidence
- `uv run pytest -q scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_workflow_security_contracts.py scripts/tests/test_workflow_yaml_syntax.py` -> 37 passed
- `python3 scripts/regression_guards.py --mode ci` -> regression_guards: ok
- `git diff --check` -> clean

## Release blocker
This addresses the SonarCloud quality gate blocker on SHA `c61587042a7ea1480cd02d0ddc64832ca04c0291`: `Security Rating on New Code` failed due GitHub Actions input injection findings.