### PR TITLE
fix(ui): paywall primary CTA readable on iOS and Android

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/PrimaryButton.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/PrimaryButton.kt
@@ -6,9 +6,12 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -17,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -64,38 +68,54 @@ fun PrimaryButton(
             this.alpha = alpha
         }
 
-    val styledModifier = if (useGradient && enabled) {
-        baseModifier.background(
-            brush = Brush.horizontalGradient(
-                colors = listOf(backgroundColor, TimerColors.AccentSecondary),
-            ),
-            shape = ButtonShape,
-        )
-    } else {
-        baseModifier
-    }
+    // Draw fill inside the button slot so label is never composited under a transparent M3 surface edge case.
+    val innerBackgroundModifier =
+        if (useGradient) {
+            val end =
+                if (enabled) TimerColors.AccentSecondary else TimerColors.AccentSecondary.copy(alpha = 0.5f)
+            val start = if (enabled) backgroundColor else backgroundColor.copy(alpha = 0.5f)
+            Modifier.background(
+                brush = Brush.horizontalGradient(colors = listOf(start, end)),
+                shape = ButtonShape,
+            )
+        } else {
+            Modifier.background(
+                color = if (enabled) backgroundColor else backgroundColor.copy(alpha = 0.5f),
+                shape = ButtonShape,
+            )
+        }
 
     Button(
         onClick = onClick,
-        modifier = styledModifier,
+        modifier = baseModifier,
         enabled = enabled,
         interactionSource = interactionSource,
         shape = ButtonShape,
         colors = ButtonDefaults.buttonColors(
-            containerColor = if (useGradient) Color.Transparent else backgroundColor,
+            containerColor = Color.Transparent,
             contentColor = contentColor,
-            disabledContainerColor = backgroundColor.copy(alpha = 0.5f),
+            disabledContainerColor = Color.Transparent,
             disabledContentColor = contentColor.copy(alpha = 0.5f),
         ),
-        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+        contentPadding = PaddingValues(0.dp),
     ) {
-        Text(
-            text = nonBlankButtonLabel(text),
-            style = MaterialTheme.typography.titleMedium,
-            color = contentColor,
-            textAlign = TextAlign.Center,
-            maxLines = 3,
-        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+                    .then(innerBackgroundModifier),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = nonBlankButtonLabel(text),
+                style = MaterialTheme.typography.titleMedium,
+                color = if (enabled) contentColor else contentColor.copy(alpha = 0.5f),
+                textAlign = TextAlign.Center,
+                maxLines = 3,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+        }
     }
 }
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/PrimaryButton.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/PrimaryButton.kt
@@ -59,14 +59,15 @@ fun PrimaryButton(
         label = "pressAlpha",
     )
 
-    val baseModifier = modifier
-        .fillMaxWidth()
-        .height(56.dp)
-        .graphicsLayer {
-            scaleX = scale
-            scaleY = scale
-            this.alpha = alpha
-        }
+    val baseModifier =
+        modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                this.alpha = alpha
+            }
 
     // Draw fill inside the button slot so label is never composited under a transparent M3 surface edge case.
     val innerBackgroundModifier =
@@ -91,12 +92,13 @@ fun PrimaryButton(
         enabled = enabled,
         interactionSource = interactionSource,
         shape = ButtonShape,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = Color.Transparent,
-            contentColor = contentColor,
-            disabledContainerColor = Color.Transparent,
-            disabledContentColor = contentColor.copy(alpha = 0.5f),
-        ),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                contentColor = contentColor,
+                disabledContainerColor = Color.Transparent,
+                disabledContentColor = contentColor.copy(alpha = 0.5f),
+            ),
         contentPadding = PaddingValues(0.dp),
     ) {
         Box(
@@ -141,23 +143,25 @@ fun SecondaryButton(
 
     Button(
         onClick = onClick,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .graphicsLayer {
-                scaleX = scale
-                scaleY = scale
-                this.alpha = alpha
-            },
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    this.alpha = alpha
+                },
         enabled = enabled,
         interactionSource = interactionSource,
         shape = ButtonShape,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = TimerColors.GlassBackground,
-            contentColor = TimerColors.TextPrimary,
-            disabledContainerColor = TimerColors.GlassBackground.copy(alpha = 0.5f),
-            disabledContentColor = TimerColors.TextPrimary.copy(alpha = 0.5f),
-        ),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = TimerColors.GlassBackground,
+                contentColor = TimerColors.TextPrimary,
+                disabledContainerColor = TimerColors.GlassBackground.copy(alpha = 0.5f),
+                disabledContentColor = TimerColors.TextPrimary.copy(alpha = 0.5f),
+            ),
         contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
     ) {
         Text(

--- a/native-ios/RandomTimer/Sources/UI/Components/PrimaryButton.swift
+++ b/native-ios/RandomTimer/Sources/UI/Components/PrimaryButton.swift
@@ -5,7 +5,8 @@ struct PrimaryButton: View {
     let title: String
     let action: () -> Void
     var backgroundColor: Color = .accentPrimary
-    var foregroundColor: Color = .textPrimary
+    /// Always a light tone: fills use crimson/red accents; label must stay readable in sheets and under system tint.
+    var foregroundColor: Color = Color.white
 
     var body: some View {
         Button(action: action) {
@@ -13,18 +14,21 @@ struct PrimaryButton: View {
                 RoundedRectangle(cornerRadius: 16)
                     .fill(backgroundColor)
                 Text(title)
-                    .font(.headline)
+                    .font(.headline.weight(.semibold))
                     .multilineTextAlignment(.center)
                     .minimumScaleFactor(0.65)
                     .lineLimit(3)
                     .padding(.horizontal, 10)
                     .foregroundStyle(foregroundColor)
+                    .foregroundColor(foregroundColor)
             }
+            .compositingGroup()
             .frame(maxWidth: .infinity)
             .frame(height: 56)
             .contentShape(RoundedRectangle(cornerRadius: 16))
         }
         .buttonStyle(PressableButtonStyle())
+        .tint(foregroundColor)
         .accessibilityLabel(title)
     }
 }


### PR DESCRIPTION
## Problem
Paywall primary CTA could appear as a solid red block with no readable label (reported on device).

## Cause (likely)
- **iOS:** System `Button` tint / sheet compositing can fight explicit label colors on accent fills.
- **Android:** Gradient on the outer `Button` modifier with a transparent M3 container can produce bad label/fill compositing on some devices.

## Changes
- **iOS `PrimaryButton`:** Default label color to `Color.white`, add `.tint(foregroundColor)`, `.compositingGroup()`, and `.foregroundColor` alongside `.foregroundStyle`.
- **Android `PrimaryButton`:** Draw gradient/solid fill in an inner `Box` inside the button content; transparent M3 container; zero horizontal content padding with inner padding on `Text`.

## Verification
- `./gradlew :app:testDebugUnitTest` — `PrimaryButtonLabelTest`, `PaywallSheetTest` (pass).

## Note for CEO
Last **green** internal pipeline that shipped both Firebase + TestFlight was **2026-04-14** (run `24399833952`, app **1.3.20**). Builds after that often failed preflight until `release-notes/1.3.21.md` landed; confirm the device build includes this PR before re-testing.

Made with [Cursor](https://cursor.com)