### PR TITLE
fix: add public store version read-back

### DIFF
--- a/.github/workflows/monthly-audio-pack.yml
+++ b/.github/workflows/monthly-audio-pack.yml
@@ -1,10 +1,10 @@
 name: Monthly Pro Audio Pack
 
+# Legacy manual generator only. Scheduled release automation is owned by
+# monthly-pro-content-release.yml, which performs version bump, regression
+# gates, store submission, and downstream public store read-back.
 on:
   workflow_dispatch:
-  schedule:
-    # 1st of every month at 6 AM UTC
-    - cron: "0 6 1 * *"
 
 jobs:
   generate-pack:
@@ -25,24 +25,27 @@ jobs:
         env:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
         run: |
+          set -euo pipefail
           python scripts/generate_pro_audio_content.py \
-            --generate-voice-assets || true
+            --generate-voice-assets
 
       - name: Generate sound assets
         env:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
         run: |
+          set -euo pipefail
           python scripts/generate_pro_audio_content.py \
-            --generate-sound-assets || true
+            --generate-sound-assets
 
       - name: Sync to Android
         run: |
+          set -euo pipefail
           # Sync voice callouts
           for f in native-ios/RandomTimer/Resources/Audio/cmd_*.mp3 native-ios/RandomTimer/Resources/Audio/elapsed_*.mp3; do
             [ -f "$f" ] || continue
             name=$(basename "$f")
             dst="native-android/app/src/main/res/raw/$name"
-            cp "$f" "$dst" 2>/dev/null && echo "Synced $name" || true
+            cp "$f" "$dst" 2>/dev/null && echo "Synced $name"
           done
           # Sync alarm sounds
           for sound in alarm gentle_chime klaxon whistle buzzer gong airhorn drum_roll siren bell; do
@@ -50,11 +53,15 @@ jobs:
             src="native-ios/RandomTimer/Resources/Sounds/${ios_name}.mp3"
             [ -f "$src" ] || src="native-ios/RandomTimer/Resources/Sounds/${sound}.mp3"
             dst="native-android/app/src/main/res/raw/${sound}.mp3"
-            [ -f "$src" ] && cp "$src" "$dst" && echo "Synced sound $sound" || true
+            if [ -f "$src" ]; then
+              cp "$src" "$dst"
+              echo "Synced sound $sound"
+            fi
           done
 
       - name: Verify pack
         run: |
+          set -euo pipefail
           echo "=== Voice Callouts ==="
           ls native-ios/RandomTimer/Resources/Audio/cmd_*.mp3 2>/dev/null | wc -l | xargs -I{} echo "{} command cues"
           ls native-ios/RandomTimer/Resources/Audio/elapsed_*.mp3 2>/dev/null | wc -l | xargs -I{} echo "{} elapsed cues"

--- a/.github/workflows/public-store-version-readback.yml
+++ b/.github/workflows/public-store-version-readback.yml
@@ -1,0 +1,65 @@
+name: Public Store Version Read-Back
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: "Expected public version for both stores. If empty, read from checked-out source."
+        required: false
+        default: ""
+      timeout_seconds:
+        description: "Maximum polling time per run"
+        required: false
+        default: "1800"
+  schedule:
+    # Poll first-week monthly release propagation without claiming publication timing.
+    - cron: "0 */6 1-7 * *"
+  workflow_run:
+    workflows: ["Native App Release"]
+    types: [completed]
+
+jobs:
+  public-store-version-readback:
+    name: Verify public store versions
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install requests==2.32.5
+
+      - name: Verify App Store and Play public versions
+        env:
+          EXPECTED_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_version || '' }}
+          TIMEOUT_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.timeout_seconds || '1800' }}
+        run: |
+          set -euo pipefail
+          args=(
+            --platform both
+            --country US
+            --timeout "${TIMEOUT_SECONDS}"
+            --poll-interval 120
+            --json-out public-store-version-readback.json
+          )
+          if [ -n "${EXPECTED_VERSION}" ]; then
+            args+=(--expected-version "${EXPECTED_VERSION}")
+          fi
+          python scripts/verify_public_store_versions.py "${args[@]}"
+
+      - name: Upload public store read-back evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: public-store-version-readback
+          path: public-store-version-readback.json
+          if-no-files-found: warn

