### PR TITLE
fix(paywall): pin CTA above home bar + scroll long content

### DIFF
--- a/.maestro/regression-paywall-sticky-cta-ios.yaml
+++ b/.maestro/regression-paywall-sticky-cta-ios.yaml
@@ -1,0 +1,17 @@
+appId: com.igorganapolsky.randomtimer
+---
+# Regression: primary CTA + restore stay in sticky chrome after scrolling long paywall content.
+- launchApp:
+    clearState: true
+- assertVisible: "Start Timer"
+- tapOn: "PRO: 1H"
+- assertVisible:
+    text: "Stop Training With the Brakes On"
+    timeout: 10000
+- scrollUntilVisible:
+    element: "CHOOSE A PLAN"
+    direction: DOWN
+    timeout: 15000
+- assertVisible: "Restore purchase"
+- takeScreenshot: evidence/ios-paywall-sticky-cta
+- stopApp

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -1,6 +1,7 @@
 package com.iganapolsky.randomtimer.ui.screens
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -11,13 +12,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -28,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
@@ -102,187 +109,202 @@ fun PaywallSheet(
         }
     }
 
+    val purchaseProductId = productIdForPlan(selectedPlan)
+    val ctaLabel =
+        ctaLabelForPlan(
+            selectedPlan = selectedPlan,
+            proPrice = proPrice,
+            monthlyPrice = monthlyPrice,
+            trialEligibilityByProductId = trialEligibilityByProductId,
+        )
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = TimerColors.BackgroundDark,
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                text = "Not now",
-                style = MaterialTheme.typography.labelMedium,
-                color = TimerColors.TextSecondary,
-                modifier =
-                    Modifier
-                        .align(Alignment.Start)
-                        .clickable(onClick = onDismiss),
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = headline,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = TimerColors.TextPrimary,
-                textAlign = TextAlign.Center,
-                modifier =
-                    Modifier.fillMaxWidth().then(
-                        if (onDebugUnlock != null) {
-                            Modifier.holdForHiddenUnlock(
-                                holdDurationMs = HIDDEN_UNLOCK_HOLD_DURATION_MS,
-                                haptic = haptic,
-                                onHoldComplete = onDebugUnlock,
-                            )
-                        } else {
+        val scrollState = rememberScrollState()
+        Scaffold(
+            containerColor = TimerColors.BackgroundDark,
+            contentColor = TimerColors.TextPrimary,
+            bottomBar = {
+                val uriHandler = LocalUriHandler.current
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .navigationBarsPadding()
+                            .padding(horizontal = 24.dp, vertical = 10.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    HorizontalDivider(color = TimerColors.TextSecondary.copy(alpha = 0.28f))
+                    Spacer(modifier = Modifier.height(12.dp))
+                    PrimaryButton(
+                        text = ctaLabel,
+                        onClick = { onPurchase(purchaseProductId) },
+                        modifier =
                             Modifier
-                        },
-                    ),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = subheadline,
-                style = MaterialTheme.typography.bodySmall,
-                color = TimerColors.TextSecondary,
-                textAlign = TextAlign.Center,
-            )
-            Text(
-                text = PAYWALL_PRICING_FOOTER,
-                style = MaterialTheme.typography.bodySmall,
-                color = TimerColors.TextSecondary,
-                textAlign = TextAlign.Center,
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = "PRO FEATURES",
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
-                color = TimerColors.AccentPrimary,
-                modifier = Modifier.align(Alignment.Start),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            PAYWALL_FEATURE_ROWS.forEach { feature ->
-                ProFeatureRow(text = feature)
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            // Plan selector — monthly vs annual (default arm from PostHog `paywall_default_plan_annual`)
-            Text(
-                text = "CHOOSE A PLAN",
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
-                color = TimerColors.AccentPrimary,
-                modifier = Modifier.align(Alignment.Start),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            PlanOptionCard(
-                title = "Monthly",
-                priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
-                badge = null,
-                isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
-                onClick = {
-                    selectedPlan = SubscriptionPlanSelection.MONTHLY
-                    onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID)
-                },
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            PlanOptionCard(
-                title = "Annual",
-                priceLabel = "${stripPriceSuffix(proPrice)}/year",
-                badge = "Best Value",
-                isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
-                onClick = {
-                    selectedPlan = SubscriptionPlanSelection.ANNUAL
-                    onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID)
-                },
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            val purchaseProductId = productIdForPlan(selectedPlan)
-            val ctaLabel =
-                ctaLabelForPlan(
-                    selectedPlan = selectedPlan,
-                    proPrice = proPrice,
-                    monthlyPrice = monthlyPrice,
-                    trialEligibilityByProductId = trialEligibilityByProductId,
-                )
-
-            PrimaryButton(
-                text = ctaLabel,
-                onClick = { onPurchase(purchaseProductId) },
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = "Restore purchase",
-                style = MaterialTheme.typography.labelMedium,
-                color = TimerColors.TextSecondary,
+                                .fillMaxWidth()
+                                .border(
+                                    width = 2.5.dp,
+                                    color = Color.White.copy(alpha = 0.95f),
+                                    shape = RoundedCornerShape(16.dp),
+                                ),
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = "Restore purchase",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = TimerColors.TextSecondary,
+                        modifier = Modifier.clickable(onClick = onRestore),
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Not now",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = TimerColors.TextSecondary,
+                        modifier = Modifier.clickable(onClick = onDismiss),
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = "Privacy Policy",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TimerColors.TextSecondary,
+                            modifier =
+                                Modifier.clickable {
+                                    uriHandler.openUri("https://igorganapolsky.github.io/Random-Timer/privacy-policy/")
+                                },
+                        )
+                        Text(
+                            text = "Terms of Use",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TimerColors.TextSecondary,
+                            modifier =
+                                Modifier.clickable {
+                                    uriHandler.openUri("https://igorganapolsky.github.io/Random-Timer/eula/")
+                                },
+                        )
+                    }
+                }
+            },
+        ) { innerPadding ->
+            Column(
                 modifier =
                     Modifier
-                        .clickable(onClick = onRestore),
-                textAlign = TextAlign.Center,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = "Not now",
-                style = MaterialTheme.typography.labelMedium,
-                color = TimerColors.TextSecondary,
-                modifier =
-                    Modifier
-                        .clickable(onClick = onDismiss),
-                textAlign = TextAlign.Center,
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Required by Play Store guidelines for subscription disclosures
-            val uriHandler = LocalUriHandler.current
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth(),
+                        .fillMaxWidth()
+                        .padding(innerPadding)
+                        .verticalScroll(scrollState)
+                        .padding(horizontal = 24.dp, vertical = 16.dp)
+                        .padding(bottom = 12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
-                    text = "Privacy Policy",
-                    style = MaterialTheme.typography.labelSmall,
+                    text = "Not now",
+                    style = MaterialTheme.typography.labelMedium,
                     color = TimerColors.TextSecondary,
                     modifier =
-                        Modifier.clickable {
-                            uriHandler.openUri("https://igorganapolsky.github.io/Random-Timer/privacy-policy/")
-                        },
+                        Modifier
+                            .align(Alignment.Start)
+                            .clickable(onClick = onDismiss),
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = headline,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = TimerColors.TextPrimary,
+                    textAlign = TextAlign.Center,
+                    modifier =
+                        Modifier.fillMaxWidth().then(
+                            if (onDebugUnlock != null) {
+                                Modifier.holdForHiddenUnlock(
+                                    holdDurationMs = HIDDEN_UNLOCK_HOLD_DURATION_MS,
+                                    haptic = haptic,
+                                    onHoldComplete = onDebugUnlock,
+                                )
+                            } else {
+                                Modifier
+                            },
+                        ),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = subheadline,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TimerColors.TextSecondary,
+                    textAlign = TextAlign.Center,
                 )
                 Text(
-                    text = "Terms of Use",
-                    style = MaterialTheme.typography.labelSmall,
+                    text = PAYWALL_PRICING_FOOTER,
+                    style = MaterialTheme.typography.bodySmall,
                     color = TimerColors.TextSecondary,
-                    modifier =
-                        Modifier.clickable {
-                            uriHandler.openUri("https://igorganapolsky.github.io/Random-Timer/eula/")
-                        },
+                    textAlign = TextAlign.Center,
                 )
-            }
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "PRO FEATURES",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = TimerColors.AccentPrimary,
+                    modifier = Modifier.align(Alignment.Start),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                PAYWALL_FEATURE_ROWS.forEach { feature ->
+                    ProFeatureRow(text = feature)
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "CHOOSE A PLAN",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = TimerColors.AccentPrimary,
+                    modifier = Modifier.align(Alignment.Start),
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                PlanOptionCard(
+                    title = "Monthly",
+                    priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
+                    badge = null,
+                    isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
+                    onClick = {
+                        selectedPlan = SubscriptionPlanSelection.MONTHLY
+                        onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID)
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                PlanOptionCard(
+                    title = "Annual",
+                    priceLabel = "${stripPriceSuffix(proPrice)}/year",
+                    badge = "Best Value",
+                    isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
+                    onClick = {
+                        selectedPlan = SubscriptionPlanSelection.ANNUAL
+                        onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID)
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+            }
         }
     }
 }

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -120,159 +120,186 @@ struct PaywallSheet: View {
         return trimmed.isEmpty ? "Continue" : trimmed
     }
 
-    var body: some View {
-        ScrollView {
-            VStack(spacing: 24) {
-                HStack {
-                    Button("Not now") {
-                        trackDismiss(method: "header_not_now")
-                        dismiss()
-                    }
-                    .font(.footnote.weight(.semibold))
-                    .foregroundColor(.textSecondary)
-
-                    Spacer()
-
-                    Button {
-                        trackDismiss(method: "close_button")
-                        dismiss()
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.title3)
-                            .foregroundColor(.textSecondary)
-                            .accessibilityLabel("Close paywall")
-                    }
-                }
-
-                VStack(spacing: 4) {
-                    Text(displayHeadline)
-                        .font(.title2)
-                        .fontWeight(.bold)
-                        .foregroundColor(.textPrimary)
-
-                    VStack(spacing: 4) {
-                        Text(displaySubheadline)
-                        Text(Self.subscriptionFooter)
-                    }
-                    .font(.caption)
-                    .foregroundColor(.textSecondary)
-                    .multilineTextAlignment(.center)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .contentShape(Rectangle())
-                .highPriorityGesture(
-                    LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration, maximumDistance: 100)
-                        .onEnded { _ in
-                            triggerDebugUnlock()
-                        }
-                )
-
-                VStack(alignment: .leading, spacing: 16) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(Self.featureTitle)
-                            .font(.caption.bold())
-                            .foregroundColor(.accentPrimary)
-                        ForEach(Self.featureRows, id: \.self) { feature in
-                            ProFeatureRow(text: feature)
-                        }
-                    }
-                }
-                .padding(.horizontal)
-
-                // Plan selector
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("CHOOSE A PLAN")
-                        .font(.caption.bold())
-                        .foregroundColor(.accentPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal)
-
-                    PlanOptionRow(
-                        title: "Monthly",
-                        priceLabel: "\(monthlyPrice)/month",
-                        badge: nil,
-                        isSelected: selectedPlan == .monthly
-                    ) {
-                        selectedPlan = .monthly
-                        trackOfferSelected(plan: "monthly", productID: ProManager.monthlyProductID)
-                    }
-
-                    PlanOptionRow(
-                        title: "Annual",
-                        priceLabel: "\(annualPrice)/year",
-                        badge: "Best Value",
-                        isSelected: selectedPlan == .annual
-                    ) {
-                        selectedPlan = .annual
-                        trackOfferSelected(plan: "annual", productID: ProManager.annualProductID)
-                    }
-
-                    PlanOptionRow(
-                        title: "Lifetime",
-                        priceLabel: lifetimePrice,
-                        badge: "One-time",
-                        isSelected: selectedPlan == .lifetime
-                    ) {
-                        selectedPlan = .lifetime
-                        trackOfferSelected(plan: "lifetime", productID: ProManager.paywallProductID)
-                    }
-                }
-
-                VStack(spacing: 12) {
-                    PrimaryButton(title: ctaButtonTitle) {
-                        Task {
-                            await purchase(productID: selectedProductID)
-                        }
-                    }
-                }
-
-                Button("Restore purchase") {
-                    Task {
-                        let result = await proManager.restorePurchases()
-                        AnalyticsService.shared.track(AnalyticsEvents.paywallRestoreResult, properties: [
-                            AnalyticsProperties.entryPoint: entryPoint.rawValue,
-                            AnalyticsProperties.result: result.rawValue,
-                        ])
-
-                        if result == .restored || result == .alreadyUnlocked {
-                            hasTrackedDismiss = true
-                            dismiss()
-                        }
-                    }
-                }
-                .font(.footnote)
-                .foregroundColor(.textSecondary)
-
+    /// Headline, value props, and plan picker — scrolls so the purchase strip can stay pinned.
+    @ViewBuilder
+    private var paywallScrollContent: some View {
+        VStack(spacing: 24) {
+            HStack {
                 Button("Not now") {
-                    trackDismiss(method: "footer_not_now")
+                    trackDismiss(method: "header_not_now")
                     dismiss()
                 }
-                .font(.footnote)
+                .font(.footnote.weight(.semibold))
                 .foregroundColor(.textSecondary)
 
-                // Required by App Store Guideline 3.1.2(c)
-                // swiftlint:disable force_unwrapping
-                HStack(spacing: 16) {
-                    Link(
-                        "Privacy Policy",
-                        destination: URL(string: "https://igorganapolsky.github.io/Random-Timer/privacy-policy/")!
-                    )
-                    Link(
-                        "Terms of Use (EULA)",
-                        destination: URL(string: "https://igorganapolsky.github.io/Random-Timer/eula/")!
-                    )
+                Spacer()
+
+                Button {
+                    trackDismiss(method: "close_button")
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
+                        .foregroundColor(.textSecondary)
+                        .accessibilityLabel("Close paywall")
                 }
-                // swiftlint:enable force_unwrapping
-                .font(.caption2)
-                .foregroundColor(.textSecondary)
             }
-            .padding(24)
-            .padding(.top, 8)
-            .padding(.bottom, 12)
-            .frame(maxWidth: .infinity, alignment: .top)
+
+            VStack(spacing: 4) {
+                Text(displayHeadline)
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundColor(.textPrimary)
+
+                VStack(spacing: 4) {
+                    Text(displaySubheadline)
+                    Text(Self.subscriptionFooter)
+                }
+                .font(.caption)
+                .foregroundColor(.textSecondary)
+                .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .highPriorityGesture(
+                LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration, maximumDistance: 100)
+                    .onEnded { _ in
+                        triggerDebugUnlock()
+                    }
+            )
+
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(Self.featureTitle)
+                        .font(.caption.bold())
+                        .foregroundColor(.accentPrimary)
+                    ForEach(Self.featureRows, id: \.self) { feature in
+                        ProFeatureRow(text: feature)
+                    }
+                }
+            }
+            .padding(.horizontal)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("CHOOSE A PLAN")
+                    .font(.caption.bold())
+                    .foregroundColor(.accentPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+
+                PlanOptionRow(
+                    title: "Monthly",
+                    priceLabel: "\(monthlyPrice)/month",
+                    badge: nil,
+                    isSelected: selectedPlan == .monthly
+                ) {
+                    selectedPlan = .monthly
+                    trackOfferSelected(plan: "monthly", productID: ProManager.monthlyProductID)
+                }
+
+                PlanOptionRow(
+                    title: "Annual",
+                    priceLabel: "\(annualPrice)/year",
+                    badge: "Best Value",
+                    isSelected: selectedPlan == .annual
+                ) {
+                    selectedPlan = .annual
+                    trackOfferSelected(plan: "annual", productID: ProManager.annualProductID)
+                }
+
+                PlanOptionRow(
+                    title: "Lifetime",
+                    priceLabel: lifetimePrice,
+                    badge: "One-time",
+                    isSelected: selectedPlan == .lifetime
+                ) {
+                    selectedPlan = .lifetime
+                    trackOfferSelected(plan: "lifetime", productID: ProManager.paywallProductID)
+                }
+            }
         }
-        .scrollIndicators(.hidden)
+    }
+
+    /// Always visible above the home indicator: primary CTA + legal / dismiss affordances.
+    @ViewBuilder
+    private var paywallStickyChrome: some View {
+        VStack(spacing: 12) {
+            PrimaryButton(title: ctaButtonTitle) {
+                Task {
+                    await purchase(productID: selectedProductID)
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(Color.white.opacity(0.95), lineWidth: 2.5)
+            )
+
+            Button("Restore purchase") {
+                Task {
+                    let result = await proManager.restorePurchases()
+                    AnalyticsService.shared.track(AnalyticsEvents.paywallRestoreResult, properties: [
+                        AnalyticsProperties.entryPoint: entryPoint.rawValue,
+                        AnalyticsProperties.result: result.rawValue,
+                    ])
+
+                    if result == .restored || result == .alreadyUnlocked {
+                        hasTrackedDismiss = true
+                        dismiss()
+                    }
+                }
+            }
+            .font(.footnote)
+            .foregroundColor(.textSecondary)
+
+            Button("Not now") {
+                trackDismiss(method: "footer_not_now")
+                dismiss()
+            }
+            .font(.footnote)
+            .foregroundColor(.textSecondary)
+
+            // Required by App Store Guideline 3.1.2(c)
+            // swiftlint:disable force_unwrapping
+            HStack(spacing: 16) {
+                Link(
+                    "Privacy Policy",
+                    destination: URL(string: "https://igorganapolsky.github.io/Random-Timer/privacy-policy/")!
+                )
+                Link(
+                    "Terms of Use (EULA)",
+                    destination: URL(string: "https://igorganapolsky.github.io/Random-Timer/eula/")!
+                )
+            }
+            // swiftlint:enable force_unwrapping
+            .font(.caption2)
+            .foregroundColor(.textSecondary)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                paywallScrollContent
+                    .padding(.horizontal, 24)
+                    .padding(.top, 8)
+                    .padding(.bottom, 28)
+            }
+            .scrollIndicators(.hidden)
+
+            Rectangle()
+                .fill(Color.white.opacity(0.18))
+                .frame(height: 1)
+                .padding(.horizontal, 12)
+
+            paywallStickyChrome
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+                .frame(maxWidth: .infinity)
+                .background(Color.backgroundDark)
+                .safeAreaPadding(.bottom, 6)
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.backgroundDark)
         .task {

--- a/scripts/device-tests/ci-maestro-ios.sh
+++ b/scripts/device-tests/ci-maestro-ios.sh
@@ -160,6 +160,7 @@ run_maestro_flow "ios-smoke" "$PROJECT_ROOT/.maestro/ios-smoke-test.yaml"
 run_maestro_flow "pro-locks" "$PROJECT_ROOT/.maestro/regression-pro-locks-visible-ios.yaml"
 run_maestro_flow "free-sound-preview" "$PROJECT_ROOT/.maestro/regression-free-sound-preview-ios.yaml"
 run_maestro_flow "sound-arsenal-paywall" "$PROJECT_ROOT/.maestro/regression-sound-arsenal-paywall-ios.yaml"
+run_maestro_flow "paywall-sticky-cta" "$PROJECT_ROOT/.maestro/regression-paywall-sticky-cta-ios.yaml"
 
 # Reset app state before Agent Device validates the home screen. Regression
 # flows may leave transient setup overlays or sheets visible.

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -96,6 +96,31 @@ def test_ios_paywall_uses_scrollable_large_presentation_to_avoid_clipped_actions
     assert ".presentationDetents([.large])" in ios_setup
 
 
+def test_paywall_sticky_chrome_keeps_primary_cta_outside_scroll():
+    """Sticky footer must hold CTA + restore + legal links so long content cannot strand the purchase path."""
+    android_paywall = _read(ANDROID_PAYWALL)
+    ios_paywall = _read(IOS_PAYWALL)
+
+    assert "Scaffold(" in android_paywall
+    assert "bottomBar = {" in android_paywall
+    assert ".verticalScroll(" in android_paywall
+    assert android_paywall.index("bottomBar = {") < android_paywall.index("PrimaryButton(")
+    assert ".navigationBarsPadding()" in android_paywall
+    for label in ("Restore purchase", "Privacy Policy", "Start Monthly", "Start Annual"):
+        assert label in android_paywall
+
+    assert "paywallStickyChrome" in ios_paywall
+    body_start = ios_paywall.find("var body: some View")
+    assert body_start != -1
+    body_region = ios_paywall[body_start:]
+    scroll_at = body_region.find("ScrollView")
+    chrome_at = body_region.find("paywallStickyChrome")
+    assert scroll_at != -1 and chrome_at != -1 and scroll_at < chrome_at
+    assert "PrimaryButton(title: ctaButtonTitle)" in ios_paywall
+    for label in ("Restore purchase", "Privacy Policy", "Terms of Use (EULA)", "Start Monthly", "Start Annual"):
+        assert label in ios_paywall
+
+
 def test_voice_callouts_present_on_both_platforms():
     android_setup = _read(ANDROID_SETUP)
     ios_setup = _read(IOS_SETUP)


### PR DESCRIPTION
## Problem
Paywall primary CTA was hard to use: easy to miss visually, and on long layouts users could not reliably reach the bottom (Android `ModalBottomSheet` used a non-scrolling `Column`; iOS relied on a single `ScrollView` with the CTA at the very end).

## Changes
- **iOS `PaywallSheet`:** Split into scrollable hero/features/plan picker + **sticky footer** (CTA, restore, dismiss, legal). Divider between regions. White stroke on CTA for contrast. `.safeAreaPadding(.bottom)` on the chrome strip.
- **Android `PaywallSheet`:** `Scaffold` inside the sheet with **`bottomBar`** for the same sticky chrome; scrollable body uses `verticalScroll` + `navigationBarsPadding` on the bar. CTA gets a white border. Plan list remains scrollable when content is tall.

## Verification
- `./gradlew :app:testDebugUnitTest` — `PaywallSheetTest`, `PrimaryButtonLabelTest` (pass).

Made with [Cursor](https://cursor.com)