### PR TITLE
fix(ci): harden monthly Pro release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,54 @@ on:
       - '**.md'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Path-Aware CI Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      android: ${{ steps.classify.outputs.android }}
+      ios: ${{ steps.classify.outputs.ios }}
+      android_device: ${{ steps.classify.outputs.android_device }}
+      ios_device: ${{ steps.classify.outputs.ios_device }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed components
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
+            python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output
+          else
+            python3 scripts/ci_changed_components.py --all --github-output
+          fi
+
   lint:
     name: Architecture Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
       - name: Architecture ban checks (Kotlin)
         run: |
           ERRORS=0
-          for f in $(find native-android -name '*.kt' -not -path '*/build/*'); do
+          while IFS= read -r -d '' f; do
             if grep -n 'AndroidViewModel' "$f" | grep -v '// allow-android-viewmodel' > /dev/null 2>&1; then
               echo "❌ $f: Uses AndroidViewModel"
               ERRORS=$((ERRORS + 1))
@@ -41,7 +74,7 @@ jobs:
               echo "❌ $f: Uses Handler(Looper) instead of coroutines"
               ERRORS=$((ERRORS + 1))
             fi
-          done
+          done < <(find native-android -name '*.kt' -not -path '*/build/*' -print0)
           if [ "$ERRORS" -gt 0 ]; then
             echo "Found $ERRORS architecture violation(s)"
             exit 1
@@ -54,22 +87,22 @@ jobs:
           SCREENS_DIR="native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens"
 
           # Ban hardcoded progress values in CircularTimer calls
-          for f in $(find "$SCREENS_DIR" -name '*.kt'); do
+          while IFS= read -r -d '' f; do
             if grep -Pn 'progress\s*=\s*(if\s*\(|0f|1f)' "$f" | grep -v '// allow-hardcoded-progress' > /dev/null 2>&1; then
               echo "❌ $f: Hardcoded progress value — use state.progress instead"
               ERRORS=$((ERRORS + 1))
             fi
-          done
+          done < <(find "$SCREENS_DIR" -name '*.kt' -print0)
 
           # Ban ignoring state fields when passing to UI components
-          for f in $(find "$SCREENS_DIR" -name '*.kt'); do
+          while IFS= read -r -d '' f; do
             if grep -Pn 'CircularTimer\(' "$f" > /dev/null 2>&1; then
               # Verify state.progress is used (not a ternary or literal)
               if ! grep -P 'progress\s*=\s*state\.progress' "$f" > /dev/null 2>&1; then
                 echo "⚠️  $f: CircularTimer may not be using state.progress — verify manually"
               fi
             fi
-          done
+          done < <(find "$SCREENS_DIR" -name '*.kt' -print0)
 
           if [ "$ERRORS" -gt 0 ]; then
             echo "Found $ERRORS UI state binding violation(s)"
@@ -80,6 +113,7 @@ jobs:
   python:
     name: Legacy Python Compile Check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
@@ -107,6 +141,7 @@ jobs:
   voice-provider-smoke:
     name: Voice Provider Smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -158,6 +193,7 @@ jobs:
   regression-guards:
     name: Regression Guards
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: .
@@ -215,7 +251,10 @@ jobs:
 
   android:
     name: Autonomous Android Tests
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: native-android
@@ -265,7 +304,10 @@ jobs:
 
   ios:
     name: Autonomous iOS Build Check
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-15
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: native-ios
@@ -321,11 +363,11 @@ jobs:
               XCODE_PATH="${candidate}"
               break
             fi
-          done < <(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V -r)
+          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort -V -r)
 
           if [ -z "${XCODE_PATH}" ]; then
             echo "No Xcode installation with iOS Simulator SDK found."
-            ls -d /Applications/Xcode*.app 2>/dev/null || true
+            find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null || true
             exit 1
           fi
 
@@ -353,36 +395,42 @@ jobs:
           echo "Using xcodebuild destination simulator ID: ${SIM_ID}"
 
       - name: Pre-boot simulator
+        env:
+          SIM_ID: ${{ steps.sim.outputs.sim_id }}
         run: |
-          xcrun simctl boot '${{ steps.sim.outputs.sim_id }}' || true
-          xcrun simctl bootstatus '${{ steps.sim.outputs.sim_id }}' -b
+          xcrun simctl boot "$SIM_ID" || true
+          xcrun simctl bootstatus "$SIM_ID" -b
           sleep 5
 
       - name: Build for testing
