### PR TITLE
fix(ci): skip impossible automatic iOS distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -164,6 +164,8 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
     runs-on: macos-26
+    outputs:
+      uploaded: ${{ steps.ios_lineage.outputs.uploadable }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -208,17 +210,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-          working-directory: native-ios
-
-      - name: Install Fastlane
-        run: gem install fastlane
-        working-directory: native-ios
-
       - name: Validate iOS signing secrets
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -251,13 +242,51 @@ jobs:
         run: python -m pip install pyjwt==2.11.0 cryptography==46.0.5 requests==2.32.5
 
       - name: Guard iOS version lineage against ASC
+        id: ios_lineage
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY_PATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
-        run: python scripts/check_ios_version_lineage.py --repo-root .
+          DISTRIBUTION_REASON: ${{ needs.gate.outputs.reason }}
+        run: |
+          set -euo pipefail
+          set +e
+          output="$(python scripts/check_ios_version_lineage.py --repo-root . 2>&1)"
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -eq 0 ]; then
+            echo "uploadable=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -q "blocked by closed App Store version"; then
+            reason="$(printf '%s\n' "$output" | tail -n 1)"
+            echo "::warning::Skipping automatic iOS TestFlight upload: $reason"
+            echo "uploadable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "uploadable=false" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Record skipped iOS TestFlight upload
+        if: steps.ios_lineage.outputs.uploadable != 'true'
+        run: echo "Automatic iOS TestFlight upload skipped because App Store Connect rejected the local version lineage."
+
+      - name: Setup Ruby
+        if: steps.ios_lineage.outputs.uploadable == 'true'
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: native-ios
+
+      - name: Install Fastlane
+        if: steps.ios_lineage.outputs.uploadable == 'true'
+        run: gem install fastlane
+        working-directory: native-ios
 
       - name: Configure git credentials for match
+        if: steps.ios_lineage.outputs.uploadable == 'true'
         env:
           GIT_AUTH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
@@ -265,6 +294,7 @@ jobs:
           git config --global url."https://x-access-token:${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup signing certificates and profiles (match)
+        if: steps.ios_lineage.outputs.uploadable == 'true'
         env:
           CI: "true"
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -276,6 +306,7 @@ jobs:
         working-directory: native-ios
 
       - name: Build and upload to TestFlight
+        if: steps.ios_lineage.outputs.uploadable == 'true'
         id: fastlane_beta
         env:
           CI: "true"
@@ -294,6 +325,7 @@ jobs:
         working-directory: native-ios
 
       - name: Verify TestFlight upload read-back
+        if: steps.ios_lineage.outputs.uploadable == 'true'
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
@@ -304,6 +336,7 @@ jobs:
           python scripts/verify_release.py --platform ios --version "$VERSION" --ios-scope testflight --wait --timeout 900 --poll-interval 60
 
       - name: Ensure TestFlight internal distribution visibility
+        if: steps.ios_lineage.outputs.uploadable == 'true'
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
@@ -321,7 +354,7 @@ jobs:
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v7
-        if: always()
+        if: always() && steps.ios_lineage.outputs.uploadable == 'true'
         with:
           name: ios-ipa-internal
           path: native-ios/RandomTimer.ipa
@@ -330,7 +363,7 @@ jobs:
   ios-testflight-signoff:
     name: iOS TestFlight Signoff
     needs: [gate, ios-testflight-internal]
-    if: needs.ios-testflight-internal.result == 'success'
+    if: needs.ios-testflight-internal.result == 'success' && needs.ios-testflight-internal.outputs.uploaded == 'true'
     runs-on: ubuntu-latest
     environment: testflight-signoff
     permissions:

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -100,6 +100,21 @@ def test_internal_distribution_workflow_hardens_play_version_probe_with_timeout_
     assert "--request-retries 3" in compute_section
 
 
+def test_internal_distribution_skips_impossible_auto_ios_uploads_without_signoff():
+    source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
+
+    ios_job = source.split("ios-testflight-internal:", 1)[1].split("ios-testflight-signoff:", 1)[0]
+    signoff_job = source.split("ios-testflight-signoff:", 1)[1].split("android-play-internal:", 1)[0]
+
+    assert "uploaded: ${{ steps.ios_lineage.outputs.uploadable }}" in ios_job
+    assert "DISTRIBUTION_REASON: ${{ needs.gate.outputs.reason }}" in ios_job
+    assert "blocked by closed App Store version" in ios_job
+    assert "Skipping automatic iOS TestFlight upload" in ios_job
+    assert "Record skipped iOS TestFlight upload" in ios_job
+    assert "if: steps.ios_lineage.outputs.uploadable == 'true'" in ios_job
+    assert "needs.ios-testflight-internal.outputs.uploaded == 'true'" in signoff_job
+
+
 def test_internal_distribution_workflow_supports_targeted_reruns_and_firebase_delivery():
     source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- prevent automatic develop/main Internal Distribution runs from failing when App Store Connect proves the local iOS marketing version is already closed
- keep manual iOS distribution strict: manual dispatch still fails on invalid iOS version lineage
- prevent TestFlight signoff when the iOS upload was skipped

## Evidence
- actionlint: `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/internal-distribution.yml` exits 0
- tests: `uv run pytest scripts/tests/test_workflow_yaml_syntax.py scripts/tests/test_growth_workflow_contracts.py::test_internal_distribution_skips_impossible_auto_ios_uploads_without_signoff scripts/tests/test_growth_workflow_contracts.py::test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evidence scripts/tests/test_growth_workflow_contracts.py::test_internal_distribution_workflow_keeps_ruby_setup_pin_in_sync_with_native_release -q` -> 4 passed
- push hygiene: 11 passed / 0 failed