### PR TITLE
chore(store): refresh Play/App Store listings + marketing snippets

### DIFF
--- a/marketing/data/promo_script_30s.md
+++ b/marketing/data/promo_script_30s.md
@@ -10,4 +10,4 @@ It forces real reaction under pressure — boxing, BJJ, combatives, conditioning
 
 Train for chaos. Not comfort.
 
-Random Tactical Timer. Free on the App Store.
+Random Tactical Timer — App Store and Google Play. Optional Pro for voices, Sound Arsenal, and long sessions.

--- a/marketing/referral_content/product_hunt_launch.md
+++ b/marketing/referral_content/product_hunt_launch.md
@@ -1,6 +1,6 @@
 # Product Hunt Launch Plan
 
-**Tagline:** Random timer for HIIT, drills & party games — you never know when it fires
+**Tagline:** Random tactical timer for combat sports & HIIT — you never know when it fires
 
 ## Description
 Random Tactical Timer picks a random moment within your chosen time range to fire an alarm.
@@ -8,18 +8,18 @@ Random Tactical Timer picks a random moment within your chosen time range to fir
 Set a minimum and maximum duration, press start, and go about your activity. You never know exactly when it goes off — keeping you sharp, alert, and engaged.
 
 Perfect for:
-- HIIT & Tabata with unpredictable rest periods
+- HIIT & Tabata with unpredictable work/rest periods
 - Reaction training for martial arts & boxing
-- Party games like Musical Chairs & Hot Potato
-- Pomodoro sessions with random breaks
+- BJJ scrambles and positional drills
+- Conditioning blocks where anticipation is the enemy
 
-No ads. No tracking. No subscriptions. Just set your range and go.
+Optional Pro unlocks AI coach voice callouts, Sound Arsenal, longer sessions, and structured round limits. No ads in the training experience; optional privacy‑respecting product analytics may run to improve the app (see Privacy Policy).
 
 ## Topics
-Productivity, Health & Fitness, Developer Tools
+Health & Fitness, Productivity, Sports
 
 ## Maker Comment
-Hey PH! I built this because every timer app lets you predict exactly when it ends. That defeats the purpose for reaction training and surprise-based games. This one keeps you guessing.
+Hey PH! I built this because every timer app lets you predict exactly when it ends. That defeats the purpose for reaction training. This one keeps you guessing — and Pro adds coach voices and a fuller sound library when you want match pressure, not a metronome.
 
 ## Pre-Launch Checklist
 - [ ] Prepare 3-5 screenshots for PH gallery

--- a/native-android/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,7 +1,5 @@
-• Real Sound Arsenal — all 8 Pro sounds replaced with studio-quality recordings
-• G.I. Jane female voice callouts with emotional intensity
-• Boxing bell, stadium air horn, military drum roll — each sound is authentic
-• Male & Female voice selection with instant preview
-• Pro lock indicators on all premium features
-• Timer range minimum 5 seconds (prevents instant fire)
-• Performance and reliability improvements
+• Clearer Pro upgrade path with a readable primary purchase button
+• Paywall tuned for training outcomes; purchase and restore stay easy to reach
+• Monthly and annual Pro subscription options where available
+• AI voice callouts, Sound Arsenal, and extended range for long tactical sessions
+• Reliability and analytics improvements behind the scenes

--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -27,11 +27,15 @@ KEY FEATURES:
 - Full-screen tactical alerts that command attention
 
 PRO FEATURES:
-- 🎙️ AI Voice Callouts: Choose male or female coach voice — 31 unique tactical cues keep you sharp during training
-- 🗣️ Two voice styles: commanding male drill sergeant or focused female coach — pick what pushes you harder
-- ⏱️ Elapsed time announcements on the minute so you never lose track
-- 🔁 Round selection (1–100) for structured training cycles
-- 📏 Extended timer range up to 1 hour
+- AI voice callouts: male or female coach voice with tactical cues so you stay sharp mid-round
+- Command-cue previews and elapsed-time style callouts for pressure drills
+- Sound Arsenal: expanded alarm library for serious training sessions
+- Round selection (1–100) for structured training cycles
+- Extended timer range up to 60 minutes for long sessions
+
+SUBSCRIPTION & UPGRADE:
+- Pro is optional. Monthly and annual subscriptions are available where offered; pricing is shown on the purchase sheet before you confirm.
+- A one-time upgrade may be offered depending on product configuration in your region.
 
 HOW IT WORKS:
 1. Set your range (e.g. 15 seconds to 3 minutes)
