### PR TITLE
ci(release): monthly store release cut + native-release dispatch

### DIFF
--- a/.github/workflows/monthly-store-release.yml
+++ b/.github/workflows/monthly-store-release.yml
@@ -50,8 +50,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          SKIP_AUDIO_MERGE: ${{ inputs.skip_audio_merge == true && '1' || '0' }}
-          DRY_RUN: ${{ inputs.dry_run == true && '1' || '0' }}
+          SKIP_AUDIO_MERGE: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_audio_merge && '1' || '0' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '1' || '0' }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"

--- a/.github/workflows/monthly-store-release.yml
+++ b/.github/workflows/monthly-store-release.yml
@@ -1,0 +1,84 @@
+# Scheduled: cut release/v* from develop (monthly Pro audio on develop + patch bump) and
+# dispatch Native App Release. Audio workflows run on the 1st; this runs on the 2nd to
+# allow PR merge. production-signoff environment on native-release.yml still requires
+# manual CEO approval before store uploads proceed.
+name: Monthly store release (cut + dispatch)
+
+on:
+  schedule:
+    # 2nd of each month 12:30 UTC — after Monthly Pro Audio Pack (1st 06:00) + Generate Pro Audio (1st 15:00)
+    - cron: "30 12 2 * *"
+  workflow_dispatch:
+    inputs:
+      skip_audio_merge:
+        description: "Do not try to merge feat/audio-pack-YYYY-MM into develop first"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Plan only (no bump, no push, no dispatch)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: monthly-store-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  cut-monthly-release:
+    name: Cut release branch from develop
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      version: ${{ steps.cut.outputs.version }}
+      pushed: ${{ steps.cut.outputs.pushed }}
+      skip_reason: ${{ steps.cut.outputs.skip_reason }}
+    steps:
+      - name: Checkout develop (full history for branch checks)
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+
+      - name: Cut release / bump / push
+        id: cut
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SKIP_AUDIO_MERGE: ${{ inputs.skip_audio_merge == true && '1' || '0' }}
+          DRY_RUN: ${{ inputs.dry_run == true && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          chmod +x scripts/shell/monthly-store-release-cut.sh
+          ./scripts/shell/monthly-store-release-cut.sh
+
+  dispatch-native-release:
+    name: Dispatch Native App Release
+    needs: [cut-monthly-release]
+    if: needs.cut-monthly-release.outputs.pushed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Trigger native-release on new release branch
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          REL_VERSION: ${{ needs.cut-monthly-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          REF="release/v${REL_VERSION}"
+          gh workflow run "Native App Release" \
+            --repo "${{ github.repository }}" \
+            --ref "$REF" \
+            -f platform=both \
+            -f android_track=production \
+            -f submit_review=false \
+            -f confirm_ios_only_release=false
+          echo "Dispatched Native App Release for $REF (await production-signoff in that run)."

--- a/scripts/monthly_release_utils.py
+++ b/scripts/monthly_release_utils.py
@@ -42,11 +42,6 @@ def next_patch_from_repo(repo_root: Path) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Compute next patch version from repo sources")
     parser.add_argument("--repo-root", type=Path, default=Path("."))
-    parser.add_argument(
-        "--print-next-patch",
-        action="store_true",
-        help="Print next X.Y.(Z+1) only (no newline extras)",
-    )
     args = parser.parse_args()
     root = args.repo_root.resolve()
     try:
@@ -54,10 +49,7 @@ def main() -> int:
     except Exception as exc:
         print(f"monthly_release_utils: {exc}", file=sys.stderr)
         return 1
-    if args.print_next_patch:
-        print(nxt)
-    else:
-        print(nxt)
+    print(nxt)
     return 0
 
 

--- a/scripts/monthly_release_utils.py
+++ b/scripts/monthly_release_utils.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Semver patch bump helper for monthly storefront releases."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def bump_semver_patch(version: str) -> str:
+    """Return X.Y.(Z+1) for valid X.Y.Z; all parts must be non-negative integers."""
+    parts = version.strip().split(".")
+    if len(parts) != 3:
+        raise ValueError(f"expected X.Y.Z, got {version!r}")
+    nums: list[int] = []
+    for p in parts:
+        if not p.isdigit():
+            raise ValueError(f"non-integer segment in {version!r}")
+        nums.append(int(p))
+    nums[2] += 1
+    return ".".join(str(n) for n in nums)
+
+
+def next_patch_from_repo(repo_root: Path) -> str:
+    from source_versions import read_source_versions
+
+    data = read_source_versions(repo_root)
+    android_name = data["android"]["version_name"]
+    ios_name = data["ios"]["version_name"]
+    if android_name != ios_name:
+        raise ValueError(
+            f"Android versionName {android_name!r} != iOS MARKETING_VERSION {ios_name!r}; align before release"
+        )
+    return bump_semver_patch(android_name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compute next patch version from repo sources")
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--print-next-patch",
+        action="store_true",
+        help="Print next X.Y.(Z+1) only (no newline extras)",
+    )
+    args = parser.parse_args()
+    root = args.repo_root.resolve()
+    try:
+        nxt = next_patch_from_repo(root)
+    except Exception as exc:
+        print(f"monthly_release_utils: {exc}", file=sys.stderr)
+        return 1
+    if args.print_next_patch:
+        print(nxt)
+    else:
+        print(nxt)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/shell/monthly-store-release-cut.sh
+++ b/scripts/shell/monthly-store-release-cut.sh
@@ -18,9 +18,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 write_kv() {
+  local kv="$1"
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    echo "$1" >> "$GITHUB_OUTPUT"
+    echo "$kv" >> "$GITHUB_OUTPUT"
   fi
+  return 0
 }
 
 SKIP_AUDIO_MERGE="${SKIP_AUDIO_MERGE:-0}"
@@ -49,7 +51,7 @@ if [[ "${SKIP_AUDIO_MERGE}" != "1" && -n "${GITHUB_REPOSITORY:-}" ]]; then
   fi
 fi
 
-NEW_VERSION=$(python3 "$REPO_ROOT/scripts/monthly_release_utils.py" --repo-root "$REPO_ROOT" --print-next-patch)
+NEW_VERSION=$(python3 "$REPO_ROOT/scripts/monthly_release_utils.py" --repo-root "$REPO_ROOT")
 write_kv "version=${NEW_VERSION}"
 
 if git ls-remote --heads origin "refs/heads/release/v${NEW_VERSION}" | grep -q .; then
@@ -92,7 +94,7 @@ fi
 
 git add -A
 if git diff --cached --quiet; then
-  echo "::error::No staged changes after bump (unexpected)"
+  echo "::error::No staged changes after bump (unexpected)" >&2
   exit 1
 fi
 

--- a/scripts/shell/monthly-store-release-cut.sh
+++ b/scripts/shell/monthly-store-release-cut.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# monthly-store-release-cut.sh — Cut release/v* from develop after optional monthly audio PR merge.
+#
+# Environment:
+#   GITHUB_REPOSITORY  owner/name (GitHub Actions)
+#   GITHUB_OUTPUT      key=value lines for workflow outputs
+#   SKIP_AUDIO_MERGE=1 skip feat/audio-pack-YYYY-MM merge attempt
+#   DRY_RUN=1          print plan only; no bump/commit/push
+#
+# Outputs (GITHUB_OUTPUT when set):
+#   version=1.2.3
+#   pushed=true|false
+#   skip_reason=...    optional
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+write_kv() {
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "$1" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+SKIP_AUDIO_MERGE="${SKIP_AUDIO_MERGE:-0}"
+DRY_RUN="${DRY_RUN:-0}"
+
+git fetch origin develop
+git checkout develop
+git pull --ff-only origin develop
+
+if [[ "${SKIP_AUDIO_MERGE}" != "1" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+  MONTH_UTC=$(date -u +%Y-%m)
+  AUDIO_BRANCH="feat/audio-pack-${MONTH_UTC}"
+  PR_NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --base develop --state open \
+    --json number,headRefName \
+    --jq "map(select(.headRefName==\"${AUDIO_BRANCH}\")) | .[0].number // empty" 2>/dev/null || true)
+  if [[ -n "${PR_NUM}" ]]; then
+    echo "Attempting squash merge of PR #${PR_NUM} (${AUDIO_BRANCH})"
+    if gh pr merge "$PR_NUM" --repo "$GITHUB_REPOSITORY" --squash --delete-branch; then
+      git fetch origin develop
+      git pull --ff-only origin develop
+    else
+      echo "::warning::Monthly audio PR #${PR_NUM} did not merge; continuing with current develop"
+    fi
+  else
+    echo "No open PR for ${AUDIO_BRANCH} (monthly audio may already be merged or not generated yet)"
+  fi
+fi
+
+NEW_VERSION=$(python3 "$REPO_ROOT/scripts/monthly_release_utils.py" --repo-root "$REPO_ROOT" --print-next-patch)
+write_kv "version=${NEW_VERSION}"
+
+if git ls-remote --heads origin "refs/heads/release/v${NEW_VERSION}" | grep -q .; then
+  echo "Remote already has release/v${NEW_VERSION}; skipping cut"
+  write_kv "pushed=false"
+  write_kv "skip_reason=branch_exists"
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "DRY_RUN: would create release/v${NEW_VERSION} from develop @ $(git rev-parse --short HEAD)"
+  write_kv "pushed=false"
+  write_kv "dry_run=true"
+  exit 0
+fi
+
+git checkout -b "release/v${NEW_VERSION}"
+
+bash "$REPO_ROOT/scripts/shell/bump-version.sh" "$NEW_VERSION"
+
+NEW_CODE=$(python3 "$REPO_ROOT/scripts/source_versions.py" --repo-root "$REPO_ROOT" --format value --key ANDROID_VERSION_CODE)
+ANDROID_CHANGELOG="$REPO_ROOT/native-android/fastlane/metadata/android/en-US/changelogs/${NEW_CODE}.txt"
+if [[ -f "$ANDROID_CHANGELOG" ]]; then
+  {
+    echo "Monthly Pro voice callouts and sound arsenal refresh. Stability fixes."
+    tail -n +2 "$ANDROID_CHANGELOG" || true
+  } >"${ANDROID_CHANGELOG}.tmp"
+  mv "${ANDROID_CHANGELOG}.tmp" "$ANDROID_CHANGELOG"
+fi
+
+IOS_RN="$REPO_ROOT/native-ios/fastlane/metadata/en-US/release_notes.txt"
+if [[ -f "$IOS_RN" ]]; then
+  {
+    echo "Monthly Pro audio refresh — voice callouts and sound library."
+    echo ""
+    cat "$IOS_RN"
+  } >"${IOS_RN}.tmp"
+  mv "${IOS_RN}.tmp" "$IOS_RN"
+fi
+
+git add -A
+if git diff --cached --quiet; then
+  echo "::error::No staged changes after bump (unexpected)"
+  exit 1
+fi
+
+git commit -m "chore(release): v${NEW_VERSION} monthly Pro audio storefront"
+
+git push -u origin "HEAD:refs/heads/release/v${NEW_VERSION}"
+
+if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+  EXISTING=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "release/v${NEW_VERSION}" \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true)
+  if [[ -z "${EXISTING}" ]]; then
+    gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "release/v${NEW_VERSION}" \
+      --title "Release v${NEW_VERSION}" \
+      --body "Automated monthly storefront release. Includes the scheduled Pro voice callouts + sound arsenal refresh when merged into \`develop\` before this cut.
+
+- Approve **production-signoff** on the [Native App Release](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/native-release.yml) run for this branch.
+- Confirm store metadata/changelogs if needed."
+  else
+    echo "PR to main already exists (#${EXISTING})"
+  fi
+fi
+
+write_kv "pushed=true"
+echo "Pushed release/v${NEW_VERSION}"

--- a/scripts/tests/test_monthly_release_utils.py
+++ b/scripts/tests/test_monthly_release_utils.py
@@ -1,0 +1,21 @@
+"""Tests for monthly storefront semver helper."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_bump_semver_patch() -> None:
+    from scripts.monthly_release_utils import bump_semver_patch
+
+    assert bump_semver_patch("1.3.19") == "1.3.20"
+    assert bump_semver_patch("0.0.0") == "0.0.1"
+
+
+def test_bump_semver_patch_rejects_invalid() -> None:
+    from scripts.monthly_release_utils import bump_semver_patch
+
+    with pytest.raises(ValueError):
+        bump_semver_patch("1.2")
+    with pytest.raises(ValueError):
+        bump_semver_patch("1.2.a")


### PR DESCRIPTION
## What
- **Schedule:** 2nd of each month **12:30 UTC** (after `Monthly Pro Audio Pack` + `Generate Pro Audio Content` on the 1st).
- **Cut script:** `scripts/shell/monthly-store-release-cut.sh` — optional squash-merge `feat/audio-pack-YYYY-MM` → `develop`, **patch** semver bump via `bump-version.sh`, store changelog/release_notes prepends, push `release/vX.Y.Z`, open **PR to `main`**.
- **Dispatch:** `Native App Release` with `platform=both`, `android_track=production`, `submit_review=false` (TestFlight / upload without auto App Review submit).

## Manual gate (unchanged)
`native-release.yml` still requires **production-signoff** — CEO approval before Play/TestFlight uploads proceed.

## Secrets
Uses `PROJECT_PAT` when set; otherwise `github.token`. If pushes or `gh pr merge` fail under branch rules, add/configure **PROJECT_PAT** with `repo` scope.

## Manual test
`workflow_dispatch` with `dry_run: true` — no push/dispatch.

Made with [Cursor](https://cursor.com)