### PR TITLE
feat(firebase): App Testing agent suites and manual CI workflow

### DIFF
--- a/.claude/skills/firebase-ops.md
+++ b/.claude/skills/firebase-ops.md
@@ -61,6 +61,10 @@ bq query --use_legacy_sql=false \
 - App ID format: `1:PROJECT_NUMBER:android:APP_ID` (e.g. `1:624873778337:android:4503588605a3273edc14e0`).
 - To see group alias: Firebase Console → App Distribution → Testers & groups → select group.
 
+### App Testing agent (Android, preview)
+
+AI-guided tests via App Distribution + Test Lab devices. Canonical doc: `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` (App Testing agent section). In-repo YAML: `firebase-apptesting/tests/`. Manual CI: `.github/workflows/firebase-app-testing-agent.yml`. Runner script: `scripts/ci_firebase_apptesting_execute.sh`.
+
 ### Automated Crash Check (CI)
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pip pytest==8.4.2 pytest-cov==7.0.0 pillow==11.3.0 google-auth==2.43.0 requests==2.32.5
+        run: python -m pip install --upgrade pip pytest==8.4.2 pytest-cov==7.0.0 pillow==11.3.0 google-auth==2.43.0 requests==2.32.5 PyYAML==6.0.2
 
       - name: Run unit tests
         run: python -m pytest scripts/tests/ -q --cov=scripts --cov-report=term --cov-report=xml:coverage-python.xml

