### PR TITLE
fix(firebase): apptesting CLI project binding + GCP troubleshooting doc

### DIFF
--- a/.claude/skills/firebase-ops.md
+++ b/.claude/skills/firebase-ops.md
@@ -63,7 +63,7 @@ bq query --use_legacy_sql=false \
 
 ### App Testing agent (Android, preview)
 
-AI-guided tests via App Distribution + Test Lab devices. Canonical doc: `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` (App Testing agent section). In-repo YAML: `firebase-apptesting/tests/`. Manual CI: `.github/workflows/firebase-app-testing-agent.yml`. Runner script: `scripts/ci_firebase_apptesting_execute.sh`.
+AI-guided tests via App Distribution + Test Lab devices. Canonical doc: `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` (App Testing agent section + troubleshooting). In-repo YAML: `firebase-apptesting/tests/`. Manual CI: `.github/workflows/firebase-app-testing-agent.yml`. Runner: `scripts/ci_firebase_apptesting_execute.sh` (uses `firebase --non-interactive -P <project_id from SA>`). If execution fails after upload, enable **Cloud Testing** + **Tool Results** APIs and grant **`roles/cloudtestservice.testAdmin`** to the CI service account (see doc).
 
 ### Automated Crash Check (CI)
 

--- a/.github/workflows/firebase-app-testing-agent.yml
+++ b/.github/workflows/firebase-app-testing-agent.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: "model=panther,version=33,locale=en,orientation=portrait"
+      debug_firebase_cli:
+        description: "Verbose firebase --debug (may log tokenized URLs; use only when diagnosing failures)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: firebase-app-testing-agent-${{ github.run_id }}
@@ -131,11 +136,15 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           FIREBASE_APP_TESTING_DEVICES: ${{ inputs.test_devices }}
           TEST_NON_BLOCKING: ${{ inputs.test_non_blocking }}
+          FIREBASE_APPTESTING_DEBUG: ${{ inputs.debug_firebase_cli }}
         run: |
           set -euo pipefail
           EXTRA_FLAGS=()
           if [ "$TEST_NON_BLOCKING" = "true" ]; then
             EXTRA_FLAGS+=(--non-blocking)
+          fi
+          if [ "$FIREBASE_APPTESTING_DEBUG" = "true" ]; then
+            EXTRA_FLAGS+=(--debug)
           fi
           bash scripts/ci_firebase_apptesting_execute.sh \
             --test-devices "$FIREBASE_APP_TESTING_DEVICES" \
@@ -149,11 +158,15 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           FIREBASE_APP_TESTING_DEVICES: ${{ inputs.test_devices }}
           TEST_NON_BLOCKING: ${{ inputs.test_non_blocking }}
+          FIREBASE_APPTESTING_DEBUG: ${{ inputs.debug_firebase_cli }}
         run: |
           set -euo pipefail
           EXTRA_FLAGS=()
           if [ "$TEST_NON_BLOCKING" = "true" ]; then
             EXTRA_FLAGS+=(--non-blocking)
+          fi
+          if [ "$FIREBASE_APPTESTING_DEBUG" = "true" ]; then
+            EXTRA_FLAGS+=(--debug)
           fi
           bash scripts/ci_firebase_apptesting_execute.sh \
             --test-devices "$FIREBASE_APP_TESTING_DEVICES" \

--- a/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
+++ b/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
@@ -146,6 +146,24 @@ bash scripts/ci_firebase_apptesting_execute.sh --apk native-android/app/build/ou
 
 **Quota / budget:** During preview, Firebase documents a **default free quota** (e.g. 200 agent tests per project per month); multi-device runs multiply usage. Stay within the repo **$20/month external spend** mandate for any paid Test Lab overages beyond preview allowances.
 
