### PR TITLE
fix: paywall PrimaryButton CTA visibility (iOS + Android)

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/PrimaryButton.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/PrimaryButton.kt
@@ -21,12 +21,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.iganapolsky.randomtimer.ui.theme.RandomTimerTheme
 import com.iganapolsky.randomtimer.ui.theme.TimerColors
 
 private val ButtonShape = RoundedCornerShape(16.dp)
+
+/** Visible CTA copy: never return whitespace-only (Material labels can collapse visually). */
+internal fun nonBlankButtonLabel(label: String): String = label.trim().ifBlank { "Continue" }
 
 @Composable
 fun PrimaryButton(
@@ -86,8 +90,11 @@ fun PrimaryButton(
         contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
     ) {
         Text(
-            text = text,
+            text = nonBlankButtonLabel(text),
             style = MaterialTheme.typography.titleMedium,
+            color = contentColor,
+            textAlign = TextAlign.Center,
+            maxLines = 3,
         )
     }
 }
@@ -134,8 +141,11 @@ fun SecondaryButton(
         contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
     ) {
         Text(
-            text = text,
+            text = nonBlankButtonLabel(text),
             style = MaterialTheme.typography.titleMedium,
+            color = TimerColors.TextPrimary,
+            textAlign = TextAlign.Center,
+            maxLines = 3,
         )
     }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/components/PrimaryButtonLabelTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/components/PrimaryButtonLabelTest.kt
@@ -1,0 +1,18 @@
+package com.iganapolsky.randomtimer.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrimaryButtonLabelTest {
+    @Test
+    fun `nonBlankButtonLabel defaults when blank`() {
+        assertEquals("Continue", nonBlankButtonLabel(""))
+        assertEquals("Continue", nonBlankButtonLabel("   "))
+        assertEquals("Continue", nonBlankButtonLabel("\t\n"))
+    }
+
+    @Test
+    fun `nonBlankButtonLabel preserves trimmed copy`() {
+        assertEquals("Start Monthly", nonBlankButtonLabel("  Start Monthly  "))
+    }
+}

--- a/native-ios/RandomTimer/Sources/UI/Components/PrimaryButton.swift
+++ b/native-ios/RandomTimer/Sources/UI/Components/PrimaryButton.swift
@@ -9,13 +9,20 @@ struct PrimaryButton: View {
 
     var body: some View {
         Button(action: action) {
-            Text(title)
-                .font(.headline)
-                .foregroundColor(foregroundColor)
-                .frame(maxWidth: .infinity)
-                .frame(height: 56)
-                .background(backgroundColor)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(backgroundColor)
+                Text(title)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.65)
+                    .lineLimit(3)
+                    .padding(.horizontal, 10)
+                    .foregroundStyle(foregroundColor)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .contentShape(RoundedRectangle(cornerRadius: 16))
         }
         .buttonStyle(PressableButtonStyle())
         .accessibilityLabel(title)

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -114,6 +114,12 @@ struct PaywallSheet: View {
         }
     }
 
+    /// Never pass an all-whitespace title to `PrimaryButton` (empty labels can disappear in sheets).
+    private var ctaButtonTitle: String {
+        let trimmed = ctaLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Continue" : trimmed
+    }
+
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
@@ -214,7 +220,7 @@ struct PaywallSheet: View {
                 }
 
                 VStack(spacing: 12) {
-                    PrimaryButton(title: ctaLabel) {
+                    PrimaryButton(title: ctaButtonTitle) {
                         Task {
                             await purchase(productID: selectedProductID)
                         }


### PR DESCRIPTION
## Problem
Primary paywall CTA could appear as a solid red bar with no readable title (reported on device; affects both platforms).

## iOS
- `PrimaryButton`: ZStack fill + title, `foregroundStyle`, scaling, `contentShape`.
- `PaywallSheet`: fallback title when CTA string is blank/whitespace.

## Android
- `PrimaryButton`: explicit `Text(color = contentColor)` so label is not lost with transparent Material container + gradient modifier; `nonBlankButtonLabel`; centered, max 3 lines.
- `SecondaryButton`: explicit text color + non-blank helper for consistency.

## Tests
- Android: `./gradlew testDebugUnitTest --tests PrimaryButtonLabelTest --tests PaywallSheetTest` (pass).

## Not claimed
- Full E2E / 100% coverage / device matrix — not run in this change; merge after CI green.