### PR TITLE
feat(metrics): iOS refund ground truth via ASC Sales reports

### DIFF
--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -39,6 +39,7 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_VENDOR_NUMBER: ${{ secrets.APPSTORE_VENDOR_NUMBER }}
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -386,7 +386,8 @@ def run(
             "refund_requests": (
                 "Android refund_requests_30d comes from Google Play voided purchases API "
                 "(purchases.voidedpurchases.list) over the snapshot window. iOS refund "
-                "requests are not yet wired in this snapshot."
+                "signal is refund units from negative Units rows in App Store Connect "
+                "SALES/SUMMARY daily reports."
             ),
             "uninstall_proxy": (
                 "Proxy only: distinct Application Installed (os) minus distinct Application "
@@ -407,11 +408,20 @@ def run(
             "android_refund_count_metric_id": (android or {}).get("refund_count_metric_id"),
             "android_reason_counts": (android or {}).get("voided_purchase_reason_counts"),
             "android_status": (android or {}).get("status"),
-            "ios_refund_requests_30d": None,
-            "ios_status": "not_implemented",
+            "ios_refund_units_30d": (
+                (ios or {}).get("ios_refund_units_30d")
+                if (ios or {}).get("status") == "ok"
+                else None
+            ),
+            "ios_refund_count_metric_id": (ios or {}).get("refund_count_metric_id"),
+            "ios_sales_report_vendor_number_present": (
+                (ios or {}).get("sales_report_vendor_number_present")
+            ),
+            "ios_sales_report_days_with_data": (ios or {}).get("sales_report_days_with_data"),
+            "ios_status": (ios or {}).get("status"),
             "note": (
-                "Android uses Google Play voided purchases API. iOS refunds are not yet "
-                "ingested into executive_metrics_snapshot."
+                "Android uses Google Play voided purchases API. iOS uses negative Units in "
+                "App Store Connect SALES/SUMMARY daily reports (requires APPSTORE_VENDOR_NUMBER)."
             ),
         },
         "uninstalls": {

--- a/scripts/real_store_downloads.py
+++ b/scripts/real_store_downloads.py
@@ -31,6 +31,7 @@ from typing import Any
 ANDROID_PACKAGE = "com.iganapolsky.randomtimer"
 IOS_BUNDLE_ID = "com.igorganapolsky.randomtimer"
 IOS_APP_ID = "6758355312"
+APP_STORE_CONNECT_API = "https://api.appstoreconnect.apple.com/v1"
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 _ASC_DIR = _SCRIPTS_DIR / "asc"

--- a/scripts/real_store_downloads.py
+++ b/scripts/real_store_downloads.py
@@ -17,7 +17,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import csv
 import datetime as dt
+import gzip
+import io
 import json
 import os
 import sys
@@ -71,6 +74,9 @@ ANDROID_REFUND_COUNT_METRIC_ID = (
 )
 IOS_REVIEW_COUNT_METRIC_ID = (
     "app_store_connect_customer_reviews_sort_created_desc_limit_50"
+)
+IOS_REFUND_COUNT_METRIC_ID = (
+    "app_store_connect_sales_reports_daily_summary_negative_units_sum"
 )
 
 
@@ -128,6 +134,74 @@ def _summarize_voided_purchases(voided: list[dict[str, Any]]) -> dict[str, Any]:
         "refund_requests_30d": len(voided),
         "voided_purchase_reason_counts": reason_counts,
     }
+
+
+def _parse_asc_sales_report_rows(raw: bytes) -> list[dict[str, str]]:
+    """Parse ASC sales report bytes (gzip TSV or plain TSV) into row dicts."""
+    if not raw:
+        return []
+    try:
+        decoded = gzip.decompress(raw).decode("utf-8", errors="replace")
+    except Exception:
+        decoded = raw.decode("utf-8", errors="replace")
+    reader = csv.DictReader(io.StringIO(decoded), delimiter="\t")
+    rows: list[dict[str, str]] = []
+    for row in reader:
+        if not isinstance(row, dict):
+            continue
+        rows.append({str(k or ""): str(v or "") for k, v in row.items()})
+    return rows
+
+
+def _summarize_ios_refunds_from_sales_rows(rows: list[dict[str, str]]) -> dict[str, Any]:
+    """Treat negative Units rows as refund units in ASC daily sales summaries."""
+    refund_units = 0.0
+    gross_units = 0.0
+    for row in rows:
+        units_raw = (row.get("Units") or "").strip()
+        if not units_raw:
+            continue
+        try:
+            units = float(units_raw)
+        except ValueError:
+            continue
+        if units < 0:
+            refund_units += abs(units)
+        elif units > 0:
+            gross_units += units
+    return {
+        "ios_refund_units_30d": int(round(refund_units)),
+        "ios_gross_units_30d": int(round(gross_units)),
+        "ios_net_units_30d": int(round(gross_units - refund_units)),
+    }
+
+
+def _fetch_asc_sales_report_bytes(
+    requests_mod: Any,
+    headers: dict[str, str],
+    vendor_number: str,
+    report_date: dt.date,
+) -> bytes | None:
+    """Fetch one daily ASC sales summary report as raw bytes."""
+    resp = _asc_get_with_retries(
+        requests_mod,
+        f"{APP_STORE_CONNECT_API}/salesReports",
+        headers=headers,
+        params={
+            "filter[frequency]": "DAILY",
+            "filter[reportDate]": report_date.strftime("%Y-%m-%d"),
+            "filter[reportSubType]": "SUMMARY",
+            "filter[reportType]": "SALES",
+            "filter[vendorNumber]": vendor_number,
+            "filter[version]": "1_0",
+        },
+        timeout=90.0,
+    )
+    if resp.status_code == 404:
+        return None
+    if resp.status_code != 200:
+        raise RuntimeError(f"ASC salesReports HTTP {resp.status_code}")
+    return resp.content or b""
 
 
 def _get_android_data(days: int) -> dict[str, Any]:
@@ -313,12 +387,47 @@ def _get_ios_data(days: int) -> dict[str, Any]:
         result["reviews_error"] = str(e)
 
     # Note: Sales and Trends API requires a separate report request
-    # which takes time to generate. For now, we use the review count
-    # and version state as ground truth.
+    # and may be unavailable for the current date until processing catches up.
+    vendor_number = (os.environ.get("APPSTORE_VENDOR_NUMBER") or "").strip()
+    if vendor_number:
+        try:
+            all_rows: list[dict[str, str]] = []
+            days_with_data = 0
+            today_utc = dt.datetime.now(dt.timezone.utc).date()
+            for offset in range(1, max(1, int(days)) + 1):
+                report_day = today_utc - dt.timedelta(days=offset)
+                blob = _fetch_asc_sales_report_bytes(
+                    requests,
+                    headers,
+                    vendor_number,
+                    report_day,
+                )
+                if not blob:
+                    continue
+                rows = _parse_asc_sales_report_rows(blob)
+                if rows:
+                    days_with_data += 1
+                    all_rows.extend(rows)
+            refund_summary = _summarize_ios_refunds_from_sales_rows(all_rows)
+            result.update(refund_summary)
+            result["refund_count_metric_id"] = IOS_REFUND_COUNT_METRIC_ID
+            result["sales_report_vendor_number_present"] = True
+            result["sales_report_days_scanned"] = int(days)
+            result["sales_report_days_with_data"] = days_with_data
+        except Exception as e:
+            result["refund_error"] = str(e)
+            result["refund_count_metric_id"] = IOS_REFUND_COUNT_METRIC_ID
+            result["sales_report_vendor_number_present"] = True
+    else:
+        result["refund_count_metric_id"] = IOS_REFUND_COUNT_METRIC_ID
+        result["sales_report_vendor_number_present"] = False
+
     result["note"] = (
         "App Store Connect Sales reports require async report generation. "
         "customerReviews count is the first page only (limit 50, newest first), "
-        "not total lifetime App Store reviews. Version state is live from the API."
+        "not total lifetime App Store reviews. Version state is live from the API. "
+        "iOS refund units are derived from negative Units rows in ASC daily SALES/SUMMARY "
+        "reports when APPSTORE_VENDOR_NUMBER is configured."
     )
 
     return result

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -164,7 +164,13 @@ def test_run_includes_refunds_and_uninstall_proxy_fields(
             "refund_count_metric_id": "android_refund_metric_id",
             "voided_purchase_reason_counts": {"0": 2, "1": 1},
         },
-        _get_ios_data=lambda days: {"status": "ok"},
+        _get_ios_data=lambda days: {
+            "status": "ok",
+            "ios_refund_units_30d": 2,
+            "refund_count_metric_id": "ios_refund_metric_id",
+            "sales_report_vendor_number_present": True,
+            "sales_report_days_with_data": 18,
+        },
     )
     monkeypatch.setitem(sys.modules, "check_crashlytics", fake_crashlytics)
     monkeypatch.setitem(sys.modules, "real_store_downloads", fake_real_store)
@@ -173,5 +179,8 @@ def test_run_includes_refunds_and_uninstall_proxy_fields(
 
     assert payload["refunds"]["android_refund_requests_30d"] == 3
     assert payload["refunds"]["android_reason_counts"] == {"0": 2, "1": 1}
+    assert payload["refunds"]["ios_refund_units_30d"] == 2
+    assert payload["refunds"]["ios_refund_count_metric_id"] == "ios_refund_metric_id"
+    assert payload["refunds"]["ios_sales_report_days_with_data"] == 18
     assert payload["uninstalls"]["ios_uninstall_proxy_30d"] == 2
     assert payload["uninstalls"]["android_uninstall_proxy_30d"] == 5

--- a/scripts/tests/test_real_store_downloads.py
+++ b/scripts/tests/test_real_store_downloads.py
@@ -13,9 +13,12 @@ sys.path.insert(0, str(SCRIPTS))
 from real_store_downloads import (  # noqa: E402
     ANDROID_REFUND_COUNT_METRIC_ID,
     ANDROID_REVIEW_COUNT_METRIC_ID,
+    IOS_REFUND_COUNT_METRIC_ID,
     IOS_REVIEW_COUNT_METRIC_ID,
+    _parse_asc_sales_report_rows,
     _fetch_all_android_voided_purchases,
     _fetch_all_play_reviews_list,
+    _summarize_ios_refunds_from_sales_rows,
     _summarize_voided_purchases,
 )
 
@@ -24,6 +27,7 @@ def test_review_metric_ids_are_stable_tokens() -> None:
     assert "google_play" in ANDROID_REVIEW_COUNT_METRIC_ID
     assert "voidedpurchases" in ANDROID_REFUND_COUNT_METRIC_ID
     assert "app_store_connect" in IOS_REVIEW_COUNT_METRIC_ID
+    assert "sales_reports" in IOS_REFUND_COUNT_METRIC_ID
 
 
 def test_fetch_all_play_reviews_list_paginates_until_no_token() -> None:
@@ -93,3 +97,31 @@ def test_summarize_voided_purchases_groups_reason_codes() -> None:
         "1": 1,
         "unknown": 1,
     }
+
+
+def test_parse_asc_sales_report_rows_handles_gzip_tsv() -> None:
+    import gzip
+
+    raw_tsv = (
+        "Provider\tUnits\tSKU\n"
+        "ABC\t-2\tpro_monthly\n"
+        "ABC\t5\tpro_yearly\n"
+    ).encode("utf-8")
+    rows = _parse_asc_sales_report_rows(gzip.compress(raw_tsv))
+    assert len(rows) == 2
+    assert rows[0]["Units"] == "-2"
+    assert rows[1]["SKU"] == "pro_yearly"
+
+
+def test_summarize_ios_refunds_uses_negative_units() -> None:
+    summary = _summarize_ios_refunds_from_sales_rows(
+        [
+            {"Units": "-2"},
+            {"Units": "-1.5"},
+            {"Units": "4"},
+            {"Units": "bad"},
+        ]
+    )
+    assert summary["ios_refund_units_30d"] == 4
+    assert summary["ios_gross_units_30d"] == 4
+    assert summary["ios_net_units_30d"] == 0


### PR DESCRIPTION
Phase 2 analytics upgrade:

- Pull App Store Connect daily SALES/SUMMARY report rows via `/v1/salesReports`
- Derive iOS refund units from negative `Units` values
- Add iOS refund ground truth fields under `refunds` in `executive_metrics.json`
- Wire `APPSTORE_VENDOR_NUMBER` into `executive-metrics.yml`
- Add parser + executive wiring tests

Made with [Cursor](https://cursor.com)