### PR TITLE
fix(maestro): extendedWaitUntil for paywall sticky CTA iOS flow

### DIFF
--- a/.maestro/regression-paywall-sticky-cta-ios.yaml
+++ b/.maestro/regression-paywall-sticky-cta-ios.yaml
@@ -4,7 +4,8 @@ appId: com.igorganapolsky.randomtimer
 - launchApp:
     clearState: true
 - assertVisible: "Start Timer"
-- tapOn: "PRO: 1H"
+- tapOn:
+    text: ".*PRO: 1H.*"
 - extendedWaitUntil:
     visible: "Stop Training With the Brakes On"
     timeout: 10000

--- a/.maestro/regression-paywall-sticky-cta-ios.yaml
+++ b/.maestro/regression-paywall-sticky-cta-ios.yaml
@@ -5,8 +5,8 @@ appId: com.igorganapolsky.randomtimer
     clearState: true
 - assertVisible: "Start Timer"
 - tapOn: "PRO: 1H"
-- assertVisible:
-    text: "Stop Training With the Brakes On"
+- extendedWaitUntil:
+    visible: "Stop Training With the Brakes On"
     timeout: 10000
 - scrollUntilVisible:
     element: "CHOOSE A PLAN"


### PR DESCRIPTION
## Summary
Device-tests run [24518173922](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/24518173922) failed on `regression-paywall-sticky-cta-ios.yaml` with `Unknown Property: timeout`.

Maestro supports `timeout` on `scrollUntilVisible` and `extendedWaitUntil`, but not on `assertVisible` (per [Maestro docs](https://docs.maestro.dev/reference/commands-available/assertvisible)).

## Change
Replace the paywall title wait with `extendedWaitUntil` + `visible` + `timeout: 10000`.

## Evidence
- Log excerpt: `> Unknown Property: timeout` at paywall-sticky-cta attempt (flow references `assertVisible` + `timeout`).

Made with [Cursor](https://cursor.com)