+### If `firebase apptesting:execute` fails after upload (“Failed to request test execution”)
+
+Upload uses **App Distribution** APIs; execution uses **Cloud Testing / Test Lab** infrastructure. A green upload followed by this failure almost always means **APIs disabled** and/or **IAM missing Test Lab permissions** on the **same** GCP project as `FIREBASE_SERVICE_ACCOUNT_JSON` → `project_id` (for `random-timer-dist-new`, that is the App Distribution backend project).
+
+**1. Enable required Google Cloud APIs** (GCP Console → APIs & Library, project = service account `project_id`):
+
+- [Google Cloud Testing API](https://console.cloud.google.com/apis/library/testing.googleapis.com?project=random-timer-dist-new) (`testing.googleapis.com`)
+- [Google Cloud Tool Results API](https://console.cloud.google.com/apis/library/toolresults.googleapis.com?project=random-timer-dist-new) (`toolresults.googleapis.com`)
+
+**2. Grant IAM on the CI service account** (`client_email` in `FIREBASE_SERVICE_ACCOUNT_JSON`), same GCP project:
+
+- **`Firebase Test Lab Admin`** — role id `roles/cloudtestservice.testAdmin` (creates/runs test matrices).
+- Keep **`Firebase App Distribution Admin`** (or equivalent) for uploads.
+
+**3. Repo automation fixes (already in tree):** `scripts/ci_firebase_apptesting_execute.sh` runs `firebase --non-interactive -P <project_id from SA>` so the CLI is bound to the same project as credentials. For raw HTTP errors, re-run the GitHub workflow with **`debug_firebase_cli: true`** (prints `firebase --debug`; **do not** paste logs that contain signed download URLs publicly).
+
+**4. Billing:** If enabling APIs requires an active billing account, attach billing for that GCP project (still subject to the repo external-spend cap for anything beyond preview/free allowances).
+
 ## Change Rules
 
 When touching Android Firebase infrastructure:

--- a/scripts/ci_firebase_apptesting_execute.sh
+++ b/scripts/ci_firebase_apptesting_execute.sh
@@ -11,20 +11,23 @@ APK_PATH=""
 TEST_DIR="$TEST_DIR_DEFAULT"
 TEST_DEVICES="${FIREBASE_APP_TESTING_DEVICES:-model=panther,version=33,locale=en,orientation=portrait}"
 NON_BLOCKING=0
+DEBUG_CLI=0
 
 usage() {
   cat <<'USAGE'
-Usage: ci_firebase_apptesting_execute.sh [--apk PATH] [--test-dir DIR] [--test-devices SPEC] [--non-blocking]
+Usage: ci_firebase_apptesting_execute.sh [--apk PATH] [--test-dir DIR] [--test-devices SPEC] [--non-blocking] [--debug]
 
   --apk             Path to release/debug APK (omit to use latest App Distribution release for --app)
-  --test-dir        Directory of agent YAML suites (default: firebase-apptesting/tests)
-  --test-devices    Semicolon-separated Test Lab device specs (default: env FIREBASE_APP_TESTING_DEVICES or Pixel-class preset)
+  --test-dir        Directory where agent YAML suites live (default: firebase-apptesting/tests)
+  --test-devices    Semicolon-separated Test Lab device specs (default: env FIREBASE_APP_TESTING_DEVICES or preset)
   --non-blocking    Pass --test-non-blocking to firebase CLI (exit before agent finishes)
+  --debug           Pass --debug to firebase CLI (verbose; may log sensitive URLs — use only when diagnosing failures)
 
 Environment:
   FIREBASE_ANDROID_APP_ID          Required Firebase Android app id
   FIREBASE_SERVICE_ACCOUNT_JSON    Service account JSON body (written to temp file for ADC)
   GOOGLE_APPLICATION_CREDENTIALS   Optional; if set, FIREBASE_SERVICE_ACCOUNT_JSON is ignored
+  FIREBASE_APPTESTING_DEBUG        If set to "true", same as --debug (for CI wiring without argv changes)
 USAGE
 }
 
@@ -46,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       NON_BLOCKING=1
       shift
       ;;
+    --debug)
+      DEBUG_CLI=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -58,6 +65,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ "${FIREBASE_APPTESTING_DEBUG:-}" == "true" ]]; then
+  DEBUG_CLI=1
+fi
+
 if [[ -z "${FIREBASE_ANDROID_APP_ID:-}" ]]; then
   echo "❌ FIREBASE_ANDROID_APP_ID is not set" >&2
   exit 1
@@ -68,6 +79,7 @@ if [[ ! -d "$TEST_DIR" ]]; then
   exit 1
 fi
 
