### PR TITLE
fix(ci): prefer GitHub token for release automerge

### DIFF
--- a/.github/workflows/autonomous-release-automerge.yml
+++ b/.github/workflows/autonomous-release-automerge.yml
@@ -22,6 +22,7 @@ jobs:
        github.event.pull_request.draft == false) ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Resolve PR number
         id: pr
@@ -44,5 +45,31 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
           set -euo pipefail
-          export GH_TOKEN="${PROJECT_PAT:-$DEFAULT_TOKEN}"
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --auto --delete-branch
+
+          enable_automerge() {
+            local label="$1"
+            local token="$2"
+
+            if [[ -z "$token" ]]; then
+              echo "Skipping ${label}: token is not configured."
+              return 1
+            fi
+
+            echo "Attempting auto-merge with ${label}."
+            GH_TOKEN="$token" gh pr merge "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --squash \
+              --auto \
+              --delete-branch
+          }
+
+          if enable_automerge "GITHUB_TOKEN" "$DEFAULT_TOKEN"; then
+            exit 0
+          fi
+
+          if enable_automerge "PROJECT_PAT fallback" "${PROJECT_PAT:-}"; then
+            exit 0
+          fi
+
+          echo "Unable to enable release auto-merge with available tokens." >&2
+          exit 1

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -52,6 +52,16 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
 
 
+def test_release_automerge_uses_default_token_before_pat_fallback() -> None:
+    contents = _read(".github/workflows/autonomous-release-automerge.yml")
+
+    assert 'GH_TOKEN="${PROJECT_PAT:-$DEFAULT_TOKEN}"' not in contents
+    assert "timeout-minutes: 5" in contents
+    assert contents.index('enable_automerge "GITHUB_TOKEN" "$DEFAULT_TOKEN"') < contents.index(
+        'enable_automerge "PROJECT_PAT fallback" "${PROJECT_PAT:-}"'
+    )
+
+
 def test_pr_ci_uses_path_aware_heavy_job_gates() -> None:
     ci = _read(".github/workflows/ci.yml")
     device_tests = _read(".github/workflows/device-tests.yml")


### PR DESCRIPTION
## Summary\n- Prefer the built-in GitHub token before PROJECT_PAT for release auto-merge.\n- Keep PROJECT_PAT only as a fallback so stale PAT secrets do not put a red X on release PRs.\n- Add a workflow contract test for token ordering.\n\n## Verification\n- uv run pytest scripts/tests/test_workflow_security_contracts.py scripts/tests/test_workflow_yaml_syntax.py -q -> 8 passed