### PR TITLE
feat(play): store automation tiers (Data Safety API, CDP Health, docs)

### DIFF
--- a/.github/workflows/play-data-safety-upload.yml
+++ b/.github/workflows/play-data-safety-upload.yml
@@ -1,0 +1,40 @@
+name: Play Data Safety upload
+
+# Tier A: machine-authenticated Data Safety CSV via androidpublisher API.
+# CSV: commit marketing/compliance/play_data_safety.csv OR set secret PLAY_DATA_SAFETY_CSV (full file body).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install google-api-python-client google-auth google-auth-httplib2
+
+      - name: Resolve CSV and upload
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+          PLAY_DATA_SAFETY_CSV: ${{ secrets.PLAY_DATA_SAFETY_CSV }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PLAY_DATA_SAFETY_CSV:-}" ]; then
+            printf '%s\n' "$PLAY_DATA_SAFETY_CSV" > /tmp/play_data_safety.csv
+          elif [ -f marketing/compliance/play_data_safety.csv ]; then
+            cp marketing/compliance/play_data_safety.csv /tmp/play_data_safety.csv
+          else
+            echo "::error::Provide secret PLAY_DATA_SAFETY_CSV or commit marketing/compliance/play_data_safety.csv"
+            exit 1
+          fi
+          python3 scripts/play_data_safety_upload.py --csv-path /tmp/play_data_safety.csv --json-stdout

