### PR TITLE
fix(ci): repair monthly Pro workflow validation

### DIFF
--- a/.github/workflows/generate-ios-voice-callouts.yml
+++ b/.github/workflows/generate-ios-voice-callouts.yml
@@ -110,7 +110,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          BRANCH="feat/pro-audio-regen-$(date -u +%Y%m%d)"
+          BRANCH="feat/pro-audio-regen-$(date -u +%Y%m%d-%H%M%S)-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git checkout -b "$BRANCH"
           git add \
             content/pro_audio/monthly_pro_audio_packs.json \

--- a/.github/workflows/monthly-pro-content-release.yml
+++ b/.github/workflows/monthly-pro-content-release.yml
@@ -107,12 +107,15 @@ jobs:
           python scripts/generate_pro_audio_content.py "${args[@]}"
 
       - name: Fetch bonus CC0 sounds from Freesound (optional)
-        if: ${{ secrets.FREESOUND_API_TOKEN != '' }}
         env:
           FREESOUND_API_TOKEN: ${{ secrets.FREESOUND_API_TOKEN }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
         run: |
           set -euo pipefail
+          if [ -z "${FREESOUND_API_TOKEN}" ]; then
+            echo "FREESOUND_API_TOKEN not configured; skipping optional Freesound fetch."
+            exit 0
+          fi
           echo "=== Fetching bonus CC0 sounds from Freesound ==="
           python scripts/generate_monthly_audio_pack.py --skip-voice || echo "::warning::Freesound fetch failed — continuing with ElevenLabs content only"
 
@@ -422,5 +425,6 @@ jobs:
           | Release branch  | ${RELEASE_BRANCH}                                  |
           | Platforms       | iOS App Review submission + Android Play production |
 
-          Native App Release dispatched. Use that run for final store-upload and read-back evidence.
+          Native App Release dispatched. Use that run for final store-upload evidence.
+          Public store availability must still be proven by public-store-version-readback.yml before publication is claimed.
           SUMMARY

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -38,6 +38,18 @@ def test_workflow_inputs_are_not_interpolated_inside_run_blocks() -> None:
     assert offenders == []
 
 
+def test_workflow_if_conditions_do_not_reference_secrets_context() -> None:
+    offenders: list[str] = []
+
+    for path in sorted((REPO_ROOT / ".github/workflows").glob("*.yml")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for line_number, line in enumerate(lines, start=1):
+            if line.lstrip().startswith("if:") and "${{ secrets." in line:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line_number}")
+
+    assert offenders == []
+
+
 def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     contents = _read(".github/workflows/monthly-pro-content-release.yml")
 
@@ -46,6 +58,8 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "Validate required secrets" in contents
     assert "Missing required secret(s):" in contents
     assert "FREESOUND_API_TOKEN" in contents
+    assert "if: ${{ secrets." not in contents
+    assert "FREESOUND_API_TOKEN not configured; skipping optional Freesound fetch." in contents
     assert contents.count("timeout-minutes:") >= 4
     assert "actions: write" in contents
     assert "--body \"Auto-generated monthly Pro content update." in contents
@@ -55,9 +69,7 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "-f submit_review=true" in contents
     assert "-f submit_review=false" not in contents
     assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
-    assert "-f submit_review=true" in contents
-    assert "-f submit_review=false" not in contents
-    assert "Public store availability must still be proven by store read-back" in contents
+    assert "Public store availability must still be proven by public-store-version-readback.yml" in contents
 
 
 def test_public_store_version_readback_requires_public_evidence() -> None:
@@ -78,6 +90,15 @@ def test_legacy_monthly_audio_pack_is_manual_only_and_fail_fast() -> None:
     assert "schedule:" not in contents
     assert "|| true" not in contents
     assert "monthly-pro-content-release.yml" in contents
+
+
+def test_manual_ios_voice_callout_regen_uses_unique_branch_per_run() -> None:
+    contents = _read(".github/workflows/generate-ios-voice-callouts.yml")
+
+    assert "schedule:" not in contents
+    assert "GITHUB_RUN_ID" in contents
+    assert "GITHUB_RUN_ATTEMPT" in contents
+    assert "feat/pro-audio-regen-$(date -u +%Y%m%d)" not in contents
 
 
 def test_release_automerge_uses_default_token_before_pat_fallback() -> None:


### PR DESCRIPTION
## Summary
- remove the invalid GitHub Actions secrets-in-if condition from monthly Pro release workflow
- make manual Pro audio regeneration branches unique per run
- add workflow contract coverage for secrets-in-if and voice regen branch uniqueness

## Evidence
- python3.11 -m pytest scripts/tests/test_workflow_security_contracts.py scripts/tests/test_verify_public_store_versions.py -q
- ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "workflow_yaml_ok=#{Dir[".github/workflows/*.{yml,yaml}"].size}"'
- git grep -n "if:.*secrets\." -- .github/workflows returned no matches
- git diff --check