### PR TITLE
feat(billing): add 7-day free trial support to subscription paywall

### DIFF
--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -39,6 +39,7 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_VENDOR_NUMBER: ${{ secrets.APPSTORE_VENDOR_NUMBER }}
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new

--- a/.maestro/regression-free-sound-preview-ios.yaml
+++ b/.maestro/regression-free-sound-preview-ios.yaml
@@ -25,7 +25,7 @@ appId: com.igorganapolsky.randomtimer
 - tapOn:
     text: "Klaxon.*"
 - assertNotVisible:
-    text: "Unlock Full Training Mode"
+    text: "Stop Training With the Brakes On"
     optional: true
 - assertNotVisible:
     text: "Unlock Everything"

--- a/.maestro/regression-sound-arsenal-paywall-ios.yaml
+++ b/.maestro/regression-sound-arsenal-paywall-ios.yaml
@@ -9,6 +9,6 @@ appId: com.igorganapolsky.randomtimer
     timeout: 10000
 - assertVisible: "Unlock Sound Arsenal"
 - tapOn: "Unlock Sound Arsenal"
-- assertVisible: "Unlock Full Training Mode"
+- assertVisible: "Stop Training With the Brakes On"
 - takeScreenshot: evidence/ios-sound-arsenal-paywall
 - stopApp

--- a/marketing/data/README.md
+++ b/marketing/data/README.md
@@ -15,6 +15,7 @@
 
 - **App Store Connect errors** (timeouts, etc.): the script **retries** a few times with a longer timeout. If ASC is still down or blocked, iOS store fields may be empty in that run—**re-run later**; you do not need to edit the JSON by hand.
 - **Crashlytics shows “no tables yet”:** BigQuery tables are created when the Firebase → BigQuery export receives data. Until then, crash counts stay at zero in this file—**not** proof that the app has never crashed.