--- a/docs/STORE_AUTOMATION_TIERS.md
+++ b/docs/STORE_AUTOMATION_TIERS.md
@@ -1,0 +1,57 @@
+# Store automation tiers (Play + Apple + GitHub)
+
+Canonical reliability rules: `docs/OPERATIONAL_RELIABILITY.md`.
+
+## Tier A — CI and CLIs (durable)
+
+Run on GitHub Actions or locally with service accounts / PATs. No interactive browser.
+
+| Capability | How in this repo |
+|------------|------------------|
+| **GitHub** PRs, checks, secrets, workflows | `gh` CLI; `.github/workflows/*` |
+| **PostHog / executive metrics** | `scripts/executive_metrics_snapshot.py`, `scripts/wqtu_dashboard.py`, workflows |
+| **Play: Data Safety (Safety labels)** | `scripts/play_data_safety_upload.py` → `applications.dataSafety` API; workflow **Play Data Safety upload** |
+| **Play: listings / releases** | `scripts/sync_android_metadata.py`, `scripts/play_publish.py`, Fastlane under `native-android/fastlane/` |
+| **Play: reviews / tracks (API-covered)** | `scripts/real_store_downloads.py`, `scripts/verify_release.py` |
+| **App Store Connect (API-covered)** | `scripts/asc/*`, Fastlane iOS |
+
+**Data Safety CSV**
+
+1. Export or build the CSV per [Google Help — Data safety](https://support.google.com/googleplay/android-developer/answer/10787469).
+2. Either commit `marketing/compliance/play_data_safety.csv` or store the full file in GitHub secret **`PLAY_DATA_SAFETY_CSV`** (watch GitHub secret size limits).
+3. Ensure **`GOOGLE_PLAY_JSON_KEY`** is set in Actions (same as other Play jobs).
+4. Run workflow **Play Data Safety upload** (manual dispatch).
+
+## Tier B — CEO machine or trusted profile (interactive once)
+
+No official API for these today; complete in the vendor web console while logged in as the account owner.
+
+| Task | Where |
+|------|--------|
+| **Play: Health apps declaration** (App content) | [Play Console](https://play.google.com/console) → app → **App content** → Health |
+| **Apple: screens with no ASC API** | [App Store Connect](https://appstoreconnect.apple.com) web UI |
+
+## Tier C — Semi-agent (your Chrome session)
+
+Uses **Playwright + Chrome DevTools Protocol** attached to **your** already-signed-in Chrome (`localhost:9222`). The agent drives UI with **your** cookies; not usable from a headless cloud agent without your session.
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/play_fill_declarations.py` | Default: **reconnaissance** on App content. **`--health`**: open **Health** declaration, select **No** radios where visible, **Save** / **Submit**, screenshots under `.artifacts/play_console/`. |
+| `scripts/play_console_declarations.py` | Broader App content walk (multiple sections). |
+
+**Start Chrome with remote debugging (macOS example):**
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+```
+
+Then:
+
+```bash
+uv run python scripts/play_fill_declarations.py --health
+# or full recon (default):
+uv run python scripts/play_fill_declarations.py
+```
+
+Play Console DOM changes over time; if a step fails, use screenshots in `.artifacts/play_console/` and finish manually.

--- a/marketing/compliance/README.md
+++ b/marketing/compliance/README.md
@@ -1,0 +1,12 @@
+# Play compliance artifacts (optional)
+
+## `play_data_safety.csv`
+
+Export your **Data Safety** answers from Play Console as CSV (see [Google Help](https://support.google.com/googleplay/android-developer/answer/10787469)), or maintain a CSV that matches Google’s current template.
+
+- **Commit this file here** if you want the **Play Data Safety upload** workflow to use the repo copy.
+- **Or** omit the file and store the entire CSV body in the GitHub Actions secret **`PLAY_DATA_SAFETY_CSV`** instead (mind secret size limits).
+
+Upload is performed by `scripts/play_data_safety_upload.py` (Tier A — no browser).
+
+**Do not** commit service account JSON; use `GOOGLE_PLAY_JSON_KEY` in CI secrets only.

--- a/scripts/play_data_safety_upload.py
+++ b/scripts/play_data_safety_upload.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Upload Play Data Safety labels via Google Play Android Publisher API.
+
+Official method: POST .../applications/{packageName}/dataSafety with body
+{"safetyLabels": "<CSV contents>"}.
+
+Docs:
+  https://developers.google.com/android-publisher/api-ref/rest/v3/applications/dataSafety
+  CSV format: https://support.google.com/googleplay/android-developer/answer/10787469
+
+Requires (same as other Play scripts):
+  GOOGLE_PLAY_JSON_KEY (inline JSON) or GOOGLE_PLAY_JSON_KEY_PATH (file path)
+
+Usage:
+  python scripts/play_data_safety_upload.py --csv-path ./export.csv
+  python scripts/play_data_safety_upload.py --csv-path ./export.csv --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCRIPTS = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS.parent
+sys.path.insert(0, str(SCRIPTS))
+
+DEFAULT_PACKAGE = "com.iganapolsky.randomtimer"
+
+
+def _credentials_and_service() -> tuple[Any, Optional[str]]:
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+        from pem_env import load_google_play_service_account_dict
+    except ImportError as exc:
+        return None, f"missing_dependency:{exc}"
+
+    import os
+
+    key_path = os.environ.get("GOOGLE_PLAY_JSON_KEY", "").strip()
+    if not key_path:
+        key_path = os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH", "").strip()
+    if not key_path:
+        return None, "no GOOGLE_PLAY_JSON_KEY or GOOGLE_PLAY_JSON_KEY_PATH"
+
+    try:
+        info = load_google_play_service_account_dict(key_path)
+        credentials = service_account.Credentials.from_service_account_info(
+            info,
+            scopes=["https://www.googleapis.com/auth/androidpublisher"],
+        )
+    except Exception as exc:
+        return None, f"credential_error:{exc}"
+
+    try:
+        service = build("androidpublisher", "v3", credentials=credentials)
+    except Exception as exc:
+        return None, f"build_error:{exc}"
+    return service, None
+
+
+def upload_data_safety_csv(package_name: str, csv_text: str, *, dry_run: bool) -> Dict[str, Any]:
+    """Call applications.dataSafety. If dry_run, only validate inputs (no Google auth)."""
+    if not csv_text or not csv_text.strip():
+        return {"status": "error", "reason": "empty_csv"}
+
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "package_name": package_name,
+            "safety_labels_bytes": len(csv_text.encode("utf-8")),
+        }
+
+    service, err = _credentials_and_service()
+    if err:
+        return {"status": "error", "reason": err}
+
+    try:
+        (service.applications().dataSafety(packageName=package_name, body={"safetyLabels": csv_text}).execute())
+    except Exception as exc:
+        return {"status": "error", "reason": str(exc), "package_name": package_name}
+
+    return {"status": "ok", "package_name": package_name}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Upload Play Data Safety CSV via androidpublisher API")
+    parser.add_argument("--csv-path", type=Path, required=True, help="Path to Data Safety export CSV")
+    parser.add_argument("--package", type=str, default=DEFAULT_PACKAGE, help="Android applicationId")
+    parser.add_argument("--dry-run", action="store_true", help="Do not call Google; print payload size only")
+    parser.add_argument("--json-stdout", action="store_true", help="Print result JSON to stdout")
+    args = parser.parse_args()
+
+    path = args.csv_path.resolve()
+    if not path.is_file():
+        msg = json.dumps({"status": "error", "reason": f"not_a_file:{path}"})
+        print(msg)
+        return 1
+
+    csv_text = path.read_text(encoding="utf-8")
+    result = upload_data_safety_csv(args.package.strip(), csv_text, dry_run=args.dry_run)
+    line = json.dumps(result, indent=2 if args.json_stdout else None)
+    print(line)
+    return 0 if result.get("status") in ("ok", "dry_run") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/play_fill_declarations.py
+++ b/scripts/play_fill_declarations.py
@@ -1,20 +1,39 @@
 #!/usr/bin/env python3
-"""Fill Google Play Console declarations by navigating directly to URLs."""
+"""Play Console helpers via CDP (Tier C): attach to your logged-in Chrome on port 9222.
 
+Modes:
+  default   Reconnaissance on App content (sections + Start links).
+  --health  Health / Health apps declaration assist: open flow, select visible "No" radios, Save/Submit.
+
+Prerequisites:
+  Chrome: --remote-debugging-port=9222
+  You already signed into play.google.com/console in that Chrome profile.
+
+Screenshots: .artifacts/play_console/ (see play_artifacts.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
 import time
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import Page, sync_playwright
+
 from play_artifacts import ARTIFACTS_DIR, screenshot_path
 
 DEV = "8239620436488925047"
 APP = "4976249162120849673"
 BASE = f"https://play.google.com/console/u/0/developers/{DEV}/app/{APP}"
+APP_CONTENT_URL = f"{BASE}/app-content"
 
-def screenshot(page, name):
+
+def screenshot(page: Page, name: str) -> None:
     path = screenshot_path(f"play_{name}.png")
     page.screenshot(path=path, full_page=True)
     print(f"  Screenshot: {path}")
 
-def click_text(page, text, timeout=5000):
+
+def click_text(page: Page, text: str, timeout: int = 5000) -> bool:
     try:
         loc = page.get_by_text(text, exact=False).first
         loc.wait_for(state="visible", timeout=timeout)
@@ -22,111 +41,176 @@ def click_text(page, text, timeout=5000):
         loc.click()
         time.sleep(2)
         return True
-    except Exception as e:
-        print(f"  Could not click '{text}': {e}")
+    except Exception as exc:
+        print(f"  Could not click '{text}': {exc}")
         return False
 
-def click_role(page, role, name, timeout=5000):
+
+def click_role(page: Page, role: str, name: str, timeout: int = 5000) -> bool:
     try:
         loc = page.get_by_role(role, name=name).first
         loc.wait_for(state="visible", timeout=timeout)
         loc.click()
         time.sleep(2)
         return True
-    except:
+    except Exception:
         return False
 
-def select_no_radio(page):
-    """Select 'No' radio button on declaration pages."""
+
+def select_no_radio(page: Page) -> bool:
+    """Select visible radio options named 'No' (declaration wizards)."""
     try:
         radios = page.get_by_role("radio", name="No").all()
+        clicked = False
         for r in radios:
             if r.is_visible():
                 r.click()
-                time.sleep(0.5)
-        return True
-    except:
+                time.sleep(0.4)
+                clicked = True
+        return clicked
+    except Exception:
         return False
 
-def click_save(page):
-    for label in ["Save", "Submit", "Next", "Confirm"]:
+
+def click_save_or_advance(page: Page) -> bool:
+    for label in ("Save", "Submit", "Next", "Confirm"):
         if click_role(page, "button", label):
             print(f"  Clicked '{label}'")
             time.sleep(2)
             return True
     return False
 
-def main():
+
+def connect_play_page(p) -> Page:
+    print("Connecting to Chrome (CDP http://localhost:9222)...")
+    browser = p.chromium.connect_over_cdp("http://localhost:9222")
+    context = browser.contexts[0]
+    play_page = None
+    for pg in context.pages:
+        if "play.google.com/console" in pg.url:
+            play_page = pg
+            break
+    if not play_page:
+        play_page = context.new_page()
+    return play_page
+
+
+def open_declaration_from_app_content(page: Page, decl_fragment: str) -> bool:
+    """Click Start/Manage/Update near a row containing decl_fragment (Play Console list UI)."""
+    try:
+        row = page.get_by_text(decl_fragment, exact=False).first
+        row.wait_for(state="visible", timeout=10000)
+        row.scroll_into_view_if_needed()
+        parent = row.locator("..").locator("..")
+        start_btn = parent.get_by_text(re.compile(r"Start|Manage|Update|Complete", re.I)).first
+        start_btn.wait_for(state="visible", timeout=5000)
+        start_btn.click()
+        time.sleep(3)
+        return True
+    except Exception as exc:
+        print(f"  Could not open declaration for {decl_fragment!r}: {exc}")
+        return False
+
+
+def run_reconnaissance(page: Page) -> None:
+    print(f"Navigating to: {APP_CONTENT_URL}")
+    page.goto(APP_CONTENT_URL, wait_until="networkidle", timeout=120000)
+    time.sleep(5)
+    screenshot(page, "01_app_content")
+    print(f"Current URL: {page.url}")
+
+    body_text = page.locator("body").text_content() or ""
+    keywords = [
+        "Data safety",
+        "Advertising ID",
+        "Government apps",
+        "Financial features",
+        "Health",
+        "Foreground service",
+        "Exact alarm",
+        "Content rating",
+        "Target audience",
+        "Privacy policy",
+        "App access",
+        "Ads",
+        "Store listing",
+    ]
+
+    print("\n=== Sections found on page ===")
+    for kw in keywords:
+        hit = kw.lower() in body_text.lower()
+        print(f"  [{'Y' if hit else 'N'}] {kw}")
+
+    print("\n=== 'Start' items (sample) ===")
+    starts = page.get_by_text("Start").all()
+    print(f"Found {len(starts)} 'Start' items")
+    for i, s in enumerate(starts[:25]):
+        try:
+            txt = (s.text_content() or "").strip()
+            parent_text = s.locator("xpath=ancestor::*[4]").text_content() or ""
+            print(f"  [{i}] '{txt}' context: {parent_text[:120]}")
+        except Exception:
+            print(f"  [{i}] (could not read)")
+
+    screenshot(page, "02_full_content")
+    print(f"\nReconnaissance done. Artifacts: {ARTIFACTS_DIR}")
+
+
+def run_health_declaration(page: Page) -> None:
+    print(f"Navigating to App content: {APP_CONTENT_URL}")
+    page.goto(APP_CONTENT_URL, wait_until="networkidle", timeout=120000)
+    time.sleep(4)
+    screenshot(page, "health_00_app_content")
+
+    opened = False
+    for fragment in ("Health apps", "Health features", "Health"):
+        if open_declaration_from_app_content(page, fragment):
+            print(f"  Opened declaration via label containing: {fragment!r}")
+            opened = True
+            break
+
+    if not opened:
+        print("::error::Could not open Health declaration — finish manually. Check screenshots.")
+        screenshot(page, "health_failed_open")
+        return
+
+    screenshot(page, "health_01_wizard_open")
+
+    max_steps = 12
+    for step in range(max_steps):
+        select_no_radio(page)
+        advanced = click_save_or_advance(page)
+        screenshot(page, f"health_step_{step:02d}")
+        if not advanced:
+            print("  No Save/Submit/Next/Confirm found; stopping semi-agent loop.")
+            break
+        time.sleep(2)
+        if "app-content" in page.url and step > 0:
+            print("  Returned to App content; Health flow may be complete.")
+            break
+
+    screenshot(page, "health_99_final")
+    print(f"Health assist finished. Review screenshots under {ARTIFACTS_DIR}")
+    print("If Google shows validation errors, complete remaining fields manually in the same Chrome window.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Play Console CDP helpers (Tier C)")
+    parser.add_argument(
+        "--health",
+        action="store_true",
+        help="Assist Health apps / Health features declaration (No radios + Save)",
+    )
+    args = parser.parse_args()
+
     with sync_playwright() as p:
-        print("Connecting to Chrome...")
-        browser = p.chromium.connect_over_cdp("http://localhost:9222")
-        context = browser.contexts[0]
-        
-        # Find or create Play Console tab
-        play_page = None
-        for pg in context.pages:
-            if "play.google.com/console" in pg.url:
-                play_page = pg
-                break
-        if not play_page:
-            play_page = context.new_page()
-        page = play_page
+        page = connect_play_page(p)
+        if args.health:
+            run_health_declaration(page)
+        else:
+            run_reconnaissance(page)
+    return 0
 
-        # Go directly to App Content page
-        content_url = f"{BASE}/app-content"
-        print(f"Navigating to: {content_url}")
-        page.goto(content_url, wait_until="networkidle", timeout=60000)
-        time.sleep(5)
-        screenshot(page, "01_app_content")
-        print(f"Current URL: {page.url}")
-        
-        # Get page text to understand what's there
-        body_text = page.locator("body").text_content()
-        
-        # Look for key sections
-        keywords = [
-            "Data safety", "Advertising ID", "Government apps",
-            "Financial features", "Health", "Foreground service", 
-            "Exact alarm", "Content rating", "Target audience",
-            "Privacy policy", "App access", "Ads", "Store listing"
-        ]
-        
-        print("\n=== Sections found on page ===")
-        for kw in keywords:
-            if kw.lower() in body_text.lower():
-                print(f"  ✓ {kw}")
-            else:
-                print(f"  ✗ {kw}")
-
-        # Find all "Start" buttons/links
-        print("\n=== Looking for action items ===")
-        starts = page.get_by_text("Start").all()
-        print(f"Found {len(starts)} 'Start' items")
-        for i, s in enumerate(starts):
-            try:
-                txt = s.text_content().strip()
-                # Get parent context
-                parent_text = s.locator("xpath=ancestor::*[4]").text_content()[:100]
-                print(f"  [{i}] '{txt}' in context: {parent_text}")
-            except:
-                print(f"  [{i}] (could not read)")
-
-        # Also look for links/buttons with declaration names
-        print("\n=== Looking for declaration links ===")
-        links = page.get_by_role("link").all()
-        for link in links:
-            try:
-                href = link.get_attribute("href") or ""
-                text = link.text_content().strip()[:60]
-                if any(k.lower() in text.lower() for k in keywords):
-                    print(f"  Link: '{text}' -> {href}")
-            except:
-                pass
-
-        # Take a full page screenshot for analysis
-        screenshot(page, "02_full_content")
-        
-        print(f"\nDone with reconnaissance. Check {ARTIFACTS_DIR}")
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/tests/test_play_data_safety_upload.py
+++ b/scripts/tests/test_play_data_safety_upload.py
@@ -1,0 +1,52 @@
+"""Tests for Play Data Safety API upload helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts import play_data_safety_upload as pdsu
+
+
+def test_upload_data_safety_csv_rejects_empty() -> None:
+    out = pdsu.upload_data_safety_csv("com.example.app", "", dry_run=False)
+    assert out["status"] == "error"
+    assert "empty" in str(out.get("reason", "")).lower()
+
+
+def test_upload_data_safety_dry_run_skips_api() -> None:
+    out = pdsu.upload_data_safety_csv("com.example.app", "a,b\n1,2", dry_run=True)
+    assert out["status"] == "dry_run"
+    assert out["safety_labels_bytes"] > 0
+
+
+def test_upload_data_safety_calls_data_safety_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _Req:
+        def execute(self) -> dict:
+            return {}
+
+    class _Apps:
+        def dataSafety(self, packageName: str, body: dict) -> _Req:
+            captured["packageName"] = packageName
+            captured["body"] = body
+            return _Req()
+
+    fake_service = MagicMock()
+    fake_service.applications.return_value = _Apps()
+
+    monkeypatch.setattr(pdsu, "_credentials_and_service", lambda: (fake_service, None))
+
+    out = pdsu.upload_data_safety_csv("com.test.app", "header\nrow", dry_run=False)
+    assert out["status"] == "ok"
+    assert captured["packageName"] == "com.test.app"
+    assert captured["body"] == {"safetyLabels": "header\nrow"}
+
+
+def test_main_exits_nonzero_for_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.csv"
+    with patch("sys.argv", ["play_data_safety_upload.py", "--csv-path", str(missing)]):
+        assert pdsu.main() == 1


### PR DESCRIPTION
## Tier A (CI / CLI)
- **`scripts/play_data_safety_upload.py`** — uploads Data Safety CSV via `applications.dataSafety` (`GOOGLE_PLAY_JSON_KEY` / `GOOGLE_PLAY_JSON_KEY_PATH`).
- **`.github/workflows/play-data-safety-upload.yml`** — `workflow_dispatch`; CSV from secret **`PLAY_DATA_SAFETY_CSV`** OR committed **`marketing/compliance/play_data_safety.csv`**.
- Tests: `scripts/tests/test_play_data_safety_upload.py`.

## Tier B + C (docs + semi-agent)
- **`docs/STORE_AUTOMATION_TIERS.md`** — maps Tier A/B/C to repo tools (GitHub, PostHog, Play, ASC, CDP).
- **`marketing/compliance/README.md`** — where to put the CSV.
- **`scripts/play_fill_declarations.py`** — `--health` mode for Health declaration assist over CDP; default remains reconnaissance.

## Evidence
`uv run pytest scripts/tests/test_play_data_safety_upload.py scripts/tests/test_workflow_yaml_syntax.py scripts/tests/test_growth_workflow_contracts.py -q` — 37 passed.

Made with [Cursor](https://cursor.com)