### PR TITLE
fix(workflow): enforce daily iOS refund ground-truth health gate

### DIFF
--- a/.github/workflows/executive-metrics.yml
+++ b/.github/workflows/executive-metrics.yml
@@ -1,6 +1,8 @@
 name: Executive metrics snapshot
 
 on:
+  schedule:
+    - cron: '17 6 * * *'
   workflow_dispatch:
     inputs:
       posthog_days:
@@ -43,8 +45,8 @@ jobs:
           CRASHLYTICS_SERVICE_ACCOUNT_JSON: ${{ secrets.CRASHLYTICS_SERVICE_ACCOUNT_JSON }}
           # Must match the Firebase project where Crashlytics → BigQuery streaming is linked.
           CRASHLYTICS_PROJECT_ID: random-timer-dist-new
-          POSTHOG_DAYS: ${{ inputs.posthog_days }}
-          CRASHLYTICS_HOURS: ${{ inputs.crashlytics_hours }}
+          POSTHOG_DAYS: ${{ inputs.posthog_days || '30' }}
+          CRASHLYTICS_HOURS: ${{ inputs.crashlytics_hours || '168' }}
         run: |
           set -euo pipefail
           python3 scripts/executive_metrics_snapshot.py \
@@ -53,7 +55,45 @@ jobs:
             --crashlytics-hours "$CRASHLYTICS_HOURS" \
             --no-dotenv
 
+      - name: Verify iOS refund ground-truth signal
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("marketing/data/executive_metrics.json")
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          refunds = payload.get("refunds") or {}
+          errors = []
+
+          if refunds.get("ios_status") != "ok":
+              errors.append("refunds.ios_status is not ok")
+          if refunds.get("ios_sales_report_vendor_number_present") is not True:
+              errors.append("refunds.ios_sales_report_vendor_number_present is not true")
+          metric_id = refunds.get("ios_refund_count_metric_id") or ""
+          if (
+              metric_id
+              != "app_store_connect_sales_reports_daily_summary_negative_units_sum"
+          ):
+              errors.append("refunds.ios_refund_count_metric_id missing expected token")
+
+          if errors:
+              raise SystemExit(
+                  "iOS refund ground-truth verification failed: " + "; ".join(errors)
+              )
+
+          print("iOS refund ground-truth verification passed.")
+          print(
+              "ios_refund_units_30d="
+              + str(refunds.get("ios_refund_units_30d"))
+              + ", ios_sales_report_days_with_data="
+              + str(refunds.get("ios_sales_report_days_with_data"))
+          )
+          PY
+
       - uses: actions/upload-artifact@v7.0.0
+        if: always()
         with:
           name: executive-metrics
           path: marketing/data/executive_metrics.json

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -18,6 +18,7 @@ IOS_SMOKE_FLOW = ROOT / ".maestro/ios-smoke-test.yaml"
 WEEKLY_SHARED_WORKFLOW = ROOT / ".github/workflows/weekly-shared.yml"
 WQTU_HEALTH_WORKFLOW = ROOT / ".github/workflows/wqtu-health.yml"
 ANALYTICS_WORKFLOW = ROOT / ".github/workflows/analytics.yml"
+EXECUTIVE_METRICS_WORKFLOW = ROOT / ".github/workflows/executive-metrics.yml"
 
 
 def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():
@@ -454,6 +455,20 @@ def test_analytics_deployment_report_reads_deployment_statuses():
     assert "/deployments/{deployment['id']}/statuses?per_page=1" in source
     assert 'latest_state = statuses[0]["state"] if statuses else "unknown"' in source
     assert '.state == "success"' not in source
+
+
+def test_executive_metrics_workflow_runs_daily_and_guards_ios_refund_signal():
+    source = EXECUTIVE_METRICS_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "schedule:" in source
+    assert "cron: '17 6 * * *'" in source
+    assert "workflow_dispatch:" in source
+    assert "Verify iOS refund ground-truth signal" in source
+    assert "python3 - <<'PY'" in source
+    assert "refunds.ios_status is not ok" in source
+    assert "refunds.ios_sales_report_vendor_number_present is not true" in source
+    assert "refunds.ios_refund_count_metric_id missing expected token" in source
+    assert "app_store_connect_sales_reports_daily_summary_negative_units_sum" in source
 
 
 def test_wqtu_health_workflow_closes_prior_alert_issue_before_creating_next_one():


### PR DESCRIPTION
## Summary
- schedule `Executive metrics snapshot` to run daily at `06:17 UTC` while keeping manual dispatch
- add an explicit workflow gate that fails when iOS refund ground-truth fields degrade (`ios_status`, vendor-number presence, refund metric id)
- always upload `executive_metrics.json` artifact for incident evidence, and add workflow contract tests to lock the behavior

## Test plan
- [x] `.venv/bin/python3 -m pytest scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_executive_metrics_snapshot.py`
- [x] Verified local lints clean for edited files

Made with [Cursor](https://cursor.com)