+        env:
+          SIM_ID: ${{ steps.sim.outputs.sim_id }}
         run: |
           xcodebuild build-for-testing \
             -project RandomTimer.xcodeproj \
             -scheme RandomTimer \
-            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.sim_id }}' \
+            -destination "platform=iOS Simulator,id=$SIM_ID" \
             -skip-testing:RandomTimerUITests \
             -quiet \
             CODE_SIGNING_ALLOWED=NO \
-            'OTHER_SWIFT_FLAGS=$(inherited) -D RT_SKIP_FIREBASE_FOR_CI'
+            "OTHER_SWIFT_FLAGS=\$(inherited) -D RT_SKIP_FIREBASE_FOR_CI"
 
       - name: Run unit tests
         timeout-minutes: 10
+        env:
+          SIM_ID: ${{ steps.sim.outputs.sim_id }}
         run: |
           rm -rf build/TestResults.xcresult
           xcodebuild test \
             -project RandomTimer.xcodeproj \
             -scheme RandomTimer \
-            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.sim_id }}' \
+            -destination "platform=iOS Simulator,id=$SIM_ID" \
             -skip-testing:RandomTimerUITests \
             -enableCodeCoverage YES \
             -resultBundlePath build/TestResults.xcresult \
             -quiet \
             CODE_SIGNING_ALLOWED=NO \
-            'OTHER_SWIFT_FLAGS=$(inherited) -D RT_SKIP_FIREBASE_FOR_CI'
+            "OTHER_SWIFT_FLAGS=\$(inherited) -D RT_SKIP_FIREBASE_FOR_CI"
 
       - name: Upload iOS xcresult
         if: always()
@@ -395,6 +443,7 @@ jobs:
   playwright-local:
     name: Playwright Local Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: tests/playwright
@@ -426,6 +475,7 @@ jobs:
   python-scripts:
     name: Python Script Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -483,6 +533,7 @@ jobs:
     name: North Star Guardrail
     if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -537,6 +588,7 @@ jobs:
   security:
     name: Autonomous Security
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ on:
       - '**.md'
       - 'docs/**'
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -25,6 +22,8 @@ jobs:
   changes:
     name: Path-Aware CI Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 5
     outputs:
       android: ${{ steps.classify.outputs.android }}
@@ -54,6 +53,8 @@ jobs:
   lint:
     name: Architecture Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -113,6 +114,8 @@ jobs:
   python:
     name: Legacy Python Compile Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -141,6 +144,8 @@ jobs:
   voice-provider-smoke:
     name: Voice Provider Smoke
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -193,6 +198,8 @@ jobs:
   regression-guards:
     name: Regression Guards
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
     defaults:
       run:
@@ -254,6 +261,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
     defaults:
       run:
@@ -307,6 +316,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ios == 'true'
     runs-on: macos-15
+    permissions:
+      contents: read
     timeout-minutes: 25
     defaults:
       run:
@@ -443,6 +454,8 @@ jobs:
   playwright-local:
     name: Playwright Local Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     defaults:
       run:
@@ -475,6 +488,8 @@ jobs:
   python-scripts:
     name: Python Script Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -533,6 +548,8 @@ jobs:
     name: North Star Guardrail
     if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -5,9 +5,6 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: device-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -16,6 +13,8 @@ jobs:
   changes:
     name: Path-Aware Device Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 5
     outputs:
       android_device: ${{ steps.classify.outputs.android_device }}
@@ -45,6 +44,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.android_device == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
 
     steps:
@@ -113,6 +114,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ios_device == 'true'
     runs-on: macos-15
+    permissions:
+      contents: read
     timeout-minutes: 35
 
     steps:

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -5,13 +5,45 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: device-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Path-Aware Device Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      android_device: ${{ steps.classify.outputs.android_device }}
+      ios_device: ${{ steps.classify.outputs.ios_device }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed components
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
+            python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output
+          else
+            python3 scripts/ci_changed_components.py --all --github-output
+          fi
+
   android-device-tests:
     name: Android Emulator + Maestro Tests
+    needs: changes
+    if: needs.changes.outputs.android_device == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -78,6 +110,8 @@ jobs:
 
   ios-device-tests:
     name: iOS Simulator + Maestro + Agent Device
+    needs: changes
+    if: needs.changes.outputs.ios_device == 'true'
     runs-on: macos-15
     timeout-minutes: 35
 
@@ -135,11 +169,11 @@ jobs:
               XCODE_PATH="${candidate}"
               break
             fi
-          done < <(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V -r)
+          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort -V -r)
 
           if [ -z "${XCODE_PATH}" ]; then
             echo "No Xcode installation with iOS Simulator SDK found."
