### PR TITLE
feat(analytics): add paywall non-conversion diagnostics loop

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -123,3 +123,18 @@ jobs:
         PY
       artifact_name: weekly-deployment-metrics-report
       artifact_path: ./deployment_report.md
+
+  analyze-paywall-conversion:
+    uses: ./.github/workflows/weekly-shared.yml
+    secrets:
+      POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+      POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+    with:
+      pip_packages: requests==2.32.5
+      run_command: |
+        set -euo pipefail
+        python scripts/paywall_conversion_report.py --repo-root . --days 30
+      artifact_name: weekly-paywall-conversion-report
+      artifact_path: |
+        ./marketing/data/paywall_conversion_report.md
+        ./marketing/data/paywall_conversion_report.json

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -289,6 +289,9 @@ class AnalyticsService
 
 // Event names for consistency
 object AnalyticsEvents {
+    const val PAYWALL_VIEW = "paywall_view"
+    const val PAYWALL_OFFER_SELECT = "paywall_offer_select"
+    const val PAYWALL_PURCHASE_FAIL_REASON = "paywall_purchase_fail_reason"
     const val APPLICATION_INSTALLED = "Application Installed"
     const val APPLICATION_OPENED = "Application Opened"
     const val TIMER_STARTED = "timer_started"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -471,6 +471,16 @@ class ProManager
                         AnalyticsProperties.DEBUG_MESSAGE to (result.debugMessage ?: ""),
                     ),
                 )
