### PR TITLE
feat(release): automate monthly Pro audio app release

### DIFF
--- a/.github/workflows/generate-ios-voice-callouts.yml
+++ b/.github/workflows/generate-ios-voice-callouts.yml
@@ -1,8 +1,6 @@
 name: Generate Pro Audio Content
 
 on:
-  schedule:
-    - cron: "0 15 1 * *"
   workflow_dispatch:
     inputs:
       pack_id:

--- a/.github/workflows/monthly-audio-pack.yml
+++ b/.github/workflows/monthly-audio-pack.yml
@@ -2,9 +2,6 @@ name: Monthly Pro Audio Pack
 
 on:
   workflow_dispatch:
-  schedule:
-    # 1st of every month at 6 AM UTC
-    - cron: "0 6 1 * *"
 
 jobs:
   generate-pack:

--- a/.github/workflows/monthly-pro-audio-release.yml
+++ b/.github/workflows/monthly-pro-audio-release.yml
@@ -1,0 +1,303 @@
+name: Monthly Pro Audio App Release
+
+on:
+  schedule:
+    # 1st of every month at 18:00 UTC, after the legacy morning audio checks.
+    - cron: "0 18 1 * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Optional explicit release version. Defaults to next patch version."
+        required: false
+        default: ""
+        type: string
+      publish_mode:
+        description: "How far the scheduled release should go."
+        required: true
+        default: production
+        type: choice
+        options:
+          - production
+          - internal_only
+      submit_review:
+        description: "Submit iOS to App Review after upload/read-back verification."
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      wait_for_internal_signoff:
+        description: "Wait for internal TestFlight/Firebase signoff statuses before dispatching production release."
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  actions: write
+  checks: read
+  contents: write
+  statuses: read
+
+concurrency:
+  group: monthly-pro-audio-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Generate, branch, and dispatch monthly Pro audio release
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      RELEASE_VERSION_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
+      PUBLISH_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_mode || 'production' }}
+      SUBMIT_REVIEW: ${{ github.event_name == 'workflow_dispatch' && inputs.submit_review || 'true' }}
+      WAIT_FOR_INTERNAL_SIGNOFF: ${{ github.event_name == 'workflow_dispatch' && inputs.wait_for_internal_signoff || 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Roll active Pro audio pack to current UTC month
+        run: |
+          set -euo pipefail
+          MONTH="$(date -u +%Y-%m)"
+          python scripts/roll_monthly_pro_audio_pack.py \
+            --month "$MONTH" \
+            --json-out "$RUNNER_TEMP/pro-audio-roll.json"
+
+      - name: Generate monthly voice callouts and sound arsenal
+        env:
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          DEFAULT_VOICE_ID: DGzg6RaUqxGRTHSBjfgF
+        run: |
+          set -euo pipefail
+          python scripts/generate_pro_audio_content.py \
+            --manifest content/pro_audio/monthly_pro_audio_packs.json \
+            --voice-id "$DEFAULT_VOICE_ID" \
+            --generate-voice-assets \
+            --generate-sound-assets \
+            --sync-android-assets
+
+      - name: Verify active Pro audio freshness
+        run: python scripts/pro_audio_freshness.py --grace-day-limit 0
+
+      - name: Resolve release version
+        id: version
+        run: |
+          set -euo pipefail
+          args=(next-version --repo-root .)
+          if [ -n "${RELEASE_VERSION_INPUT:-}" ]; then
+            args+=(--version "$RELEASE_VERSION_INPUT")
+          fi
+          VERSION="$(python scripts/monthly_pro_audio_release.py "${args[@]}")"
+          BRANCH="release/v${VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "release_version=$VERSION"
+          echo "release_branch=$BRANCH"
+
+      - name: Bump app versions and write release notes
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          bash scripts/shell/bump-version.sh "$VERSION"
+          python scripts/monthly_pro_audio_release.py write-notes \
+            --repo-root . \
+            --version "$VERSION" \
+            --json-out "$RUNNER_TEMP/monthly-release.json"
+          python scripts/release_notes.py --repo-root . --version "$VERSION"
+          python scripts/validate_release_branch.py --repo-root . --head-ref "release/v${VERSION}"
+
+      - name: Create release branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="${{ steps.version.outputs.branch }}"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Release branch already exists: $BRANCH"
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          git add \
+            content/pro_audio/monthly_pro_audio_packs.json \
+            content/pro_audio/runtime \
+            native-ios/RandomTimer/Resources/Audio \
+            native-ios/RandomTimer/Resources/Sounds \
+            native-android/app/src/main/assets \
+            native-android/app/src/main/res/raw \
+            native-android/app/build.gradle.kts \
+            native-android/fastlane/metadata/android/en-US/changelogs \
+            native-ios/RandomTimer.xcodeproj/project.pbxproj \
+            native-ios/fastlane/metadata/en-US/release_notes.txt \
+            release-notes
+
+          if git diff --cached --quiet; then
+            echo "No monthly release changes were produced."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(release): monthly Pro audio v${VERSION}"
+          git push origin "$BRANCH"
+
+          SHA="$(git rev-parse HEAD)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$SHA"
+
+      - name: Upload monthly release evidence
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: monthly-pro-audio-release-evidence
+          path: |
+            ${{ runner.temp }}/pro-audio-roll.json
+            ${{ runner.temp }}/monthly-release.json
+          if-no-files-found: warn
+
+      - name: Wait for release branch checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.branch.outputs.sha }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 72); do
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/check-runs?per_page=100" > "$RUNNER_TEMP/check-runs.json"
+            set +e
+            python - "$RUNNER_TEMP/check-runs.json" <<'PY'
+          import json
+          import sys
+
+          data = json.load(open(sys.argv[1], encoding="utf-8"))
+          runs = data.get("check_runs", [])
+          if not runs:
+              print("waiting: no check runs reported yet")
+              raise SystemExit(2)
+          failed = []
+          blocking = []
+          for run in runs:
+              status = run.get("status")
+              conclusion = run.get("conclusion")
+              if status == "completed" and conclusion in {"failure", "cancelled", "timed_out", "action_required"}:
+                  failed.append(f"{run.get('name')} conclusion={conclusion}")
+              elif status != "completed" or conclusion not in {"success", "neutral", "skipped"}:
+                  blocking.append(f"{run.get('name')} status={status} conclusion={conclusion}")
+          if failed:
+              print("failed release branch checks:")
+              for item in failed:
+                  print(f"- {item}")
+              raise SystemExit(1)
+          if blocking:
+              print("waiting/blocking checks:")
+              for item in blocking:
+                  print(f"- {item}")
+              raise SystemExit(2)
+          print(f"release branch checks passed: {len(runs)} check runs")
+          PY
+            rc=$?
+            set -e
+            if [ "$rc" -eq 1 ]; then
+              exit 1
+            fi
+            if [ "$rc" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 72 ]; then
+              echo "Timed out waiting for release branch checks."
+              exit 1
+            fi
+            sleep 300
+          done
+
+      - name: Dispatch internal distribution
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          set -euo pipefail
+          gh workflow run internal-distribution.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_BRANCH" \
+            -f ref="$RELEASE_BRANCH" \
+            -f target=all
+          echo "Dispatched internal distribution for $RELEASE_BRANCH"
+
+      - name: Wait for internal signoff statuses
+        if: env.WAIT_FOR_INTERNAL_SIGNOFF == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.branch.outputs.sha }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 72); do
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/status" > "$RUNNER_TEMP/internal-signoff-status.json"
+            set +e
+            python - "$RUNNER_TEMP/internal-signoff-status.json" <<'PY'
+          import json
+          import sys
+
+          data = json.load(open(sys.argv[1], encoding="utf-8"))
+          latest = {}
+          for status in data.get("statuses", []):
+              context = status.get("context")
+              if context and context not in latest:
+                  latest[context] = status.get("state")
+          required = ("internal-signoff/testflight", "internal-signoff/firebase")
+          failed = [context for context in required if latest.get(context) in {"failure", "error"}]
+          if failed:
+              print("failed internal signoff statuses:")
+              for context in required:
+                  print(f"- {context}: {latest.get(context, 'missing')}")
+              raise SystemExit(1)
+          missing = [context for context in required if latest.get(context) != "success"]
+          if missing:
+              print("waiting for internal signoff statuses:")
+              for context in required:
+                  print(f"- {context}: {latest.get(context, 'missing')}")
+              raise SystemExit(2)
+          print("internal signoff statuses verified: " + ", ".join(required))
+          PY
+            rc=$?
+            set -e
+            if [ "$rc" -eq 1 ]; then
+              exit 1
+            fi
+            if [ "$rc" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 72 ]; then
+              echo "Timed out waiting for internal signoff statuses."
+              exit 1
+            fi
+            sleep 300
+          done
+
+      - name: Dispatch production store release
+        if: env.PUBLISH_MODE == 'production'
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN != '' && secrets.ADMIN_TOKEN || github.token }}
+          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          set -euo pipefail
+          gh workflow run native-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_BRANCH" \
+            -f platform=both \
+            -f android_track=production \
+            -f submit_review="$SUBMIT_REVIEW"
+          echo "Dispatched native-release.yml for $RELEASE_BRANCH with submit_review=$SUBMIT_REVIEW"

