### PR TITLE
fix: reconcile PR labels after checks finish

### DIFF
--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -3,6 +3,8 @@ name: PR State Machine
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  check_suite:
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/scripts/tests/test_pr_state_machine_workflow.py
+++ b/scripts/tests/test_pr_state_machine_workflow.py
@@ -8,7 +8,8 @@ PR_STATE_MACHINE_WORKFLOW = ROOT / ".github/workflows/pr-state-machine.yml"
 def test_pr_state_machine_reconciles_when_ci_workflow_completes():
     source = PR_STATE_MACHINE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "check_suite:" in source or "pull_request_target:" in source
+    assert "check_suite:" in source
+    assert "types: [completed]" in source
     assert "listPullRequestsAssociatedWithCommit" in source
     assert "workflow_dispatch:" in source or "workflow_dispatch" in source
 


### PR DESCRIPTION
## Summary
- add `check_suite: completed` trigger to the PR State Machine workflow
- tighten the workflow contract test so stale `pr-state:ci_running` labels cannot regress

## Verification
- `python3.11 -m pytest scripts/tests/test_pr_state_machine_workflow.py -q`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-state-machine.yml"); puts "yaml ok"'`\n- `git diff --check`