--- a/.github/workflows/firebase-app-testing-agent.yml
+++ b/.github/workflows/firebase-app-testing-agent.yml
@@ -1,0 +1,164 @@
+name: Firebase App Testing Agent
+
+# Manual AI-guided UI verification via Firebase App Distribution (Android).
+# Preview: enable App Testing agent in Firebase Console → App Distribution first.
+# https://firebase.google.com/docs/app-distribution/android/app-testing-agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to checkout (empty = commit SHA that triggered this run)"
+        required: false
+        type: string
+      skip_build:
+        description: "Skip APK build; agent uses latest App Distribution release for FIREBASE_ANDROID_APP_ID"
+        required: false
+        type: boolean
+        default: false
+      test_non_blocking:
+        description: "Exit after tests are queued (check Firebase console for outcomes)"
+        required: false
+        type: boolean
+        default: true
+      test_devices:
+        description: "Semicolon-separated Test Lab device specs"
+        required: false
+        type: string
+        default: "model=panther,version=33,locale=en,orientation=portrait"
+
+concurrency:
+  group: firebase-app-testing-agent-${{ github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  agent:
+    name: Android App Testing agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+
+      - name: Validate secrets for selected mode
+        env:
+          SKIP_BUILD: ${{ inputs.skip_build }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for name in FIREBASE_SERVICE_ACCOUNT_JSON FIREBASE_ANDROID_APP_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "Missing secret: $name"
+              exit 1
+            fi
+          done
+          if ! [[ "$FIREBASE_ANDROID_APP_ID" =~ ^1:[0-9]+:android:[a-fA-F0-9]+$ ]]; then
+            echo "FIREBASE_ANDROID_APP_ID must match 1:PROJECT_NUMBER:android:APP_ID"
+            exit 1
+          fi
+          if [ "$SKIP_BUILD" != "true" ]; then
+            for name in GOOGLE_SERVICES_JSON ANDROID_KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
+              if [ -z "${!name:-}" ]; then
+                echo "Missing secret (required when skip_build is false): $name"
+                exit 1
+              fi
+            done
+          fi
+
+      - name: Preflight release checks (Android)
+        if: ${{ !inputs.skip_build }}
+        run: bash scripts/shell/preflight-release.sh --platform android --layer 1
+
+      - name: Setup Java
+        if: ${{ !inputs.skip_build }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Create google-services.json
+        if: ${{ !inputs.skip_build }}
+        working-directory: native-android
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Decode keystore
+        if: ${{ !inputs.skip_build }}
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > /tmp/release.keystore
+
+      - name: Build release APK
+        if: ${{ !inputs.skip_build }}
+        working-directory: native-android
+        env:
+          KEYSTORE_PATH: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+        run: |
+          set -euo pipefail
+          ./gradlew -PciVersionCode="${{ github.run_number }}" assembleRelease --no-daemon
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools@latest
+
+      - name: Run App Testing agent (with built APK)
+        if: ${{ !inputs.skip_build }}
+        env:
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          FIREBASE_APP_TESTING_DEVICES: ${{ inputs.test_devices }}
+          TEST_NON_BLOCKING: ${{ inputs.test_non_blocking }}
+        run: |
+          set -euo pipefail
+          EXTRA_FLAGS=()
+          if [ "$TEST_NON_BLOCKING" = "true" ]; then
+            EXTRA_FLAGS+=(--non-blocking)
+          fi
+          bash scripts/ci_firebase_apptesting_execute.sh \
+            --test-devices "$FIREBASE_APP_TESTING_DEVICES" \
+            "${EXTRA_FLAGS[@]}" \
+            --apk "$GITHUB_WORKSPACE/native-android/app/build/outputs/apk/release/app-release.apk"
+
+      - name: Run App Testing agent (latest App Distribution release)
+        if: ${{ inputs.skip_build }}
+        env:
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          FIREBASE_APP_TESTING_DEVICES: ${{ inputs.test_devices }}
+          TEST_NON_BLOCKING: ${{ inputs.test_non_blocking }}
+        run: |
+          set -euo pipefail
+          EXTRA_FLAGS=()
+          if [ "$TEST_NON_BLOCKING" = "true" ]; then
+            EXTRA_FLAGS+=(--non-blocking)
+          fi
+          bash scripts/ci_firebase_apptesting_execute.sh \
+            --test-devices "$FIREBASE_APP_TESTING_DEVICES" \
+            "${EXTRA_FLAGS[@]}"
+
+      - name: Cleanup keystore
+        if: always()
+        run: rm -f /tmp/release.keystore

--- a/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
+++ b/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
@@ -127,6 +127,25 @@ Most recent verified Android Firebase release evidence:
 - Distribution audience in live run log:
   - tester `iganapolsky@gmail.com`
 
+## App Testing agent (Android, preview)
+
+Firebase [App Testing agent](https://firebase.google.com/docs/app-distribution/android/app-testing-agent) runs natural-language / YAML test cases against your app on **Test Lab devices** (Gemini in Firebase). It is a **preview** feature: opt in under **Firebase Console → App Distribution** for the same project as `FIREBASE_ANDROID_APP_ID` (see [accessing the preview](https://firebase.google.com/docs/app-distribution/troubleshooting?platform=android#app-testing-agent-preview)).
+
+**In-repo suites:** `firebase-apptesting/tests/` (validated by `scripts/tests/test_firebase_apptesting_yaml.py`).
+
+**CI (manual):** GitHub Actions workflow `.github/workflows/firebase-app-testing-agent.yml` (`workflow_dispatch`). It installs `firebase-tools`, builds a **release APK** (unless `skip_build`), then runs `scripts/ci_firebase_apptesting_execute.sh`. Uses the same secrets as internal Firebase distribution (`FIREBASE_ANDROID_APP_ID`, `FIREBASE_SERVICE_ACCOUNT_JSON`, plus Android signing and `GOOGLE_SERVICES_JSON` when building).
+
+**Local / ad hoc:**
+
+```bash
+export FIREBASE_ANDROID_APP_ID="1:…:android:…"
+export FIREBASE_SERVICE_ACCOUNT_JSON="$(cat /path/to/sa.json)"   # or set GOOGLE_APPLICATION_CREDENTIALS
+npm install -g firebase-tools@latest
+bash scripts/ci_firebase_apptesting_execute.sh --apk native-android/app/build/outputs/apk/release/app-release.apk
+```
+
+**Quota / budget:** During preview, Firebase documents a **default free quota** (e.g. 200 agent tests per project per month); multi-device runs multiply usage. Stay within the repo **$20/month external spend** mandate for any paid Test Lab overages beyond preview allowances.
+
 ## Change Rules
 
 When touching Android Firebase infrastructure:

--- a/firebase-apptesting/tests/random-timer-smoke.yaml
+++ b/firebase-apptesting/tests/random-timer-smoke.yaml
@@ -1,0 +1,29 @@
+# Firebase App Testing agent (Android) — natural-language cases.
+# Schema: https://firebase.google.com/docs/app-distribution/android/app-testing-agent
+#
+# Import these into Firebase Console → App Distribution → Test Cases, or run:
+#   bash scripts/ci_firebase_apptesting_execute.sh --apk path/to.apk
+tests:
+  - displayName: Home and timer-range Pro gate (smoke)
+    id: rt-smoke-home-range-gate
+    steps:
+      - goal: >
+          Open Random Tactical Timer. If Android shows permission dialogs
+          (notifications, etc.), accept them. Reach the main timer setup screen.
+          Do not sign in with a social account. Do not complete any purchase.
+        hint: >
+          Dismiss any one-time overlays. Stay on the primary setup screen where
+          the user configures a drill before starting.
+        finalScreenAssertion: >
+          The text "Start Timer" is visible on the screen.
+      - goal: >
+          Find and tap the Pro upgrade affordance for the timer range
+          (caption mentioning PRO and a one-hour style cap, often with a lock).
+          Scroll the main content vertically if the control is not on screen.
+        hint: >
+          Prefer tapping the compact Pro label in the Timer Range card, not
+          unrelated navigation. If unsure, scroll down slightly and retry once.
+        finalScreenAssertion: >
+          A full-screen or sheet paywall is visible, and text related to choosing
+          a subscription plan or training upgrade is visible (for example words
+          like "plan", "CHOOSE", or "Stop Training").

--- a/scripts/ci_firebase_apptesting_execute.sh
+++ b/scripts/ci_firebase_apptesting_execute.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Run Firebase App Testing agent against an APK or the latest App Distribution release.
+# Requires: firebase-tools (npm), GOOGLE_APPLICATION_CREDENTIALS or FIREBASE_SERVICE_ACCOUNT_JSON,
+#           FIREBASE_ANDROID_APP_ID (1:project:android:hex form).
+# Docs: https://firebase.google.com/docs/app-distribution/android/app-testing-agent
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR_DEFAULT="$REPO_ROOT/firebase-apptesting/tests"
+APK_PATH=""
+TEST_DIR="$TEST_DIR_DEFAULT"
+TEST_DEVICES="${FIREBASE_APP_TESTING_DEVICES:-model=panther,version=33,locale=en,orientation=portrait}"
+NON_BLOCKING=0
+
+usage() {
+  cat <<'USAGE'
+Usage: ci_firebase_apptesting_execute.sh [--apk PATH] [--test-dir DIR] [--test-devices SPEC] [--non-blocking]
+
+  --apk             Path to release/debug APK (omit to use latest App Distribution release for --app)
+  --test-dir        Directory of agent YAML suites (default: firebase-apptesting/tests)
+  --test-devices    Semicolon-separated Test Lab device specs (default: env FIREBASE_APP_TESTING_DEVICES or Pixel-class preset)
+  --non-blocking    Pass --test-non-blocking to firebase CLI (exit before agent finishes)
+
+Environment:
+  FIREBASE_ANDROID_APP_ID          Required Firebase Android app id
+  FIREBASE_SERVICE_ACCOUNT_JSON    Service account JSON body (written to temp file for ADC)
+  GOOGLE_APPLICATION_CREDENTIALS   Optional; if set, FIREBASE_SERVICE_ACCOUNT_JSON is ignored
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apk)
+      APK_PATH="${2:?}"
+      shift 2
+      ;;
+    --test-dir)
+      TEST_DIR="${2:?}"
+      shift 2
+      ;;
+    --test-devices)
+      TEST_DEVICES="${2:?}"
+      shift 2
+      ;;
+    --non-blocking)
+      NON_BLOCKING=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${FIREBASE_ANDROID_APP_ID:-}" ]]; then
+  echo "❌ FIREBASE_ANDROID_APP_ID is not set" >&2
+  exit 1
+fi
+
+if [[ ! -d "$TEST_DIR" ]]; then
+  echo "❌ Test directory not found: $TEST_DIR" >&2
+  exit 1
+fi
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  if [[ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+    echo "❌ GOOGLE_APPLICATION_CREDENTIALS is not a file: $GOOGLE_APPLICATION_CREDENTIALS" >&2
+    exit 1
+  fi
+else
+  if [[ -z "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]]; then
+    echo "❌ Set GOOGLE_APPLICATION_CREDENTIALS or FIREBASE_SERVICE_ACCOUNT_JSON" >&2
+    exit 1
+  fi
+  CREDS_FILE="$(mktemp)"
+  trap 'rm -f "$CREDS_FILE"' EXIT
+  printf '%s\n' "$FIREBASE_SERVICE_ACCOUNT_JSON" >"$CREDS_FILE"
+  export GOOGLE_APPLICATION_CREDENTIALS="$CREDS_FILE"
+fi
+
+if ! command -v firebase >/dev/null 2>&1; then
+  echo "❌ firebase CLI not found. Install: npm install -g firebase-tools" >&2
+  exit 1
+fi
+
+ARGS=(
+  apptesting:execute
+  "--app=$FIREBASE_ANDROID_APP_ID"
+  "--test-dir=$TEST_DIR"
+  "--test-devices=$TEST_DEVICES"
+)
+
+if [[ "$NON_BLOCKING" -eq 1 ]]; then
+  ARGS+=(--test-non-blocking)
+fi
+
+if [[ -n "$APK_PATH" ]]; then
+  if [[ ! -f "$APK_PATH" ]]; then
+    echo "❌ APK not found: $APK_PATH" >&2
+    exit 1
+  fi
+  ARGS+=("$APK_PATH")
+fi
+
+echo "Running: firebase ${ARGS[*]}"
+firebase "${ARGS[@]}"

--- a/scripts/tests/test_firebase_apptesting_yaml.py
+++ b/scripts/tests/test_firebase_apptesting_yaml.py
@@ -1,0 +1,77 @@
+"""Contract tests for Firebase App Testing agent YAML (Android)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+TEST_SUITE_DIR = ROOT / "firebase-apptesting" / "tests"
+REQUIRED_SUITE = TEST_SUITE_DIR / "random-timer-smoke.yaml"
+
+
+def _load(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{path} must parse to a mapping"
+    return data
+
+
+def test_firebase_apptesting_smoke_suite_exists() -> None:
+    assert REQUIRED_SUITE.is_file(), f"Missing {REQUIRED_SUITE.relative_to(ROOT)}"
+
+
+def test_firebase_apptesting_smoke_suite_schema() -> None:
+    if not REQUIRED_SUITE.is_file():
+        pytest.fail("random-timer-smoke.yaml missing")
+
+    doc = _load(REQUIRED_SUITE)
+    tests = doc.get("tests")
+    assert isinstance(tests, list) and tests, '"tests" must be a non-empty list'
+
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(tests):
+        assert isinstance(entry, dict), f"tests[{index}] must be a mapping"
+        display = entry.get("displayName")
+        tid = entry.get("id")
+        steps = entry.get("steps")
+        assert isinstance(display, str) and display.strip(), f"tests[{index}].displayName required"
+        assert isinstance(tid, str) and tid.strip(), f"tests[{index}].id required"
+        assert tid not in seen_ids, f"duplicate test id: {tid}"
+        seen_ids.add(tid)
+        assert isinstance(steps, list) and steps, f"tests[{index}].steps must be non-empty"
+
+        for s_index, step in enumerate(steps):
+            assert isinstance(step, dict), f"tests[{index}].steps[{s_index}] must be a mapping"
+            goal = step.get("goal")
+            final_assert = step.get("finalScreenAssertion")
+            assert isinstance(goal, str) and goal.strip(), (
+                f"tests[{index}].steps[{s_index}].goal required"
+            )
+            assert isinstance(final_assert, str) and final_assert.strip(), (
+                f"tests[{index}].steps[{s_index}].finalScreenAssertion required"
+            )
+
+    prior_ids: set[str] = set()
+    for index, entry in enumerate(tests):
+        assert isinstance(entry, dict)
+        tid = entry.get("id")
+        assert isinstance(tid, str)
+        prereq = entry.get("prerequisiteTestCaseId")
+        if prereq is not None:
+            assert isinstance(prereq, str) and prereq.strip()
+            assert prereq in prior_ids, (
+                f"tests[{index}].prerequisiteTestCaseId {prereq!r} must refer to an earlier test"
+            )
+        prior_ids.add(tid)
+
+
+def test_all_yaml_files_under_firebase_apptesting_parse() -> None:
+    if not TEST_SUITE_DIR.is_dir():
+        pytest.skip("firebase-apptesting/tests not present")
+
+    for path in sorted(TEST_SUITE_DIR.rglob("*.yaml")):
+        _load(path)
+    for path in sorted(TEST_SUITE_DIR.rglob("*.yml")):
+        _load(path)


### PR DESCRIPTION
## Summary
Implements [Firebase App Testing agent (Android)](https://firebase.google.com/docs/app-distribution/android/app-testing-agent): versioned YAML under `firebase-apptesting/tests/`, runner `scripts/ci_firebase_apptesting_execute.sh`, and manual `.github/workflows/firebase-app-testing-agent.yml` (`workflow_dispatch`).

## Evidence
- `python3.11 -m pytest scripts/tests/test_firebase_apptesting_yaml.py scripts/tests/test_workflow_security_contracts.py::test_workflow_inputs_are_not_interpolated_inside_run_blocks -q` → 4 passed (local).

## Notes
- **Console:** Opt in to the App Testing agent preview under Firebase Console → App Distribution (see `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md`).
- **Budget:** Preview includes documented free quota; monitor Test Lab usage against the repo spend cap.
- **CI:** `PyYAML==6.0.2` added to the Python Script Tests job for YAML contract tests.

Made with [Cursor](https://cursor.com)