+CREDS_FILE=""
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   if [[ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
     echo "❌ GOOGLE_APPLICATION_CREDENTIALS is not a file: $GOOGLE_APPLICATION_CREDENTIALS" >&2
@@ -89,6 +101,22 @@ if ! command -v firebase >/dev/null 2>&1; then
   exit 1
 fi
 
+# Bind CLI + ADC to the same GCP project as the service account (fixes "Requesting test execution"
+# failures when the default Firebase project is unset or mismatched vs App Distribution).
+FIREBASE_CLI_PROJECT=""
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  FIREBASE_CLI_PROJECT="$(
+    python3 -c 'import json,sys; print(json.load(open(sys.argv[1],encoding="utf-8"))["project_id"])' \
+      "$GOOGLE_APPLICATION_CREDENTIALS"
+  )"
+fi
+if [[ -z "$FIREBASE_CLI_PROJECT" ]]; then
+  echo "❌ Could not read project_id from service account JSON" >&2
+  exit 1
+fi
+export GOOGLE_CLOUD_PROJECT="$FIREBASE_CLI_PROJECT"
+export GCLOUD_PROJECT="$FIREBASE_CLI_PROJECT"
+
 ARGS=(
   apptesting:execute
   "--app=$FIREBASE_ANDROID_APP_ID"
@@ -108,5 +136,11 @@ if [[ -n "$APK_PATH" ]]; then
   ARGS+=("$APK_PATH")
 fi
 
-echo "Running: firebase ${ARGS[*]}"
-firebase "${ARGS[@]}"
+FB=(firebase --non-interactive -P "$FIREBASE_CLI_PROJECT")
+if [[ "$DEBUG_CLI" -eq 1 ]]; then
+  FB+=(--debug)
+fi
+FB+=("${ARGS[@]}")
+
+echo "Running: ${FB[*]}"
+"${FB[@]}"

--- a/scripts/tests/test_ci_firebase_apptesting_execute_cli.py
+++ b/scripts/tests/test_ci_firebase_apptesting_execute_cli.py
@@ -1,0 +1,42 @@
+"""Smoke tests for scripts/ci_firebase_apptesting_execute.sh (no Firebase network calls)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ci_firebase_apptesting_execute.sh"
+
+
+def test_ci_firebase_apptesting_execute_help_exits_zero() -> None:
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Usage:" in proc.stdout
+
+
+def test_ci_firebase_apptesting_execute_requires_firebase_app_id(tmp_path: Path) -> None:
+    sa_path = tmp_path / "sa.json"
+    sa_path.write_text(json.dumps({"project_id": "unit-test-project-only"}), encoding="utf-8")
+
+    env = os.environ.copy()
+    env["GOOGLE_APPLICATION_CREDENTIALS"] = str(sa_path)
+    env.pop("FIREBASE_ANDROID_APP_ID", None)
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--apk", str(tmp_path / "missing.apk")],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == 1
+    assert "FIREBASE_ANDROID_APP_ID" in proc.stderr


### PR DESCRIPTION
## Problem
`firebase apptesting:execute` uploaded the APK then failed at **Requesting test execution** — upload (App Distribution) and execution (Cloud Testing) use different backend requirements.

## Repo changes
- **Script:** Read `project_id` from the service account JSON, export `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT`, and invoke `firebase --non-interactive -P <project_id> apptesting:execute ...` so the CLI is not guessing the wrong Firebase/GCP project.
- **Workflow:** New `debug_firebase_cli` input → passes `--debug` when diagnosing IAM/API errors (verbose; do not paste logs with signed URLs).
- **Docs:** `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` — exact API library links + `roles/cloudtestservice.testAdmin` + billing note.
- **Tests:** Shell smoke tests for `--help` and missing `FIREBASE_ANDROID_APP_ID`.

## Evidence (local)
`bash -n scripts/ci_firebase_apptesting_execute.sh` and `pytest scripts/tests/test_ci_firebase_apptesting_execute_cli.py scripts/tests/test_firebase_apptesting_yaml.py ...` → **6 passed**.

## Still required in GCP (cannot be done from git alone)
If execution still fails after merge, enable **Cloud Testing** + **Tool Results** APIs and grant **Firebase Test Lab Admin** (`roles/cloudtestservice.testAdmin`) to the App Distribution CI service account — see the doc section added in this PR.

Made with [Cursor](https://cursor.com)