### PR TITLE
docs(firebase): App Testing 403 — App Distribution vs Test Lab

### DIFF
--- a/.claude/skills/firebase-ops.md
+++ b/.claude/skills/firebase-ops.md
@@ -63,7 +63,7 @@ bq query --use_legacy_sql=false \
 
 ### App Testing agent (Android, preview)
 
-AI-guided tests via App Distribution + Test Lab devices. Canonical doc: `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` (App Testing agent section + troubleshooting). In-repo YAML: `firebase-apptesting/tests/`. Manual CI: `.github/workflows/firebase-app-testing-agent.yml`. Runner: `scripts/ci_firebase_apptesting_execute.sh` (uses `firebase --non-interactive -P <project_id from SA>`). If execution fails after upload, enable **Cloud Testing** + **Tool Results** APIs and grant **`roles/cloudtestservice.testAdmin`** to the CI service account (see doc).
+AI-guided tests via App Distribution + Test Lab devices. Canonical doc: `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` (App Testing agent section + troubleshooting). In-repo YAML: `firebase-apptesting/tests/`. Manual CI: `.github/workflows/firebase-app-testing-agent.yml`. Runner: `scripts/ci_firebase_apptesting_execute.sh` (uses `firebase --non-interactive -P <project_id from SA>`). If upload succeeds but **`createReleaseTest`** returns **403** on **`firebaseappdistribution.googleapis.com`**, grant **`roles/firebaseappdistro.admin`** to the CI SA (not a upload-only custom role). If the failure is on **Test Lab**, enable **Cloud Testing** + **Tool Results** APIs and grant **`roles/cloudtestservice.testAdmin`** (see doc).
 
 ### Automated Crash Check (CI)
 

--- a/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
+++ b/docs/FIREBASE_ANDROID_INFRASTRUCTURE.md
@@ -148,21 +148,39 @@ bash scripts/ci_firebase_apptesting_execute.sh --apk native-android/app/build/ou
 
 ### If `firebase apptesting:execute` fails after upload (“Failed to request test execution”)
 
-Upload uses **App Distribution** APIs; execution uses **Cloud Testing / Test Lab** infrastructure. A green upload followed by this failure almost always means **APIs disabled** and/or **IAM missing Test Lab permissions** on the **same** GCP project as `FIREBASE_SERVICE_ACCOUNT_JSON` → `project_id` (for `random-timer-dist-new`, that is the App Distribution backend project).
+There are **two** different backends involved. Use `firebase --debug` (or the workflow input **`debug_firebase_cli`**) to see which RPC returns `403`.
 
-**1. Enable required Google Cloud APIs** (GCP Console → APIs & Library, project = service account `project_id`):
+#### A) `403` on `firebaseappdistribution.googleapis.com` … `createReleaseTest` (v1alpha **tests**)
+
+The CLI uploads the binary with **App Distribution** “release” permissions, then calls **App Distribution App Testing** (`…/releases/…/tests`, `createReleaseTest`). A **narrow** custom role that only allows `firebaseappdistro.releases.update` (upload) is **not** enough: the caller must be allowed to **create release tests** on that API surface.
+
+**Fix (recommended):** On the **same GCP project** as the service account’s `project_id` (e.g. `random-timer-dist-new`), grant the CI principal (**`client_email`** in `FIREBASE_SERVICE_ACCOUNT_JSON`) the predefined role:
+
+- **`Firebase App Distribution Admin`** — IAM id **`roles/firebaseappdistro.admin`**  
+  ([Google Cloud role doc](https://cloud.google.com/iam/docs/roles-permissions/firebaseappdistro#firebaseappdistro.admin))
+
+In **GCP Console → IAM**, confirm the role is listed **by that exact name/id**, not only “Firebase App Tester” / a home-grown role with partial `firebaseappdistro.*` permissions.
+
+If `roles/firebaseappdistro.admin` is already present and `403` persists, try adding **`Firebase Quality Admin`** — **`roles/firebase.qualityAdmin`** (broader quality surface; use only if your org policy allows). After any IAM change, wait **1–3 minutes** and retry.
+
+#### B) `403` / `SERVICE_DISABLED` on **Cloud Testing** / **Test Lab** (`testing.googleapis.com`)
+
+Agent runs still need Test Lab infrastructure enabled and authorized:
+
+**1. Enable APIs** (APIs & Library, project = service account `project_id`):
 
 - [Google Cloud Testing API](https://console.cloud.google.com/apis/library/testing.googleapis.com?project=random-timer-dist-new) (`testing.googleapis.com`)
 - [Google Cloud Tool Results API](https://console.cloud.google.com/apis/library/toolresults.googleapis.com?project=random-timer-dist-new) (`toolresults.googleapis.com`)
 
-**2. Grant IAM on the CI service account** (`client_email` in `FIREBASE_SERVICE_ACCOUNT_JSON`), same GCP project:
+**2. IAM for Test Lab matrices:** **`Firebase Test Lab Admin`** — **`roles/cloudtestservice.testAdmin`**.
 
-- **`Firebase Test Lab Admin`** — role id `roles/cloudtestservice.testAdmin` (creates/runs test matrices).
-- Keep **`Firebase App Distribution Admin`** (or equivalent) for uploads.
+#### C) Repo / CI aids (already in tree)
 
-**3. Repo automation fixes (already in tree):** `scripts/ci_firebase_apptesting_execute.sh` runs `firebase --non-interactive -P <project_id from SA>` so the CLI is bound to the same project as credentials. For raw HTTP errors, re-run the GitHub workflow with **`debug_firebase_cli: true`** (prints `firebase --debug`; **do not** paste logs that contain signed download URLs publicly).
+`scripts/ci_firebase_apptesting_execute.sh` runs `firebase --non-interactive -P <project_id from SA>`. Re-run `.github/workflows/firebase-app-testing-agent.yml` with **`debug_firebase_cli: true`** when diagnosing; **do not** paste logs that contain signed binary download URLs.
 
-**4. Billing:** If enabling APIs requires an active billing account, attach billing for that GCP project (still subject to the repo external-spend cap for anything beyond preview/free allowances).
+#### D) Billing
+
+If enabling APIs requires billing, attach it for that GCP project (still subject to the repo external-spend cap for anything beyond preview/free allowances).
 
 ## Change Rules
 


### PR DESCRIPTION
## Summary
Updates troubleshooting for `firebase apptesting:execute` when **upload succeeds** but **`createReleaseTest`** returns **403** on `firebaseappdistribution.googleapis.com` (v1alpha **tests**): the CI service account needs **`roles/firebaseappdistro.admin`** (not an upload-only custom role). Test Lab APIs + `roles/cloudtestservice.testAdmin` remain documented for the device-run phase.

## Evidence
Doc-only change; aligns with observed `firebase --debug` failure mode (App Distribution tests RPC, not `testing.googleapis.com`).

Made with [Cursor](https://cursor.com)