### PR TITLE
chore(release): bump develop to 1.3.22 / iOS 437 (ASC lineage)

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1774900003
-        versionName = "1.3.21"
+        versionCode = ciVersionCode ?: 1774900004
+        versionName = "1.3.22"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1774900004.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1774900004.txt
@@ -1,0 +1,4 @@
+Paywall and Pro:
+- Primary purchase button label stays readable on iOS and Android.
+- Monthly Pro, clearer upgrade copy, and post-first-session paywall timing.
+- April Pro audio and Sound Arsenal freshness.

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 437;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -712,7 +712,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.21;
+				MARKETING_VERSION = 1.3.22;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -725,7 +725,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 437;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.21;
+				MARKETING_VERSION = 1.3.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -814,7 +814,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 437;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -822,7 +822,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.21;
+				MARKETING_VERSION = 1.3.22;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -835,7 +835,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 437;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -844,7 +844,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.21;
+				MARKETING_VERSION = 1.3.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,3 +1,4 @@
+• Paywall primary button text stays readable on iOS and Android
 • Monthly Pro subscription support
 • Clearer Pro paywall focused on training outcomes
 • Paywall timing moved after the first completed timer session

--- a/release-notes/1.3.22.md
+++ b/release-notes/1.3.22.md
@@ -1,0 +1,13 @@
+# Release 1.3.22
+
+## Summary
+Aligns `develop` with App Store Connect pre-release **1.3.22** so internal TestFlight uploads are not blocked by marketing-version lineage checks, and ships the paywall primary CTA contrast fix.
+
+## Customer-visible changes
+- Paywall primary action label stays readable on crimson buttons (iOS and Android).
+- Continues Pro subscription, paywall framing, and training-quality improvements from prior 1.3.x releases.
+
+## Release operations
+- Android `versionName` **1.3.22**, source `versionCode` **1774900004** (CI may still override `versionCode` from Play state when configured).
+- iOS `MARKETING_VERSION` **1.3.22**, `CURRENT_PROJECT_VERSION` **437** (greater than ASC build **436** for version **1.3.22**).
+- Versioned release note file required by internal distribution preflight.


### PR DESCRIPTION
Internal Distribution iOS job failed on `develop` after #1208 with:

`Local iOS marketing version 1.3.21 regresses behind App Store Connect version 1.3.22`

ASC already had pre-release **1.3.22** (build **436**). This PR bumps repo to **1.3.22** / **437** and Android **1774900004**, adds `release-notes/1.3.22.md`, Play changelog `1774900004.txt`, and store release notes line.

Evidence: local `preflight-release.sh --layer 1` for ios + android **passed**.

Made with [Cursor](https://cursor.com)