### PR TITLE
docs: CTO PR hygiene session start protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ Store and executive JSON expose **`review_count_metric_id`** where applicable so
 
 Autonomous PR/branch hygiene and **never committing PATs** are defined in `CLAUDE.md` (including rotating leaked tokens, verifying `gh pr checks` before merge, resolving automated review threads that gate CI, and completion criteria for **"Done merging PRs"**). Do not embed CEO credentials in repo docs. External RAG/memory: use only when verified configured in-session.
 
+**CTO session start (PR hygiene):** follow `CLAUDE.md` → *PR Management & System Hygiene* → *CTO session start protocol* (`gh auth status`, `git fetch --prune`, open PR audit, orphan branch map, merge only on green required checks, post-merge CI on `develop`/`main`). Say **"Done merging PRs"** only with merge SHAs and verified CI — never after a PAT appears in chat (rotate the token first; do not record it in docs).
+
 **Stack Overflow:** Draft answers as Markdown under `marketing/referral_content/stackoverflow_answers/` (see `docs/STACK_OVERFLOW_PLAYBOOK.md`); include `develop` permalinks to this repo where we actually use the pattern, plus disclosure when linking our code.
 
 ## Agent-Model Matching Standard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,16 @@ The CI workflow (`.github/workflows/ci.yml`) builds and uploads a debug APK on e
 
 ## PR Management & System Hygiene
 
+### CTO session start protocol (PR hygiene)
+
+1. Read repo directives (`CLAUDE.md`, `AGENTS.md`, `docs/GEMINI.md`).
+2. Confirm GitHub auth via `gh auth status` (keyring / `gh auth login`). **Never** paste PATs into chat, issues, or tracked files; **revoke and rotate** immediately if a token is exposed anywhere.
+3. `git fetch --prune`; list open PRs (`gh pr list --state open`) and per-PR readiness (`gh pr view <n> --json mergeStateStatus,statusCheckRollup`, `gh pr checks <n>`).
+4. Map `origin/*` branches to open PR heads; triage orphan or stale branches (merge candidate vs delete) without removing registered worktrees or dirty agent trees.
+5. Merge only when branch protection + required checks are satisfied (`mergeStateStatus` clean / documented waiver); record **merge commit SHA** and post-merge CI evidence.
+6. Verify CI on the current `develop` and `main` tips (e.g. `gh run list --workflow ci.yml --branch develop`).
+7. **RAG / external memory:** read or write only when that integration is verified in the active session; otherwise state **not verified** instead of claiming persistence.
+
 Use `/pr-management` skill for the full process. At minimum:
 1. Audit all open PRs with CI status
 2. Identify orphan branches

--- a/docs/GEMINI.md
+++ b/docs/GEMINI.md
@@ -90,3 +90,6 @@ cd native-ios && xcodebuild -scheme RandomTimer test
 
 ### PR management & secrets (cross-reference)
 - Periodic PR audits, branch hygiene, and **no secrets in repo** are spelled out in `CLAUDE.md` (including PAT rotation if a token is ever exposed).
+
+### CTO session start protocol (PR hygiene)
+- Same numbered protocol as `CLAUDE.md` → *PR Management & System Hygiene* → *CTO session start protocol*: auth without pasting PATs, prune + open PR list + checks, orphan branch triage, merge only when required checks are green, verify `develop`/`main` CI, RAG only if verified in-session.


### PR DESCRIPTION
Persists the CEO session checklist into `CLAUDE.md`, `AGENTS.md`, and `docs/GEMINI.md` (no secrets). Covers: `gh auth` without PAT paste, PR audit, orphan branch triage, merge gate, post-merge CI, RAG only when verified.

Made with [Cursor](https://cursor.com)