@@ -47,4 +51,4 @@ WORKS FOR:
 - HIIT and CrossFit WOD timer that punishes predictability
 - Unpredictable round timer for sparring and pad work
 
-Zero ads. No tracking. Free core random timer with an optional Pro upgrade for advanced tactical training features.
+No ads in the training experience. Optional anonymous product analytics (for example via PostHog) may be used to improve stability and features—see the Privacy Policy linked on the store listing. Optional Pro subscription unlocks advanced training features above.

--- a/native-android/fastlane/metadata/android/en-US/short_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Random timer for unpredictable MMA, boxing, BJJ & HIIT. AI voice callouts.
+Random tactical timer: MMA, boxing, BJJ & HIIT. Random cues + AI coach voices.

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -12,8 +12,9 @@ FEATURES
 - Random trigger timing inside your selected range
 - Hidden countdown mode to stop timer watching
 - Male or female AI coach voice callouts (Pro)
-- Loop mode with optional round limits
-- Extended session range up to 60 minutes
+- Loop mode with optional round limits (Pro)
+- Extended session range up to 60 minutes (Pro)
+- Sound Arsenal and richer alarm options for serious sessions (Pro)
 
 TRAINING USES
 - Boxing pad rounds, bag work, and shadowboxing flurries
@@ -25,7 +26,9 @@ TRAINING USES
 Stop timing your drills. Start training your response.
 
 SUBSCRIPTION INFO
-Pro Tactical is available as an auto-renewable subscription at $29.99/year. Payment is charged to your Apple ID account at confirmation of purchase. Subscription automatically renews unless canceled at least 24 hours before the end of the current period. Manage subscriptions in Settings > Apple ID > Subscriptions.
+Pro Tactical is offered as auto-renewable subscriptions (including monthly and annual options where available) and a one-time upgrade may be offered depending on App Store configuration in your region. Example list pricing when configured in App Store Connect: $3.99/month and $29.99/year; actual price is shown on Apple’s purchase confirmation sheet before you buy. Payment is charged to your Apple ID account at confirmation of purchase. Subscription automatically renews unless canceled at least 24 hours before the end of the current period. Manage subscriptions in Settings > Apple ID > Subscriptions.
+
+Optional product analytics may be collected to improve stability and features—see the Privacy Policy below.
 
 Privacy Policy: https://igorganapolsky.github.io/Random-Timer/privacy-policy/
 Terms of Use (EULA): https://igorganapolsky.github.io/Random-Timer/eula/

--- a/native-ios/fastlane/metadata/en-US/keywords.txt
+++ b/native-ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-random timer,countdown,reaction,boxing,mma,bjj,muay thai,sparring,combat,military,hiit,crossfit,wod
+random,timer,reaction,boxing,mma,bjj,sparring,hiit,crossfit,wod,military,interval,dryfire

--- a/native-ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/native-ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Random timer for dry fire, boxing, BJJ, HIIT, and reaction drills.
+Unpredictable intervals for combat sports & HIIT. AI coach voices, 60‑min sessions, full sound library—optional Pro.

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,7 +1,5 @@
-• Paywall primary button text stays readable on iOS and Android
-• Monthly Pro subscription support
-• Clearer Pro paywall focused on training outcomes
-• Paywall timing moved after the first completed timer session
-• April Pro audio and Sound Arsenal freshness
-• Cleaner review timing and analytics reliability
-• Release pipeline hardening for safer store updates
+• Clearer Pro upgrade with a readable primary purchase button
+• Paywall tuned for training outcomes; purchase, restore, and legal links stay reachable
+• Monthly and annual Pro subscriptions where available
+• AI voice callouts, Sound Arsenal, and extended range for long tactical sessions
+• Review timing and analytics reliability improvements

--- a/native-ios/fastlane/metadata/en-US/subtitle.txt
+++ b/native-ios/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Dry Fire, Boxing, BJJ, HIIT
+Random HIIT & combat rounds


### PR DESCRIPTION
Updates fastlane store copy (Android en-US + iOS en-US) for current Pro positioning: subscriptions, Sound Arsenal, voice callouts, 60-minute sessions, and accurate privacy/analytics language (no more 'no tracking' where PostHog may be used).

Also refreshes `marketing/data/promo_script_30s.md` and `marketing/referral_content/product_hunt_launch.md` so outbound materials match the product.

Evidence: iOS `subtitle.txt` verified at 27 characters (App Store 30-char limit).

Made with [Cursor](https://cursor.com)