### PR TITLE
fix: remove unverified monthly Pro audio claims

### DIFF
--- a/.github/workflows/monthly-pro-content-release.yml
+++ b/.github/workflows/monthly-pro-content-release.yml
@@ -1,7 +1,8 @@
 # Monthly Pro Content Release Pipeline
 #
 # Runs on the 1st of each month at 08:00 UTC (+ manual dispatch).
-# Delivers fresh voice callouts and CC0 sound effects to both stores without manual CEO gates.
+# Generates verified Pro audio updates, then dispatches store release automation.
+# Public store availability must still be proven by store read-back; App Review timing is not guaranteed.
 #
 # ─────────────────────────────────────────────────────────────────────────
 # Required Secrets
@@ -446,10 +447,10 @@ jobs:
           EOF
 
 # ============================================================
-# Job 5 — Publish to both stores (only if regression tests pass)
+# Job 5 — Submit store release (only if regression tests pass)
 # ============================================================
   publish-production:
-    name: "Step 5 — Publish to App Store + Play Store"
+    name: "Step 5 — Submit App Store + publish Play Store"
     needs: [generate-content, merge-and-cut-release, regression-gate]
     if: needs.merge-and-cut-release.outputs.release_branch != '' && needs.regression-gate.result == 'success'
     runs-on: ubuntu-latest
@@ -473,13 +474,13 @@ jobs:
             --ref "${RELEASE_BRANCH}" \
             -f platform=both \
             -f android_track=production \
-            -f submit_review=false \
+            -f submit_review=true \
             -f confirm_ios_only_release=false \
             -f skip_internal_signoff=true \
             -f skip_production_signoff=true
 
           echo "✅ Dispatched Native App Release for ${RELEASE_BRANCH}"
-          echo "Both Play Store and App Store uploads will proceed via native-release.yml (signoff gates waived for monthly schedule)."
+          echo "Play production upload and App Store review submission will proceed via native-release.yml (signoff gates waived for monthly schedule)."
 
       - name: Write pipeline completion summary
         env:
@@ -488,15 +489,15 @@ jobs:
           RELEASE_BRANCH: ${{ needs.merge-and-cut-release.outputs.release_branch }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ## Monthly Pro Content Release — Pipeline Complete
+          ## Monthly Pro Content Release — Dispatch Complete
 
           | Field           | Value                         |
           |-----------------|-------------------------------|
           | Version         | ${RELEASE_VERSION}            |
           | Month           | ${MONTH_LABEL}                |
           | Release branch  | ${RELEASE_BRANCH}             |
-          | Platforms       | iOS (App Store) + Android (Play Store) |
+          | Platforms       | iOS App Review submission + Android Play production |
 
-          Native App Release has been dispatched. Monitor its run for the final
-          store-upload confirmation.
+          Native App Release has been dispatched. Use that run for final
+          store-upload, App Review submission, and public store read-back evidence.
           EOF

--- a/docs/audio/pro_monthly_audio_strategy.md
+++ b/docs/audio/pro_monthly_audio_strategy.md
@@ -31,7 +31,8 @@ Turn ElevenLabs into a recurring Pro content engine instead of a one-off asset g
 - Pro clients refresh the hosted manifest on entitlement restore, purchase, and app foreground.
 - Hosted assets are cached locally and validated with SHA-256 before activation.
 - Playback services prefer verified cached assets and fall back to bundled assets immediately if the runtime pack is missing, corrupt, or unavailable.
-- This gives existing Pro users monthly audio refreshes without requiring a store build.
+- This gives existing Pro users verified audio refreshes for supported foreground playback without waiting on store review.
+- Public store-version claims still require store read-back evidence after App Store review and Play production rollout.
 
 ## Platform Limitation
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 internal const val HIDDEN_UNLOCK_HOLD_DURATION_MS = 8_000L
 internal const val PAYWALL_HEADLINE = "Stop Training With the Brakes On"
-internal const val PAYWALL_SUBHEADLINE = "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library that updates every month."
+internal const val PAYWALL_SUBHEADLINE = "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library built for pressure drills."
 internal const val PAYWALL_PRICING_FOOTER = "Cancel anytime. Subscription auto-renews until cancelled."
 internal val PAYWALL_FEATURE_ROWS =
     listOf(
@@ -50,7 +50,7 @@ internal val PAYWALL_FEATURE_ROWS =
         "Live voice callouts keep you sharp under pressure",
         "Loop drills with round limits — just like competition",
         "Full sound arsenal — real bells, horns, and sirens",
-        "Fresh callout packs every 30 days — Pro gets them first",
+        "Verified audio drops when new packs are ready",
     )
 
 /** Identifies which subscription plan the user has selected on the paywall. */

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -14,7 +14,7 @@ class PaywallSheetTest {
     fun `paywall copy focuses on training outcomes`() {
         assertEquals("Stop Training With the Brakes On", PAYWALL_HEADLINE)
         assertEquals(
-            "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library that updates every month.",
+            "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library built for pressure drills.",
             PAYWALL_SUBHEADLINE,
         )
         assertEquals("Cancel anytime. Subscription auto-renews until cancelled.", PAYWALL_PRICING_FOOTER)
@@ -24,7 +24,7 @@ class PaywallSheetTest {
                 "Live voice callouts keep you sharp under pressure",
                 "Loop drills with round limits — just like competition",
                 "Full sound arsenal — real bells, horns, and sirens",
-                "Fresh callout packs every 30 days — Pro gets them first",
+                "Verified audio drops when new packs are ready",
             ),
             PAYWALL_FEATURE_ROWS,
         )

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -27,7 +27,7 @@ struct PaywallSheet: View {
     static let headline = "Stop Training With the Brakes On"
     static let subheadline =
         "Go unlimited — sessions up to 60 minutes, live voice callouts, "
-        + "and a full sound library that updates every month."
+        + "and a full sound library built for pressure drills."
     static let subscriptionFooter =
         "Cancel anytime. Subscription auto-renews until cancelled. "
         + "Price shown on Apple's confirmation sheet."
@@ -37,7 +37,7 @@ struct PaywallSheet: View {
         "Live voice callouts keep you sharp under pressure",
         "Loop drills with round limits — just like competition",
         "Full sound arsenal — real bells, horns, and sirens",
-        "Fresh callout packs every 30 days — Pro gets them first",
+        "Verified audio drops when new packs are ready",
     ]
 
     @EnvironmentObject var proManager: ProManager

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -13,7 +13,7 @@ final class TimerConfigProClampingTests: XCTestCase {
         XCTAssertEqual(
             PaywallSheet.subheadline,
             "Go unlimited — sessions up to 60 minutes, live voice callouts, "
-                + "and a full sound library that updates every month."
+                + "and a full sound library built for pressure drills."
         )
         let expectedFooter =
             "Cancel anytime. Subscription auto-renews until cancelled. "
@@ -26,7 +26,7 @@ final class TimerConfigProClampingTests: XCTestCase {
                 "Live voice callouts keep you sharp under pressure",
                 "Loop drills with round limits — just like competition",
                 "Full sound arsenal — real bells, horns, and sirens",
-                "Fresh callout packs every 30 days — Pro gets them first",
+                "Verified audio drops when new packs are ready",
             ]
         )
     }

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -193,7 +193,7 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
         "Live voice callouts keep you sharp under pressure",
         "Loop drills with round limits — just like competition",
         "Full sound arsenal — real bells, horns, and sirens",
-        "Fresh callout packs every 30 days — Pro gets them first",
+        "Verified audio drops when new packs are ready",
     ):
         assert expected in android_paywall
         assert expected in ios_paywall

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -50,6 +50,9 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "actions: write" in contents
     assert "--body-file \"$body_file\"" in contents
     assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
+    assert "-f submit_review=true" in contents
+    assert "-f submit_review=false" not in contents
+    assert "Public store availability must still be proven by store read-back" in contents
 
 
 def test_release_automerge_uses_default_token_before_pat_fallback() -> None:


### PR DESCRIPTION
## Summary
- Removes the unverified monthly audio-refresh promise from iOS and Android Pro paywall copy.
- Updates matching mobile/parity tests so the old calendar-based claim cannot return unnoticed.
- Changes the monthly Pro release workflow to submit iOS for App Review (`submit_review=true`) and explicitly require public store read-back evidence before claiming store availability.
- Clarifies the Pro audio strategy doc: hosted audio refreshes can update supported foreground playback, but public store-version claims require App Store/Play read-back after release.

## Root Cause
The app copy promised monthly Pro audio updates, while CI only had partial generation/release automation. The monthly workflow also dispatched native release with `submit_review=false`, so it could not publish a new iOS App Store version as promised.

## Validation
- `python3.11 -m pytest scripts/tests/test_workflow_security_contracts.py scripts/tests/test_mobile_feature_parity.py -q` -> `26 passed`
- `./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.ui.screens.PaywallSheetTest'` -> `BUILD SUCCESSFUL`
- `xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,id=70E5F08F-4266-4DBA-8A9D-237AA5CE0F6A' -only-testing:RandomTimerTests/TimerConfigProClampingTests/testPaywallCopyFocusesOnTrainingOutcomes test` -> `TEST SUCCEEDED`
- `git diff --check` -> clean
- `rg -n "updates every month|Fresh callout packs|every 30 days|monthly audio refreshes|new sound arsenal|1st of each month|full sound library that updates" -S` -> no matches

## Notes
`actionlint` is not installed locally, so workflow syntax validation is covered by the Python workflow contract test in this PR.