### PR TITLE
fix(release): add store listing links to every GitHub Release

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -940,6 +940,13 @@ jobs:
 
           NOTES="${NOTES}
 
+          ## Download
+
+          | Store | Link |
+          |-------|------|
+          | Google Play | [Random Tactical Timer on Google Play](https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer) |
+          | Apple App Store | [Random Tactical Timer on the App Store](https://apps.apple.com/us/app/random-tactical-timer/id6758355312) |
+
           ### Release metadata
           - Commit: ${GITHUB_SHA}
           - Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"


### PR DESCRIPTION
## Summary
- Every GitHub Release created by `native-release.yml` now automatically includes a Download table with Google Play and App Store links
- No more manual editing of release notes to add store links

## Test plan
- [ ] Verify next release created by `native-release.yml` includes the Download table

🤖 Generated with [Claude Code](https://claude.com/claude-code)