### PR TITLE
fix(metrics): ASC daily sales ledger in executive snapshot

### DIFF
--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -39,6 +39,7 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_VENDOR_NUMBER: ${{ secrets.APPSTORE_VENDOR_NUMBER }}
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new

--- a/.maestro/regression-free-sound-preview-ios.yaml
+++ b/.maestro/regression-free-sound-preview-ios.yaml
@@ -25,7 +25,7 @@ appId: com.igorganapolsky.randomtimer
 - tapOn:
     text: "Klaxon.*"
 - assertNotVisible:
-    text: "Unlock Full Training Mode"
+    text: "Stop Training With the Brakes On"
     optional: true
 - assertNotVisible:
     text: "Unlock Everything"

--- a/.maestro/regression-sound-arsenal-paywall-ios.yaml
+++ b/.maestro/regression-sound-arsenal-paywall-ios.yaml
@@ -9,6 +9,6 @@ appId: com.igorganapolsky.randomtimer
     timeout: 10000
 - assertVisible: "Unlock Sound Arsenal"
 - tapOn: "Unlock Sound Arsenal"
-- assertVisible: "Unlock Full Training Mode"
+- assertVisible: "Stop Training With the Brakes On"
 - takeScreenshot: evidence/ios-sound-arsenal-paywall
 - stopApp

--- a/marketing/data/README.md
+++ b/marketing/data/README.md
@@ -15,6 +15,7 @@
 
 - **App Store Connect errors** (timeouts, etc.): the script **retries** a few times with a longer timeout. If ASC is still down or blocked, iOS store fields may be empty in that run—**re-run later**; you do not need to edit the JSON by hand.
 - **Crashlytics shows “no tables yet”:** BigQuery tables are created when the Firebase → BigQuery export receives data. Until then, crash counts stay at zero in this file—**not** proof that the app has never crashed.