--- a/.github/workflows/public-store-version-readback.yml
+++ b/.github/workflows/public-store-version-readback.yml
@@ -27,8 +27,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/scripts/tests/test_verify_public_store_versions.py
+++ b/scripts/tests/test_verify_public_store_versions.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import verify_public_store_versions as vps
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict | None = None, headers: dict[str, str] | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.headers = headers or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_reads_ios_and_android_versions(tmp_path: Path):
+    ios_project = tmp_path / "native-ios/RandomTimer.xcodeproj"
+    ios_project.mkdir(parents=True)
+    (ios_project / "project.pbxproj").write_text(
+        "MARKETING_VERSION = 1.3.20;\nMARKETING_VERSION = 1.3.20;\n",
+        encoding="utf-8",
+    )
+    android_dir = tmp_path / "native-android/app"
+    android_dir.mkdir(parents=True)
+    (android_dir / "build.gradle.kts").write_text('versionName = "1.3.20"\n', encoding="utf-8")
+
+    assert vps.read_ios_version(tmp_path) == "1.3.20"
+    assert vps.read_android_version(tmp_path) == "1.3.20"
+
+
+def test_app_store_public_version_passes(monkeypatch):
+    monkeypatch.setattr(
+        vps.requests,
+        "get",
+        lambda *_args, **_kwargs: _Resp(
+            200,
+            {
+                "resultCount": 1,
+                "results": [
+                    {
+                        "version": "1.3.20",
+                        "currentVersionReleaseDate": "2026-04-14T12:00:00Z",
+                    }
+                ],
+            },
+            {"date": "Tue, 14 Apr 2026 20:00:00 GMT"},
+        ),
+    )
+
+    result = vps.verify_app_store_public_version("6758355312", "1.3.20")
+
+    assert result.passed is True
+    assert result.status == "PUBLIC"
+    assert result.observed_version == "1.3.20"
+    assert "release_date=2026-04-14T12:00:00Z" in result.details
+
+
+def test_app_store_public_version_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        vps.requests,
+        "get",
+        lambda *_args, **_kwargs: _Resp(
+            200,
+            {"results": [{"version": "1.3.19"}]},
+            {"date": "Tue, 14 Apr 2026 20:00:00 GMT"},
+        ),
+    )
+
+    result = vps.verify_app_store_public_version("6758355312", "1.3.20")
+
+    assert result.passed is False
+    assert result.status == "VERSION_MISMATCH"
+    assert result.observed_version == "1.3.19"
+    assert result.expected_version == "1.3.20"
+
+
+def test_play_public_version_uses_existing_play_verifier(monkeypatch):
+    monkeypatch.setattr(
+        vps.play,
+        "verify_public_listing",
+        lambda url, expected_version: vps.play.PublicListingResult(
+            True,
+            "PUBLIC",
+            f"HTTP 200 public_version=1.3.20 expected_version={expected_version} url={url}",
+        ),
+    )
+
+    result = vps.verify_play_public_version("com.iganapolsky.randomtimer", "1.3.20")
+
+    assert result.passed is True
+    assert result.status == "PUBLIC"
+    assert result.observed_version == "1.3.20"
+
+
+def test_poll_until_public_times_out_without_converting_version_mismatch(monkeypatch):
+    monkeypatch.setattr(vps.time, "sleep", lambda *_args, **_kwargs: None)
+
+    def verify_once():
+        return [
+            vps.StoreVersionResult(
+                "ios",
+                False,
+                "VERSION_MISMATCH",
+                "https://itunes.apple.com/lookup?id=1",
+                "1.3.20",
+                "1.3.19",
+                "public_version=1.3.19",
+            )
+        ]
+
+    results = vps.poll_until_public(verify_once, timeout=0, poll_interval=1)
+
+    assert results[0].status == "VERSION_MISMATCH"
+    assert "timed out after 0s" in results[0].details

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -52,6 +52,17 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
 
 
+def test_public_store_version_readback_requires_public_evidence() -> None:
+    contents = _read(".github/workflows/public-store-version-readback.yml")
+
+    assert "workflow_run:" in contents
+    assert 'workflows: ["Native App Release"]' in contents
+    assert 'cron: "0 */6 1-7 * *"' in contents
+    assert "scripts/verify_public_store_versions.py" in contents
+    assert "--json-out public-store-version-readback.json" in contents
+    assert "Upload public store read-back evidence" in contents
+
+
 def test_release_automerge_uses_default_token_before_pat_fallback() -> None:
     contents = _read(".github/workflows/autonomous-release-automerge.yml")
 

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -63,6 +63,14 @@ def test_public_store_version_readback_requires_public_evidence() -> None:
     assert "Upload public store read-back evidence" in contents
 
 
