### PR TITLE
chore(release): add v1.3.21 notes

### DIFF
--- a/release-notes/1.3.21.md
+++ b/release-notes/1.3.21.md
@@ -1,0 +1,18 @@
+# Release 1.3.21
+
+## Summary
+Conversion-focused release for Random Tactical Timer, aimed at making Pro easier to understand, easier to try, and easier to buy after users experience a completed training session.
+
+## Customer-visible changes
+- Moved the Pro paywall behind the first completed timer session so users feel the core training loop before seeing the upgrade.
+- Rewrote Pro positioning around the "Stop Training With the Brakes On" outcome-focused message.
+- Added a monthly Pro subscription option at $3.99/month alongside existing Pro access paths.
+- Shows a free-trial CTA when a trial is available.
+- Keeps April Pro voice callouts and Sound Arsenal content current.
+- Restores Android review prompt behavior after real training engagement.
+
+## Analytics and release operations
+- Tracks revenue on every purchase path for better monetization visibility.
+- Fixes iOS abandon-rate accounting so background transitions do not inflate abandonment.
+- Aligns Android `versionName` and iOS `MARKETING_VERSION` at `1.3.21`.
+- Preserves store release gates with internal signoff, production signoff or scheduled-release waiver, and store read-back verification before claiming publication.


### PR DESCRIPTION
## Summary
- add missing release-notes/1.3.21.md required by Android release preflight

## Verification
- bash scripts/shell/preflight-release.sh --platform android --layer 1