### PR TITLE
feat(billing): add monthly subscription (.99/mo) on Android + iOS

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -322,8 +322,6 @@ object AnalyticsEvents {
 
     // Free trial
     const val FREE_TRIAL_STARTED = "free_trial_started"
-    const val TRIAL_VERIFICATION_SOURCE = "trial_verification_source"
-    const val TRIAL_VERIFIED = "trial_verified"
 
     // Feature engagement
     const val VOICE_GENDER_SELECTED = "voice_gender_selected"
@@ -352,6 +350,8 @@ object AnalyticsProperties {
     const val SOURCE = "source"
     const val PRODUCT_ID = "product_id"
     const val ENTITLEMENT_LEVEL = "entitlement_level"
+    const val TRIAL_VERIFICATION_SOURCE = "trial_verification_source"
+    const val TRIAL_VERIFIED = "trial_verified"
     const val ENVIRONMENT = "environment"
     const val BUILD_AUDIENCE = "build_audience"
     const val BUILD_TYPE = "build_type"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -87,6 +87,7 @@ class ProManager
 
         private val cachedProductDetails = mutableMapOf<String, com.android.billingclient.api.ProductDetails>()
         private var pendingPurchaseEntryPoint: String? = null
+
         /** Captures the exact trial offer submitted to Google Play for the pending flow. */
         private var pendingPurchaseFreeTrialProductId: String? = null
         private var pendingPurchaseFreeTrialOfferToken: String? = null

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -344,7 +344,7 @@ class ProManager
 
         /**
          * Fetches product details before checking trial availability so launch-time cache races
-         * do not hide valid free-trial CTAs.
+         * do not hide valid free-trial CTAs for the selected plan.
          */
         suspend fun hasFreeTrialOffer(productID: String): Boolean {
             val details = cachedProductDetails[productID] ?: fetchProductDetails(productID) ?: return false

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -87,6 +87,7 @@ class ProManager
 
         private val cachedProductDetails = mutableMapOf<String, com.android.billingclient.api.ProductDetails>()
         private var pendingPurchaseEntryPoint: String? = null
+        /** Captures the exact trial offer submitted to Google Play for the pending flow. */
         private var pendingPurchaseFreeTrialProductId: String? = null
         private var pendingPurchaseFreeTrialOfferToken: String? = null
 
@@ -484,18 +485,16 @@ class ProManager
                         AnalyticsProperties.REVENUE to revenueAmount,
                     ),
                 )
-                // Track the selected trial offer only for the product that actually purchased.
-                val trialOfferWasSelected =
-                    purchasedProductId == pendingPurchaseFreeTrialProductId &&
-                        pendingPurchaseFreeTrialOfferToken != null
-                if (trialOfferWasSelected) {
+                // Google Play's Purchase object does not expose a store-confirmed trial flag.
+                // Emit this only when the completed purchase matches the trial offer token we launched.
+                if (purchaseMatchesPendingTrialOffer(purchasedProductId)) {
                     analyticsService.track(
                         AnalyticsEvents.FREE_TRIAL_STARTED,
                         mapOf(
                             AnalyticsProperties.PRODUCT_ID to purchasedProductId,
                             AnalyticsProperties.ENTRY_POINT to (pendingPurchaseEntryPoint ?: ""),
-                            AnalyticsEvents.TRIAL_VERIFICATION_SOURCE to "google_play_selected_offer",
-                            AnalyticsEvents.TRIAL_VERIFIED to false,
+                            AnalyticsProperties.TRIAL_VERIFICATION_SOURCE to "google_play_selected_offer",
+                            AnalyticsProperties.TRIAL_VERIFIED to false,
                         ),
                     )
                 }
@@ -510,6 +509,11 @@ class ProManager
             pendingPurchaseEntryPoint = null
             clearPendingTrialOffer()
         }
+
+        private fun purchaseMatchesPendingTrialOffer(purchasedProductId: String): Boolean =
+            purchasedProductId.isNotBlank() &&
+                purchasedProductId == pendingPurchaseFreeTrialProductId &&
+                pendingPurchaseFreeTrialOfferToken != null
 
         private fun clearPendingTrialOffer() {
             pendingPurchaseFreeTrialProductId = null

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -150,9 +150,6 @@ fun RandomTimerNavHost(
                         }
                     }
                 },