-            ls -d /Applications/Xcode*.app 2>/dev/null || true
+            find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null || true
             exit 1
           fi
 

--- a/.github/workflows/monthly-pro-content-release.yml
+++ b/.github/workflows/monthly-pro-content-release.yml
@@ -71,6 +71,7 @@ jobs:
   generate-content:
     name: "Step 1 — Generate monthly audio content"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write
     outputs:
@@ -80,12 +81,29 @@ jobs:
       changes_committed: ${{ steps.commit.outputs.changes_committed }}
 
     steps:
+      - name: Validate required automation token
+        env:
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+          FREESOUND_API_TOKEN: ${{ secrets.FREESOUND_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in PROJECT_PAT FREESOUND_API_TOKEN; do
+            if [ -z "${!key}" ]; then
+              missing+=("$key")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::Missing required monthly release secret(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
       - name: Checkout develop (full history)
         uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          token: ${{ secrets.PROJECT_PAT }}
 
       - name: Compute month label
         id: meta
@@ -104,19 +122,21 @@ jobs:
         env:
           FREESOUND_API_TOKEN: ${{ secrets.FREESOUND_API_TOKEN }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          SKIP_VOICE: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_voice && 'true' || 'false' }}
+          DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
-          # Build the argument list conditionally
-          ARGS=""
-          if [[ "${{ github.event_name == 'workflow_dispatch' && inputs.skip_voice }}" == "true" ]]; then
-            ARGS="--skip-voice"
+          # Build the argument list conditionally.
+          args=()
+          if [[ "${SKIP_VOICE}" == "true" ]]; then
+            args+=("--skip-voice")
           fi
-          if [[ "${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}" == "true" ]]; then
-            ARGS="$ARGS --dry-run"
+          if [[ "${DRY_RUN_INPUT}" == "true" ]]; then
+            args+=("--dry-run")
           fi
 
-          python scripts/generate_monthly_audio_pack.py $ARGS
+          python scripts/generate_monthly_audio_pack.py "${args[@]}"
 
       # ── Step 1b: Sync audio to Android raw resources ──────────
       - name: Sync generated audio to Android
@@ -128,7 +148,8 @@ jobs:
             [ -f "$f" ] || continue
             name=$(basename "$f")
             dst="native-android/app/src/main/res/raw/${name}"
-            cp "$f" "$dst" && echo "Synced ${name}" || true
+            cp "$f" "$dst"
+            echo "Synced ${name}"
           done
           # Sync alarm / timer sounds
           for f in native-ios/RandomTimer/Resources/Sounds/*.mp3; do
@@ -138,19 +159,22 @@ jobs:
             # [a-z0-9_].  Normalise hyphens to underscores.
             android_name="${name//-/_}"
             dst="native-android/app/src/main/res/raw/${android_name}"
-            cp "$f" "$dst" && echo "Synced sound ${android_name}" || true
+            cp "$f" "$dst"
+            echo "Synced sound ${android_name}"
           done
 
       # ── Step 1c: Bump patch version ───────────────────────────
       - name: Bump patch version
         id: bump
+        env:
+          DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
         run: |
           set -euo pipefail
           MONTH_LABEL="${{ steps.meta.outputs.month_label }}"
           CHANGELOG_MSG="Monthly Pro content update — ${MONTH_LABEL}"
 
           DRY_RUN_FLAG=""
-          if [[ "${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}" == "true" ]]; then
+          if [[ "${DRY_RUN_INPUT}" == "true" ]]; then
             DRY_RUN_FLAG="--dry-run"
           fi
 
@@ -168,7 +192,7 @@ jobs:
       - name: Commit and push changes to develop
         id: commit
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
         run: |
           set -euo pipefail
@@ -179,17 +203,22 @@ jobs:
           CONTENT_BRANCH="feat/monthly-content-${MONTH_TAG}"
           echo "content_branch=${CONTENT_BRANCH}" >> "$GITHUB_OUTPUT"
 
-          # Check for any new or modified audio/version files
-          git add \
-            native-ios/RandomTimer/Resources/Audio/ \
-            native-ios/RandomTimer/Resources/Sounds/ \
-            native-android/app/src/main/res/raw/ \
-            native-android/app/src/main/assets/ \
-            native-android/app/build.gradle.kts \
-            "native-ios/RandomTimer.xcodeproj/project.pbxproj" \
-            native-android/fastlane/metadata/ \
-            native-ios/fastlane/metadata/ \
-            --ignore-errors 2>/dev/null || true
+          # Check for any new or modified audio/version files.
+          paths=(
+            "native-ios/RandomTimer/Resources/Audio/"
+            "native-ios/RandomTimer/Resources/Sounds/"
+            "native-android/app/src/main/res/raw/"
+            "native-android/app/src/main/assets/"
+            "native-android/app/build.gradle.kts"
+            "native-ios/RandomTimer.xcodeproj/project.pbxproj"
+            "native-android/fastlane/metadata/"
+            "native-ios/fastlane/metadata/"
+          )
+          for path in "${paths[@]}"; do
+            if [ -e "$path" ]; then
+              git add "$path"
+            fi
+          done
 
           if git diff --cached --quiet; then
             echo "No changes to commit."
@@ -209,23 +238,32 @@ jobs:
           git commit -m "feat(audio): monthly Pro content update for ${MONTH_LABEL} — v${NEW_VERSION}"
           git push origin "${CONTENT_BRANCH}"
 
-          # Open a PR from content branch → develop for audit trail
-          gh pr create \
-            --base develop \
-            --head "${CONTENT_BRANCH}" \
-            --title "feat(audio): Monthly Pro content — ${MONTH_LABEL} (v${NEW_VERSION})" \
-            --body "Auto-generated monthly Pro content update.
+          # Open a PR from content branch to develop for audit trail.
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          Auto-generated monthly Pro content update.
 
-## Contents
-- New CC0 sound effects from Freesound
-- ElevenLabs voice callouts (if credits available)
-- Patch version bump to ${NEW_VERSION}
-- Changelog updated: Monthly Pro content update — ${MONTH_LABEL}
+          ## Contents
+          - New CC0 sound effects from Freesound
+          - ElevenLabs voice callouts, if credits are available
+          - Patch version bump to ${NEW_VERSION}
+          - Changelog updated: Monthly Pro content update - ${MONTH_LABEL}
 
-## Review
-This PR is created automatically by the Monthly Pro Content Release pipeline.
-The pipeline merges this branch to develop, cuts release/v*, and dispatches Native App Release when content lands." \
-            --repo "$GITHUB_REPOSITORY" || true
+          ## Review
+          This PR is created automatically by the Monthly Pro Content Release pipeline.
+          The pipeline merges this branch to develop, cuts release/v*, and dispatches Native App Release when content lands.
+          EOF
+
+          if gh pr view "${CONTENT_BRANCH}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "PR already exists for ${CONTENT_BRANCH}."
+          else
+            gh pr create \
+              --base develop \
+              --head "${CONTENT_BRANCH}" \
+              --title "feat(audio): Monthly Pro content - ${MONTH_LABEL} (v${NEW_VERSION})" \
+              --body-file "$body_file" \
+              --repo "$GITHUB_REPOSITORY"
+          fi
 
           echo "changes_committed=true" >> "$GITHUB_OUTPUT"
 
@@ -249,8 +287,10 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
     needs: [generate-content]
     if: needs.generate-content.outputs.changes_committed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
+      actions: write
     outputs:
       internal_run_id: ${{ steps.dispatch.outputs.internal_run_id }}
 
@@ -258,7 +298,7 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
       - name: Dispatch internal-distribution workflow
         id: dispatch
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
           CONTENT_BRANCH: ${{ needs.generate-content.outputs.content_branch }}
         run: |
           set -euo pipefail
@@ -310,6 +350,7 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
     needs: [generate-content]
     if: needs.generate-content.outputs.changes_committed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -323,11 +364,11 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          token: ${{ secrets.PROJECT_PAT }}
 
       - name: Merge content branch into develop
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT }}
           CONTENT_BRANCH: ${{ needs.generate-content.outputs.content_branch }}
         run: |
           set -euo pipefail
@@ -343,7 +384,7 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
       - name: Cut release branch from develop
         id: cut
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT }}
           NEW_VERSION: ${{ needs.generate-content.outputs.new_version }}
         run: |
           set -euo pipefail
@@ -366,6 +407,9 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
     needs: [merge-and-cut-release]
     if: needs.merge-and-cut-release.outputs.release_branch != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: Checkout release branch
         uses: actions/checkout@v6
@@ -373,7 +417,7 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
           ref: ${{ needs.merge-and-cut-release.outputs.release_branch }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -409,13 +453,15 @@ The pipeline merges this branch to develop, cuts release/v*, and dispatches Nati
     needs: [generate-content, merge-and-cut-release, regression-gate]
     if: needs.merge-and-cut-release.outputs.release_branch != '' && needs.regression-gate.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
+      actions: write
 
     steps:
       - name: Dispatch Native App Release (platform=both)
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_PAT != '' && secrets.PROJECT_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
           RELEASE_BRANCH: ${{ needs.merge-and-cut-release.outputs.release_branch }}
           RELEASE_VERSION: ${{ needs.merge-and-cut-release.outputs.release_version }}
         run: |

--- a/scripts/ci_changed_components.py
+++ b/scripts/ci_changed_components.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+ANDROID_PREFIXES = (
+    "native-android/",
+)
+IOS_PREFIXES = (
+    "native-ios/",
+)
+SHARED_APP_PREFIXES = (
+    ".maestro/",
+    "content/pro_audio/",
+)
+ANDROID_DEVICE_PATHS = (
+    "scripts/device-tests/ci-maestro.sh",
+)
+IOS_DEVICE_PATHS = (
+    "scripts/device-tests/ci-maestro-ios.sh",
+)
+
+
+def _clean_path(raw: str) -> str:
+    return raw.strip().replace("\\", "/")
+
+
+def classify(paths: list[str], force_all: bool = False) -> dict[str, bool]:
+    if force_all:
+        return {
+            "android": True,
+            "ios": True,
+            "android_device": True,
+            "ios_device": True,
+        }
+
+    changed = [_clean_path(path) for path in paths if _clean_path(path)]
+    shared_app = any(path.startswith(SHARED_APP_PREFIXES) for path in changed)
+    android = shared_app or any(path.startswith(ANDROID_PREFIXES) for path in changed)
+    ios = shared_app or any(path.startswith(IOS_PREFIXES) for path in changed)
+    android_device = android or any(path in ANDROID_DEVICE_PATHS for path in changed)
+    ios_device = ios or any(path in IOS_DEVICE_PATHS for path in changed)
+
+    return {
+        "android": android,
+        "ios": ios,
+        "android_device": android_device,
+        "ios_device": ios_device,
+    }
+
+
+def _read_paths(path: str | None) -> list[str]:
+    if not path or path == "-":
+        return [line.rstrip("\n") for line in os.sys.stdin]
+    return Path(path).read_text(encoding="utf-8").splitlines()
+
+
+def _write_github_output(outputs: dict[str, bool]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={str(value).lower()}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Classify changed files for path-aware CI gates.")
+    parser.add_argument("--files", help="Newline-delimited changed-file list. Use '-' or omit for stdin.")
+    parser.add_argument("--all", action="store_true", help="Force all app/device components on.")
+    parser.add_argument("--github-output", action="store_true", help="Write booleans to $GITHUB_OUTPUT.")
+    args = parser.parse_args()
+
+    outputs = classify(_read_paths(args.files), force_all=args.all)
+    if args.github_output:
+        _write_github_output(outputs)
+    print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_ci_changed_components.py
+++ b/scripts/tests/test_ci_changed_components.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from scripts.ci_changed_components import classify
+
+
+def test_workflow_only_changes_skip_native_heavy_jobs() -> None:
+    result = classify(
+        [
+            ".github/workflows/ci.yml",
+            ".github/workflows/device-tests.yml",
+            "scripts/tests/test_workflow_security_contracts.py",
+        ]
+    )
+
+    assert result == {
+        "android": False,
+        "ios": False,
+        "android_device": False,
+        "ios_device": False,
+    }
+
+
+def test_android_changes_enable_android_and_device_jobs_only() -> None:
+    result = classify(["native-android/app/src/main/java/com/example/Timer.kt"])
+
+    assert result == {
+        "android": True,
+        "ios": False,
+        "android_device": True,
+        "ios_device": False,
+    }
+
+
+def test_ios_changes_enable_ios_and_device_jobs_only() -> None:
+    result = classify(["native-ios/RandomTimer/TimerSetupScreen.swift"])
+
+    assert result == {
+        "android": False,
+        "ios": True,
+        "android_device": False,
+        "ios_device": True,
+    }
+
+
+def test_shared_app_assets_enable_both_platforms() -> None:
+    result = classify(["content/pro_audio/monthly_pro_audio_packs.json"])
+
+    assert result == {
+        "android": True,
+        "ios": True,
+        "android_device": True,
+        "ios_device": True,
+    }
+
+
+def test_non_pr_events_force_all_jobs() -> None:
+    result = classify(["docs/README.md"], force_all=True)
+
+    assert result == {
+        "android": True,
+        "ios": True,
+        "android_device": True,
+        "ios_device": True,
+    }

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -52,6 +52,23 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
 
 
+def test_pr_ci_uses_path_aware_heavy_job_gates() -> None:
+    ci = _read(".github/workflows/ci.yml")
+    device_tests = _read(".github/workflows/device-tests.yml")
+
+    assert "permissions:\n  contents: read" in ci
+    assert "permissions:\n  contents: read" in device_tests
+    assert "Path-Aware CI Gate" in ci
+    assert "Path-Aware Device Gate" in device_tests
+    assert "python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output" in ci
+    assert "python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output" in device_tests
+    assert "if: needs.changes.outputs.android == 'true'" in ci
+    assert "if: needs.changes.outputs.ios == 'true'" in ci
+    assert "if: needs.changes.outputs.android_device == 'true'" in device_tests
+    assert "if: needs.changes.outputs.ios_device == 'true'" in device_tests
+    assert ci.count("timeout-minutes:") >= 9
+
+
 def test_security_workflow_moves_permissions_to_jobs() -> None:
     contents = _read(".github/workflows/security.yml")
     assert "\npermissions:\n" not in contents.split("jobs:", 1)[0]

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -56,8 +56,10 @@ def test_pr_ci_uses_path_aware_heavy_job_gates() -> None:
     ci = _read(".github/workflows/ci.yml")
     device_tests = _read(".github/workflows/device-tests.yml")
 
-    assert "permissions:\n  contents: read" in ci
-    assert "permissions:\n  contents: read" in device_tests
+    assert "\npermissions:\n" not in ci.split("concurrency:", 1)[0]
+    assert "\npermissions:\n" not in device_tests.split("concurrency:", 1)[0]
+    assert ci.count("permissions:\n      contents: read") >= 9
+    assert device_tests.count("permissions:\n      contents: read") >= 3
     assert "Path-Aware CI Gate" in ci
     assert "Path-Aware Device Gate" in device_tests
     assert "python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output" in ci

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -38,6 +38,20 @@ def test_workflow_inputs_are_not_interpolated_inside_run_blocks() -> None:
     assert offenders == []
 
 
+def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
+    contents = _read(".github/workflows/monthly-pro-content-release.yml")
+
+    assert "PROJECT_PAT != ''" not in contents
+    assert "github.token" not in contents
+    assert "Validate required automation token" in contents
+    assert "Missing required monthly release secret(s):" in contents
+    assert "FREESOUND_API_TOKEN" in contents
+    assert contents.count("timeout-minutes:") >= 5
+    assert "actions: write" in contents
+    assert "--body-file \"$body_file\"" in contents
+    assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
+
+
 def test_security_workflow_moves_permissions_to_jobs() -> None:
     contents = _read(".github/workflows/security.yml")
     assert "\npermissions:\n" not in contents.split("jobs:", 1)[0]


### PR DESCRIPTION
## Summary
- fixes invalid monthly workflow YAML that caused zero-job Actions failures
- adds explicit required-secret validation, job timeouts, action dispatch permissions, and env-backed workflow inputs
- removes masked token fallback and unmasked PR creation failures

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/monthly-pro-content-release.yml
- uv run pytest scripts/tests/test_workflow_yaml_syntax.py scripts/tests/test_workflow_security_contracts.py scripts/tests/test_growth_workflow_contracts.py::test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device -q

## Credential readback
- GitHub secret list contains PROJECT_PAT and store release secrets
- FREESOUND_API_TOKEN is not present locally or in GitHub secrets; workflow now fails fast with an explicit missing-secret error instead of failing later inside generation