--- a/docs/audio/pro_monthly_audio_strategy.md
+++ b/docs/audio/pro_monthly_audio_strategy.md
@@ -44,7 +44,20 @@ Turn ElevenLabs into a recurring Pro content engine instead of a one-off asset g
 
 ## Generation Workflow
 
-Use `scripts/generate_pro_audio_content.py` to:
+The authoritative scheduled path is `.github/workflows/monthly-pro-audio-release.yml`.
+It runs on the 1st of each month, rolls the active pack to the current UTC month,
+renders voice callouts and sound-arsenal assets, creates a `release/vX.Y.Z`
+branch, waits for release branch checks, dispatches internal distribution, and
+then dispatches `native-release.yml` for both stores when production mode is
+enabled.
+
+Legacy audio-only workflows remain manual utilities:
+
+- `.github/workflows/generate-ios-voice-callouts.yml`
+- `.github/workflows/monthly-audio-pack.yml`
+
+Use `scripts/roll_monthly_pro_audio_pack.py` to create or activate the current
+month's script/prompt pack. Use `scripts/generate_pro_audio_content.py` to:
 
 - export generated platform catalogs from the canonical manifest
 - export the hosted runtime manifest with hashed asset metadata

--- a/scripts/monthly_pro_audio_release.py
+++ b/scripts/monthly_pro_audio_release.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Prepare customer-facing release notes for monthly Pro audio releases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.source_versions import read_source_versions
+except ModuleNotFoundError:
+    from source_versions import read_source_versions
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "content" / "pro_audio" / "monthly_pro_audio_packs.json"
+IOS_RELEASE_NOTES_PATH = REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "release_notes.txt"
+ANDROID_CHANGELOG_DIR = REPO_ROOT / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "changelogs"
+VERSIONED_RELEASE_NOTES_DIR = REPO_ROOT / "release-notes"
+SEMVER_RE = re.compile(r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$")
+
+
+class MonthlyReleaseError(RuntimeError):
+    """Raised when the monthly release payload cannot be prepared."""
+
+
+def _parse_semver(version: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(version.strip())
+    if not match:
+        raise MonthlyReleaseError(f"Expected semantic version X.Y.Z, got {version!r}")
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+    )
+
+
+def next_patch_version(current_version: str) -> str:
+    major, minor, patch = _parse_semver(current_version)
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def resolve_release_version(repo_root: Path, requested_version: str = "") -> str:
+    versions = read_source_versions(repo_root)
+    android_version = str(versions["android"]["version_name"])
+    ios_version = str(versions["ios"]["version_name"])
+    if android_version != ios_version:
+        raise MonthlyReleaseError(
+            f"Android/iOS version mismatch: android={android_version} ios={ios_version}"
+        )
+
+    if requested_version.strip():
+        requested = _parse_semver(requested_version)
+        current = _parse_semver(android_version)
+        if requested <= current:
+            raise MonthlyReleaseError(
+                f"Requested version {requested_version} must be greater than current version {android_version}"
+            )
+        return requested_version.strip()
+    return next_patch_version(android_version)
+
+
+def _load_active_pack(repo_root: Path) -> dict[str, Any]:
+    manifest = json.loads((repo_root / "content/pro_audio/monthly_pro_audio_packs.json").read_text(encoding="utf-8"))
+    active_pack_id = manifest.get("activePackId")
+    for pack in manifest.get("packs", []):
+        if pack.get("id") == active_pack_id:
+            return pack
+    raise MonthlyReleaseError(f"Active Pro audio pack {active_pack_id!r} is missing from manifest.")
+
+
+def _customer_month(release_month: str) -> str:
+    year, month = (int(part) for part in release_month.split("-"))
+    names = (
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    )
+    return f"{names[month - 1]} {year}"
+
+
+def render_versioned_release_notes(version: str, pack: dict[str, Any]) -> str:
+    release_month = str(pack["releaseMonth"])
+    active_pack_id = str(pack["id"])
+    theme = str(pack.get("theme") or "Monthly Pro audio")
+    customer_month = _customer_month(release_month)
+    return f"""# Release {version}
+
+## Summary
+Monthly Pro audio release for {customer_month}: {theme}.
+
+## Customer-visible changes
+- Adds a new Pro voice callout pack for {customer_month}.
+- Refreshes bundled Pro Sound Arsenal audio for iOS and Android.
+- Keeps the hosted Pro audio manifest current for entitlement restore, purchase, and app foreground refresh.
+
+## Release operations
+- Generated from active Pro audio pack `{active_pack_id}`.
+- Bundles iOS and Android audio assets so store builds carry the monthly fallback sounds.
+- Preserves hosted runtime delivery for existing Pro users where the app can safely refresh remote voice assets.
+"""
+
+
+def render_store_release_notes(pack: dict[str, Any]) -> str:
+    customer_month = _customer_month(str(pack["releaseMonth"]))
+    theme = str(pack.get("theme") or "Monthly Pro audio")
+    return "\n".join(
+        [
+            f"Monthly Pro audio refresh for {customer_month}.",
+            f"New voice callouts: {theme}.",
+            "Refreshed bundled Pro Sound Arsenal audio for iOS and Android.",
+            "Reliability improvements for hosted Pro audio delivery.",
+        ]
+    )
+
+
+def write_release_notes(repo_root: Path, version: str, *, json_out: Path | None = None) -> dict[str, Any]:
+    _parse_semver(version)
+    versions = read_source_versions(repo_root)
+    pack = _load_active_pack(repo_root)
+    android_code = int(versions["android"]["version_code"])
+
+    versioned_path = repo_root / "release-notes" / f"{version}.md"
+    android_changelog_path = (
+        repo_root
+        / "native-android"
+        / "fastlane"
+        / "metadata"
+        / "android"
+        / "en-US"
+        / "changelogs"
+        / f"{android_code}.txt"
+    )
+    ios_release_notes_path = repo_root / "native-ios" / "fastlane" / "metadata" / "en-US" / "release_notes.txt"
+
+    versioned_path.parent.mkdir(parents=True, exist_ok=True)
+    android_changelog_path.parent.mkdir(parents=True, exist_ok=True)
+    ios_release_notes_path.parent.mkdir(parents=True, exist_ok=True)
+
+    versioned_text = render_versioned_release_notes(version, pack)
+    store_text = render_store_release_notes(pack)
+    versioned_path.write_text(versioned_text, encoding="utf-8")
+    android_changelog_path.write_text(store_text + "\n", encoding="utf-8")
+    ios_release_notes_path.write_text(store_text + "\n", encoding="utf-8")
+
+    payload = {
+        "version": version,
+        "android_version_code": android_code,
+        "ios_version": versions["ios"]["version_name"],
+        "active_pack_id": pack["id"],
+        "release_month": pack["releaseMonth"],
+        "files": [
+            str(versioned_path.relative_to(repo_root)),
+            str(android_changelog_path.relative_to(repo_root)),
+            str(ios_release_notes_path.relative_to(repo_root)),
+        ],
+    }
+    if json_out:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    next_parser = subparsers.add_parser("next-version", help="Print the next monthly release version.")
+    next_parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    next_parser.add_argument("--version", default="", help="Explicit version override.")
+
+    notes_parser = subparsers.add_parser("write-notes", help="Write store and GitHub release notes.")
+    notes_parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    notes_parser.add_argument("--version", required=True)
+    notes_parser.add_argument("--json-out", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    try:
+        if args.command == "next-version":
+            print(resolve_release_version(repo_root, args.version))
+            return 0
+        if args.command == "write-notes":
+            payload = write_release_notes(repo_root, args.version, json_out=args.json_out)
+            print(json.dumps(payload, indent=2))
+            return 0
+    except MonthlyReleaseError as exc:
+        print(f"[ERROR] {exc}")
+        return 1
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 
@@ -14,10 +13,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 RELEASE_GUARD_PATHS = {
     ".github/workflows/android-production-retry.yml",
+    ".github/workflows/monthly-pro-audio-release.yml",
     ".github/workflows/native-release.yml",
     "scripts/pre-commit",
     "scripts/regression_guards.py",
     "scripts/source_versions.py",
+    "scripts/monthly_pro_audio_release.py",
+    "scripts/roll_monthly_pro_audio_pack.py",
     "scripts/verify_play_public_listing.py",
     "scripts/tests/test_growth_workflow_contracts.py",
     "scripts/tests/test_regression_guards.py",

--- a/scripts/roll_monthly_pro_audio_pack.py
+++ b/scripts/roll_monthly_pro_audio_pack.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Create or activate the current monthly Pro audio pack."""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+from datetime import UTC, datetime
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST_PATH = REPO_ROOT / "content" / "pro_audio" / "monthly_pro_audio_packs.json"
+
+ELAPSED_SECONDS = (15, 30, 45, 60, 75, 90, 105, 120, 150, 180, 210, 240, 300, 420, 540, 600)
+
+MONTHLY_THEMES: tuple[dict[str, Any], ...] = (
+    {
+        "slug": "combat_sports_cadence",
+        "theme": "Combat sports cadence",
+        "sound_style": "Dry gym acoustics, fight-night urgency, clean transient attack",
+        "commands": (
+            "Hands up. Move.",
+            "Circle off the line.",
+            "Sharp feet. Sharp eyes.",
+            "Reset your stance.",
+            "Breathe and fire back.",
+            "Win the next exchange.",
+            "Cut the angle.",
+            "Stay loose. Stay dangerous.",
+            "Pressure forward.",
+            "Defend and return.",
+            "Do not admire the work.",
+            "Snap back to guard.",
+            "Own the center.",
+            "Change levels.",
+            "Eyes on target.",
+            "Fast exit. Fast reset.",
+            "Keep your base.",
+            "Hands return home.",
+            "Punch out. Move out.",
+            "Footwork first.",
+            "Make the next rep clean.",
+            "Drive through the bell.",
+            "Stay in the pocket.",
+            "Finish disciplined.",
+        ),
+        "elapsed": (
+            "Keep your guard high.",
+            "Stay on rhythm.",
+            "Do not square up.",
+            "Breathe under pressure.",
+            "Win the next beat.",
+            "Keep working angles.",
+        ),
+    },
+    {
+        "slug": "tactical_range_discipline",
+        "theme": "Tactical range discipline",
+        "sound_style": "Outdoor range clarity, command-post pressure, no musical tail",
+        "commands": (
+            "Scan and move.",
+            "Muzzle discipline.",
+            "Find cover.",
+            "Control your breathing.",
+            "Move with intent.",
+            "Eyes up.",
+            "Stay accountable.",
+            "Check your sector.",
+            "Smooth is fast.",
+            "Hold the line.",
+            "Pressure test your plan.",
+            "No wasted motion.",
+            "Reset and assess.",
+            "Stay behind cover.",
+            "Communicate clearly.",
+            "Keep your footing.",
+            "Own your lane.",
+            "Move on command.",
+            "Maintain spacing.",
+            "Work the problem.",
+            "Precision first.",
+            "Keep your head on a swivel.",
+            "Recover and reengage.",
+            "Finish the drill clean.",
+        ),
+        "elapsed": (
+            "Assess and move.",
+            "Keep the plan simple.",
+            "Stay deliberate.",
+            "Control the tempo.",
+            "Work from cover.",
+            "Maintain discipline.",
+        ),
+    },
+    {
+        "slug": "hiit_power_rounds",
+        "theme": "HIIT power rounds",
+        "sound_style": "Training-floor punch, bright alarm edge, high-energy but not musical",
+        "commands": (
+            "Explode now.",
+            "Drive your knees.",
+            "Stay tall.",
+            "Push the floor away.",
+            "Fast hands.",
+            "Keep the engine hot.",
+            "Brace and move.",
+            "No dead reps.",
+            "Attack the interval.",
+            "Own your breathing.",
+            "Stay springy.",
+            "Keep your hips under you.",
+            "Find another gear.",
+            "Recover in motion.",
+            "Make it crisp.",
+            "Stay light.",
+            "Punch the clock.",
+            "Work with purpose.",
+            "Keep tension.",
+            "Move clean.",
+            "Power through.",
+            "Do not drift.",
+            "Hold form.",
+            "Finish loud.",
+        ),
+        "elapsed": (
+            "Stay explosive.",
+            "Keep form tight.",
+            "Breathe and drive.",
+            "Hold the pace.",
+            "Make every rep count.",
+            "Stay under control.",
+        ),
+    },
+    {
+        "slug": "defensive_tactics_pressure",
+        "theme": "Defensive tactics pressure",
+        "sound_style": "Close-quarters training intensity, clipped alert tones, no voice",
+        "commands": (
+            "Create space.",
+            "Protect your base.",
+            "Frame and move.",
+            "Hands active.",
+            "Clear the line.",
+            "Control the tie.",
+            "Stay off the wall.",
+            "Move your feet.",
+            "Break contact.",
+            "Own the underhook.",
+            "Turn the corner.",
+            "Keep posture.",
+            "Stand up strong.",
+            "Get back to stance.",
+            "Do not freeze.",
+            "Win inside position.",
+            "Pressure and angle.",
+            "Hips back.",
+            "Eyes forward.",
+            "Recover your balance.",
+            "Fight the grip.",
+            "Reset the distance.",
+            "Stay technical.",
+            "Finish safe.",
+        ),
+        "elapsed": (
+            "Protect your posture.",
+            "Keep your base alive.",
+            "Make space now.",
+            "Stay technical.",
+            "Control the position.",
+            "Recover your stance.",
+        ),
+    },
+)
+
+SOUND_BASES: dict[str, str] = {
+    "intense": "Command-post emergency tone, clipped attack, clear loop point",
+    "gentle": "Clean single training chime with soft tail, subtle but clear",
+    "klaxon": "Forceful midrange klaxon, loopable, urgent and controlled",
+    "whistle": "Coach whistle blast, crisp onset, realistic air pressure",
+    "buzzer": "Gym timer buzzer, square attack, short decay",
+    "gong": "Focused metal gong strike, controlled resonance, clean tail",
+    "airhorn": "Stadium air horn burst, authoritative and short",
+    "drumRoll": "Military snare roll, tight cadence, decisive final accent",
+    "siren": "Compact training siren sweep, urgent but not harsh",
+    "bell": "Boxing round bell, bright strike, fast room decay",
+}
+
+
+def _month_key() -> str:
+    return datetime.now(UTC).strftime("%Y-%m")
+
+
+def _validate_month(value: str) -> str:
+    candidate = value.strip()
+    if not re.fullmatch(r"\d{4}-\d{2}", candidate):
+        raise SystemExit(f"Expected --month as YYYY-MM, got {value!r}")
+    year, month = candidate.split("-")
+    if not 1 <= int(month) <= 12:
+        raise SystemExit(f"Expected --month between 01 and 12, got {value!r}")
+    return f"{int(year):04d}-{int(month):02d}"
+
+
+def _theme_for_month(month: str) -> dict[str, Any]:
+    year, month_number = (int(part) for part in month.split("-"))
+    index = (year * 12 + month_number - 1) % len(MONTHLY_THEMES)
+    return MONTHLY_THEMES[index]
+
+
+def _slugify(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
+    return normalized or "monthly_audio"
+
+
+def _spoken_time(seconds: int) -> str:
+    labels = {
+        15: "Fifteen seconds",
+        30: "Thirty seconds",
+        45: "Forty-five seconds",
+        60: "One minute",
+        75: "One minute fifteen",
+        90: "One minute thirty",
+        105: "One minute forty-five",
+        120: "Two minutes",
+        150: "Two minutes thirty",
+        180: "Three minutes",
+        210: "Three minutes thirty",
+        240: "Four minutes",
+        300: "Five minutes",
+        420: "Seven minutes",
+        540: "Nine minutes",
+        600: "Ten minutes",
+    }
+    return labels.get(seconds, f"{seconds} seconds")
+
+
+def _load_manifest() -> dict[str, Any]:
+    return json.loads(DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _write_manifest(manifest: dict[str, Any]) -> None:
+    DEFAULT_MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+def _existing_pack_for_month(manifest: dict[str, Any], month: str) -> dict[str, Any] | None:
+    return next((pack for pack in manifest.get("packs", []) if pack.get("releaseMonth") == month), None)
+
+
+def _active_pack(manifest: dict[str, Any]) -> dict[str, Any]:
+    active_pack_id = manifest.get("activePackId")
+    for pack in manifest.get("packs", []):
+        if pack.get("id") == active_pack_id:
+            return pack
+    raise SystemExit(f"Active Pro audio pack {active_pack_id!r} is missing from manifest.")
+
+
+def _sound_prompt(sound: dict[str, Any], theme: dict[str, Any]) -> str:
+    sound_type = str(sound.get("soundType") or sound.get("filename") or "").strip()
+    base = SOUND_BASES.get(sound_type, str(sound.get("prompt") or "Training alert sound").rstrip("."))
+    return f"{base}. {theme['sound_style']}. Loopable, no voice."
+
+
+def build_pack(month: str, base_pack: dict[str, Any], theme: dict[str, Any]) -> dict[str, Any]:
+    pack = deepcopy(base_pack)
+    commands = list(theme["commands"])
+    elapsed = list(theme["elapsed"])
+    pack["id"] = f"{month}_{theme['slug']}"
+    pack["releaseMonth"] = month
+    pack["theme"] = f"{theme['theme']} ({month} content window)"
+    pack["previewElapsed"] = {
+        "filename": "preview_elapsed",
+        "text": f"Thirty seconds elapsed. {elapsed[0]}",
+    }
+    pack["fallbackCommandFilename"] = _slugify(commands[0])
+    pack["commandCues"] = [
+        {"filename": _slugify(command), "text": command}
+        for command in commands
+    ]
+    pack["elapsedCues"] = [
+        {
+            "second": second,
+            "filename": f"elapsed_{second}s",
+            "text": f"{_spoken_time(second)} elapsed. {elapsed[index % len(elapsed)]}",
+        }
+        for index, second in enumerate(ELAPSED_SECONDS)
+    ]
+    pack["soundArsenal"] = [
+        {
+            **sound,
+            "prompt": _sound_prompt(sound, theme),
+        }
+        for sound in base_pack.get("soundArsenal", [])
+    ]
+    return pack
+
+
+def roll_manifest(manifest: dict[str, Any], month: str) -> dict[str, Any]:
+    existing = _existing_pack_for_month(manifest, month)
+    if existing is not None:
+        manifest["activePackId"] = existing["id"]
+        return {
+            "changed": False,
+            "activePackId": existing["id"],
+            "releaseMonth": month,
+            "theme": existing.get("theme", ""),
+        }
+
+    base_pack = _active_pack(manifest)
+    theme = _theme_for_month(month)
+    pack = build_pack(month, base_pack, theme)
+    manifest.setdefault("packs", []).append(pack)
+    manifest["activePackId"] = pack["id"]
+    return {
+        "changed": True,
+        "activePackId": pack["id"],
+        "releaseMonth": month,
+        "theme": pack["theme"],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--month", default="", help="Target release month as YYYY-MM. Defaults to current UTC month.")
+    parser.add_argument("--json-out", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    month = _validate_month(args.month or _month_key())
+    manifest = _load_manifest()
+    result = roll_manifest(manifest, month)
+    _write_manifest(manifest)
+    payload = {"status": "ok", **result}
+    print(json.dumps(payload, indent=2))
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -17,6 +17,9 @@ DEVICE_TESTS_WORKFLOW = ROOT / ".github/workflows/device-tests.yml"
 IOS_SMOKE_FLOW = ROOT / ".maestro/ios-smoke-test.yaml"
 WEEKLY_SHARED_WORKFLOW = ROOT / ".github/workflows/weekly-shared.yml"
 WQTU_HEALTH_WORKFLOW = ROOT / ".github/workflows/wqtu-health.yml"
+MONTHLY_PRO_AUDIO_RELEASE_WORKFLOW = ROOT / ".github/workflows/monthly-pro-audio-release.yml"
+GENERATE_IOS_VOICE_WORKFLOW = ROOT / ".github/workflows/generate-ios-voice-callouts.yml"
+MONTHLY_AUDIO_PACK_WORKFLOW = ROOT / ".github/workflows/monthly-audio-pack.yml"
 
 
 def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():
@@ -147,6 +150,32 @@ def test_internal_distribution_runs_automatically_on_develop_and_main_push_for_i
     assert 'TARGET="all"' in source
     assert 'REASON="auto_push_develop"' in source
     assert 'REASON="auto_push_main"' in source
+
+
+def test_monthly_pro_audio_release_workflow_schedules_store_release_orchestrator():
+    source = MONTHLY_PRO_AUDIO_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'cron: "0 18 1 * *"' in source
+    assert "scripts/roll_monthly_pro_audio_pack.py" in source
+    assert "scripts/generate_pro_audio_content.py" in source
+    assert "--generate-voice-assets" in source
+    assert "--generate-sound-assets" in source
+    assert "--sync-android-assets" in source
+    assert "scripts/pro_audio_freshness.py --grace-day-limit 0" in source
+    assert "scripts/shell/bump-version.sh" in source
+    assert 'BRANCH="release/v${VERSION}"' in source
+    assert "gh workflow run internal-distribution.yml" in source
+    assert "gh workflow run native-release.yml" in source
+    assert "-f platform=both" in source
+    assert "-f android_track=production" in source
+    assert '-f submit_review="$SUBMIT_REVIEW"' in source
+
+
+def test_legacy_audio_generation_workflows_are_manual_only():
+    for path in (GENERATE_IOS_VOICE_WORKFLOW, MONTHLY_AUDIO_PACK_WORKFLOW):
+        trigger_block = path.read_text(encoding="utf-8").split("jobs:", 1)[0]
+        assert "workflow_dispatch:" in trigger_block
+        assert "schedule:" not in trigger_block
 
 
 def test_ios_internal_retry_dispatch_targets_ios_only():

--- a/scripts/tests/test_monthly_pro_audio_release.py
+++ b/scripts/tests/test_monthly_pro_audio_release.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.monthly_pro_audio_release import (
+    MonthlyReleaseError,
+    next_patch_version,
+    render_store_release_notes,
+    render_versioned_release_notes,
+    resolve_release_version,
+    write_release_notes,
+)
+
+
+def _write_minimal_repo(root: Path, *, android_version: str = "1.2.3", ios_version: str = "1.2.3") -> None:
+    (root / "native-android/app").mkdir(parents=True)
+    (root / "native-ios/RandomTimer.xcodeproj").mkdir(parents=True)
+    (root / "content/pro_audio").mkdir(parents=True)
+    (root / "native-android/app/build.gradle.kts").write_text(
+        f'''
+android {{
+    defaultConfig {{
+        versionCode = ciVersionCode ?: 123
+        versionName = "{android_version}"
+    }}
+}}
+''',
+        encoding="utf-8",
+    )
+    (root / "native-ios/RandomTimer.xcodeproj/project.pbxproj").write_text(
+        f"""
+MARKETING_VERSION = {ios_version};
+CURRENT_PROJECT_VERSION = 456;
+""",
+        encoding="utf-8",
+    )
+    manifest = {
+        "activePackId": "2026-05_combat_sports_cadence",
+        "packs": [
+            {
+                "id": "2026-05_combat_sports_cadence",
+                "releaseMonth": "2026-05",
+                "theme": "Combat sports cadence (2026-05 content window)",
+            }
+        ],
+    }
+    (root / "content/pro_audio/monthly_pro_audio_packs.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+
+
+def test_next_patch_version() -> None:
+    assert next_patch_version("1.3.19") == "1.3.20"
+
+
+def test_resolve_release_version_defaults_to_next_patch(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path)
+
+    assert resolve_release_version(tmp_path) == "1.2.4"
+
+
+def test_resolve_release_version_rejects_platform_mismatch(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path, android_version="1.2.3", ios_version="1.2.4")
+
+    with pytest.raises(MonthlyReleaseError, match="version mismatch"):
+        resolve_release_version(tmp_path)
+
+
+def test_resolve_release_version_rejects_non_incrementing_override(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path)
+
+    with pytest.raises(MonthlyReleaseError, match="must be greater"):
+        resolve_release_version(tmp_path, requested_version="1.2.3")
+
+
+def test_render_release_notes_are_customer_facing_without_placeholders() -> None:
+    pack = {
+        "id": "2026-05_combat_sports_cadence",
+        "releaseMonth": "2026-05",
+        "theme": "Combat sports cadence (2026-05 content window)",
+    }
+
+    versioned = render_versioned_release_notes("1.3.20", pack)
+    store = render_store_release_notes(pack)
+
+    assert "TODO" not in versioned
+    assert "TODO" not in store
+    assert "Monthly Pro audio release for May 2026" in versioned
+    assert "New voice callouts" in store
+    assert "Pro Sound Arsenal" in store
+
+
+def test_write_release_notes_updates_store_and_versioned_files(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path)
+
+    payload = write_release_notes(tmp_path, "1.2.4", json_out=tmp_path / "evidence.json")
+
+    assert payload["version"] == "1.2.4"
+    assert payload["android_version_code"] == 123
+    assert (tmp_path / "release-notes/1.2.4.md").is_file()
+    assert (tmp_path / "native-android/fastlane/metadata/android/en-US/changelogs/123.txt").is_file()
+    assert (tmp_path / "native-ios/fastlane/metadata/en-US/release_notes.txt").is_file()
+    assert "TODO" not in (tmp_path / "release-notes/1.2.4.md").read_text(encoding="utf-8")
+    assert (tmp_path / "evidence.json").is_file()

--- a/scripts/tests/test_roll_monthly_pro_audio_pack.py
+++ b/scripts/tests/test_roll_monthly_pro_audio_pack.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+from scripts.roll_monthly_pro_audio_pack import roll_manifest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "content" / "pro_audio" / "monthly_pro_audio_packs.json"
+
+
+def _manifest_copy() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_roll_manifest_creates_new_current_month_pack() -> None:
+    manifest = _manifest_copy()
+
+    result = roll_manifest(manifest, "2026-05")
+
+    assert result["changed"] is True
+    assert result["releaseMonth"] == "2026-05"
+    assert manifest["activePackId"] == result["activePackId"]
+    pack = next(item for item in manifest["packs"] if item["id"] == result["activePackId"])
+    assert pack["releaseMonth"] == "2026-05"
+    assert len(pack["commandCues"]) == 24
+    assert len(pack["elapsedCues"]) == 16
+    assert len(pack["soundArsenal"]) == 10
+    assert all("elapsed" in cue["text"].casefold() for cue in pack["elapsedCues"])
+    assert pack["fallbackCommandFilename"] == pack["commandCues"][0]["filename"]
+    drum_roll = next(sound for sound in pack["soundArsenal"] if sound["soundType"] == "drumRoll")
+    assert "Military snare roll" in drum_roll["prompt"]
+
+
+def test_roll_manifest_is_idempotent_for_existing_month() -> None:
+    manifest = _manifest_copy()
+    first = roll_manifest(manifest, "2026-06")
+    count_after_first = len(manifest["packs"])
+
+    second = roll_manifest(manifest, "2026-06")
+
+    assert first["changed"] is True
+    assert second["changed"] is False
+    assert second["activePackId"] == first["activePackId"]
+    assert len(manifest["packs"]) == count_after_first


### PR DESCRIPTION
## Summary
- Adds an authoritative scheduled monthly Pro audio app release workflow for the 1st of each month at 18:00 UTC.
- Rolls the active Pro audio pack to the current UTC month, renders voice callouts and sound arsenal assets strictly, bumps app versions, writes store/GitHub release notes, creates a release/vX.Y.Z branch, waits for branch checks, dispatches internal distribution, then dispatches native-release.yml for both stores in production mode.
- Converts the old audio-only monthly workflows to manual utilities so there is one scheduled monthly path instead of duplicate generators.

## Verification
- uv run ruff check scripts/roll_monthly_pro_audio_pack.py scripts/monthly_pro_audio_release.py scripts/tests/test_roll_monthly_pro_audio_pack.py scripts/tests/test_monthly_pro_audio_release.py scripts/tests/test_growth_workflow_contracts.py scripts/regression_guards.py
- uv run pytest scripts/tests/test_roll_monthly_pro_audio_pack.py scripts/tests/test_monthly_pro_audio_release.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_workflow_yaml_syntax.py -q
- python3 scripts/regression_guards.py --mode staged
- python3 scripts/monthly_pro_audio_release.py next-version --repo-root . -> 1.3.20
- temp manifest roll for 2026-05 -> activePackId=2026-05_combat_sports_cadence, commands=24, elapsed=16, sounds=10