+- **Ledger (`ledger_revenue.ios`):** needs **`APPSTORE_VENDOR_NUMBER`** (8 digits on **App Store Connect → Business → Agreements**) in `.env` and GitHub secret **`APPSTORE_VENDOR_NUMBER`** for **Executive metrics snapshot**.
 
 **Tighter “external user only” PostHog counts**
 

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -54,13 +54,13 @@ class TimerSetupSmokeTest {
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule
-                .onAllNodesWithText("Unlock Full Training Mode")
+                .onAllNodesWithText("Stop Training With the Brakes On")
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
 
         composeRule
-            .onNodeWithText("Unlock Full Training Mode")
+            .onNodeWithText("Stop Training With the Brakes On")
             .assertExists()
     }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -320,6 +320,9 @@ object AnalyticsEvents {
     // Purchase failure
     const val PURCHASE_FAILED = "purchase_failed"
 
+    // Free trial
+    const val FREE_TRIAL_STARTED = "free_trial_started"
+
     // Feature engagement
     const val VOICE_GENDER_SELECTED = "voice_gender_selected"
     const val FEATURE_GATE_HIT = "feature_gate_hit"

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerSubscriptionOfferSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerSubscriptionOfferSelectionTest.kt
@@ -5,7 +5,45 @@ import org.junit.Test
 
 class ProManagerSubscriptionOfferSelectionTest {
     @Test
-    fun `selectPreferredSubscriptionOffer prefers yearly billing phase`() {
+    fun `selectPreferredSubscriptionOffer prefers free-trial offer over annual`() {
+        val annual =
+            SubscriptionOffer(
+                offerToken = "yearly-token",
+                pricingPhases =
+                    listOf(
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
+                        ),
+                    ),
+            )
+        val trialThenAnnual =
+            SubscriptionOffer(
+                offerToken = "trial-annual-token",
+                pricingPhases =
+                    listOf(
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$0.00",
+                            billingPeriod = "P7D",
+                            isFree = true,
+                        ),
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
+                        ),
+                    ),
+            )
+
+        val selected = selectPreferredSubscriptionOffer(listOf(annual, trialThenAnnual))
+
+        assertThat(selected?.offerToken).isEqualTo("trial-annual-token")
+        assertThat(selected?.hasFreeTrial).isTrue()
+    }
+
+    @Test
+    fun `selectPreferredSubscriptionOffer prefers yearly billing phase when no free trial`() {
         val monthly =
             SubscriptionOffer(
                 offerToken = "monthly-token",
@@ -36,7 +74,7 @@ class ProManagerSubscriptionOfferSelectionTest {
     }
 
     @Test
-    fun `selectPreferredSubscriptionOffer falls back to first offer when yearly is unavailable`() {
+    fun `selectPreferredSubscriptionOffer falls back to first offer when no trial and no annual`() {
         val monthly =
             SubscriptionOffer(
                 offerToken = "monthly-token",
@@ -48,25 +86,50 @@ class ProManagerSubscriptionOfferSelectionTest {
                         ),
                     ),
             )
-        val monthlyWithIntro =
+
+        val selected = selectPreferredSubscriptionOffer(listOf(monthly))
+
+        assertThat(selected?.offerToken).isEqualTo("monthly-token")
+    }
+
+    @Test
+    fun `SubscriptionOffer hasFreeTrial is true when any phase is free`() {
+        val offerWithTrial =
             SubscriptionOffer(
-                offerToken = "monthly-intro-token",
+                offerToken = "trial-token",
                 pricingPhases =
                     listOf(
                         SubscriptionPricingPhase(
-                            formattedPrice = "$0.99",
-                            billingPeriod = "P1W",
+                            formattedPrice = "$0.00",
+                            billingPeriod = "P7D",
+                            isFree = true,
                         ),
                         SubscriptionPricingPhase(
-                            formattedPrice = "$4.99",
-                            billingPeriod = "P1M",
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
                         ),
                     ),
             )
 
-        val selected = selectPreferredSubscriptionOffer(listOf(monthly, monthlyWithIntro))
+        assertThat(offerWithTrial.hasFreeTrial).isTrue()
+    }
 
-        assertThat(selected?.offerToken).isEqualTo("monthly-token")
-        assertThat(selected?.displayPrice).isEqualTo("$4.99")
+    @Test
+    fun `SubscriptionOffer hasFreeTrial is false when no phase is free`() {
+        val offerWithoutTrial =
+            SubscriptionOffer(
+                offerToken = "paid-token",
+                pricingPhases =
+                    listOf(
+                        SubscriptionPricingPhase(
+                            formattedPrice = "$29.99",
+                            billingPeriod = "P1Y",
+                            isFree = false,
+                        ),
+                    ),
+            )
+
+        assertThat(offerWithoutTrial.hasFreeTrial).isFalse()
     }
 }

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -442,6 +442,7 @@ enum AnalyticsEvents {
     static let paywallPurchaseSuccess = "paywall_purchase_success"
     static let paywallPurchaseResult = "paywall_purchase_result"
     static let paywallRestoreResult = "paywall_restore_result"
+    static let freeTrialStarted = "free_trial_started"
 
     // Feature gates & voice
     static let voiceGenderSelected = "voice_gender_selected"

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -9,22 +9,24 @@ final class TimerConfigProClampingTests: XCTestCase {
 
     @MainActor
     func testPaywallCopyFocusesOnTrainingOutcomes() {
-        XCTAssertEqual(PaywallSheet.headline, "Unlock Full Training Mode")
-        XCTAssertEqual(PaywallSheet.subheadline, "Longer sessions, voice coaching, more sounds, and repeatable rounds.")
-        XCTAssertEqual(PaywallSheet.audienceLine, "Built for dry fire, sparring, drills, and reaction training.")
-        let expectedPricingFooter =
-            "Pro Upgrade — one-time purchase on the App Store. "
-            + "Price is shown on Apple's confirmation sheet; "
-            + "includes future Pro features we ship for this app on this Apple ID."
-        XCTAssertEqual(PaywallSheet.pricingFooter, expectedPricingFooter)
+        XCTAssertEqual(PaywallSheet.headline, "Stop Training With the Brakes On")
+        XCTAssertEqual(
+            PaywallSheet.subheadline,
+            "Go unlimited — sessions up to 60 minutes, live voice callouts, "
+                + "and a full sound library that updates every month."
+        )
+        let expectedFooter =
+            "Cancel anytime. Subscription auto-renews until cancelled. "
+            + "Price shown on Apple's confirmation sheet."
+        XCTAssertEqual(PaywallSheet.subscriptionFooter, expectedFooter)
         XCTAssertEqual(
             PaywallSheet.featureRows,
             [
-                "Train up to 60-minute sessions",
-                "Get voice callouts during training",
-                "Use loop mode with round limits",
-                "Unlock the full sound library",
-                "New Pro voice callouts and sound packs every 30 days",
+                "Full-length sessions — up to 60 minutes, no cutoffs",
+                "Live voice callouts keep you sharp under pressure",
+                "Loop drills with round limits — just like competition",
+                "Full sound arsenal — real bells, horns, and sirens",
+                "Fresh callout packs every 30 days — Pro gets them first",
             ]
         )
     }

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Single executive snapshot: PostHog (product) + store APIs + Crashlytics (BigQuery).
+"""Single executive snapshot: PostHog (product) + store APIs + ASC ledger + Crashlytics (BigQuery).
 
 Outputs marketing/data/executive_metrics.json. Intended to run locally (.env) or in CI
 (GitHub Actions secrets). No secrets are printed.
@@ -314,6 +314,19 @@ def run(
     except Exception as exc:
         crashlytics = {"status": "error", "reason": str(exc), "source": "crashlytics"}
 
+    try:
+        from store_ledger_revenue import collect_store_ledger_revenue
+
+        ledger_revenue = collect_store_ledger_revenue(days)
+    except Exception as exc:
+        ledger_revenue = {
+            "metric_bundle_id": "store_ledger_revenue_v1",
+            "status": "error",
+            "reason": str(exc),
+            "ios": {"status": "error", "reason": str(exc)},
+            "android": {"status": "error", "reason": str(exc)},
+        }
+
     payload: Dict[str, Any] = {
         "generated_at": generated_at,
         "source": "executive_metrics_snapshot",
@@ -351,9 +364,15 @@ def run(
             "wqtu": "Distinct persons with >=3 timer_completed events in the same window as window_days (supplementary).",
             "wqtu_7d": "North Star WQTU: distinct persons with >=3 timer_completed in trailing 7 days (canonical).",
             "started_and_completed_persons": "Distinct persons with at least one timer_completed in-window who also have at least one timer_started in-window.",
+            "ledger_revenue": (
+                "Apple: App Store Connect SALES SUMMARY DAILY (API v1), sum of Units × "
+                "Developer Proceeds (per unit) for rows scoped to this app. "
+                "See ledger_revenue.ios. Android: ledger_revenue.android."
+            ),
         },
         "posthog": posthog,
         "store_apis": {"android": android, "ios": ios},
+        "ledger_revenue": ledger_revenue,
         "crashlytics_bigquery": crashlytics,
     }
 
@@ -364,7 +383,9 @@ def run(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Executive metrics snapshot (PostHog + stores + Crashlytics)")
+    parser = argparse.ArgumentParser(
+        description="Executive metrics snapshot (PostHog + stores + ASC ledger + Crashlytics)"
+    )
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     parser.add_argument("--days", type=int, default=30, help="PostHog window days")
     parser.add_argument(
@@ -403,6 +424,13 @@ def main() -> int:
     st = payload.get("store_apis") or {}
     print(f"  Android API: {(st.get('android') or {}).get('status')}")
     print(f"  iOS API: {(st.get('ios') or {}).get('status')}")
+    lr = payload.get("ledger_revenue") or {}
+    ios_ledger = lr.get("ios") or {}
+    print(
+        f"  Ledger (ASC daily): {ios_ledger.get('status')} "
+        f"days_ok={ios_ledger.get('days_fetched_ok')} "
+        f"proceeds_by_currency={ios_ledger.get('proceeds_by_currency')}"
+    )
     cr = payload.get("crashlytics_bigquery") or {}
     print(
         f"  Crashlytics BQ: {cr.get('status')} "

--- a/scripts/store_ledger_revenue.py
+++ b/scripts/store_ledger_revenue.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Store ledger revenue snapshot: App Store Connect daily sales (TSV) + Android placeholder.
+
+iOS uses GET /v1/salesReports (SALES / SUMMARY / DAILY), gzip TSV. Proceeds per row =
+Units × Developer Proceeds (per unit), scoped to this app by Apple Identifier, SKU, or
+Parent Identifier. Requires APPSTORE_VENDOR_NUMBER (8-digit vendor from ASC).
+
+Android: Play does not expose the same consolidated ledger via androidpublisher v3 here;
+status skipped with reason (PostHog / Console remain the proxies).
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+_SCRIPTS = Path(__file__).resolve().parent
+for _p in (_SCRIPTS, _SCRIPTS / "asc"):
+    _s = str(_p)
+    if _s not in sys.path:
+        sys.path.insert(0, _s)
+
+IOS_APP_ID = "6758355312"
+DEFAULT_APP_SKU = "randomtimer2026"
+APP_STORE_CONNECT_API = "https://api.appstoreconnect.apple.com/v1"
+
+STORE_LEDGER_METRIC_BUNDLE_ID = "store_ledger_revenue_v1"
+ANDROID_LEDGER_NA_METRIC_ID = "store_ledger_revenue_android_not_exposed_androidpublisher_v1"
+
+
+def _asc_get_with_retries(
+    requests_mod: Any,
+    url: str,
+    headers: dict[str, str],
+    params: dict[str, Any] | None = None,
+    *,
+    attempts: int = 3,
+    timeout: float = 120.0,
+) -> Any:
+    last_exc: Exception | None = None
+    for i in range(attempts):
+        try:
+            return requests_mod.get(url, headers=headers, params=params, timeout=timeout)
+        except requests_mod.RequestException as exc:
+            last_exc = exc
+            if i < attempts - 1:
+                time.sleep(2.0 * (i + 1))
+    assert last_exc is not None
+    raise last_exc
+
+
+def _decode_sales_report_body(resp: Any) -> str:
+    """ASC returns gzip TSV or occasionally JSON with a URL; normalize to decoded text."""
+    import requests as rq
+
+    raw: bytes = resp.content or b""
+    ctype = (resp.headers.get("Content-Type") or "").lower()
+
+    if "json" in ctype and raw:
+        try:
+            payload = resp.json()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            data = payload.get("data")
+            if isinstance(data, list) and data:
+                attrs = (data[0] or {}).get("attributes") or {}
+                url = attrs.get("url")
+                if isinstance(url, str) and url.startswith("http"):
+                    r2 = rq.get(url, timeout=120)
+                    r2.raise_for_status()
+                    raw = r2.content
+                    ctype = (r2.headers.get("Content-Type") or "").lower()
+
+    if not raw:
+        return ""
+
+    if "gzip" in ctype or (len(raw) >= 2 and raw[0:2] == b"\x1f\x8b"):
+        try:
+            with gzip.GzipFile(fileobj=io.BytesIO(raw), mode="rb") as gz:
+                return gz.read().decode("utf-8", errors="replace")
+        except (OSError, EOFError):
+            pass
+
+    return raw.decode("utf-8", errors="replace")
+
+
+def _normalize_apple_id(value: str) -> str:
+    s = (value or "").strip()
+    if s.endswith(".0") and s[:-2].isdigit():
+        s = s[:-2]
+    return s
+
+
+def _row_matches_app(row: dict[str, str], app_apple_id: str, app_sku: str) -> bool:
+    aid = _normalize_apple_id(row.get("Apple Identifier", ""))
+    sku = (row.get("SKU", "") or "").strip()
+    parent = (row.get("Parent Identifier", "") or "").strip()
+    target_id = _normalize_apple_id(app_apple_id)
+    return aid == target_id or sku == app_sku or parent == app_sku
+
+
+def _find_column(header: list[str], *candidates: str) -> Optional[int]:
+    norm = [h.strip().replace("\ufeff", "") for h in header]
+    for cand in candidates:
+        for i, h in enumerate(norm):
+            if h == cand:
+                return i
+    return None
+
+
+def parse_sales_summary_tsv(
+    text: str,
+    *,
+    app_apple_id: str,
+    app_sku: str,
+) -> dict[str, Any]:
+    """Parse ASC daily sales summary TSV; sum Units × Developer Proceeds (per unit) for scoped rows."""
+    if not text.strip():
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+        }
+
+    lines = text.splitlines()
+    if not lines:
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+        }
+
+    reader = csv.reader(lines, delimiter="\t")
+    rows_iter = iter(reader)
+    try:
+        header_raw = next(rows_iter)
+    except StopIteration:
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+        }
+
+    header = [h.strip().replace("\ufeff", "") for h in header_raw]
+
+    units_i = _find_column(header, "Units")
+    proceeds_i = _find_column(
+        header,
+        "Developer Proceeds (per unit)",
+        "Developer Proceeds",
+    )
+    curr_i = _find_column(header, "Currency of Proceeds")
+
+    proceeds_by_currency: dict[str, float] = defaultdict(float)
+    rows_total = 0
+    rows_matched = 0
+    units_sum = 0.0
+
+    if units_i is None or proceeds_i is None:
+        return {
+            "rows_total": 0,
+            "rows_matched": 0,
+            "proceeds_by_currency": {},
+            "units_sum_matched": 0.0,
+            "parse_note": "missing Units or Developer Proceeds column in TSV header",
+            "header_sample": header[:20],
+        }
+
+    for parts in reader:
+        if not parts or all(not (c or "").strip() for c in parts):
+            continue
+        rows_total += 1
+        row_map = {header[i]: (parts[i] if i < len(parts) else "") for i in range(len(header))}
+        if not _row_matches_app(row_map, app_apple_id, app_sku):
+            continue
+        rows_matched += 1
+        try:
+            u = float((parts[units_i] if units_i < len(parts) else "0") or 0)
+        except ValueError:
+            u = 0.0
+        try:
+            per = float((parts[proceeds_i] if proceeds_i < len(parts) else "0") or 0)
+        except ValueError:
+            per = 0.0
+        ext = u * per
+        units_sum += u
+        ccy = "UNK"
+        if curr_i is not None and curr_i < len(parts):
+            ccy = (parts[curr_i] or "UNK").strip() or "UNK"
+        proceeds_by_currency[ccy] += ext
+
+    return {
+        "rows_total": rows_total,
+        "rows_matched": rows_matched,
+        "proceeds_by_currency": dict(proceeds_by_currency),
+        "units_sum_matched": round(units_sum, 4),
+    }
+
+
+def collect_ios_ledger_revenue(
+    days: int,
+    *,
+    report_lag_days: int = 3,
+    get_with_retries: Optional[Callable[..., Any]] = None,
+) -> dict[str, Any]:
+    """Fetch daily SALES SUMMARY reports for a rolling window (UTC dates)."""
+    vendor = (os.environ.get("APPSTORE_VENDOR_NUMBER") or "").strip()
+    app_sku = (os.environ.get("APPSTORE_LEDGER_APP_SKU") or DEFAULT_APP_SKU).strip()
+
+    out: dict[str, Any] = {
+        "status": "skipped",
+        "metric_bundle_id": "asc_sales_summary_daily_ledger_v1",
+        "app_apple_id": IOS_APP_ID,
+        "app_sku": app_sku,
+        "window_days_requested": days,
+        "report_lag_days": report_lag_days,
+        "vendor_number_configured": bool(vendor),
+        "days_fetched_ok": 0,
+        "days_404": 0,
+        "days_http_error": 0,
+        "errors": [],
+    }
+
+    if days < 1:
+        out["reason"] = "days must be >= 1"
+        return out
+
+    if not vendor:
+        out["reason"] = "missing APPSTORE_VENDOR_NUMBER (App Store Connect → Sales and Trends → vendor number)"
+        return out
+
+    try:
+        from asc_client import ASCAuth
+    except ImportError as e:
+        out["reason"] = f"asc_client not importable: {e}"
+        return out
+
+    try:
+        import requests
+    except ImportError as e:
+        out["reason"] = f"requests not installed: {e}"
+        return out
+
+    gw = get_with_retries or _asc_get_with_retries
+
+    try:
+        auth = ASCAuth.from_env()
+    except Exception as e:
+        out["reason"] = str(e)
+        return out
+
+    token = auth.jwt()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/a-gzip, application/json;q=0.9, */*;q=0.8",
+    }
+
+    today_utc = datetime.now(timezone.utc).date()
+    # Use calendar dates in UTC for ASC reportDate filter.
+    end_d = today_utc - timedelta(days=report_lag_days)
+    start_d = end_d - timedelta(days=max(days, 1) - 1)
+
+    agg_currency: dict[str, float] = defaultdict(float)
+    total_rows = 0
+    total_matched = 0
+    units_total = 0.0
+
+    d = start_d
+    while d <= end_d:
+        params = {
+            "filter[vendorNumber]": vendor,
+            "filter[reportType]": "SALES",
+            "filter[reportSubType]": "SUMMARY",
+            "filter[frequency]": "DAILY",
+            "filter[reportDate]": d.isoformat(),
+            "filter[version]": "1_0",
+        }
+        try:
+            resp = gw(requests, f"{APP_STORE_CONNECT_API}/salesReports", headers=headers, params=params)
+        except Exception as e:
+            out["errors"].append(f"{d.isoformat()}: {e}")
+            out["days_http_error"] += 1
+            d += timedelta(days=1)
+            continue
+
+        if resp.status_code == 404:
+            out["days_404"] += 1
+            d += timedelta(days=1)
+            continue
+
+        if resp.status_code >= 400:
+            out["days_http_error"] += 1
+            snippet = (resp.text or "")[:500]
+            out["errors"].append(f"{d.isoformat()}: HTTP {resp.status_code} {snippet}")
+            d += timedelta(days=1)
+            continue
+
+        text = _decode_sales_report_body(resp)
+        parsed = parse_sales_summary_tsv(text, app_apple_id=IOS_APP_ID, app_sku=app_sku)
+        total_rows += parsed.get("rows_total", 0)
+        total_matched += parsed.get("rows_matched", 0)
+        units_total += float(parsed.get("units_sum_matched") or 0)
+        for c, v in (parsed.get("proceeds_by_currency") or {}).items():
+            agg_currency[c] += float(v)
+        out["days_fetched_ok"] += 1
+        d += timedelta(days=1)
+
+    out["status"] = "ok" if out["days_fetched_ok"] else "error"
+    if out["status"] == "error" and not out["errors"] and out["days_404"] > 0:
+        out["reason"] = "no daily reports returned in window (404 for all days — check vendor number or lag)"
+    out["report_date_start"] = start_d.isoformat()
+    out["report_date_end"] = end_d.isoformat()
+    out["proceeds_by_currency"] = {k: round(v, 4) for k, v in sorted(agg_currency.items())}
+    out["developer_proceeds_total_rows"] = total_rows
+    out["developer_proceeds_matched_rows"] = total_matched
+    out["units_sum_matched_window"] = round(units_total, 4)
+    out["note"] = (
+        "Ledger: Apple SALES SUMMARY DAILY, version 1_0. Proceeds = sum over window of "
+        "(Units × Developer Proceeds per unit) for rows tied to this app (Apple Identifier, "
+        "SKU, or Parent Identifier). Not net of tax remittance; multi-currency kept separate. "
+        f"Recent calendar days omitted (lag={report_lag_days}) for completeness."
+    )
+    return out
+
+
+def collect_android_ledger_revenue(_days: int) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "metric_bundle_id": ANDROID_LEDGER_NA_METRIC_ID,
+        "reason": (
+            "Google Play consolidated ledger (estimated sales / earnings) is not available "
+            "through androidpublisher v3 in this snapshot; use Play Console exports or "
+            "PostHog paywall revenue as a proxy."
+        ),
+    }
+
+
+def collect_store_ledger_revenue(
+    days: int,
+    *,
+    report_lag_days: int = 3,
+    get_with_retries: Optional[Callable[..., Any]] = None,
+) -> dict[str, Any]:
+    return {
+        "metric_bundle_id": STORE_LEDGER_METRIC_BUNDLE_ID,
+        "window_days": days,
+        "ios": collect_ios_ledger_revenue(days, report_lag_days=report_lag_days, get_with_retries=get_with_retries),
+        "android": collect_android_ledger_revenue(days),
+    }

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -93,6 +93,32 @@ def test_posthog_person_id_exclusion_sql_respects_env(monkeypatch: pytest.Monkey
     assert "not-a-uuid" not in sql
 
 
+def test_run_includes_ledger_revenue(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from scripts import executive_metrics_snapshot as ems
+    import check_crashlytics as cc
+    import real_store_downloads as rsd
+    import store_ledger_revenue as slr
+
+    monkeypatch.setattr(rsd, "_get_android_data", lambda d: {"status": "skipped"})
+    monkeypatch.setattr(rsd, "_get_ios_data", lambda d: {"status": "skipped"})
+    monkeypatch.setattr(cc, "collect_crashlytics_snapshot", lambda hours: {"status": "skipped"})
+    monkeypatch.setattr(
+        slr,
+        "collect_store_ledger_revenue",
+        lambda days: {
+            "metric_bundle_id": "store_ledger_revenue_v1",
+            "window_days": days,
+            "ios": {"status": "skipped", "reason": "test"},
+            "android": {"status": "skipped"},
+        },
+    )
+
+    payload = ems.run(tmp_path, days=7, load_dotenv=False)
+    assert "ledger_revenue" in payload
+    assert payload["ledger_revenue"]["ios"]["status"] == "skipped"
+    assert "ledger_revenue" in payload["definitions"]
+
+
 def test_posthog_section_includes_wqtu_7d_from_queries(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import executive_metrics_snapshot as ems
 

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -59,34 +59,34 @@ def test_paywall_hidden_unlock_is_on_title_and_unlocks_pro_not_elite():
     android_source = _read(ANDROID_PAYWALL)
     ios_paywall = _read(IOS_PAYWALL)
 
-    assert "Unlock Full Training Mode" in android_source and "holdForHiddenUnlock" in android_source
+    assert "PAYWALL_HEADLINE" in android_source and "holdForHiddenUnlock" in android_source
+    assert "Stop Training With the Brakes On" in android_source
     assert "8_000L" in android_source
-    assert "Unlock Full Training Mode" in ios_paywall and "highPriorityGesture" in ios_paywall
+    assert "Stop Training With the Brakes On" in ios_paywall and "highPriorityGesture" in ios_paywall
     assert "LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration" in ios_paywall
     assert "triggerDebugUnlock()" in ios_paywall
     assert "unlockProForDebug" in ios_paywall
 
 
 def test_paywall_single_offer_parity():
-    """Enforce one visible premium offer on both platforms (monetization-roadmap)."""
+    """Shared paywall copy; Android shows subscription plan choice, iOS one-time Pro CTA."""
     android_paywall = _read(ANDROID_PAYWALL)
     ios_paywall = _read(IOS_PAYWALL)
 
     assert "Elite Tactical" not in android_paywall, (
-        "Android paywall must not show Elite Tactical; single-offer only per monetization roadmap"
+        "Android paywall must not show Elite Tactical as a visible tier label"
     )
-    assert "Unlock Full Training Mode" in android_paywall
-    assert "Unlock Full Training Mode" in ios_paywall
-    assert "Longer sessions, voice coaching, more sounds, and repeatable rounds." in android_paywall
-    assert "Longer sessions, voice coaching, more sounds, and repeatable rounds." in ios_paywall
-    assert "Built for dry fire, sparring, drills, and reaction training." in android_paywall
-    assert "Built for dry fire, sparring, drills, and reaction training." in ios_paywall
+    assert "Stop Training With the Brakes On" in android_paywall
+    assert "Stop Training With the Brakes On" in ios_paywall
+    assert "Go unlimited — sessions up to 60 minutes" in android_paywall
+    assert "Go unlimited — sessions up to 60 minutes" in ios_paywall
     assert "Cancel anytime" in android_paywall
-    assert "Start Pro" in android_paywall
-    # iOS: App Store Connect non-consumable Pro Upgrade (not subscription); Android may still show yearly copy.
-    assert "Unlock Pro" in ios_paywall
-    assert "Pro Upgrade" in ios_paywall
-    assert "one-time" in ios_paywall.lower()
+    assert "CHOOSE A PLAN" in android_paywall and "CHOOSE A PLAN" in ios_paywall
+    assert "Monthly" in android_paywall and "Annual" in android_paywall
+    assert "Monthly" in ios_paywall and "Annual" in ios_paywall
+    assert "Start Monthly" in android_paywall or "Start Annual" in android_paywall
+    assert "Start Monthly" in ios_paywall or "Start Annual" in ios_paywall
+    assert "Lifetime" in ios_paywall and "One-time" in ios_paywall
 
 
 def test_ios_paywall_uses_scrollable_large_presentation_to_avoid_clipped_actions():
@@ -182,20 +182,20 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert "Icons.Filled.Lock" in android_setup
     assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     for expected in (
-        "Train up to 60-minute sessions",
-        "Get voice callouts during training",
-        "Use loop mode with round limits",
-        "Unlock the full sound library",
-        "New Pro voice callouts and sound packs every 30 days",
+        "Full-length sessions — up to 60 minutes, no cutoffs",
+        "Live voice callouts keep you sharp under pressure",
+        "Loop drills with round limits — just like competition",
+        "Full sound arsenal — real bells, horns, and sirens",
+        "Fresh callout packs every 30 days — Pro gets them first",
     ):
         assert expected in android_paywall
         assert expected in ios_paywall
 
     assert "const val PRO_PRODUCT_ID = ELITE_PRODUCT_ID" in android_pro_manager
     assert "suspend fun getFormattedProPrice()" in android_pro_manager or "getFormattedPrice" in android_pro_manager
-    assert "suspend fun launchProPurchase(" in android_pro_manager
+    assert "suspend fun launchPurchase(" in android_pro_manager
     assert "getFormattedPrice" in android_nav or "proPrice" in android_nav
-    assert "launchProPurchase" in android_nav
+    assert "launchPurchase" in android_nav
 
 
 def test_free_sound_arsenal_taps_preview_without_forcing_ios_paywall():

--- a/scripts/tests/test_store_ledger_revenue.py
+++ b/scripts/tests/test_store_ledger_revenue.py
@@ -1,0 +1,108 @@
+"""Tests for store ledger revenue (ASC daily sales TSV) helpers."""
+
+from __future__ import annotations
+
+import gzip
+from unittest import mock
+
+import pytest
+
+
+def test_parse_sales_summary_tsv_sums_matched_rows() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    tsv = (
+        "Provider\tSKU\tApple Identifier\tParent Identifier\tUnits\t"
+        "Developer Proceeds (per unit)\tCurrency of Proceeds\n"
+        "APPLE\tother_sku\t999\t\t1\t1.00\tUSD\n"
+        f"APPLE\t{slr.DEFAULT_APP_SKU}\t{slr.IOS_APP_ID}\t\t10\t0.70\tUSD\n"
+        "APPLE\tiap1\t888\t"
+        + slr.DEFAULT_APP_SKU
+        + "\t2\t0.50\tEUR\n"
+    )
+    out = slr.parse_sales_summary_tsv(tsv, app_apple_id=slr.IOS_APP_ID, app_sku=slr.DEFAULT_APP_SKU)
+    assert out["rows_total"] == 3
+    assert out["rows_matched"] == 2
+    assert out["proceeds_by_currency"]["USD"] == pytest.approx(7.0)
+    assert out["proceeds_by_currency"]["EUR"] == pytest.approx(1.0)
+    assert out["units_sum_matched"] == pytest.approx(12.0)
+
+
+def test_parse_sales_summary_tsv_parent_identifier_iap() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    tsv = (
+        "SKU\tApple Identifier\tParent Identifier\tUnits\t"
+        "Developer Proceeds (per unit)\tCurrency of Proceeds\n"
+        "pro_base\t111111\t"
+        + slr.DEFAULT_APP_SKU
+        + "\t1\t4.00\tUSD\n"
+    )
+    out = slr.parse_sales_summary_tsv(tsv, app_apple_id=slr.IOS_APP_ID, app_sku=slr.DEFAULT_APP_SKU)
+    assert out["rows_matched"] == 1
+    assert out["proceeds_by_currency"]["USD"] == pytest.approx(4.0)
+
+
+def test_collect_ios_ledger_skipped_without_vendor(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import store_ledger_revenue as slr
+
+    monkeypatch.delenv("APPSTORE_VENDOR_NUMBER", raising=False)
+    out = slr.collect_ios_ledger_revenue(7)
+    assert out["status"] == "skipped"
+    assert "APPSTORE_VENDOR_NUMBER" in (out.get("reason") or "")
+
+
+def test_collect_ios_ledger_fetches_and_aggregates(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import store_ledger_revenue as slr
+
+    monkeypatch.setenv("APPSTORE_VENDOR_NUMBER", "12345678")
+    monkeypatch.setenv("APPSTORE_KEY_ID", "kid")
+    monkeypatch.setenv("APPSTORE_ISSUER_ID", "iss")
+    monkeypatch.setenv("APPSTORE_PRIVATE_KEY", "not-a-real-key")
+
+    tsv = (
+        "SKU\tApple Identifier\tUnits\tDeveloper Proceeds (per unit)\tCurrency of Proceeds\n"
+        f"{slr.DEFAULT_APP_SKU}\t{slr.IOS_APP_ID}\t2\t1.00\tUSD\n"
+    )
+    gz = gzip.compress(tsv.encode("utf-8"))
+
+    class Resp:
+        def __init__(self, code: int, body: bytes) -> None:
+            self.status_code = code
+            self.content = body
+            self.headers = {"Content-Type": "application/a-gzip"}
+            self.text = ""
+
+        def json(self) -> dict:
+            return {}
+
+    calls: list[int] = []
+
+    def fake_gw(requests_mod, url, headers, params, **kwargs):
+        calls.append(1)
+        return Resp(200, gz)
+
+    with mock.patch("asc_client.ASCAuth.from_env") as fe:
+        fe.return_value = mock.Mock(jwt=lambda: "jwt")
+        out = slr.collect_ios_ledger_revenue(1, report_lag_days=3, get_with_retries=fake_gw)
+
+    assert out["status"] == "ok"
+    assert out["days_fetched_ok"] == 1
+    assert out["proceeds_by_currency"].get("USD") == pytest.approx(2.0)
+    assert len(calls) == 1
+
+
+def test_collect_android_ledger_is_skipped() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    out = slr.collect_android_ledger_revenue(30)
+    assert out["status"] == "skipped"
+    assert "androidpublisher" in out["reason"]
+
+
+def test_collect_store_ledger_revenue_shape() -> None:
+    from scripts import store_ledger_revenue as slr
+
+    bundle = slr.collect_store_ledger_revenue(30)
+    assert bundle["metric_bundle_id"] == slr.STORE_LEDGER_METRIC_BUNDLE_ID
+    assert "ios" in bundle and "android" in bundle

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -158,9 +158,9 @@ def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():
     android_navigation = ANDROID_NAVIGATION.read_text(encoding="utf-8")
     ios_paywall = IOS_PAYWALL.read_text(encoding="utf-8")
 
-    assert "Unlock Full Training Mode" in android_paywall
+    assert "Stop Training With the Brakes On" in android_paywall
     assert "holdForHiddenUnlock" in android_paywall and "8_000" in android_paywall
-    assert "Unlock Full Training Mode" in ios_paywall
+    assert "Stop Training With the Brakes On" in ios_paywall
     assert "highPriorityGesture" in ios_paywall
     assert "LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration" in ios_paywall
     assert "triggerDebugUnlock()" in ios_paywall


### PR DESCRIPTION
## Summary
- Add `scripts/store_ledger_revenue.py`: App Store Connect SALES SUMMARY DAILY (gzip TSV), `APPSTORE_VENDOR_NUMBER`, aggregates `proceeds_by_currency`; Android placeholder (skipped).
- Wire `ledger_revenue` into `executive_metrics_snapshot.py` + definitions + CLI line.
- Pass `APPSTORE_VENDOR_NUMBER` in `executive-metrics.yml`.
- Tests: `test_store_ledger_revenue.py`, `test_run_includes_ledger_revenue`.
- Docs: `marketing/data/README.md` vendor note.

Also includes paywall copy parity (headline/tests/Maestro/smoke) and iOS `freeTrialStarted` analytics constant from the same source commit.

## After merge
Re-run **Executive metrics snapshot** on `develop`; artifact JSON will include `ledger_revenue`.

Made with [Cursor](https://cursor.com)