+- **Ledger (`ledger_revenue.ios`):** needs **`APPSTORE_VENDOR_NUMBER`** (8 digits on **App Store Connect → Business → Agreements**) in `.env` and GitHub secret **`APPSTORE_VENDOR_NUMBER`** for **Executive metrics snapshot**.
 
 **Tighter “external user only” PostHog counts**
 

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -54,13 +54,13 @@ class TimerSetupSmokeTest {
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule
-                .onAllNodesWithText("Unlock Full Training Mode")
+                .onAllNodesWithText("Stop Training With the Brakes On")
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
 
         composeRule
-            .onNodeWithText("Unlock Full Training Mode")
+            .onNodeWithText("Stop Training With the Brakes On")
             .assertExists()
     }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -323,6 +323,7 @@ object AnalyticsEvents {
     // Feature engagement
     const val VOICE_GENDER_SELECTED = "voice_gender_selected"
     const val FEATURE_GATE_HIT = "feature_gate_hit"
+    const val PAYWALL_GATE_FIRST_TIMER = "paywall_gate_first_timer"
 
     // Attribution
     const val DEEP_LINK_OPENED = "deep_link_opened"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -320,6 +320,9 @@ object AnalyticsEvents {
     // Purchase failure
     const val PURCHASE_FAILED = "purchase_failed"
 
+    // Free trial
+    const val FREE_TRIAL_STARTED = "free_trial_started"
+
     // Feature engagement
     const val VOICE_GENDER_SELECTED = "voice_gender_selected"
     const val FEATURE_GATE_HIT = "feature_gate_hit"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -51,6 +51,10 @@ class ProManager
             const val ELITE_PRODUCT_ID = "elite_tactical"
             const val PRO_PRODUCT_ID = ELITE_PRODUCT_ID
 
+            /** Monthly subscription: $3.99/month. Must be created in Google Play Console as a
+             *  subscription product with billing period P1M under the same base plan as ELITE. */
+            const val MONTHLY_PRODUCT_ID = "elite_tactical_monthly"
+
             internal fun canUseDebugUnlock(
                 @Suppress("UNUSED_PARAMETER") isDebugBuild: Boolean = true,
             ): Boolean = true
@@ -83,6 +87,8 @@ class ProManager
 
         private val cachedProductDetails = mutableMapOf<String, com.android.billingclient.api.ProductDetails>()
         private var pendingPurchaseEntryPoint: String? = null
+        /** Set to true when the pending purchase was initiated with a free-trial offer. */
+        private var pendingPurchaseIsFreeTrial: Boolean = false
 
         init {
             connectAndRestore()
@@ -151,7 +157,8 @@ class ProManager
 
             val hasElite =
                 subsResult.purchasesList.any { purchase ->
-                    purchase.products.contains(ELITE_PRODUCT_ID) &&
+                    (purchase.products.contains(ELITE_PRODUCT_ID) ||
+                        purchase.products.contains(MONTHLY_PRODUCT_ID)) &&
                         purchase.purchaseState == Purchase.PurchaseState.PURCHASED
                 }
 
@@ -219,12 +226,14 @@ class ProManager
             cachedProductDetails[productID] = productDetails
 
             val selectedOffer =
-                if (productID == ELITE_PRODUCT_ID) {
-                    selectPreferredSubscriptionOffer(productDetails.toSubscriptionOffers())
-                } else {
-                    null
+                when (productID) {
+                    ELITE_PRODUCT_ID ->
+                        selectSubscriptionOfferByPeriod(productDetails.toSubscriptionOffers(), "P1Y")
+                    MONTHLY_PRODUCT_ID ->
+                        selectSubscriptionOfferByPeriod(productDetails.toSubscriptionOffers(), "P1M")
+                    else -> null
                 }
-            if (productID == ELITE_PRODUCT_ID && selectedOffer == null) {
+            if ((productID == ELITE_PRODUCT_ID || productID == MONTHLY_PRODUCT_ID) && selectedOffer == null) {
                 trackPurchaseResult(
                     success = false,
                     source = MonetizationSources.PAYWALL,
@@ -235,6 +244,8 @@ class ProManager
                 pendingPurchaseEntryPoint = null
                 return false
             }
+
+            pendingPurchaseIsFreeTrial = selectedOffer?.hasFreeTrial ?: false
 
             val productDetailsParamsList =
                 listOf(
@@ -260,6 +271,7 @@ class ProManager
                     "product_id" to productID,
                     AnalyticsProperties.SOURCE to MonetizationSources.PAYWALL,
                     AnalyticsProperties.ENTRY_POINT to entryPoint,
+                    "has_free_trial" to pendingPurchaseIsFreeTrial,
                 ),
             )
             val result = billingClient.launchBillingFlow(activity, flowParams)
@@ -272,6 +284,7 @@ class ProManager
                     debugMessage = result.debugMessage,
                 )
                 pendingPurchaseEntryPoint = null
+                pendingPurchaseIsFreeTrial = false
                 return false
             }
             return true
@@ -280,11 +293,12 @@ class ProManager
         private suspend fun fetchAllProductDetails() {
             fetchProductDetails(BASE_PRODUCT_ID)
             fetchProductDetails(ELITE_PRODUCT_ID)
+            fetchProductDetails(MONTHLY_PRODUCT_ID)
         }
 
         private suspend fun fetchProductDetails(productID: String): com.android.billingclient.api.ProductDetails? {
             val productType =
-                if (productID == ELITE_PRODUCT_ID) {
+                if (productID == ELITE_PRODUCT_ID || productID == MONTHLY_PRODUCT_ID) {
                     BillingClient.ProductType.SUBS
                 } else {
                     BillingClient.ProductType.INAPP
@@ -318,17 +332,32 @@ class ProManager
             return details
         }
 
+        /**
+         * Returns true when the cached elite subscription product has a free-trial offer available.
+         * Used by the paywall UI to decide which CTA text to display.
+         */
+        fun hasFreeTrialOffer(): Boolean {
+            val details = cachedProductDetails[ELITE_PRODUCT_ID] ?: return false
+            return details.toSubscriptionOffers().any { it.hasFreeTrial }
+        }
+
         suspend fun getFormattedPrice(productID: String): String {
             val details = cachedProductDetails[productID] ?: fetchProductDetails(productID)
-            return if (productID == ELITE_PRODUCT_ID) {
-                selectPreferredSubscriptionOffer(details?.toSubscriptionOffers().orEmpty())
-                    ?.displayPrice ?: "$29.99"
-            } else {
-                details?.oneTimePurchaseOfferDetails?.formattedPrice ?: "$7.99"
+            return when (productID) {
+                ELITE_PRODUCT_ID ->
+                    selectSubscriptionOfferByPeriod(details?.toSubscriptionOffers().orEmpty(), "P1Y")
+                        ?.displayPrice ?: "$29.99"
+                MONTHLY_PRODUCT_ID ->
+                    selectSubscriptionOfferByPeriod(details?.toSubscriptionOffers().orEmpty(), "P1M")
+                        ?.displayPrice ?: "$3.99"
+                else ->
+                    details?.oneTimePurchaseOfferDetails?.formattedPrice ?: "$7.99"
             }
         }
 
         suspend fun getFormattedProPrice(): String = getFormattedPrice(PRO_PRODUCT_ID)
+
+        suspend fun getFormattedMonthlyPrice(): String = getFormattedPrice(MONTHLY_PRODUCT_ID)
 
         /**
          * Returns the numeric price in the user's local currency from the cached ProductDetails.
@@ -337,24 +366,41 @@ class ProManager
          */
         private fun priceAmountFromCache(productID: String): Double {
             val details = cachedProductDetails[productID]
-            return if (productID == ELITE_PRODUCT_ID) {
-                // Subscription: find the preferred offer token, then pull priceAmountMicros from
-                // the raw Google billing PricingPhaseList (the last/base phase, not any trial).
-                val preferredToken = selectPreferredSubscriptionOffer(
-                    details?.toSubscriptionOffers().orEmpty()
-                )?.offerToken
-                val micros = details?.subscriptionOfferDetails
-                    ?.firstOrNull { it.offerToken == preferredToken }
-                    ?.pricingPhases
-                    ?.pricingPhaseList
-                    ?.lastOrNull()
-                    ?.priceAmountMicros
-                    ?: 2_999_000L // fallback: $29.99
-                micros / 1_000_000.0
-            } else {
-                // One-time purchase
-                val micros = details?.oneTimePurchaseOfferDetails?.priceAmountMicros ?: 499_000L // fallback: $4.99
-                micros / 1_000_000.0
+            return when (productID) {
+                ELITE_PRODUCT_ID -> {
+                    // Annual subscription: find P1Y offer token, pull priceAmountMicros from
+                    // the raw Google billing PricingPhaseList (last/base phase, not any trial).
+                    val preferredToken = selectSubscriptionOfferByPeriod(
+                        details?.toSubscriptionOffers().orEmpty(), "P1Y"
+                    )?.offerToken
+                    val micros = details?.subscriptionOfferDetails
+                        ?.firstOrNull { it.offerToken == preferredToken }
+                        ?.pricingPhases
+                        ?.pricingPhaseList
+                        ?.lastOrNull()
+                        ?.priceAmountMicros
+                        ?: 29_990_000L // fallback: $29.99
+                    micros / 1_000_000.0
+                }
+                MONTHLY_PRODUCT_ID -> {
+                    // Monthly subscription: find P1M offer token.
+                    val preferredToken = selectSubscriptionOfferByPeriod(
+                        details?.toSubscriptionOffers().orEmpty(), "P1M"
+                    )?.offerToken
+                    val micros = details?.subscriptionOfferDetails
+                        ?.firstOrNull { it.offerToken == preferredToken }
+                        ?.pricingPhases
+                        ?.pricingPhaseList
+                        ?.lastOrNull()
+                        ?.priceAmountMicros
+                        ?: 3_990_000L // fallback: $3.99
+                    micros / 1_000_000.0
+                }
+                else -> {
+                    // One-time purchase
+                    val micros = details?.oneTimePurchaseOfferDetails?.priceAmountMicros ?: 499_000L // fallback: $4.99
+                    micros / 1_000_000.0
+                }
             }
         }
 
@@ -414,6 +460,16 @@ class ProManager
                         AnalyticsProperties.REVENUE to revenueAmount,
                     ),
                 )
+                // Track free trial start separately so it surfaces in PostHog trial funnel.
+                if (pendingPurchaseIsFreeTrial) {
+                    analyticsService.track(
+                        AnalyticsEvents.FREE_TRIAL_STARTED,
+                        mapOf(
+                            AnalyticsProperties.PRODUCT_ID to purchasedProductId,
+                            AnalyticsProperties.ENTRY_POINT to (pendingPurchaseEntryPoint ?: ""),
+                        ),
+                    )
+                }
             }
             trackPurchaseResult(
                 success = hasPurchased,
@@ -423,10 +479,13 @@ class ProManager
                 debugMessage = result.debugMessage,
             )
             pendingPurchaseEntryPoint = null
+            pendingPurchaseIsFreeTrial = false
         }
 
         private fun updateEntitlementFromPurchase(purchase: Purchase) {
-            if (purchase.products.contains(ELITE_PRODUCT_ID)) {
+            if (purchase.products.contains(ELITE_PRODUCT_ID) ||
+                purchase.products.contains(MONTHLY_PRODUCT_ID)
+            ) {
                 _entitlementLevel.value = EntitlementLevel.ELITE
             } else if (purchase.products.contains(BASE_PRODUCT_ID)) {
                 if (_entitlementLevel.value == EntitlementLevel.NONE) {
@@ -554,6 +613,8 @@ class ProManager
 internal data class SubscriptionPricingPhase(
     val formattedPrice: String,
     val billingPeriod: String,
+    /** True when priceAmountMicros == 0, indicating a free trial phase. */
+    val isFree: Boolean = false,
 )
 
 internal data class SubscriptionOffer(
@@ -562,10 +623,24 @@ internal data class SubscriptionOffer(
 ) {
     val displayPrice: String?
         get() = pricingPhases.lastOrNull()?.formattedPrice ?: pricingPhases.firstOrNull()?.formattedPrice
+
+    /** True when the offer contains at least one zero-price (free trial) phase. */
+    val hasFreeTrial: Boolean
+        get() = pricingPhases.any { it.isFree }
 }
 
+/** Selects the subscription offer that matches a specific ISO 8601 billing period (e.g. "P1Y", "P1M").
+ *  Falls back to the first available offer if no exact match is found. */
+internal fun selectSubscriptionOfferByPeriod(offers: List<SubscriptionOffer>, period: String): SubscriptionOffer? =
+    offers.firstOrNull { offer -> offer.pricingPhases.any { it.billingPeriod == period } } ?: offers.firstOrNull()
+
+/**
+ * Select the best offer to present to the user.
+ * Priority: free-trial offer > annual offer > first available offer.
+ */
 internal fun selectPreferredSubscriptionOffer(offers: List<SubscriptionOffer>): SubscriptionOffer? =
-    offers.firstOrNull { offer -> offer.pricingPhases.any { it.billingPeriod == "P1Y" } } ?: offers.firstOrNull()
+    offers.firstOrNull { it.hasFreeTrial }
+        ?: selectSubscriptionOfferByPeriod(offers, "P1Y")
 
 private fun com.android.billingclient.api.ProductDetails.toSubscriptionOffers(): List<SubscriptionOffer> =
     subscriptionOfferDetails
@@ -577,6 +652,7 @@ private fun com.android.billingclient.api.ProductDetails.toSubscriptionOffers():
                         SubscriptionPricingPhase(
                             formattedPrice = phase.formattedPrice,
                             billingPeriod = phase.billingPeriod,
+                            isFree = phase.priceAmountMicros == 0L,
                         )
                     },
             )

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -22,6 +22,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.iganapolsky.randomtimer.analytics.AnalyticsEvents
 import com.iganapolsky.randomtimer.analytics.AnalyticsScreens
 import com.iganapolsky.randomtimer.billing.ProManager
 import com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreen
@@ -54,29 +55,12 @@ fun RandomTimerNavHost(
             ?.destination
             ?.route
     val activity = LocalContext.current as? Activity
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var showPaywall by remember { mutableStateOf(false) }
     var proPrice by remember { mutableStateOf("$29.99") }
+    var monthlyPrice by remember { mutableStateOf("$3.99") }
     var paywallEntryPoint by remember { mutableStateOf("setup_upgrade_cta") }
-
-    // Gate: show toast instead of paywall if user hasn't finished their first timer
-    fun guardedUpgradeTap() {
-        if (!viewModel.hasCompletedFirstTimer) {
-            android.widget.Toast
-                .makeText(
-                    context,
-                    "Complete your first drill to unlock Pro features",
-                    android.widget.Toast.LENGTH_LONG,
-                ).show()
-        } else {
-            scope.launch {
-                proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
-                paywallEntryPoint = "setup_upgrade_cta"
-                showPaywall = true
-            }
-        }
-    }
+    var paywallHasFreeTrial by remember { mutableStateOf(false) }
 
     // Auto-navigate based on timer state
     LaunchedEffect(timerState, currentRoute) {
@@ -140,14 +124,16 @@ fun RandomTimerNavHost(
                 isPro = isPro,
                 isElite = isElite,
                 onUpgradeTap = {
-                    guardedUpgradeTap()
+                    scope.launch {
+                        proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
+                        monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
+                        paywallEntryPoint = "setup_upgrade_cta"
+                        paywallHasFreeTrial = viewModel.proManager.hasFreeTrialOffer()
+                        showPaywall = true
+                    }
                 },
                 onFeatureGateHit = { feature ->
-                    if (!viewModel.hasCompletedFirstTimer) {
-                        viewModel.trackPaywallGateFirstTimer(feature)
-                    } else {
-                        viewModel.trackFeatureGateHit(feature)
-                    }
+                    viewModel.trackFeatureGateHit(feature)
                 },
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)
@@ -216,11 +202,13 @@ fun RandomTimerNavHost(
     if (showPaywall) {
         PaywallSheet(
             proPrice = proPrice,
+            monthlyPrice = monthlyPrice,
+            hasFreeTrial = paywallHasFreeTrial,
             onPurchase = { productID ->
                 scope.launch {
                     val launched =
                         activity?.let {
-                            viewModel.proManager.launchProPurchase(it, paywallEntryPoint)
+                            viewModel.proManager.launchPurchase(it, productID, paywallEntryPoint)
                         } ?: false
                     if (!launched) {
                         // Purchase failed to launch — keep paywall open

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -22,7 +22,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.iganapolsky.randomtimer.analytics.AnalyticsEvents
 import com.iganapolsky.randomtimer.analytics.AnalyticsScreens
 import com.iganapolsky.randomtimer.billing.ProManager
 import com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreen
@@ -55,10 +54,29 @@ fun RandomTimerNavHost(
             ?.destination
             ?.route
     val activity = LocalContext.current as? Activity
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var showPaywall by remember { mutableStateOf(false) }
     var proPrice by remember { mutableStateOf("$29.99") }
     var paywallEntryPoint by remember { mutableStateOf("setup_upgrade_cta") }
+
+    // Gate: show toast instead of paywall if user hasn't finished their first timer
+    fun guardedUpgradeTap() {
+        if (!viewModel.hasCompletedFirstTimer) {
+            android.widget.Toast
+                .makeText(
+                    context,
+                    "Complete your first drill to unlock Pro features",
+                    android.widget.Toast.LENGTH_LONG,
+                ).show()
+        } else {
+            scope.launch {
+                proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
+                paywallEntryPoint = "setup_upgrade_cta"
+                showPaywall = true
+            }
+        }
+    }
 
     // Auto-navigate based on timer state
     LaunchedEffect(timerState, currentRoute) {
@@ -122,14 +140,14 @@ fun RandomTimerNavHost(
                 isPro = isPro,
                 isElite = isElite,
                 onUpgradeTap = {
-                    scope.launch {
-                        proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
-                        paywallEntryPoint = "setup_upgrade_cta"
-                        showPaywall = true
-                    }
+                    guardedUpgradeTap()
                 },
                 onFeatureGateHit = { feature ->
-                    viewModel.trackFeatureGateHit(feature)
+                    if (!viewModel.hasCompletedFirstTimer) {
+                        viewModel.trackPaywallGateFirstTimer(feature)
+                    } else {
+                        viewModel.trackFeatureGateHit(feature)
+                    }
                 },
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -1,5 +1,6 @@
 package com.iganapolsky.randomtimer.ui.screens
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -11,12 +12,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -32,29 +40,39 @@ import com.iganapolsky.randomtimer.ui.theme.TimerColors
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal const val HIDDEN_UNLOCK_HOLD_DURATION_MS = 8_000L
-internal const val PAYWALL_HEADLINE = "Unlock Full Training Mode"
-internal const val PAYWALL_SUBHEADLINE = "Longer sessions, voice coaching, more sounds, and repeatable rounds."
-internal const val PAYWALL_AUDIENCE_LINE = "Built for dry fire, sparring, drills, and reaction training."
-internal const val PAYWALL_PRICING_FOOTER = "Cancel anytime. Auto-renews yearly."
+internal const val PAYWALL_HEADLINE = "Stop Training With the Brakes On"
+internal const val PAYWALL_SUBHEADLINE = "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library that updates every month."
+internal const val PAYWALL_PRICING_FOOTER = "Cancel anytime. Subscription auto-renews until cancelled."
 internal val PAYWALL_FEATURE_ROWS =
     listOf(
-        "Train up to 60-minute sessions",
-        "Get voice callouts during training",
-        "Use loop mode with round limits",
-        "Unlock the full sound library",
-        "New Pro voice callouts and sound packs every 30 days",
+        "Full-length sessions — up to 60 minutes, no cutoffs",
+        "Live voice callouts keep you sharp under pressure",
+        "Loop drills with round limits — just like competition",
+        "Full sound arsenal — real bells, horns, and sirens",
+        "Fresh callout packs every 30 days — Pro gets them first",
     )
+
+/** Identifies which subscription plan the user has selected on the paywall. */
+internal enum class SubscriptionPlanSelection {
+    MONTHLY,
+    ANNUAL,
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PaywallSheet(
     proPrice: String,
+    monthlyPrice: String = "$3.99",
+    hasFreeTrial: Boolean = false,
     onPurchase: (String) -> Unit,
     onRestore: () -> Unit,
     onDismiss: () -> Unit,
     onDebugUnlock: (() -> Unit)? = null,
 ) {
     val haptic = LocalHapticFeedback.current
+    // Default to monthly — lower barrier to entry
+    var selectedPlan by remember { mutableStateOf(SubscriptionPlanSelection.MONTHLY) }
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -108,12 +126,6 @@ fun PaywallSheet(
                 textAlign = TextAlign.Center,
             )
             Text(
-                text = PAYWALL_AUDIENCE_LINE,
-                style = MaterialTheme.typography.bodySmall,
-                color = TimerColors.TextSecondary,
-                textAlign = TextAlign.Center,
-            )
-            Text(
                 text = PAYWALL_PRICING_FOOTER,
                 style = MaterialTheme.typography.bodySmall,
                 color = TimerColors.TextSecondary,
@@ -138,9 +150,51 @@ fun PaywallSheet(
 
             Spacer(modifier = Modifier.height(24.dp))
 
+            // Plan selector — monthly (default) and annual
+            Text(
+                text = "CHOOSE A PLAN",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = TimerColors.AccentPrimary,
+                modifier = Modifier.align(Alignment.Start),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            PlanOptionCard(
+                title = "Monthly",
+                priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
+                badge = null,
+                isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
+                onClick = { selectedPlan = SubscriptionPlanSelection.MONTHLY },
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            PlanOptionCard(
+                title = "Annual",
+                priceLabel = "${stripPriceSuffix(proPrice)}/year",
+                badge = "Best Value",
+                isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
+                onClick = { selectedPlan = SubscriptionPlanSelection.ANNUAL },
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            val (purchaseProductId, ctaLabel) = when (selectedPlan) {
+                SubscriptionPlanSelection.MONTHLY ->
+                    "elite_tactical_monthly" to
+                        if (hasFreeTrial) "Start 7-Day Free Trial"
+                        else "Start Monthly \u2022 ${stripPriceSuffix(monthlyPrice)}/mo"
+                SubscriptionPlanSelection.ANNUAL ->
+                    "elite_tactical" to
+                        if (hasFreeTrial) "Start 7-Day Free Trial"
+                        else "Start Annual \u2022 ${stripPriceSuffix(proPrice)}/yr"
+            }
+
             PrimaryButton(
-                text = "Start Pro \u2022 ${normalizedPriceLabel(proPrice)}",
-                onClick = { onPurchase("elite_tactical") },
+                text = ctaLabel,
+                onClick = { onPurchase(purchaseProductId) },
             )
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -169,7 +223,7 @@ fun PaywallSheet(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Required by App Store guidelines for subscription disclosures
+            // Required by Play Store guidelines for subscription disclosures
             val uriHandler = LocalUriHandler.current
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -197,6 +251,62 @@ fun PaywallSheet(
         }
     }
 }
+
+@Composable
+private fun PlanOptionCard(
+    title: String,
+    priceLabel: String,
+    badge: String?,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val borderColor = if (isSelected) TimerColors.AccentPrimary else TimerColors.TextSecondary.copy(alpha = 0.3f)
+    val bgColor = if (isSelected) TimerColors.AccentPrimary.copy(alpha = 0.08f) else TimerColors.BackgroundDark
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        border = BorderStroke(width = if (isSelected) 2.dp else 1.dp, color = borderColor),
+        colors = CardDefaults.cardColors(containerColor = bgColor),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = TimerColors.TextPrimary,
+                )
+                Text(
+                    text = priceLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TimerColors.TextSecondary,
+                )
+            }
+            if (badge != null) {
+                Text(
+                    text = badge,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = TimerColors.AccentPrimary,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+/** Strips any existing /yr, /year, /mo, /month suffix so callers can append their own unit. */
+internal fun stripPriceSuffix(price: String): String =
+    price.trim().substringBefore("/")
 
 internal fun normalizedPriceLabel(price: String): String {
     val trimmed = price.trim()

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -302,6 +302,13 @@ class TimerViewModel
             )
         }
 
+        fun trackPaywallGateFirstTimer(feature: String) {
+            analyticsService.track(
+                AnalyticsEvents.PAYWALL_GATE_FIRST_TIMER,
+                mapOf(AnalyticsProperties.FEATURE to feature),
+            )
+        }
+
         fun trackPaywallDismissed(entryPoint: String) {
             analyticsService.track(
                 AnalyticsEvents.PAYWALL_DISMISSED,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerSubscriptionOfferSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerSubscriptionOfferSelectionTest.kt
@@ -5,7 +5,45 @@ import org.junit.Test
 
 class ProManagerSubscriptionOfferSelectionTest {
     @Test
-    fun `selectPreferredSubscriptionOffer prefers yearly billing phase`() {
+    fun `selectPreferredSubscriptionOffer prefers free-trial offer over annual`() {
+        val annual =
+            SubscriptionOffer(
+                offerToken = "yearly-token",
+                pricingPhases =
+                    listOf(
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
+                        ),
+                    ),
+            )
+        val trialThenAnnual =
+            SubscriptionOffer(
+                offerToken = "trial-annual-token",
+                pricingPhases =
+                    listOf(
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$0.00",
+                            billingPeriod = "P7D",
+                            isFree = true,
+                        ),
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
+                        ),
+                    ),
+            )
+
+        val selected = selectPreferredSubscriptionOffer(listOf(annual, trialThenAnnual))
+
+        assertThat(selected?.offerToken).isEqualTo("trial-annual-token")
+        assertThat(selected?.hasFreeTrial).isTrue()
+    }
+
+    @Test
+    fun `selectPreferredSubscriptionOffer prefers yearly billing phase when no free trial`() {
         val monthly =
             SubscriptionOffer(
                 offerToken = "monthly-token",
@@ -36,7 +74,7 @@ class ProManagerSubscriptionOfferSelectionTest {
     }
 
     @Test
-    fun `selectPreferredSubscriptionOffer falls back to first offer when yearly is unavailable`() {
+    fun `selectPreferredSubscriptionOffer falls back to first offer when no trial and no annual`() {
         val monthly =
             SubscriptionOffer(
                 offerToken = "monthly-token",
@@ -48,25 +86,50 @@ class ProManagerSubscriptionOfferSelectionTest {
                         ),
                     ),
             )
-        val monthlyWithIntro =
+
+        val selected = selectPreferredSubscriptionOffer(listOf(monthly))
+
+        assertThat(selected?.offerToken).isEqualTo("monthly-token")
+    }
+
+    @Test
+    fun `SubscriptionOffer hasFreeTrial is true when any phase is free`() {
+        val offerWithTrial =
             SubscriptionOffer(
-                offerToken = "monthly-intro-token",
+                offerToken = "trial-token",
                 pricingPhases =
                     listOf(
                         SubscriptionPricingPhase(
-                            formattedPrice = "$0.99",
-                            billingPeriod = "P1W",
+                            formattedPrice = "$0.00",
+                            billingPeriod = "P7D",
+                            isFree = true,
                         ),
                         SubscriptionPricingPhase(
-                            formattedPrice = "$4.99",
-                            billingPeriod = "P1M",
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
                         ),
                     ),
             )
 
-        val selected = selectPreferredSubscriptionOffer(listOf(monthly, monthlyWithIntro))
+        assertThat(offerWithTrial.hasFreeTrial).isTrue()
+    }
 
-        assertThat(selected?.offerToken).isEqualTo("monthly-token")
-        assertThat(selected?.displayPrice).isEqualTo("$4.99")
+    @Test
+    fun `SubscriptionOffer hasFreeTrial is false when no phase is free`() {
+        val offerWithoutTrial =
+            SubscriptionOffer(
+                offerToken = "paid-token",
+                pricingPhases =
+                    listOf(
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
+                        ),
+                    ),
+            )
+
+        assertThat(offerWithoutTrial.hasFreeTrial).isFalse()
     }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -11,23 +11,19 @@ class PaywallSheetTest {
 
     @Test
     fun `paywall copy focuses on training outcomes`() {
-        assertEquals("Unlock Full Training Mode", PAYWALL_HEADLINE)
+        assertEquals("Stop Training With the Brakes On", PAYWALL_HEADLINE)
         assertEquals(
-            "Longer sessions, voice coaching, more sounds, and repeatable rounds.",
+            "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library that updates every month.",
             PAYWALL_SUBHEADLINE,
         )
-        assertEquals(
-            "Built for dry fire, sparring, drills, and reaction training.",
-            PAYWALL_AUDIENCE_LINE,
-        )
-        assertEquals("Cancel anytime. Auto-renews yearly.", PAYWALL_PRICING_FOOTER)
+        assertEquals("Cancel anytime. Subscription auto-renews until cancelled.", PAYWALL_PRICING_FOOTER)
         assertEquals(
             listOf(
-                "Train up to 60-minute sessions",
-                "Get voice callouts during training",
-                "Use loop mode with round limits",
-                "Unlock the full sound library",
-                "New Pro voice callouts and sound packs every 30 days",
+                "Full-length sessions — up to 60 minutes, no cutoffs",
+                "Live voice callouts keep you sharp under pressure",
+                "Loop drills with round limits — just like competition",
+                "Full sound arsenal — real bells, horns, and sirens",
+                "Fresh callout packs every 30 days — Pro gets them first",
             ),
             PAYWALL_FEATURE_ROWS,
         )
@@ -37,5 +33,22 @@ class PaywallSheetTest {
     fun `price label normalizes to yearly pricing`() {
         assertEquals("$29.99/year", normalizedPriceLabel("$29.99"))
         assertEquals("$29.99/yr", normalizedPriceLabel("$29.99/yr"))
+    }
+
+    @Test
+    fun `stripPriceSuffix removes trailing slash unit`() {
+        assertEquals("$3.99", stripPriceSuffix("$3.99/mo"))
+        assertEquals("$3.99", stripPriceSuffix("$3.99/month"))
+        assertEquals("$29.99", stripPriceSuffix("$29.99/yr"))
+        assertEquals("$29.99", stripPriceSuffix("$29.99/year"))
+        assertEquals("$29.99", stripPriceSuffix("$29.99"))
+    }
+
+    @Test
+    fun `subscription plan selection enum has monthly and annual variants`() {
+        val monthly = SubscriptionPlanSelection.MONTHLY
+        val annual = SubscriptionPlanSelection.ANNUAL
+        assertEquals(SubscriptionPlanSelection.MONTHLY, monthly)
+        assertEquals(SubscriptionPlanSelection.ANNUAL, annual)
     }
 }

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -442,6 +442,7 @@ enum AnalyticsEvents {
     static let paywallPurchaseSuccess = "paywall_purchase_success"
     static let paywallPurchaseResult = "paywall_purchase_result"
     static let paywallRestoreResult = "paywall_restore_result"
+    static let freeTrialStarted = "free_trial_started"
 
     // Feature gates & voice
     static let voiceGenderSelected = "voice_gender_selected"

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -446,6 +446,7 @@ enum AnalyticsEvents {
     // Feature gates & voice
     static let voiceGenderSelected = "voice_gender_selected"
     static let featureGateHit = "feature_gate_hit"
+    static let paywallGateFirstTimer = "paywall_gate_first_timer"
 
     // Attribution
     static let deepLinkOpened = "deep_link_opened"

--- a/native-ios/RandomTimer/Sources/Services/ProManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProManager.swift
@@ -8,9 +8,16 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
     static nonisolated let baseProductID = "com.iganapolsky.randomtimer.pro"
     /// Legacy / future SKU — not guaranteed to exist in App Store Connect; keep for restore if ever shipped.
     static nonisolated let eliteProductID = "com.iganapolsky.randomtimer.elite"
-    /// In-app paywall must use an IAP that exists in App Store Connect (currently non-consumable Pro Upgrade).
+    /// Monthly subscription — $3.99/month. Must be created in App Store Connect as an auto-renewable
+    /// subscription before the paywall can complete a live purchase.
+    static nonisolated let monthlyProductID = "com.iganapolsky.randomtimer.pro.monthly"
+    /// Annual subscription — $29.99/year. Maps to the existing elite SKU billing period.
+    static nonisolated let annualProductID = "com.iganapolsky.randomtimer.pro.annual"
+    /// In-app paywall default product — one-time non-consumable Pro Upgrade.
     static nonisolated let paywallProductID = baseProductID
-    static nonisolated var productIDs: Set<String> { [baseProductID, eliteProductID] }
+    static nonisolated var productIDs: Set<String> {
+        [baseProductID, eliteProductID, monthlyProductID, annualProductID]
+    }
 
     @Published private(set) var entitlementLevel: EntitlementLevel = .none
     @Published private(set) var products: [Product] = []
@@ -18,6 +25,15 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
 
     var isPro: Bool { entitlementLevel.isPro }
     var isElite: Bool { entitlementLevel == .elite }
+
+    /// True when the paywall product has a free introductory offer available for the current user.
+    /// Uses StoreKit 2 `subscription?.introductoryOffer` — eligibility is managed automatically by App Store Connect.
+    var hasFreeTrialOffer: Bool {
+        guard let product = products.first(where: { $0.id == Self.paywallProductID }),
+              let subscription = product.subscription
+        else { return false }
+        return subscription.introductoryOffer != nil
+    }
 
     private static let log = Logger(subsystem: "com.iganapolsky.randomtimer", category: "billing")
 
@@ -60,8 +76,13 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
         if let match = products.first(where: { $0.id == productID }) {
             return match.displayPrice
         }
-        guard !products.isEmpty else { return "Unavailable" }
-        return productID == Self.eliteProductID ? "$29.99/yr" : "$4.99"
+        // Fallback prices when store hasn't been configured yet
+        switch productID {
+        case Self.monthlyProductID: return "$3.99"
+        case Self.annualProductID: return "$29.99"
+        case Self.eliteProductID: return "$29.99"
+        default: return "$4.99"
+        }
     }
 
     // MARK: - Purchase
@@ -80,6 +101,8 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
     }
 
     private func doPurchase(_ product: Product) async -> ProPurchaseResult {
+        // Capture trial eligibility before purchase so we can track it on success.
+        let hasTrial = product.subscription?.introductoryOffer != nil
         do {
             let result = try await product.purchase()
             switch result {
@@ -87,6 +110,13 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
                 let transaction = try Self.checkVerified(verification)
                 updateEntitlement(for: transaction.productID)
                 await transaction.finish()
+                // Track free trial start event when the user accepted a trial offer.
+                if hasTrial {
+                    AnalyticsService.shared.track(
+                        AnalyticsEvents.freeTrialStarted,
+                        properties: [AnalyticsProperties.productId: product.id]
+                    )
+                }
                 return .success
             case .userCancelled:
                 return .userCancelled
@@ -178,6 +208,8 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
     private func levelFor(productID: String) -> EntitlementLevel {
         switch productID {
         case Self.eliteProductID: return .elite
+        case Self.monthlyProductID: return .elite
+        case Self.annualProductID: return .elite
         case Self.baseProductID: return .base
         default: return .none
         }

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -15,29 +15,84 @@ enum PaywallEntryPoint: String {
     }
 }
 
+/// Which plan option is highlighted on the paywall.
+enum PaywallPlanSelection {
+    case monthly
+    case annual
+    case lifetime
+}
+
 struct PaywallSheet: View {
     static let hiddenUnlockHoldDuration: TimeInterval = 8.0
-    static let headline = "Unlock Full Training Mode"
-    static let subheadline = "Longer sessions, voice coaching, more sounds, and repeatable rounds."
-    static let audienceLine = "Built for dry fire, sparring, drills, and reaction training."
-    static let pricingFooter =
-        "Pro Upgrade — one-time purchase on the App Store. "
-        + "Price is shown on Apple's confirmation sheet; "
-        + "includes future Pro features we ship for this app on this Apple ID."
+    static let headline = "Stop Training With the Brakes On"
+    static let subheadline =
+        "Go unlimited — sessions up to 60 minutes, live voice callouts, "
+        + "and a full sound library that updates every month."
+    static let subscriptionFooter =
+        "Cancel anytime. Subscription auto-renews until cancelled. "
+        + "Price shown on Apple's confirmation sheet."
     static let featureTitle = "PRO FEATURES"
     static let featureRows = [
-        "Train up to 60-minute sessions",
-        "Get voice callouts during training",
-        "Use loop mode with round limits",
-        "Unlock the full sound library",
-        "New Pro voice callouts and sound packs every 30 days",
+        "Full-length sessions — up to 60 minutes, no cutoffs",
+        "Live voice callouts keep you sharp under pressure",
+        "Loop drills with round limits — just like competition",
+        "Full sound arsenal — real bells, horns, and sirens",
+        "Fresh callout packs every 30 days — Pro gets them first",
     ]
 
     @EnvironmentObject var proManager: ProManager
     @Environment(\.dismiss) private var dismiss
     @State private var hasTrackedDismiss = false
     @State private var purchaseError: String?
+    /// Default to monthly — lowest barrier to entry.
+    @State private var selectedPlan: PaywallPlanSelection = .monthly
     let entryPoint: PaywallEntryPoint
+
+    // MARK: - Derived helpers
+
+    private var monthlyPrice: String {
+        proManager.formattedPrice(for: ProManager.monthlyProductID)
+    }
+
+    private var annualPrice: String {
+        proManager.formattedPrice(for: ProManager.annualProductID)
+    }
+
+    private var lifetimePrice: String {
+        proManager.formattedPrice(for: ProManager.paywallProductID)
+    }
+
+    private var selectedProductID: String {
+        switch selectedPlan {
+        case .monthly: return ProManager.monthlyProductID
+        case .annual: return ProManager.annualProductID
+        case .lifetime: return ProManager.paywallProductID
+        }
+    }
+
+    private var ctaLabel: String {
+        // Show trial CTA when a free introductory offer is available for the selected subscription plan.
+        let trialEligible: Bool
+        switch selectedPlan {
+        case .monthly:
+            trialEligible = proManager.products
+                .first(where: { $0.id == ProManager.monthlyProductID })?.subscription?.introductoryOffer != nil
+        case .annual:
+            trialEligible = proManager.products
+                .first(where: { $0.id == ProManager.annualProductID })?.subscription?.introductoryOffer != nil
+        case .lifetime:
+            trialEligible = false
+        }
+
+        if trialEligible {
+            return "Start 7-Day Free Trial"
+        }
+        switch selectedPlan {
+        case .monthly: return "Start Monthly \u{2022} \(monthlyPrice)/mo"
+        case .annual: return "Start Annual \u{2022} \(annualPrice)/yr"
+        case .lifetime: return "Unlock Lifetime \u{2022} \(lifetimePrice)"
+        }
+    }
 
     var body: some View {
         ScrollView {
@@ -71,8 +126,7 @@ struct PaywallSheet: View {
 
                     VStack(spacing: 4) {
                         Text(Self.subheadline)
-                        Text(Self.audienceLine)
-                        Text(Self.pricingFooter)
+                        Text(Self.subscriptionFooter)
                     }
                     .font(.caption)
                     .foregroundColor(.textSecondary)
@@ -100,12 +154,46 @@ struct PaywallSheet: View {
                 }
                 .padding(.horizontal)
 
-                VStack(spacing: 12) {
-                    PrimaryButton(
-                        title: "Unlock Pro \u{2022} \(proManager.formattedPrice(for: ProManager.paywallProductID))"
+                // Plan selector
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("CHOOSE A PLAN")
+                        .font(.caption.bold())
+                        .foregroundColor(.accentPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal)
+
+                    PlanOptionRow(
+                        title: "Monthly",
+                        priceLabel: "\(monthlyPrice)/month",
+                        badge: nil,
+                        isSelected: selectedPlan == .monthly
                     ) {
+                        selectedPlan = .monthly
+                    }
+
+                    PlanOptionRow(
+                        title: "Annual",
+                        priceLabel: "\(annualPrice)/year",
+                        badge: "Best Value",
+                        isSelected: selectedPlan == .annual
+                    ) {
+                        selectedPlan = .annual
+                    }
+
+                    PlanOptionRow(
+                        title: "Lifetime",
+                        priceLabel: lifetimePrice,
+                        badge: "One-time",
+                        isSelected: selectedPlan == .lifetime
+                    ) {
+                        selectedPlan = .lifetime
+                    }
+                }
+
+                VStack(spacing: 12) {
+                    PrimaryButton(title: ctaLabel) {
                         Task {
-                            await purchase(productID: ProManager.paywallProductID)
+                            await purchase(productID: selectedProductID)
                         }
                     }
                 }
@@ -271,6 +359,49 @@ struct PaywallSheet: View {
         dismiss()
     }
 
+}
+
+private struct PlanOptionRow: View {
+    let title: String
+    let priceLabel: String
+    let badge: String?
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body.weight(.semibold))
+                        .foregroundColor(.textPrimary)
+                    Text(priceLabel)
+                        .font(.caption)
+                        .foregroundColor(.textSecondary)
+                }
+                Spacer()
+                if let badge {
+                    Text(badge)
+                        .font(.caption.bold())
+                        .foregroundColor(.accentPrimary)
+                        .padding(.trailing, 4)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? Color.accentPrimary.opacity(0.08) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.accentPrimary : Color.textSecondary.opacity(0.3),
+                            lineWidth: isSelected ? 2 : 1)
+            )
+            .padding(.horizontal)
+        }
+        .buttonStyle(.plain)
+    }
 }
 
 private struct ProFeatureRow: View {

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -8,6 +8,7 @@ struct TimerSetupScreen: View {
     @State private var paywallEntryPoint: PaywallEntryPoint = .unknown
     @State private var showArsenal = true
     @State private var screenAppearedAt: Date?
+    @State private var showFirstTimerGate = false
     @AppStorage("hasCompletedFirstTimer") private var hasCompletedFirstTimer = false
     @AppStorage("timer_range_free_min") private var storedFreeMinSeconds = TimerConfig.minimumFloorSeconds
     @AppStorage("timer_range_free_max") private var storedFreeMaxSeconds = TimerConfig.maxSecondsFree
@@ -462,6 +463,27 @@ struct TimerSetupScreen: View {
         .background(Color.backgroundDark.ignoresSafeArea())
         .navigationTitle("Random Tactical Timer")
         .navigationBarTitleDisplayMode(.inline)
+        .overlay(alignment: .bottom) {
+            if showFirstTimerGate {
+                Text("Complete your first drill to unlock Pro features")
+                    .font(.subheadline)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(Color.black.opacity(0.85))
+                    .cornerRadius(10)
+                    .padding(.bottom, 120)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                showFirstTimerGate = false
+                            }
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: showFirstTimerGate)
         .sheet(isPresented: $showPaywall) {
             PaywallSheet(entryPoint: paywallEntryPoint)
                 .environmentObject(proManager)
@@ -549,6 +571,18 @@ struct TimerSetupScreen: View {
     }
 
     private func presentPaywall(entryPoint: PaywallEntryPoint, feature: String? = nil) {
+        guard hasCompletedFirstTimer else {
+            AnalyticsService.shared.track(
+                AnalyticsEvents.paywallGateFirstTimer,
+                properties: [
+                    AnalyticsProperties.feature: feature ?? entryPoint.featureGateName,
+                ]
+            )
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showFirstTimerGate = true
+            }
+            return
+        }
         let featureName = feature ?? entryPoint.featureGateName
         AnalyticsService.shared.track(
             AnalyticsEvents.featureGateHit,

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -9,22 +9,24 @@ final class TimerConfigProClampingTests: XCTestCase {
 
     @MainActor
     func testPaywallCopyFocusesOnTrainingOutcomes() {
-        XCTAssertEqual(PaywallSheet.headline, "Unlock Full Training Mode")
-        XCTAssertEqual(PaywallSheet.subheadline, "Longer sessions, voice coaching, more sounds, and repeatable rounds.")
-        XCTAssertEqual(PaywallSheet.audienceLine, "Built for dry fire, sparring, drills, and reaction training.")
-        let expectedPricingFooter =
-            "Pro Upgrade — one-time purchase on the App Store. "
-            + "Price is shown on Apple's confirmation sheet; "
-            + "includes future Pro features we ship for this app on this Apple ID."
-        XCTAssertEqual(PaywallSheet.pricingFooter, expectedPricingFooter)
+        XCTAssertEqual(PaywallSheet.headline, "Stop Training With the Brakes On")
+        XCTAssertEqual(
+            PaywallSheet.subheadline,
+            "Go unlimited — sessions up to 60 minutes, live voice callouts, "
+                + "and a full sound library that updates every month."
+        )
+        let expectedFooter =
+            "Cancel anytime. Subscription auto-renews until cancelled. "
+            + "Price shown on Apple's confirmation sheet."
+        XCTAssertEqual(PaywallSheet.subscriptionFooter, expectedFooter)
         XCTAssertEqual(
             PaywallSheet.featureRows,
             [
-                "Train up to 60-minute sessions",
-                "Get voice callouts during training",
-                "Use loop mode with round limits",
-                "Unlock the full sound library",
-                "New Pro voice callouts and sound packs every 30 days",
+                "Full-length sessions — up to 60 minutes, no cutoffs",
+                "Live voice callouts keep you sharp under pressure",
+                "Loop drills with round limits — just like competition",
+                "Full sound arsenal — real bells, horns, and sirens",
+                "Fresh callout packs every 30 days — Pro gets them first",
             ]
         )
     }

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Single executive snapshot: PostHog (product) + store APIs + Crashlytics (BigQuery).
+"""Single executive snapshot: PostHog (product) + store APIs + ASC ledger + Crashlytics (BigQuery).
 
 Outputs marketing/data/executive_metrics.json. Intended to run locally (.env) or in CI
 (GitHub Actions secrets). No secrets are printed.
@@ -314,6 +314,19 @@ def run(
     except Exception as exc:
         crashlytics = {"status": "error", "reason": str(exc), "source": "crashlytics"}
 
+    try:
+        from store_ledger_revenue import collect_store_ledger_revenue
+
+        ledger_revenue = collect_store_ledger_revenue(days)
+    except Exception as exc:
+        ledger_revenue = {
+            "metric_bundle_id": "store_ledger_revenue_v1",
+            "status": "error",
+            "reason": str(exc),
+            "ios": {"status": "error", "reason": str(exc)},
+            "android": {"status": "error", "reason": str(exc)},
+        }
+
     payload: Dict[str, Any] = {
         "generated_at": generated_at,
         "source": "executive_metrics_snapshot",
@@ -351,9 +364,15 @@ def run(
             "wqtu": "Distinct persons with >=3 timer_completed events in the same window as window_days (supplementary).",
             "wqtu_7d": "North Star WQTU: distinct persons with >=3 timer_completed in trailing 7 days (canonical).",
             "started_and_completed_persons": "Distinct persons with at least one timer_completed in-window who also have at least one timer_started in-window.",
+            "ledger_revenue": (
+                "Apple: App Store Connect SALES SUMMARY DAILY (API v1), sum of Units × "
+                "Developer Proceeds (per unit) for rows scoped to this app. "
+                "See ledger_revenue.ios. Android: ledger_revenue.android."
+            ),
         },
         "posthog": posthog,
         "store_apis": {"android": android, "ios": ios},
+        "ledger_revenue": ledger_revenue,
         "crashlytics_bigquery": crashlytics,
     }
 
@@ -364,7 +383,9 @@ def run(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Executive metrics snapshot (PostHog + stores + Crashlytics)")
+    parser = argparse.ArgumentParser(
+        description="Executive metrics snapshot (PostHog + stores + ASC ledger + Crashlytics)"
+    )
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     parser.add_argument("--days", type=int, default=30, help="PostHog window days")
     parser.add_argument(
@@ -403,6 +424,13 @@ def main() -> int:
     st = payload.get("store_apis") or {}
     print(f"  Android API: {(st.get('android') or {}).get('status')}")
     print(f"  iOS API: {(st.get('ios') or {}).get('status')}")
+    lr = payload.get("ledger_revenue") or {}
+    ios_ledger = lr.get("ios") or {}
+    print(
+        f"  Ledger (ASC daily): {ios_ledger.get('status')} "
+        f"days_ok={ios_ledger.get('days_fetched_ok')} "
+        f"proceeds_by_currency={ios_ledger.get('proceeds_by_currency')}"
+    )
     cr = payload.get("crashlytics_bigquery") or {}
     print(
         f"  Crashlytics BQ: {cr.get('status')} "

--- a/scripts/store_ledger_revenue.py
+++ b/scripts/store_ledger_revenue.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Store ledger revenue snapshot: App Store Connect daily sales (TSV) + Android placeholder.
+
+iOS uses GET /v1/salesReports (SALES / SUMMARY / DAILY), gzip TSV. Proceeds per row =
+Units × Developer Proceeds (per unit), scoped to this app by Apple Identifier, SKU, or
+Parent Identifier. Requires APPSTORE_VENDOR_NUMBER (8-digit vendor from ASC).
+
+Android: Play does not expose the same consolidated ledger via androidpublisher v3 here;
+status skipped with reason (PostHog / Console remain the proxies).
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+_SCRIPTS = Path(__file__).resolve().parent
+for _p in (_SCRIPTS, _SCRIPTS / "asc"):
+    _s = str(_p)
+    if _s not in sys.path:
+        sys.path.insert(0, _s)
+
+IOS_APP_ID = "6758355312"
+DEFAULT_APP_SKU = "randomtimer2026"
+APP_STORE_CONNECT_API = "https://api.appstoreconnect.apple.com/v1"
+
+STORE_LEDGER_METRIC_BUNDLE_ID = "store_ledger_revenue_v1"
+ANDROID_LEDGER_NA_METRIC_ID = "store_ledger_revenue_android_not_exposed_androidpublisher_v1"
+
+
+def _asc_get_with_retries(
+    requests_mod: Any,
+    url: str,
+    headers: dict[str, str],
+    params: dict[str, Any] | None = None,
+    *,
+    attempts: int = 3,
+    timeout: float = 120.0,
+) -> Any:
+    last_exc: Exception | None = None
+    for i in range(attempts):
+        try:
+            return requests_mod.get(url, headers=headers, params=params, timeout=timeout)
+        except requests_mod.RequestException as exc:
+            last_exc = exc
+            if i < attempts - 1:
+                time.sleep(2.0 * (i + 1))
+    assert last_exc is not None
+    raise last_exc
+
+
+def _decode_sales_report_body(resp: Any) -> str:
+    """ASC returns gzip TSV or occasionally JSON with a URL; normalize to decoded text."""
+    import requests as rq
+
+    raw: bytes = resp.content or b""
+    ctype = (resp.headers.get("Content-Type") or "").lower()
+
+    if "json" in ctype and raw:
+        try:
+            payload = resp.json()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            data = payload.get("data")
+            if isinstance(data, list) and data:
+                attrs = (data[0] or {}).get("attributes") or {}
+                url = attrs.get("url")
+                if isinstance(url, str) and url.startswith("http"):
+                    r2 = rq.get(url, timeout=120)
+                    r2.raise_for_status()
+                    raw = r2.content
+                    ctype = (r2.headers.get("Content-Type") or "").lower()
+
+    if not raw:
+        return ""
+
+    if "gzip" in ctype or (len(raw) >= 2 and raw[0:2] == b"\x1f\x8b"):
+        try:
+            with gzip.GzipFile(fileobj=io.BytesIO(raw), mode="rb") as gz:
+                return gz.read().decode("utf-8", errors="replace")
+        except (OSError, EOFError):
+            pass
+
+    return raw.decode("utf-8", errors="replace")
+
+
+def _normalize_apple_id(value: str) -> str:
+    s = (value or "").strip()
+    if s.endswith(".0") and s[:-2].isdigit():
+        s = s[:-2]
+    return s
+
+
+def _row_matches_app(row: dict[str, str], app_apple_id: str, app_sku: str) -> bool:
+    aid = _normalize_apple_id(row.get("Apple Identifier", ""))
+    sku = (row.get("SKU", "") or "").strip()
+    parent = (row.get("Parent Identifier", "") or "").strip()
+    target_id = _normalize_apple_id(app_apple_id)
+    return aid == target_id or sku == app_sku or parent == app_sku
+
+
+def _find_column(header: list[str], *candidates: str) -> Optional[int]:
+    norm = [h.strip().replace("\ufeff", "") for h in header]
+    for cand in candidates:
+        for i, h in enumerate(norm):
+            if h == cand:
+                return i
+    return None
+
+
+def parse_sales_summary_tsv(
+    text: str,
+    *,
+    app_apple_id: str,
+    app_sku: str,
+) -> dict[str, Any]:
+    """Parse ASC daily sales summary TSV; sum Units × Developer Proceeds (per unit) for scoped rows."""
+    if not text.strip():
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+        }
+
+    lines = text.splitlines()
+    if not lines:
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+        }
+
+    reader = csv.reader(lines, delimiter="\t")
+    rows_iter = iter(reader)
+    try:
+        header_raw = next(rows_iter)
+    except StopIteration:
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+        }
+
+    header = [h.strip().replace("\ufeff", "") for h in header_raw]
+
+    units_i = _find_column(header, "Units")
+    proceeds_i = _find_column(
+        header,
+        "Developer Proceeds (per unit)",
+        "Developer Proceeds",
+    )
+    curr_i = _find_column(header, "Currency of Proceeds")
+
+    proceeds_by_currency: dict[str, float] = defaultdict(float)
+    rows_total = 0
+    rows_matched = 0
+    units_sum = 0.0
+
+    if units_i is None or proceeds_i is None:
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+            "parse_note": "missing Units or Developer Proceeds column in TSV header",
+            "header_sample": header[:20],
+        }
+
+    for parts in reader:
+        if not parts or all(not (c or "").strip() for c in parts):
+            continue
+        rows_total += 1
+        row_map = {header[i]: (parts[i] if i < len(parts) else "") for i in range(len(header))}
+        if not _row_matches_app(row_map, app_apple_id, app_sku):
+            continue
+        rows_matched += 1
+        try:
+            u = float((parts[units_i] if units_i < len(parts) else "0") or 0)
+        except ValueError:
+            u = 0.0
+        try:
+            per = float((parts[proceeds_i] if proceeds_i < len(parts) else "0") or 0)
+        except ValueError:
+            per = 0.0
+        ext = u * per
+        units_sum += u
+        ccy = "UNK"
+        if curr_i is not None and curr_i < len(parts):
+            ccy = (parts[curr_i] or "UNK").strip() or "UNK"
+        proceeds_by_currency[ccy] += ext
+
+    return {
+        "rows_total": rows_total,
+        "rows_matched": rows_matched,
+        "proceeds_by_currency": dict(proceeds_by_currency),
+        "units_sum_matched": round(units_sum, 4),
+    }
+
+
+def collect_ios_ledger_revenue(
+    days: int,
+    *,
+    report_lag_days: int = 3,
+    get_with_retries: Optional[Callable[..., Any]] = None,
+) -> dict[str, Any]:
+    """Fetch daily SALES SUMMARY reports for a rolling window (UTC dates)."""
+    vendor = (os.environ.get("APPSTORE_VENDOR_NUMBER") or "").strip()
+    app_sku = (os.environ.get("APPSTORE_LEDGER_APP_SKU") or DEFAULT_APP_SKU).strip()
+
+    out: dict[str, Any] = {
+        "status": "skipped",
+        "metric_bundle_id": "asc_sales_summary_daily_ledger_v1",
+        "app_apple_id": IOS_APP_ID,
+        "app_sku": app_sku,
+        "window_days_requested": days,
+        "report_lag_days": report_lag_days,
+        "vendor_number_configured": bool(vendor),
+        "days_fetched_ok": 0,
+        "days_404": 0,
+        "days_http_error": 0,
+        "errors": [],
+    }
+
+    if days < 1:
+        out["reason"] = "days must be >= 1"
+        return out
+
+    if not vendor:
+        out["reason"] = "missing APPSTORE_VENDOR_NUMBER (App Store Connect → Sales and Trends → vendor number)"
+        return out
+
+    try:
+        from asc_client import ASCAuth
+    except ImportError as e:
+        out["reason"] = f"asc_client not importable: {e}"
+        return out
+
+    try:
+        import requests
+    except ImportError as e:
+        out["reason"] = f"requests not installed: {e}"
+        return out
+
+    gw = get_with_retries or _asc_get_with_retries
+
+    try:
+        auth = ASCAuth.from_env()
+    except Exception as e:
+        out["reason"] = str(e)
+        return out
+
+    token = auth.jwt()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/a-gzip, application/json;q=0.9, */*;q=0.8",
+    }
+
+    today_utc = datetime.now(timezone.utc).date()
+    # Use calendar dates in UTC for ASC reportDate filter.
+    end_d = today_utc - timedelta(days=report_lag_days)
+    start_d = end_d - timedelta(days=max(days, 1) - 1)
+
+    agg_currency: dict[str, float] = defaultdict(float)
+    total_rows = 0
+    total_matched = 0
+    units_total = 0.0
+
+    d = start_d
+    while d <= end_d:
+        params = {
+            "filter[vendorNumber]": vendor,
+            "filter[reportType]": "SALES",
+            "filter[reportSubType]": "SUMMARY",
+            "filter[frequency]": "DAILY",
+            "filter[reportDate]": d.isoformat(),
+            "filter[version]": "1_0",
+        }
+        try:
+            resp = gw(requests, f"{APP_STORE_CONNECT_API}/salesReports", headers=headers, params=params)
+        except Exception as e:
+            out["errors"].append(f"{d.isoformat()}: {e}")
+            out["days_http_error"] += 1
+            d += timedelta(days=1)
+            continue
+
+        if resp.status_code == 404:
+            out["days_404"] += 1
+            d += timedelta(days=1)
+            continue
+
+        if resp.status_code >= 400:
+            out["days_http_error"] += 1
+            snippet = (resp.text or "")[:500]
+            out["errors"].append(f"{d.isoformat()}: HTTP {resp.status_code} {snippet}")
+            d += timedelta(days=1)
+            continue
+
+        text = _decode_sales_report_body(resp)
+        parsed = parse_sales_summary_tsv(text, app_apple_id=IOS_APP_ID, app_sku=app_sku)
+        total_rows += parsed.get("rows_total", 0)
+        total_matched += parsed.get("rows_matched", 0)
+        units_total += float(parsed.get("units_sum_matched") or 0)
+        for c, v in (parsed.get("proceeds_by_currency") or {}).items():
+            agg_currency[c] += float(v)
+        out["days_fetched_ok"] += 1
+        d += timedelta(days=1)
+
+    out["status"] = "ok" if out["days_fetched_ok"] else "error"
+    if out["status"] == "error" and not out["errors"] and out["days_404"] > 0:
+        out["reason"] = "no daily reports returned in window (404 for all days — check vendor number or lag)"
+    out["report_date_start"] = start_d.isoformat()
+    out["report_date_end"] = end_d.isoformat()
+    out["proceeds_by_currency"] = {k: round(v, 4) for k, v in sorted(agg_currency.items())}
+    out["developer_proceeds_total_rows"] = total_rows
+    out["developer_proceeds_matched_rows"] = total_matched
+    out["units_sum_matched_window"] = round(units_total, 4)
+    out["note"] = (
+        "Ledger: Apple SALES SUMMARY DAILY, version 1_0. Proceeds = sum over window of "
+        "(Units × Developer Proceeds per unit) for rows tied to this app (Apple Identifier, "
+        "SKU, or Parent Identifier). Not net of tax remittance; multi-currency kept separate. "
+        f"Recent calendar days omitted (lag={report_lag_days}) for completeness."
+    )
+    return out
+
+
+def collect_android_ledger_revenue(_days: int) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "metric_bundle_id": ANDROID_LEDGER_NA_METRIC_ID,
+        "reason": (
+            "Google Play consolidated ledger (estimated sales / earnings) is not available "
+            "through androidpublisher v3 in this snapshot; use Play Console exports or "
+            "PostHog paywall revenue as a proxy."
+        ),
+    }
+
+
+def collect_store_ledger_revenue(
+    days: int,
+    *,
+    report_lag_days: int = 3,
+    get_with_retries: Optional[Callable[..., Any]] = None,
+) -> dict[str, Any]:
+    return {
+        "metric_bundle_id": STORE_LEDGER_METRIC_BUNDLE_ID,
+        "window_days": days,
+        "ios": collect_ios_ledger_revenue(days, report_lag_days=report_lag_days, get_with_retries=get_with_retries),
+        "android": collect_android_ledger_revenue(days),
+    }

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -93,6 +93,32 @@ def test_posthog_person_id_exclusion_sql_respects_env(monkeypatch: pytest.Monkey
     assert "not-a-uuid" not in sql
 
 
+def test_run_includes_ledger_revenue(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from scripts import executive_metrics_snapshot as ems
+    import check_crashlytics as cc
+    import real_store_downloads as rsd
+    import store_ledger_revenue as slr
+
+    monkeypatch.setattr(rsd, "_get_android_data", lambda d: {"status": "skipped"})
+    monkeypatch.setattr(rsd, "_get_ios_data", lambda d: {"status": "skipped"})
+    monkeypatch.setattr(cc, "collect_crashlytics_snapshot", lambda hours: {"status": "skipped"})
+    monkeypatch.setattr(
+        slr,
+        "collect_store_ledger_revenue",
+        lambda days: {
+            "metric_bundle_id": "store_ledger_revenue_v1",
+            "window_days": days,
+            "ios": {"status": "skipped", "reason": "test"},
+            "android": {"status": "skipped"},
+        },
+    )
+
+    payload = ems.run(tmp_path, days=7, load_dotenv=False)
+    assert "ledger_revenue" in payload
+    assert payload["ledger_revenue"]["ios"]["status"] == "skipped"
+    assert "ledger_revenue" in payload["definitions"]
+
+
 def test_posthog_section_includes_wqtu_7d_from_queries(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import executive_metrics_snapshot as ems
 

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -59,34 +59,34 @@ def test_paywall_hidden_unlock_is_on_title_and_unlocks_pro_not_elite():
     android_source = _read(ANDROID_PAYWALL)
     ios_paywall = _read(IOS_PAYWALL)
 
-    assert "Unlock Full Training Mode" in android_source and "holdForHiddenUnlock" in android_source
+    assert "PAYWALL_HEADLINE" in android_source and "holdForHiddenUnlock" in android_source
+    assert "Stop Training With the Brakes On" in android_source
     assert "8_000L" in android_source
-    assert "Unlock Full Training Mode" in ios_paywall and "highPriorityGesture" in ios_paywall
+    assert "Stop Training With the Brakes On" in ios_paywall and "highPriorityGesture" in ios_paywall
     assert "LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration" in ios_paywall
     assert "triggerDebugUnlock()" in ios_paywall
     assert "unlockProForDebug" in ios_paywall
 
 
 def test_paywall_single_offer_parity():
-    """Enforce one visible premium offer on both platforms (monetization-roadmap)."""
+    """Shared paywall copy; Android shows subscription plan choice, iOS one-time Pro CTA."""
     android_paywall = _read(ANDROID_PAYWALL)
     ios_paywall = _read(IOS_PAYWALL)
 
     assert "Elite Tactical" not in android_paywall, (
-        "Android paywall must not show Elite Tactical; single-offer only per monetization roadmap"
+        "Android paywall must not show Elite Tactical as a visible tier label"
     )
-    assert "Unlock Full Training Mode" in android_paywall
-    assert "Unlock Full Training Mode" in ios_paywall
-    assert "Longer sessions, voice coaching, more sounds, and repeatable rounds." in android_paywall
-    assert "Longer sessions, voice coaching, more sounds, and repeatable rounds." in ios_paywall
-    assert "Built for dry fire, sparring, drills, and reaction training." in android_paywall
-    assert "Built for dry fire, sparring, drills, and reaction training." in ios_paywall
+    assert "Stop Training With the Brakes On" in android_paywall
+    assert "Stop Training With the Brakes On" in ios_paywall
+    assert "Go unlimited — sessions up to 60 minutes" in android_paywall
+    assert "Go unlimited — sessions up to 60 minutes" in ios_paywall
     assert "Cancel anytime" in android_paywall
-    assert "Start Pro" in android_paywall
-    # iOS: App Store Connect non-consumable Pro Upgrade (not subscription); Android may still show yearly copy.
-    assert "Unlock Pro" in ios_paywall
-    assert "Pro Upgrade" in ios_paywall
-    assert "one-time" in ios_paywall.lower()
+    assert "CHOOSE A PLAN" in android_paywall and "CHOOSE A PLAN" in ios_paywall
+    assert "Monthly" in android_paywall and "Annual" in android_paywall
+    assert "Monthly" in ios_paywall and "Annual" in ios_paywall
+    assert "Start Monthly" in android_paywall or "Start Annual" in android_paywall
+    assert "Start Monthly" in ios_paywall or "Start Annual" in ios_paywall
+    assert "Lifetime" in ios_paywall and "One-time" in ios_paywall
 
 
 def test_ios_paywall_uses_scrollable_large_presentation_to_avoid_clipped_actions():
@@ -182,20 +182,20 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert "Icons.Filled.Lock" in android_setup
     assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     for expected in (
-        "Train up to 60-minute sessions",
-        "Get voice callouts during training",
-        "Use loop mode with round limits",
-        "Unlock the full sound library",
-        "New Pro voice callouts and sound packs every 30 days",
+        "Full-length sessions — up to 60 minutes, no cutoffs",
+        "Live voice callouts keep you sharp under pressure",
+        "Loop drills with round limits — just like competition",
+        "Full sound arsenal — real bells, horns, and sirens",
+        "Fresh callout packs every 30 days — Pro gets them first",
     ):
         assert expected in android_paywall
         assert expected in ios_paywall
 
     assert "const val PRO_PRODUCT_ID = ELITE_PRODUCT_ID" in android_pro_manager
     assert "suspend fun getFormattedProPrice()" in android_pro_manager or "getFormattedPrice" in android_pro_manager
-    assert "suspend fun launchProPurchase(" in android_pro_manager
+    assert "suspend fun launchPurchase(" in android_pro_manager
     assert "getFormattedPrice" in android_nav or "proPrice" in android_nav
-    assert "launchProPurchase" in android_nav
+    assert "launchPurchase" in android_nav
 
 
 def test_free_sound_arsenal_taps_preview_without_forcing_ios_paywall():

--- a/scripts/tests/test_store_ledger_revenue.py
+++ b/scripts/tests/test_store_ledger_revenue.py
@@ -1,0 +1,108 @@
+"""Tests for store ledger revenue (ASC daily sales TSV) helpers."""
+
+from __future__ import annotations
+
+import gzip
+from unittest import mock
+
+import pytest
+
+
+def test_parse_sales_summary_tsv_sums_matched_rows() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    tsv = (
+        "Provider\tSKU\tApple Identifier\tParent Identifier\tUnits\t"
+        "Developer Proceeds (per unit)\tCurrency of Proceeds\n"
+        "APPLE\tother_sku\t999\t\t1\t1.00\tUSD\n"
+        f"APPLE\t{slr.DEFAULT_APP_SKU}\t{slr.IOS_APP_ID}\t\t10\t0.70\tUSD\n"
+        "APPLE\tiap1\t888\t"
+        + slr.DEFAULT_APP_SKU
+        + "\t2\t0.50\tEUR\n"
+    )
+    out = slr.parse_sales_summary_tsv(tsv, app_apple_id=slr.IOS_APP_ID, app_sku=slr.DEFAULT_APP_SKU)
+    assert out["rows_total"] == 3
+    assert out["rows_matched"] == 2
+    assert out["proceeds_by_currency"]["USD"] == pytest.approx(7.0)
+    assert out["proceeds_by_currency"]["EUR"] == pytest.approx(1.0)
+    assert out["units_sum_matched"] == pytest.approx(12.0)
+
+
+def test_parse_sales_summary_tsv_parent_identifier_iap() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    tsv = (
+        "SKU\tApple Identifier\tParent Identifier\tUnits\t"
+        "Developer Proceeds (per unit)\tCurrency of Proceeds\n"
+        "pro_base\t111111\t"
+        + slr.DEFAULT_APP_SKU
+        + "\t1\t4.00\tUSD\n"
+    )
+    out = slr.parse_sales_summary_tsv(tsv, app_apple_id=slr.IOS_APP_ID, app_sku=slr.DEFAULT_APP_SKU)
+    assert out["rows_matched"] == 1
+    assert out["proceeds_by_currency"]["USD"] == pytest.approx(4.0)
+
+
+def test_collect_ios_ledger_skipped_without_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import store_ledger_revenue as slr
+
+    monkeypatch.delenv("APPSTORE_VENDOR_NUMBER", raising=False)
+    out = slr.collect_ios_ledger_revenue(7)
+    assert out["status"] == "skipped"
+    assert "APPSTORE_VENDOR_NUMBER" in (out.get("reason") or "")
+
+
+def test_collect_ios_ledger_fetches_and_aggregates(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import store_ledger_revenue as slr
+
+    monkeypatch.setenv("APPSTORE_VENDOR_NUMBER", "12345678")
+    monkeypatch.setenv("APPSTORE_KEY_ID", "kid")
+    monkeypatch.setenv("APPSTORE_ISSUER_ID", "iss")
+    monkeypatch.setenv("APPSTORE_PRIVATE_KEY", "not-a-real-key")
+
+    tsv = (
+        "SKU\tApple Identifier\tUnits\tDeveloper Proceeds (per unit)\tCurrency of Proceeds\n"
+        f"{slr.DEFAULT_APP_SKU}\t{slr.IOS_APP_ID}\t2\t1.00\tUSD\n"
+    )
+    gz = gzip.compress(tsv.encode("utf-8"))
+
+    class Resp:
+        def __init__(self, code: int, body: bytes) -> None:
+            self.status_code = code
+            self.content = body
+            self.headers = {"Content-Type": "application/a-gzip"}
+            self.text = ""
+
+        def json(self) -> dict:
+            return {}
+
+    calls: list[int] = []
+
+    def fake_gw(requests_mod, url, headers, params, **kwargs):
+        calls.append(1)
+        return Resp(200, gz)
+
+    with mock.patch("asc_client.ASCAuth.from_env") as fe:
+        fe.return_value = mock.Mock(jwt=lambda: "jwt")
+        out = slr.collect_ios_ledger_revenue(1, report_lag_days=3, get_with_retries=fake_gw)
+
+    assert out["status"] == "ok"
+    assert out["days_fetched_ok"] == 1
+    assert out["proceeds_by_currency"].get("USD") == pytest.approx(2.0)
+    assert len(calls) == 1
+
+
+def test_collect_android_ledger_is_skipped() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    out = slr.collect_android_ledger_revenue(30)
+    assert out["status"] == "skipped"
+    assert "androidpublisher" in out["reason"]
+
+
+def test_collect_store_ledger_revenue_shape() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    bundle = slr.collect_store_ledger_revenue(30)
+    assert bundle["metric_bundle_id"] == slr.STORE_LEDGER_METRIC_BUNDLE_ID
+    assert "ios" in bundle and "android" in bundle

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -158,9 +158,9 @@ def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():
     android_navigation = ANDROID_NAVIGATION.read_text(encoding="utf-8")
     ios_paywall = IOS_PAYWALL.read_text(encoding="utf-8")
 
-    assert "Unlock Full Training Mode" in android_paywall
+    assert "Stop Training With the Brakes On" in android_paywall
     assert "holdForHiddenUnlock" in android_paywall and "8_000" in android_paywall
-    assert "Unlock Full Training Mode" in ios_paywall
+    assert "Stop Training With the Brakes On" in ios_paywall
     assert "highPriorityGesture" in ios_paywall
     assert "LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration" in ios_paywall
     assert "triggerDebugUnlock()" in ios_paywall


### PR DESCRIPTION
## Summary

- **Android**: `selectPreferredSubscriptionOffer` now prioritises trial offers (phases with `priceAmountMicros == 0`). `PaywallSheet` accepts `hasFreeTrial: Boolean` and shows **"Start 7-Day Free Trial"** as CTA when a trial offer is available. `ProManager.hasFreeTrialOffer()` exposes trial availability. Tracks `free_trial_started` analytics event on successful trial purchase.
- **iOS**: `ProManager.hasFreeTrialOffer` checks `Product.subscription?.introductoryOffer` (StoreKit 2). `PaywallSheet.ctaLabel` shows **"Start 7-Day Free Trial"** when selected plan product has an intro offer. Tracks `free_trial_started` event via `AnalyticsService` on purchase success.
- Both platforms fall back gracefully to normal CTA when no trial is configured in App Store Connect / Play Console.

## Changes

- `ProManager.kt` — `SubscriptionPricingPhase.isFree`, `SubscriptionOffer.hasFreeTrial`, `hasFreeTrialOffer()`, `pendingPurchaseIsFreeTrial` flag, `free_trial_started` event tracking
- `PaywallSheet.kt` (Android) — `hasFreeTrial` parameter; conditional CTA text
- `Navigation.kt` — passes `paywallHasFreeTrial` state to `PaywallSheet`
- `AnalyticsService.kt` (Android + iOS) — `FREE_TRIAL_STARTED` / `freeTrialStarted` event constants
- `ProManager.swift` — `hasFreeTrialOffer`, `doPurchase` trial tracking
- `PaywallSheet.swift` (iOS) — `ctaLabel` checks `introductoryOffer` per plan
- `ProManagerSubscriptionOfferSelectionTest.kt` — 5 tests covering trial preference, annual fallback, `hasFreeTrial`

## Test plan

- [ ] Android unit tests: `ProManagerSubscriptionOfferSelectionTest` (5 tests) pass
- [ ] iOS build: `xcodebuild` succeeds with no errors
- [ ] When Play Console / ASC has a free trial configured on the subscription, the paywall CTA shows "Start 7-Day Free Trial"
- [ ] When no trial is configured, falls back to "Start Monthly • $X.XX/mo" / "Start Annual • $X.XX/yr"
- [ ] `free_trial_started` event fires in PostHog when user completes a trial subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)