+def test_legacy_monthly_audio_pack_is_manual_only_and_fail_fast() -> None:
+    contents = _read(".github/workflows/monthly-audio-pack.yml")
+
+    assert "schedule:" not in contents
+    assert "|| true" not in contents
+    assert "monthly-pro-content-release.yml" in contents
+
+
 def test_release_automerge_uses_default_token_before_pat_fallback() -> None:
     contents = _read(".github/workflows/autonomous-release-automerge.yml")
 

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -61,6 +61,7 @@ def test_public_store_version_readback_requires_public_evidence() -> None:
     assert "scripts/verify_public_store_versions.py" in contents
     assert "--json-out public-store-version-readback.json" in contents
     assert "Upload public store read-back evidence" in contents
+    assert "workflow_run.head_sha" not in contents
 
 
 def test_legacy_monthly_audio_pack_is_manual_only_and_fail_fast() -> None:

--- a/scripts/verify_public_store_versions.py
+++ b/scripts/verify_public_store_versions.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Verify public App Store and Google Play versions by storefront read-back."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import requests
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import verify_play_public_listing as play
+
+DEFAULT_IOS_APP_ID = "6758355312"
+DEFAULT_ANDROID_PACKAGE = "com.iganapolsky.randomtimer"
+DEFAULT_COUNTRY = "US"
+DEFAULT_TIMEOUT = 900
+DEFAULT_POLL_INTERVAL = 60
+
+
+@dataclass
+class StoreVersionResult:
+    platform: str
+    passed: bool
+    status: str
+    url: str
+    expected_version: str
+    observed_version: str
+    details: str
+
+
+def read_ios_version(repo_root: Path = ROOT) -> str:
+    project = repo_root / "native-ios/RandomTimer.xcodeproj/project.pbxproj"
+    text = project.read_text(encoding="utf-8")
+    versions = set(re.findall(r"MARKETING_VERSION\s*=\s*([0-9]+(?:\.[0-9]+)+);", text))
+    if not versions:
+        raise RuntimeError(f"Could not read MARKETING_VERSION from {project}")
+    if len(versions) != 1:
+        raise RuntimeError(f"Multiple iOS MARKETING_VERSION values found: {sorted(versions)}")
+    return versions.pop()
+
+
+def read_android_version(repo_root: Path = ROOT) -> str:
+    gradle = repo_root / "native-android/app/build.gradle.kts"
+    text = gradle.read_text(encoding="utf-8")
+    match = re.search(r'versionName\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise RuntimeError(f"Could not read versionName from {gradle}")
+    return match.group(1)
+
+
+def build_app_store_lookup_url(app_id: str, country: str) -> str:
+    normalized = (country or DEFAULT_COUNTRY).strip().upper()
+    return f"https://itunes.apple.com/lookup?id={app_id}&country={normalized}"
+
+
+def verify_app_store_public_version(
+    app_id: str,
+    expected_version: str,
+    country: str = DEFAULT_COUNTRY,
+) -> StoreVersionResult:
+    url = build_app_store_lookup_url(app_id, country)
+    try:
+        response = requests.get(
+            url,
+            timeout=30,
+            headers={"User-Agent": "Random-Timer-Store-Version-Readback/1.0"},
+        )
+    except requests.RequestException as exc:
+        return StoreVersionResult("ios", False, "ERROR", url, expected_version, "", str(exc))
+
+    date_header = response.headers.get("date", "unknown")
+    if response.status_code != 200:
+        return StoreVersionResult(
+            "ios",
+            False,
+            f"HTTP_{response.status_code}",
+            url,
+            expected_version,
+            "",
+            f"HTTP {response.status_code} on {date_header}",
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        return StoreVersionResult("ios", False, "INVALID_JSON", url, expected_version, "", str(exc))
+
+    results = payload.get("results") or []
+    if not results:
+        return StoreVersionResult(
+            "ios",
+            False,
+            "NOT_FOUND",
+            url,
+            expected_version,
+            "",
+            f"No App Store result on {date_header}",
+        )
+
+    item = results[0]
+    observed = str(item.get("version") or "")
+    release_date = str(item.get("currentVersionReleaseDate") or "unknown")
+    details = f"HTTP 200 on {date_header} public_version={observed} release_date={release_date}"
+    if observed != expected_version:
+        return StoreVersionResult(
+            "ios",
+            False,
+            "VERSION_MISMATCH",
+            url,
+            expected_version,
+            observed,
+            details,
+        )
+    return StoreVersionResult("ios", True, "PUBLIC", url, expected_version, observed, details)
+
+
+def verify_play_public_version(
+    package: str,
+    expected_version: str,
+    country: str = DEFAULT_COUNTRY,
+) -> StoreVersionResult:
+    url = play.build_store_url(package, country)
+    result = play.verify_public_listing(url, expected_version=expected_version)
+    observed = ""
+    match = re.search(r"public_version=([0-9]+(?:\.[0-9]+)+)", result.details)
+    if match:
+        observed = match.group(1)
+    return StoreVersionResult(
+        "android",
+        result.passed,
+        result.status,
+        url,
+        expected_version,
+        observed,
+        result.details,
+    )
+
+
+def poll_until_public(
+    verify_once,
+    timeout: int,
+    poll_interval: int,
+) -> list[StoreVersionResult]:
+    deadline = time.time() + timeout
+    latest: list[StoreVersionResult] = []
+
+    while True:
+        latest = verify_once()
+        if all(item.passed for item in latest):
+            return latest
+
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            timed_out: list[StoreVersionResult] = []
+            for item in latest:
+                if item.passed:
+                    timed_out.append(item)
+                else:
+                    timed_out.append(
+                        StoreVersionResult(
+                            item.platform,
+                            False,
+                            item.status if item.status == "VERSION_MISMATCH" else "TIMEOUT",
+                            item.url,
+                            item.expected_version,
+                            item.observed_version,
+                            f"{item.details} (timed out after {timeout}s)",
+                        )
+                    )
+            return timed_out
+
+        time.sleep(min(poll_interval, max(0, remaining)))
+
+
+def print_results(results: list[StoreVersionResult]) -> bool:
+    print()
+    print("== Public Store Version Read-Back ==")
+    all_passed = True
+    for item in results:
+        marker = "PASS" if item.passed else "FAIL"
+        all_passed = all_passed and item.passed
+        print(f"{marker} {item.platform}: status={item.status}")
+        print(f"  url: {item.url}")
+        print(f"  expected_version: {item.expected_version}")
+        print(f"  observed_version: {item.observed_version or 'unknown'}")
+        print(f"  details: {item.details}")
+    print("====================================")
+    print()
+    return all_passed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", choices=["ios", "android", "both"], default="both")
+    parser.add_argument("--expected-version", default="", help="Expected public version for both stores")
+    parser.add_argument("--ios-expected-version", default="", help="Override expected iOS version")
+    parser.add_argument("--android-expected-version", default="", help="Override expected Android version")
+    parser.add_argument("--ios-app-id", default=DEFAULT_IOS_APP_ID)
+    parser.add_argument("--android-package", default=DEFAULT_ANDROID_PACKAGE)
+    parser.add_argument("--country", default=DEFAULT_COUNTRY)
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument("--json-out", default="", help="Optional path for JSON evidence output")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    ios_expected = args.ios_expected_version or args.expected_version
+    android_expected = args.android_expected_version or args.expected_version
+
+    if args.platform in {"ios", "both"} and not ios_expected:
+        ios_expected = read_ios_version()
+    if args.platform in {"android", "both"} and not android_expected:
+        android_expected = read_android_version()
+
+    def verify_once() -> list[StoreVersionResult]:
+        checks: list[StoreVersionResult] = []
+        if args.platform in {"ios", "both"}:
+            checks.append(
+                verify_app_store_public_version(
+                    args.ios_app_id,
+                    ios_expected,
+                    country=args.country,
+                )
+            )
+        if args.platform in {"android", "both"}:
+            checks.append(
+                verify_play_public_version(
+                    args.android_package,
+                    android_expected,
+                    country=args.country,
+                )
+            )
+        return checks
+
+    results = poll_until_public(verify_once, args.timeout, args.poll_interval)
+    passed = print_results(results)
+
+    if args.json_out:
+        Path(args.json_out).write_text(
+            json.dumps({"passed": passed, "results": [asdict(item) for item in results]}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a read-only public App Store + Google Play version verifier
- add a scheduled/manual/workflow_run gate after Native App Release
- upload JSON evidence so release claims can be checked against public storefronts
- convert the legacy `monthly-audio-pack` workflow to manual-only and fail-fast, so it no longer pretends to satisfy monthly release automation

## Live evidence from this branch
`python3.11 scripts/verify_public_store_versions.py --platform both --timeout 0 --poll-interval 1 --json-out /tmp/public-store-version-readback.json` currently fails because public stores show `1.3.19` while source expects `1.3.21`.

## Verification
- `python3.11 -m pytest scripts/tests/test_verify_public_store_versions.py scripts/tests/test_verify_play_public_listing.py scripts/tests/test_workflow_security_contracts.py -q`
- `python3.11 -m py_compile scripts/verify_public_store_versions.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/public-store-version-readback.yml"); YAML.load_file(".github/workflows/monthly-audio-pack.yml"); puts "yaml ok"'`\n- `git diff --check`