### PR TITLE
fix(release): add release-notes/1.3.21.md for internal distribution preflight

### DIFF
--- a/release-notes/1.3.21.md
+++ b/release-notes/1.3.21.md
@@ -1,0 +1,11 @@
+# Release 1.3.21
+
+## Summary
+Integration-branch version advance after the 1.3.20 release train so Android `versionName` and iOS `MARKETING_VERSION` both read **1.3.21** ahead of the next release candidate.
+
+## Customer-visible changes
+- Carries forward the 1.3.20 monetization and training-quality work: monthly Pro option, outcome-focused paywall copy, paywall after the first completed timer session, April 2026 Pro audio and Sound Arsenal freshness, improved review-prompt timing, and cleaner timer-abandonment analytics on iOS.
+
+## Release operations
+- Aligned Android `versionName` and iOS `MARKETING_VERSION` at `1.3.21` (Android source `versionCode` remains `1774900003` until the next Play-facing bump).
+- Added this versioned release note file required by `scripts/shell/preflight-release.sh` layer 1 for internal distribution gates.


### PR DESCRIPTION
Internal Distribution run failed after merging paywall visibility work because preflight layer 1 requires `release-notes/<MARKETING_VERSION>.md` while `develop` was at 1.3.21 without that file (log: missing `release-notes/1.3.21.md`).

Evidence: `gh run view 24482990677 --log-failed` shows all three internal jobs failing at preflight with that path.

This PR adds the missing versioned release note so Firebase / TestFlight / Play internal jobs can pass preflight.

Made with [Cursor](https://cursor.com)