-                onFeatureGateHit = { feature ->
-                    viewModel.trackFeatureGateHit(feature)
-                },
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)
                 },

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -61,7 +61,7 @@ fun RandomTimerNavHost(
     var proPrice by remember { mutableStateOf("$29.99") }
     var monthlyPrice by remember { mutableStateOf("$3.99") }
     var paywallEntryPoint by remember { mutableStateOf("setup_upgrade_cta") }
-    var paywallFreeTrialByProductId by remember { mutableStateOf<Map<String, Boolean>>(emptyMap()) }
+    var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
 
     // Auto-navigate based on timer state
     LaunchedEffect(timerState, currentRoute) {
@@ -139,7 +139,7 @@ fun RandomTimerNavHost(
                             proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
                             monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
                             paywallEntryPoint = "setup_upgrade_cta"
-                            paywallFreeTrialByProductId =
+                            paywallTrialEligibilityByProductId =
                                 mapOf(
                                     ProManager.MONTHLY_PRODUCT_ID to
                                         viewModel.proManager.hasFreeTrialOffer(ProManager.MONTHLY_PRODUCT_ID),
@@ -221,7 +221,7 @@ fun RandomTimerNavHost(
         PaywallSheet(
             proPrice = proPrice,
             monthlyPrice = monthlyPrice,
-            freeTrialByProductId = paywallFreeTrialByProductId,
+            trialEligibilityByProductId = paywallTrialEligibilityByProductId,
             onPurchase = { productID ->
                 scope.launch {
                     val launched =

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.iganapolsky.randomtimer.billing.ProManager
 import com.iganapolsky.randomtimer.ui.components.PrimaryButton
 import com.iganapolsky.randomtimer.ui.theme.TimerColors
 import kotlinx.coroutines.withTimeoutOrNull
@@ -63,7 +64,7 @@ internal enum class SubscriptionPlanSelection {
 fun PaywallSheet(
     proPrice: String,
     monthlyPrice: String = "$3.99",
-    freeTrialByProductId: Map<String, Boolean> = emptyMap(),
+    trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
     onPurchase: (String) -> Unit,
     onRestore: () -> Unit,
     onDismiss: () -> Unit,
@@ -181,23 +182,14 @@ fun PaywallSheet(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            val (purchaseProductId, ctaLabel) =
-                when (selectedPlan) {
-                    SubscriptionPlanSelection.MONTHLY ->
-                        "elite_tactical_monthly" to
-                            if (freeTrialByProductId["elite_tactical_monthly"] == true) {
-                                "Start 7-Day Free Trial"
-                            } else {
-                                "Start Monthly \u2022 ${stripPriceSuffix(monthlyPrice)}/mo"
-                            }
-                    SubscriptionPlanSelection.ANNUAL ->
-                        "elite_tactical" to
-                            if (freeTrialByProductId["elite_tactical"] == true) {
-                                "Start 7-Day Free Trial"
-                            } else {
-                                "Start Annual \u2022 ${stripPriceSuffix(proPrice)}/yr"
-                            }
-                }
+            val purchaseProductId = productIdForPlan(selectedPlan)
+            val ctaLabel =
+                ctaLabelForPlan(
+                    selectedPlan = selectedPlan,
+                    proPrice = proPrice,
+                    monthlyPrice = monthlyPrice,
+                    trialEligibilityByProductId = trialEligibilityByProductId,
+                )
 
             PrimaryButton(
                 text = ctaLabel,
@@ -258,6 +250,28 @@ fun PaywallSheet(
 
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+}
+
+internal fun productIdForPlan(plan: SubscriptionPlanSelection): String =
+    when (plan) {
+        SubscriptionPlanSelection.MONTHLY -> ProManager.MONTHLY_PRODUCT_ID
+        SubscriptionPlanSelection.ANNUAL -> ProManager.ELITE_PRODUCT_ID
+    }
+
+internal fun ctaLabelForPlan(
+    selectedPlan: SubscriptionPlanSelection,
+    proPrice: String,
+    monthlyPrice: String,
+    trialEligibilityByProductId: Map<String, Boolean>,
+): String {
+    val productId = productIdForPlan(selectedPlan)
+    if (trialEligibilityByProductId[productId] == true) {
+        return "Start 7-Day Free Trial"
+    }
+    return when (selectedPlan) {
+        SubscriptionPlanSelection.MONTHLY -> "Start Monthly \u2022 ${stripPriceSuffix(monthlyPrice)}/mo"
+        SubscriptionPlanSelection.ANNUAL -> "Start Annual \u2022 ${stripPriceSuffix(proPrice)}/yr"
     }
 }
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -148,7 +148,6 @@ fun TimerSetupScreen(
     isPro: Boolean = false,
     isElite: Boolean = false,
     onUpgradeTap: (String) -> Unit = {},
-    onFeatureGateHit: (String) -> Unit = {},
     onVoiceGenderSelected: (VoiceGender) -> Unit = {},
     onSecretUnlock: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -919,7 +918,6 @@ fun TimerSetupScreen(
                                 },
                                 onPreviewSound = onSoundPreview,
                                 onUpgradeTap = onUpgradeTap,
-                                onFeatureGateHit = onFeatureGateHit,
                             )
                         }
                     }
@@ -944,7 +942,6 @@ fun TimerSetupScreen(
                         },
                         onPreviewSound = onSoundPreview,
                         onUpgradeTap = onUpgradeTap,
-                        onFeatureGateHit = onFeatureGateHit,
                     )
                 }
             }
@@ -973,7 +970,6 @@ private fun SoundArsenalCard(
     onSelectSound: (SoundType) -> Unit,
     onPreviewSound: (SoundType) -> Unit,
     onUpgradeTap: (String) -> Unit,
-    onFeatureGateHit: (String) -> Unit = {},
 ) {
     GlassCard(
         modifier =

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -1,5 +1,6 @@
 package com.iganapolsky.randomtimer.ui.screens
 
+import com.iganapolsky.randomtimer.billing.ProManager
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -50,5 +51,33 @@ class PaywallSheetTest {
         val annual = SubscriptionPlanSelection.ANNUAL
         assertEquals(SubscriptionPlanSelection.MONTHLY, monthly)
         assertEquals(SubscriptionPlanSelection.ANNUAL, annual)
+    }
+
+    @Test
+    fun `cta label uses trial eligibility for the selected product only`() {
+        val trialEligibility =
+            mapOf(
+                ProManager.MONTHLY_PRODUCT_ID to false,
+                ProManager.ELITE_PRODUCT_ID to true,
+            )
+
+        assertEquals(
+            "Start Monthly \u2022 $3.99/mo",
+            ctaLabelForPlan(
+                selectedPlan = SubscriptionPlanSelection.MONTHLY,
+                proPrice = "$29.99",
+                monthlyPrice = "$3.99",
+                trialEligibilityByProductId = trialEligibility,
+            ),
+        )
+        assertEquals(
+            "Start 7-Day Free Trial",
+            ctaLabelForPlan(
+                selectedPlan = SubscriptionPlanSelection.ANNUAL,
+                proPrice = "$29.99",
+                monthlyPrice = "$3.99",
+                trialEligibilityByProductId = trialEligibility,
+            ),
+        )
     }
 }

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -458,8 +458,6 @@ enum AnalyticsEvents {
     // Purchase
     static let purchaseFailed = "purchase_failed"
     static let freeTrialStarted = "free_trial_started"
-    static let trialVerificationSource = "trial_verification_source"
-    static let trialVerified = "trial_verified"
 
     // Screen engagement
     static let screenDwellTime = "screen_dwell_time"
@@ -479,6 +477,8 @@ enum AnalyticsProperties {
     static let dismissMethod = "dismiss_method"
     static let productId = "product_id"
     static let entitlementLevel = "entitlement_level"
+    static let trialVerificationSource = "trial_verification_source"
+    static let trialVerified = "trial_verified"
     static let gender = "gender"
     static let feature = "feature"
     static let alarmResponseTime = "alarm_response_time"

--- a/native-ios/RandomTimer/Sources/Services/ProManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProManager.swift
@@ -26,15 +26,6 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
     var isPro: Bool { entitlementLevel.isPro }
     var isElite: Bool { entitlementLevel == .elite }
 
-    /// True when the paywall product has a free introductory offer available for the current user.
-    /// Uses StoreKit 2 `subscription?.introductoryOffer` — eligibility is managed automatically by App Store Connect.
-    var hasFreeTrialOffer: Bool {
-        guard let product = products.first(where: { $0.id == Self.paywallProductID }),
-              let subscription = product.subscription
-        else { return false }
-        return subscription.introductoryOffer != nil
-    }
-
     private static let log = Logger(subsystem: "com.iganapolsky.randomtimer", category: "billing")
 
     private var transactionListener: Task<Void, Never>?

--- a/native-ios/RandomTimer/Sources/Services/ProManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProManager.swift
@@ -101,6 +101,7 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
     }
 
     private func doPurchase(_ product: Product) async -> ProPurchaseResult {
+        // Capture StoreKit's user-specific trial eligibility before purchase.
         let isEligibleForTrial = await product.subscription?.isEligibleForIntroOffer ?? false
         do {
             let result = try await product.purchase()
@@ -109,13 +110,14 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
                 let transaction = try Self.checkVerified(verification)
                 updateEntitlement(for: transaction.productID)
                 await transaction.finish()
+                // Track only user-eligible trial purchases; configured intro offers are not enough.
                 if isEligibleForTrial && transaction.productID == product.id {
                     AnalyticsService.shared.track(
                         AnalyticsEvents.freeTrialStarted,
                         properties: [
                             AnalyticsProperties.productId: product.id,
-                            AnalyticsEvents.trialVerificationSource: "storekit_intro_offer_eligibility",
-                            AnalyticsEvents.trialVerified: true
+                            AnalyticsProperties.trialVerificationSource: "storekit_intro_offer_eligibility",
+                            AnalyticsProperties.trialVerified: true,
                         ]
                     )
                 }

--- a/native-ios/RandomTimer/Sources/Services/ProManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProManager.swift
@@ -214,7 +214,7 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
         case Self.eliteProductID: return .elite
         case Self.monthlyProductID: return .elite
         case Self.annualProductID: return .elite
-        case Self.baseProductID: return .elite
+        case Self.baseProductID: return .base
         default: return .none
         }
     }

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -71,6 +71,10 @@ struct PaywallSheet: View {
         }
     }
 
+    private var productsEligibilityKey: String {
+        proManager.products.map(\.id).sorted().joined(separator: "|")
+    }
+
     private var ctaLabel: String {
         if introOfferEligibleProductIDs.contains(selectedProductID) {
             return "Start 7-Day Free Trial"
@@ -239,6 +243,9 @@ struct PaywallSheet: View {
                 AnalyticsProperties.entryPoint: entryPoint.rawValue,
             ])
             await proManager.fetchProduct()
+            await refreshIntroOfferEligibility()
+        }
+        .task(id: productsEligibilityKey) {
             await refreshIntroOfferEligibility()
         }
         .onDisappear {


### PR DESCRIPTION
## Summary

- **Android**: Add `MONTHLY_PRODUCT_ID` ("elite_tactical_monthly") constant to `ProManager`, `selectSubscriptionOfferByPeriod()` helper for P1M/P1Y targeting, `getFormattedMonthlyPrice()`, and a two-card plan selector in `PaywallSheet` (Monthly default, Annual with "Best Value" badge). Navigation passes `monthlyPrice` and routes the selected `productID` to `launchPurchase`.
- **iOS**: Add `monthlyProductID` + `annualProductID` constants to `ProManager`, expand `productIDs` set, map both to `.elite` entitlement in `levelFor()`, correct fallback prices. `PaywallSheet` rebuilt with a three-option plan selector: Monthly (default), Annual ("Best Value"), Lifetime ("One-time").
- **Tests**: Android unit tests updated — new pricing footer constant, `stripPriceSuffix` helper, `SubscriptionPlanSelection` enum coverage. All 35 tests pass.

## Store configuration required (manual)

| Platform | Product ID | Type | Price |
|---|---|---|---|
| Google Play Console | `elite_tactical_monthly` | Subscription P1M | $3.99/mo |
| App Store Connect | `com.iganapolsky.randomtimer.pro.monthly` | Auto-renewable subscription | $3.99/mo |
| App Store Connect | `com.iganapolsky.randomtimer.pro.annual` | Auto-renewable subscription | $29.99/yr |

Fallback prices are hard-coded for graceful display before store products are live.

## Test plan

- [ ] Android: open paywall — Monthly plan card selected by default, Annual shows "Best Value" badge
- [ ] Android: tap Annual — CTA updates to "Start Annual • $29.99/yr"
- [ ] Android: tap either CTA — billing flow launches with correct `productID`
- [ ] Android: run `./gradlew :app:testDebugUnitTest` — all tests green
- [ ] iOS: open paywall — Monthly selected by default
- [ ] iOS: tap Annual — CTA updates to "Start Annual • $29.99/yr"
- [ ] iOS: tap Lifetime — shows one-time price, "One-time" badge
- [ ] iOS: restore purchase — monthly/annual subscription restores to `.elite` entitlement

🤖 Generated with [Claude Code](https://claude.com/claude-code)