+                analyticsService.track(
+                    AnalyticsEvents.PAYWALL_PURCHASE_FAIL_REASON,
+                    mapOf(
+                        AnalyticsProperties.REASON to reason,
+                        AnalyticsProperties.PRODUCT_ID to failedProductId,
+                        AnalyticsProperties.ENTRY_POINT to (pendingPurchaseEntryPoint ?: ""),
+                        AnalyticsProperties.RESPONSE_CODE to result.responseCode,
+                        AnalyticsProperties.DEBUG_MESSAGE to (result.debugMessage ?: ""),
+                    ),
+                )
             }
             if (hasPurchased) {
                 val purchasedProductId = purchases?.firstOrNull()?.products?.firstOrNull() ?: ""

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -219,6 +219,13 @@ fun RandomTimerNavHost(
             proPrice = proPrice,
             monthlyPrice = monthlyPrice,
             trialEligibilityByProductId = paywallTrialEligibilityByProductId,
+            onPlanSelected = { plan, productId ->
+                viewModel.trackPaywallOfferSelected(
+                    entryPoint = paywallEntryPoint,
+                    productId = productId,
+                    plan = plan,
+                )
+            },
             onPurchase = { productID ->
                 scope.launch {
                     val launched =

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -74,6 +75,9 @@ fun PaywallSheet(
     val haptic = LocalHapticFeedback.current
     // Default to monthly — lower barrier to entry
     var selectedPlan by remember { mutableStateOf(SubscriptionPlanSelection.MONTHLY) }
+    LaunchedEffect(Unit) {
+        onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID)
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -66,6 +66,7 @@ fun PaywallSheet(
     monthlyPrice: String = "$3.99",
     trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
     onPurchase: (String) -> Unit,
+    onPlanSelected: (plan: String, productId: String) -> Unit = { _, _ -> },
     onRestore: () -> Unit,
     onDismiss: () -> Unit,
     onDebugUnlock: (() -> Unit)? = null,
@@ -167,7 +168,10 @@ fun PaywallSheet(
                 priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
                 badge = null,
                 isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
-                onClick = { selectedPlan = SubscriptionPlanSelection.MONTHLY },
+                onClick = {
+                    selectedPlan = SubscriptionPlanSelection.MONTHLY
+                    onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID)
+                },
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -177,7 +181,10 @@ fun PaywallSheet(
                 priceLabel = "${stripPriceSuffix(proPrice)}/year",
                 badge = "Best Value",
                 isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
-                onClick = { selectedPlan = SubscriptionPlanSelection.ANNUAL },
+                onClick = {
+                    selectedPlan = SubscriptionPlanSelection.ANNUAL
+                    onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID)
+                },
             )
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -283,8 +283,27 @@ class TimerViewModel
 
         fun trackPaywallViewed(entryPoint: String) {
             analyticsService.track(
+                AnalyticsEvents.PAYWALL_VIEW,
+                mapOf(AnalyticsProperties.ENTRY_POINT to entryPoint),
+            )
+            analyticsService.track(
                 AnalyticsEvents.PAYWALL_VIEWED,
                 mapOf(AnalyticsProperties.ENTRY_POINT to entryPoint),
+            )
+        }
+
+        fun trackPaywallOfferSelected(
+            entryPoint: String,
+            productId: String,
+            plan: String,
+        ) {
+            analyticsService.track(
+                AnalyticsEvents.PAYWALL_OFFER_SELECT,
+                mapOf(
+                    AnalyticsProperties.ENTRY_POINT to entryPoint,
+                    AnalyticsProperties.PRODUCT_ID to productId,
+                    "plan" to plan,
+                ),
             )
         }
 

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -420,6 +420,9 @@ final class AnalyticsService { // swiftlint:disable:this type_body_length
 
 // Event names for consistency
 enum AnalyticsEvents {
+    static let paywallView = "paywall_view"
+    static let paywallOfferSelect = "paywall_offer_select"
+    static let paywallPurchaseFailReason = "paywall_purchase_fail_reason"
     static let applicationInstalled = "Application Installed"
     static let applicationOpened = "Application Opened"
     static let timerStarted = "timer_started"

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -161,6 +161,7 @@ struct PaywallSheet: View {
                         isSelected: selectedPlan == .monthly
                     ) {
                         selectedPlan = .monthly
+                        trackOfferSelected(plan: "monthly", productID: ProManager.monthlyProductID)
                     }
 
                     PlanOptionRow(
@@ -170,6 +171,7 @@ struct PaywallSheet: View {
                         isSelected: selectedPlan == .annual
                     ) {
                         selectedPlan = .annual
+                        trackOfferSelected(plan: "annual", productID: ProManager.annualProductID)
                     }
 
                     PlanOptionRow(
@@ -179,6 +181,7 @@ struct PaywallSheet: View {
                         isSelected: selectedPlan == .lifetime
                     ) {
                         selectedPlan = .lifetime
+                        trackOfferSelected(plan: "lifetime", productID: ProManager.paywallProductID)
                     }
                 }
 
@@ -239,6 +242,9 @@ struct PaywallSheet: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.backgroundDark)
         .task {
+            AnalyticsService.shared.track(AnalyticsEvents.paywallView, properties: [
+                AnalyticsProperties.entryPoint: entryPoint.rawValue,
+            ])
             AnalyticsService.shared.track(AnalyticsEvents.paywallViewed, properties: [
                 AnalyticsProperties.entryPoint: entryPoint.rawValue,
             ])
@@ -292,6 +298,11 @@ struct PaywallSheet: View {
                 failReason = "unknown"
             }
             AnalyticsService.shared.track(AnalyticsEvents.purchaseFailed, properties: [
+                AnalyticsProperties.reason: failReason,
+                AnalyticsProperties.productId: productID,
+                AnalyticsProperties.entryPoint: entryPoint.rawValue,
+            ])
+            AnalyticsService.shared.track(AnalyticsEvents.paywallPurchaseFailReason, properties: [
                 AnalyticsProperties.reason: failReason,
                 AnalyticsProperties.productId: productID,
                 AnalyticsProperties.entryPoint: entryPoint.rawValue,
@@ -358,6 +369,14 @@ struct PaywallSheet: View {
         AnalyticsService.shared.track(AnalyticsEvents.paywallDismissed, properties: [
             AnalyticsProperties.entryPoint: entryPoint.rawValue,
             AnalyticsProperties.dismissMethod: method,
+        ])
+    }
+
+    private func trackOfferSelected(plan: String, productID: String) {
+        AnalyticsService.shared.track(AnalyticsEvents.paywallOfferSelect, properties: [
+            AnalyticsProperties.entryPoint: entryPoint.rawValue,
+            AnalyticsProperties.productId: productID,
+            "plan": plan,
         ])
     }
 

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -242,6 +242,7 @@ struct PaywallSheet: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.backgroundDark)
         .task {
+            trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)
             AnalyticsService.shared.track(AnalyticsEvents.paywallView, properties: [
                 AnalyticsProperties.entryPoint: entryPoint.rawValue,
             ])
@@ -380,6 +381,17 @@ struct PaywallSheet: View {
             AnalyticsProperties.productId: productID,
             "plan": plan,
         ])
+    }
+
+    private func planName(for plan: PaywallPlanSelection) -> String {
+        switch plan {
+        case .monthly:
+            return "monthly"
+        case .annual:
+            return "annual"
+        case .lifetime:
+            return "lifetime"
+        }
     }
 
     private func triggerDebugUnlock() {

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -302,11 +302,13 @@ struct PaywallSheet: View {
                 AnalyticsProperties.productId: productID,
                 AnalyticsProperties.entryPoint: entryPoint.rawValue,
             ])
-            AnalyticsService.shared.track(AnalyticsEvents.paywallPurchaseFailReason, properties: [
-                AnalyticsProperties.reason: failReason,
-                AnalyticsProperties.productId: productID,
-                AnalyticsProperties.entryPoint: entryPoint.rawValue,
-            ])
+            if result != .userCancelled {
+                AnalyticsService.shared.track(AnalyticsEvents.paywallPurchaseFailReason, properties: [
+                    AnalyticsProperties.reason: failReason,
+                    AnalyticsProperties.productId: productID,
+                    AnalyticsProperties.entryPoint: entryPoint.rawValue,
+                ])
+            }
 
             switch result {
             case .productUnavailable:

--- a/scripts/paywall_conversion_report.py
+++ b/scripts/paywall_conversion_report.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Weekly paywall conversion and non-conversion diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from store_downloads_snapshot import LIVE_EVENTS_PREDICATE, posthog_query
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(float(numerator) / float(denominator), 4)
+
+
+def _scalar(query: str, api_key: str, project_id: str, errors: List[str]) -> int:
+    result = posthog_query(query, api_key, project_id, errors)
+    if not result or not result.get("results"):
+        return 0
+    row = result["results"][0]
+    if not row:
+        return 0
+    return _safe_int(row[0])
+
+
+def _table(
+    query: str,
+    api_key: str,
+    project_id: str,
+    errors: List[str],
+) -> list[list[Any]]:
+    result = posthog_query(query, api_key, project_id, errors)
+    rows = (result or {}).get("results")
+    if not isinstance(rows, list):
+        return []
+    return rows
+
+
+def _funnel_counts(api_key: str, project_id: str, days: int, errors: List[str]) -> Dict[str, int]:
+    win = f"{days} day"
+    views = _scalar(
+        f"""
+        SELECT count()
+        FROM events
+        WHERE event IN ('paywall_view', 'paywall_viewed')
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    offer_selects = _scalar(
+        f"""
+        SELECT count()
+        FROM events
+        WHERE event = 'paywall_offer_select'
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    purchase_attempts = _scalar(
+        f"""
+        SELECT count()
+        FROM events
+        WHERE event = 'paywall_purchase_attempt'
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    purchase_successes = _scalar(
+        f"""
+        SELECT count()
+        FROM events
+        WHERE event = 'paywall_purchase_success'
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    return {
+        "views": views,
+        "offer_selects": offer_selects,
+        "purchase_attempts": purchase_attempts,
+        "purchase_successes": purchase_successes,
+    }
+
+
+def _failure_reasons(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
+    win = f"{days} day"
+    rows = _table(
+        f"""
+        SELECT
+          coalesce(
+            toString(coalesce(properties.reason, properties.result, 'unknown')),
+            'unknown'
+          ) AS reason,
+          count() AS failures
+        FROM events
+        WHERE event IN ('paywall_purchase_fail_reason', 'purchase_failed')
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        GROUP BY reason
+        ORDER BY failures DESC
+        LIMIT 12
+        /* top_failure_reasons */
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    return [{"reason": str(row[0] or "unknown"), "count": _safe_int(row[1])} for row in rows]
+
+
+def _entry_point_funnel(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
+    win = f"{days} day"
+    rows = _table(
+        f"""
+        SELECT
+          coalesce(toString(properties.entry_point), 'unknown') AS entry_point,
+          countIf(event IN ('paywall_view', 'paywall_viewed')) AS views,
+          countIf(event = 'paywall_purchase_attempt') AS attempts,
+          countIf(event = 'paywall_purchase_success') AS successes
+        FROM events
+        WHERE event IN ('paywall_view', 'paywall_viewed', 'paywall_purchase_attempt', 'paywall_purchase_success')
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        GROUP BY entry_point
+        ORDER BY views DESC
+        LIMIT 15
+        /* entry_point_funnel */
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        views = _safe_int(row[1])
+        attempts = _safe_int(row[2])
+        successes = _safe_int(row[3])
+        out.append(
+            {
+                "entry_point": str(row[0] or "unknown"),
+                "views": views,
+                "attempts": attempts,
+                "successes": successes,
+                "view_to_attempt_rate": _rate(attempts, views),
+                "attempt_to_success_rate": _rate(successes, attempts),
+            }
+        )
+    return out
+
+
+def build_markdown(payload: Dict[str, Any]) -> str:
+    funnel = payload.get("funnel", {})
+    lines = [
+        "# Paywall Conversion Report",
+        "",
+        f"Generated: {payload.get('generated_at', '')}",
+        f"Window (days): {payload.get('window_days', 30)}",
+        "",
+        "## Funnel",
+        f"- Views: **{funnel.get('views', 0)}**",
+        f"- Offer Selects: **{funnel.get('offer_selects', 0)}**",
+        f"- Purchase Attempts: **{funnel.get('purchase_attempts', 0)}**",
+        f"- Purchase Successes: **{funnel.get('purchase_successes', 0)}**",
+        f"- View -> Offer Select: **{funnel.get('view_to_select_rate', 0):.1%}**",
+        f"- Select -> Purchase Attempt: **{funnel.get('select_to_attempt_rate', 0):.1%}**",
+        f"- Attempt -> Purchase Success: **{funnel.get('attempt_to_success_rate', 0):.1%}**",
+        "",
+        "## Top Failure Reasons",
+        "| Reason | Count |",
+        "|--------|-------|",
+    ]
+    for row in payload.get("top_failure_reasons", []):
+        lines.append(f"| {row.get('reason', 'unknown')} | {row.get('count', 0)} |")
+    if not payload.get("top_failure_reasons"):
+        lines.append("| (none) | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Entry Point Funnel",
+            "| Entry Point | Views | Attempts | Successes | View->Attempt | Attempt->Success |",
+            "|-------------|-------|----------|-----------|---------------|------------------|",
+        ]
+    )
+    for row in payload.get("entry_points", []):
+        lines.append(
+            f"| {row.get('entry_point', 'unknown')} | {row.get('views', 0)} | "
+            f"{row.get('attempts', 0)} | {row.get('successes', 0)} | "
+            f"{row.get('view_to_attempt_rate', 0):.1%} | {row.get('attempt_to_success_rate', 0):.1%} |"
+        )
+    if not payload.get("entry_points"):
+        lines.append("| (none) | 0 | 0 | 0 | 0.0% | 0.0% |")
+
+    if payload.get("query_errors"):
+        lines.extend(
+            [
+                "",
+                "## Query Diagnostics",
+                f"- Query errors: **{len(payload.get('query_errors', []))}**",
+                f"- Last error: `{payload['query_errors'][-1]}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
+    output_dir = repo_root / "marketing" / "data"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "paywall_conversion_report.json"
+    md_path = output_dir / "paywall_conversion_report.md"
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+    api_key = (
+        os.getenv("POSTHOG_PERSONAL_API_KEY", "").strip()
+        or os.getenv("POSTHOG_API_KEY", "").strip()
+        or os.getenv("posthog_api_key", "").strip()
+    )
+    project_id = os.getenv("POSTHOG_PROJECT_ID", "").strip()
+    errors: list[str] = []
+
+    payload: Dict[str, Any] = {
+        "generated_at": generated_at,
+        "window_days": int(days),
+        "status": "ok",
+        "reason": "",
+        "funnel": {
+            "views": 0,
+            "offer_selects": 0,
+            "purchase_attempts": 0,
+            "purchase_successes": 0,
+            "view_to_select_rate": 0.0,
+            "select_to_attempt_rate": 0.0,
+            "attempt_to_success_rate": 0.0,
+        },
+        "top_failure_reasons": [],
+        "entry_points": [],
+        "query_errors": [],
+    }
+
+    if not api_key or not project_id:
+        payload["status"] = "skipped"
+        payload["reason"] = "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID"
+        md = build_markdown(payload)
+        json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        md_path.write_text(md, encoding="utf-8")
+        return payload
+
+    counts = _funnel_counts(api_key, project_id, days, errors)
+    failures = _failure_reasons(api_key, project_id, days, errors)
+    entry_points = _entry_point_funnel(api_key, project_id, days, errors)
+
+    payload["funnel"] = {
+        **counts,
+        "view_to_select_rate": _rate(counts["offer_selects"], counts["views"]),
+        "select_to_attempt_rate": _rate(counts["purchase_attempts"], counts["offer_selects"]),
+        "attempt_to_success_rate": _rate(counts["purchase_successes"], counts["purchase_attempts"]),
+    }
+    payload["top_failure_reasons"] = failures
+    payload["entry_points"] = entry_points
+    payload["query_errors"] = errors
+    if errors:
+        payload["status"] = "degraded"
+        payload["reason"] = "one or more PostHog queries failed"
+
+    md = build_markdown(payload)
+    json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    md_path.write_text(md, encoding="utf-8")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate paywall conversion report")
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument("--days", type=int, default=30, help="Lookback window")
+    args = parser.parse_args()
+    result = run(Path(args.repo_root).resolve(), days=args.days)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -457,6 +457,17 @@ def test_analytics_deployment_report_reads_deployment_statuses():
     assert '.state == "success"' not in source
 
 
+def test_analytics_workflow_publishes_weekly_paywall_conversion_report_artifact():
+    source = ANALYTICS_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "analyze-paywall-conversion:" in source
+    assert "python scripts/paywall_conversion_report.py --repo-root . --days 30" in source
+    assert "pip_packages: requests==2.32.5" in source
+    assert "artifact_name: weekly-paywall-conversion-report" in source
+    assert "marketing/data/paywall_conversion_report.md" in source
+    assert "marketing/data/paywall_conversion_report.json" in source
+
+
 def test_executive_metrics_workflow_runs_daily_and_guards_ios_refund_signal():
     source = EXECUTIVE_METRICS_WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_paywall_conversion_report.py
+++ b/scripts/tests/test_paywall_conversion_report.py
@@ -1,0 +1,107 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+class PaywallConversionReportTests(unittest.TestCase):
+    def test_build_markdown_includes_funnel_and_failure_reasons(self):
+        from scripts import paywall_conversion_report as report
+
+        payload = {
+            "window_days": 30,
+            "funnel": {
+                "views": 100,
+                "offer_selects": 55,
+                "purchase_attempts": 21,
+                "purchase_successes": 3,
+                "view_to_select_rate": 0.55,
+                "select_to_attempt_rate": 0.3818,
+                "attempt_to_success_rate": 0.1429,
+            },
+            "top_failure_reasons": [
+                {"reason": "user_cancelled", "count": 12},
+                {"reason": "network_error", "count": 4},
+            ],
+            "entry_points": [
+                {"entry_point": "setup_upgrade_cta", "views": 70, "attempts": 15, "successes": 2},
+            ],
+        }
+
+        markdown = report.build_markdown(payload)
+
+        self.assertIn("Paywall Conversion Report", markdown)
+        self.assertIn("View -> Offer Select", markdown)
+        self.assertIn("user_cancelled", markdown)
+        self.assertIn("setup_upgrade_cta", markdown)
+
+    def test_run_writes_reports_when_credentials_missing(self):
+        from scripts import paywall_conversion_report as report
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "POSTHOG_PERSONAL_API_KEY": "",
+                    "POSTHOG_API_KEY": "",
+                    "POSTHOG_PROJECT_ID": "",
+                },
+                clear=True,
+            ):
+                result = report.run(root, days=14)
+
+            self.assertEqual("skipped", result["status"])
+            json_path = root / "marketing" / "data" / "paywall_conversion_report.json"
+            md_path = root / "marketing" / "data" / "paywall_conversion_report.md"
+            self.assertTrue(json_path.exists())
+            self.assertTrue(md_path.exists())
+
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual("skipped", payload["status"])
+            self.assertIn("missing POSTHOG", payload["reason"])
+
+    def test_run_populates_funnel_from_posthog_queries(self):
+        from scripts import paywall_conversion_report as report
+
+        scalar_results = iter(
+            [
+                [[120]],  # views
+                [[60]],   # offer selects
+                [[24]],   # attempts
+                [[6]],    # successes
+            ]
+        )
+        table_results = iter(
+            [
+                [["user_cancelled", 10], ["network_error", 3]],
+                [["setup_upgrade_cta", 80, 16, 4], ["sound_gate", 40, 8, 2]],
+            ]
+        )
+
+        def fake_posthog_query(_query: str, _api_key: str, _project_id: str, _errors):
+            if "top_failure_reasons" in _query:
+                return {"results": next(table_results)}
+            if "entry_point_funnel" in _query:
+                return {"results": next(table_results)}
+            return {"results": next(scalar_results)}
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with mock.patch.dict(
+                "os.environ",
+                {"POSTHOG_PERSONAL_API_KEY": "phx", "POSTHOG_PROJECT_ID": "123"},
+                clear=True,
+            ), mock.patch.object(report, "posthog_query", side_effect=fake_posthog_query):
+                result = report.run(root, days=30)
+
+            self.assertEqual("ok", result["status"])
+            self.assertEqual(120, result["funnel"]["views"])
+            self.assertEqual(6, result["funnel"]["purchase_successes"])
+            self.assertAlmostEqual(0.5, result["funnel"]["view_to_select_rate"], places=4)
+            self.assertEqual("user_cancelled", result["top_failure_reasons"][0]["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add cross-platform paywall funnel instrumentation for `paywall_view`, `paywall_offer_select`, and `paywall_purchase_fail_reason` while preserving existing compatibility events
- add a weekly PostHog-backed paywall conversion report script that surfaces funnel stage rates, top failure reasons, and entry-point performance
- wire report generation into the scheduled analytics workflow and publish markdown/json artifacts each run

## Test plan
- [x] `.venv/bin/python3 -m pytest scripts/tests/test_paywall_conversion_report.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_executive_metrics_snapshot.py`
- [x] `cd native-android && ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.ui.screens.PaywallSheetTest' --no-daemon`

Made with [Cursor](https://cursor.com)