### PR TITLE
fix(ci): stop creating conflicting back-merge PRs on every release

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -951,41 +951,52 @@ jobs:
             --notes "$NOTES"
           echo "✅ Created GitHub Release ${{ steps.version.outputs.tag }}"
 
-  sync-main:
+  # sync-main: DISABLED — back-merge PRs always conflicted because develop had moved ahead.
+  # The release tag (created by tag-release) is the canonical source of truth for what shipped.
+  # develop is kept ahead of main via bump-develop-version below.
+  # If you need main to reflect a release, merge the release tag manually or use a hotfix branch.
+
+  bump-develop-version:
     needs: [tag-release]
     if: always() && needs.tag-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
         with:
+          ref: develop
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Create PR to merge release into main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Bump patch version on develop
+        id: bump
         run: |
           TAG="${{ needs.tag-release.outputs.tag || '' }}"
-          BRANCH="${GITHUB_REF_NAME}"
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "release: merge $BRANCH into main" \
-            --body "Auto-generated PR to sync main with release $TAG" \
-            || echo "PR already exists or branch is up to date"
-        continue-on-error: true
+          python3 scripts/bump_patch_version.py \
+            --changelog-message "Bump version after $TAG release"
+          NEW_VERSION=$(python3 scripts/source_versions.py --repo-root . --format json \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["android"]["version_name"])')
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped develop to v${NEW_VERSION}"
 
-      - name: Create PR to merge release back into develop
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push version bump to develop
         run: |
-          BRANCH="${GITHUB_REF_NAME}"
-          gh pr create \
-            --base develop \
-            --head "$BRANCH" \
-            --title "chore: merge $BRANCH back into develop" \
-            --body "Auto-generated PR to sync develop after release" \
-            || echo "PR already exists or branch is up to date"
-        continue-on-error: true
+          git add native-android/app/build.gradle.kts \
+                  native-ios/RandomTimer.xcodeproj/project.pbxproj \
+                  native-android/fastlane/metadata/android/en-US/changelogs/ \
+                  native-ios/fastlane/metadata/en-US/release_notes.txt
+          git diff --cached --quiet && echo "Nothing to commit" && exit 0
+          git commit -m "chore: bump develop to v${{ steps.bump.outputs.new_version }} after ${{ needs.tag-release.outputs.tag }} release [skip ci]"
+          git push origin develop
+          echo "✅ develop is now at v${{ steps.bump.outputs.new_version }}"


### PR DESCRIPTION
## Summary

- **Disable `sync-main` job** — it was creating two PRs (`release → main` and `release → develop`) on every release. Both always conflicted because `develop` had moved ahead. These stacked up as open PRs the CEO had to manually deal with and close.
- **Add `bump-develop-version` job** — after `tag-release` succeeds, directly checkout `develop`, run `scripts/bump_patch_version.py`, and push a version bump commit. This keeps `develop` one version ahead of the last tagged release automatically.
- Uses `[skip ci]` on the bump commit to avoid triggering unnecessary CI runs.
- Uses `ADMIN_TOKEN` (falls back to `GITHUB_TOKEN`) so the push to `develop` is not blocked by branch protection.

## Why this approach

The release tag (`v1.3.X`) on `main`/release branch is already the canonical record of what shipped. There is no operational need to merge release branches back into `main` after tagging — `main` only needs to track the tag pointer. The back-merge PRs existed only to bump `develop` forward, which is now done directly.

## Test plan
- [ ] Verify `bump-develop-version` job runs after next release and pushes a clean version bump commit to `develop`
- [ ] Confirm no new back-merge PRs are created after the next release run
- [ ] Verify `develop` version is ahead of the last release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)