### PR TITLE
fix(ci): align public store read-back with shipped release

### DIFF
--- a/.github/workflows/public-store-version-readback.yml
+++ b/.github/workflows/public-store-version-readback.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       expected_version:
-        description: "Expected public version for both stores. If empty, read from checked-out source."
+        description: "Expected public version for both stores. If empty, compare to latest GitHub release tag (not repo marketing versions)."
         required: false
         default: ""
       timeout_seconds:
@@ -51,6 +51,8 @@ jobs:
           )
           if [ -n "${EXPECTED_VERSION}" ]; then
             args+=(--expected-version "${EXPECTED_VERSION}")
+          else
+            args+=(--expected-source github_latest_release)
           fi
           python scripts/verify_public_store_versions.py "${args[@]}"
 

--- a/docs/OPERATIONAL_RELIABILITY.md
+++ b/docs/OPERATIONAL_RELIABILITY.md
@@ -21,6 +21,7 @@ Every quantitative claim MUST identify:
 - Play `reviews.list` counts are **not** “public Play review totals.” Use `review_count_metric_id` in `executive_metrics.json` / `real_store_downloads` output.
 - PostHog “installs” from `Application Installed` are **not** Play Console download units. Executive PostHog scalars map to `posthog.metric_field_ids` under `metric_bundle_id` `posthog_executive_pragmatic_live_hogql_v1`.
 - Crashlytics **`fatal_events_in_window`** is **COUNT(\*)** of fatal rows in the BQ lookback window (canonical crash volume). **`fatal_events`** is the sum of crash counts in the **parsed top-issue sample** (see `metric_field_ids` — not a full-window total if many issue groups exist).
+- **Public storefront version read-back** (`scripts/verify_public_store_versions.py`): iOS uses the **iTunes public lookup** `version` field (US storefront JSON — a public proxy, not a substitute for App Store Connect internal state). Android uses a **regex on the public Play HTML** (embedded `141` payload string — a fragile listing proxy, not Play Console track truth). Default expected version for automation is the **latest GitHub release tag** so integration-branch repo versions are not mistaken for “what must be live” in the US storefront.
 
 ## 2. Evidence, not assertions
 

--- a/docs/POSTHOG_ANALYTICS.md
+++ b/docs/POSTHOG_ANALYTICS.md
@@ -4,6 +4,8 @@ This project uses PostHog as the single source of truth for product analytics on
 
 ## Runtime contract
 
+**SDK and event definitions in this repository do not prove delivery to PostHog in production.** Treat “fully wired” as verified only after a live check (PostHog Live, HogQL, or an authenticated API query) shows recent events from production builds.
+
 - iOS and Android emit the same event names and screen names.
 - Both platforms identify users with a persistent anonymous `distinct_id`.
 - Firebase Analytics collection is disabled on Android to avoid duplicated event streams.

--- a/scripts/tests/test_verify_play_public_listing.py
+++ b/scripts/tests/test_verify_play_public_listing.py
@@ -54,6 +54,7 @@ def test_verify_public_listing_requires_expected_version(monkeypatch):
     assert result.status == "PUBLIC"
     assert "public_version=1.3.17" in result.details
     assert "expected_version=1.3.17" in result.details
+    assert "android_listing_semantics=embedded_play_html_141_string_proxy" in result.details
 
 
 def test_verify_public_listing_reports_version_mismatch(monkeypatch):

--- a/scripts/tests/test_verify_public_store_versions.py
+++ b/scripts/tests/test_verify_public_store_versions.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from scripts import verify_public_store_versions as vps
 
@@ -55,6 +58,7 @@ def test_app_store_public_version_passes(monkeypatch):
     assert result.status == "PUBLIC"
     assert result.observed_version == "1.3.20"
     assert "release_date=2026-04-14T12:00:00Z" in result.details
+    assert "ios_semantics=itunes_lookup_public_version_field" in result.details
 
 
 def test_app_store_public_version_mismatch(monkeypatch):
@@ -114,3 +118,95 @@ def test_poll_until_public_times_out_without_converting_version_mismatch(monkeyp
 
     assert results[0].status == "VERSION_MISMATCH"
     assert "timed out after 0s" in results[0].details
+
+
+def test_read_github_latest_release_version_strips_v_prefix(monkeypatch):
+    monkeypatch.setattr(
+        vps.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout='{"tagName":"v1.3.21"}\n',
+            stderr="",
+        ),
+    )
+
+    assert vps.read_github_latest_release_version(Path("/tmp")) == "1.3.21"
+
+
+def test_read_github_latest_release_version_requires_gh(monkeypatch):
+    def boom(*_a, **_kw):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(vps.subprocess, "run", boom)
+
+    with pytest.raises(RuntimeError, match="gh CLI is required"):
+        vps.read_github_latest_release_version(Path("/tmp"))
+
+
+def test_resolve_expected_versions_uses_repo_sources(tmp_path: Path):
+    ios_project = tmp_path / "native-ios/RandomTimer.xcodeproj"
+    ios_project.mkdir(parents=True)
+    (ios_project / "project.pbxproj").write_text(
+        "MARKETING_VERSION = 1.3.20;\nMARKETING_VERSION = 1.3.20;\n",
+        encoding="utf-8",
+    )
+    android_dir = tmp_path / "native-android/app"
+    android_dir.mkdir(parents=True)
+    (android_dir / "build.gradle.kts").write_text('versionName = "1.3.19"\n', encoding="utf-8")
+
+    ios_e, android_e, label = vps.resolve_expected_versions(
+        platform="both",
+        expected_version="",
+        ios_expected_version="",
+        android_expected_version="",
+        expected_source="repo",
+        repo_root=tmp_path,
+    )
+
+    assert label == "repo_sources"
+    assert ios_e == "1.3.20"
+    assert android_e == "1.3.19"
+
+
+def test_resolve_expected_versions_uses_github_release(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(vps, "read_github_latest_release_version", lambda _root: "1.3.18")
+
+    ios_e, android_e, label = vps.resolve_expected_versions(
+        platform="both",
+        expected_version="",
+        ios_expected_version="",
+        android_expected_version="",
+        expected_source="github_latest_release",
+        repo_root=tmp_path,
+    )
+
+    assert label == "github_latest_release"
+    assert ios_e == "1.3.18"
+    assert android_e == "1.3.18"
+
+
+def test_resolve_expected_versions_explicit_fills_missing_from_repo(tmp_path: Path):
+    ios_project = tmp_path / "native-ios/RandomTimer.xcodeproj"
+    ios_project.mkdir(parents=True)
+    (ios_project / "project.pbxproj").write_text(
+        "MARKETING_VERSION = 9.9.9;\nMARKETING_VERSION = 9.9.9;\n",
+        encoding="utf-8",
+    )
+    android_dir = tmp_path / "native-android/app"
+    android_dir.mkdir(parents=True)
+    (android_dir / "build.gradle.kts").write_text('versionName = "8.8.8"\n', encoding="utf-8")
+
+    ios_e, android_e, label = vps.resolve_expected_versions(
+        platform="both",
+        expected_version="",
+        ios_expected_version="1.0.0",
+        android_expected_version="",
+        expected_source="github_latest_release",
+        repo_root=tmp_path,
+    )
+
+    assert label == "explicit_cli"
+    assert ios_e == "1.0.0"
+    assert android_e == "8.8.8"

--- a/scripts/verify_play_public_listing.py
+++ b/scripts/verify_play_public_listing.py
@@ -15,6 +15,10 @@ import requests
 DEFAULT_TIMEOUT = 900
 DEFAULT_POLL_INTERVAL = 60
 
+PLAY_LISTING_VERSION_SEMANTICS = (
+    "android_listing_semantics=embedded_play_html_141_string_proxy_not_Play_Console_ground_truth"
+)
+
 
 @dataclass
 class PublicListingResult:
@@ -58,6 +62,7 @@ def verify_public_listing(url: str, expected_version: str = "") -> PublicListing
         details = [f"HTTP 200 on {date_header}"]
         if observed_version:
             details.append(f"public_version={observed_version}")
+            details.append(PLAY_LISTING_VERSION_SEMANTICS)
         if expected_version:
             details.append(f"expected_version={expected_version}")
             if not observed_version:

--- a/scripts/verify_public_store_versions.py
+++ b/scripts/verify_public_store_versions.py
@@ -90,9 +90,31 @@ def read_github_latest_release_version(repo_root: Path = ROOT) -> str:
         raise RuntimeError("gh release view returned empty tagName (no GitHub release?)")
 
     version = tag[1:] if tag.startswith("v") else tag
-    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+)+", version):
+    if not re.fullmatch(r"\d+(?:\.\d+)+", version):
         raise RuntimeError(f"Unexpected release tag format: {tag!r} -> {version!r}")
     return version
+
+
+def _fill_missing_expected_from_repo(
+    platform: str, ios: str, android: str, repo_root: Path
+) -> tuple[str, str]:
+    if platform in {"ios", "both"} and not ios:
+        ios = read_ios_version(repo_root)
+    if platform in {"android", "both"} and not android:
+        android = read_android_version(repo_root)
+    return ios, android
+
+
+def _expected_from_repo_sources(platform: str, repo_root: Path) -> tuple[str, str]:
+    ios = read_ios_version(repo_root) if platform in {"ios", "both"} else ""
+    android = read_android_version(repo_root) if platform in {"android", "both"} else ""
+    return ios, android
+
+
+def _expected_from_shared_release(platform: str, shared: str) -> tuple[str, str]:
+    ios = shared if platform in {"ios", "both"} else ""
+    android = shared if platform in {"android", "both"} else ""
+    return ios, android
 
 
 def resolve_expected_versions(
@@ -110,25 +132,15 @@ def resolve_expected_versions(
     explicit_any = bool(expected_version or ios_expected_version or android_expected_version)
 
     if explicit_any:
-        label = "explicit_cli"
-        if platform in {"ios", "both"} and not ios:
-            ios = read_ios_version(repo_root)
-        if platform in {"android", "both"} and not android:
-            android = read_android_version(repo_root)
-        return ios, android, label
+        ios, android = _fill_missing_expected_from_repo(platform, ios, android, repo_root)
+        return ios, android, "explicit_cli"
 
     if expected_source == "repo":
-        if platform in {"ios", "both"}:
-            ios = read_ios_version(repo_root)
-        if platform in {"android", "both"}:
-            android = read_android_version(repo_root)
+        ios, android = _expected_from_repo_sources(platform, repo_root)
         return ios, android, "repo_sources"
 
     shared = read_github_latest_release_version(repo_root)
-    if platform in {"ios", "both"}:
-        ios = shared
-    if platform in {"android", "both"}:
-        android = shared
+    ios, android = _expected_from_shared_release(platform, shared)
     return ios, android, "github_latest_release"
 
 

--- a/scripts/verify_public_store_versions.py
+++ b/scripts/verify_public_store_versions.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-"""Verify public App Store and Google Play versions by storefront read-back."""
+"""Verify public App Store and Google Play versions by storefront read-back.
+
+Expected versions default to the **latest GitHub release tag** (not repo marketing
+versions on integration branches). Override with ``--expected-version`` or
+``--expected-source repo`` when comparing storefronts to checked-out sources.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
 import re
+import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -56,6 +62,74 @@ def read_android_version(repo_root: Path = ROOT) -> str:
     if not match:
         raise RuntimeError(f"Could not read versionName from {gradle}")
     return match.group(1)
+
+
+def read_github_latest_release_version(repo_root: Path = ROOT) -> str:
+    """Return X.Y.Z from ``gh release view`` for the repo at ``repo_root``."""
+    try:
+        proc = subprocess.run(
+            ["gh", "release", "view", "--json", "tagName"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "gh CLI is required for --expected-source github_latest_release "
+            "(install GitHub CLI and authenticate, e.g. gh auth login)"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        err = (exc.stderr or exc.stdout or "").strip() or str(exc)
+        raise RuntimeError(f"gh release view failed: {err}") from exc
+
+    data = json.loads(proc.stdout)
+    tag = str(data.get("tagName") or "").strip()
+    if not tag:
+        raise RuntimeError("gh release view returned empty tagName (no GitHub release?)")
+
+    version = tag[1:] if tag.startswith("v") else tag
+    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+)+", version):
+        raise RuntimeError(f"Unexpected release tag format: {tag!r} -> {version!r}")
+    return version
+
+
+def resolve_expected_versions(
+    *,
+    platform: str,
+    expected_version: str,
+    ios_expected_version: str,
+    android_expected_version: str,
+    expected_source: str,
+    repo_root: Path,
+) -> tuple[str, str, str]:
+    """Return (ios_expected, android_expected, evidence_label)."""
+    ios = ios_expected_version or expected_version
+    android = android_expected_version or expected_version
+    explicit_any = bool(expected_version or ios_expected_version or android_expected_version)
+
+    if explicit_any:
+        label = "explicit_cli"
+        if platform in {"ios", "both"} and not ios:
+            ios = read_ios_version(repo_root)
+        if platform in {"android", "both"} and not android:
+            android = read_android_version(repo_root)
+        return ios, android, label
+
+    if expected_source == "repo":
+        if platform in {"ios", "both"}:
+            ios = read_ios_version(repo_root)
+        if platform in {"android", "both"}:
+            android = read_android_version(repo_root)
+        return ios, android, "repo_sources"
+
+    shared = read_github_latest_release_version(repo_root)
+    if platform in {"ios", "both"}:
+        ios = shared
+    if platform in {"android", "both"}:
+        android = shared
+    return ios, android, "github_latest_release"
 
 
 def build_app_store_lookup_url(app_id: str, country: str) -> str:
@@ -110,7 +184,10 @@ def verify_app_store_public_version(
     item = results[0]
     observed = str(item.get("version") or "")
     release_date = str(item.get("currentVersionReleaseDate") or "unknown")
-    details = f"HTTP 200 on {date_header} public_version={observed} release_date={release_date}"
+    details = (
+        f"HTTP 200 on {date_header} public_version={observed} release_date={release_date} "
+        "ios_semantics=itunes_lookup_public_version_field_not_App_Store_Connect_ground_truth"
+    )
     if observed != expected_version:
         return StoreVersionResult(
             "ios",
@@ -182,9 +259,10 @@ def poll_until_public(
         time.sleep(min(poll_interval, max(0, remaining)))
 
 
-def print_results(results: list[StoreVersionResult]) -> bool:
+def print_results(results: list[StoreVersionResult], expected_source_label: str) -> bool:
     print()
     print("== Public Store Version Read-Back ==")
+    print(f"expected_source: {expected_source_label}")
     all_passed = True
     for item in results:
         marker = "PASS" if item.passed else "FAIL"
@@ -205,6 +283,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-version", default="", help="Expected public version for both stores")
     parser.add_argument("--ios-expected-version", default="", help="Override expected iOS version")
     parser.add_argument("--android-expected-version", default="", help="Override expected Android version")
+    parser.add_argument(
+        "--expected-source",
+        choices=["github_latest_release", "repo"],
+        default="github_latest_release",
+        help=(
+            "Where to read expected versions when --expected-version is not set: "
+            "latest GitHub release tag (default) or native repo versionName/MARKETING_VERSION."
+        ),
+    )
     parser.add_argument("--ios-app-id", default=DEFAULT_IOS_APP_ID)
     parser.add_argument("--android-package", default=DEFAULT_ANDROID_PACKAGE)
     parser.add_argument("--country", default=DEFAULT_COUNTRY)
@@ -216,13 +303,14 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    ios_expected = args.ios_expected_version or args.expected_version
-    android_expected = args.android_expected_version or args.expected_version
-
-    if args.platform in {"ios", "both"} and not ios_expected:
-        ios_expected = read_ios_version()
-    if args.platform in {"android", "both"} and not android_expected:
-        android_expected = read_android_version()
+    ios_expected, android_expected, expected_source_label = resolve_expected_versions(
+        platform=args.platform,
+        expected_version=args.expected_version,
+        ios_expected_version=args.ios_expected_version,
+        android_expected_version=args.android_expected_version,
+        expected_source=args.expected_source,
+        repo_root=ROOT,
+    )
 
     def verify_once() -> list[StoreVersionResult]:
         checks: list[StoreVersionResult] = []
@@ -245,11 +333,19 @@ def main() -> int:
         return checks
 
     results = poll_until_public(verify_once, args.timeout, args.poll_interval)
-    passed = print_results(results)
+    passed = print_results(results, expected_source_label)
 
     if args.json_out:
         Path(args.json_out).write_text(
-            json.dumps({"passed": passed, "results": [asdict(item) for item in results]}, indent=2) + "\n",
+            json.dumps(
+                {
+                    "passed": passed,
+                    "expected_source": expected_source_label,
+                    "results": [asdict(item) for item in results],
+                },
+                indent=2,
+            )
+            + "\n",
             encoding="utf-8",
         )
 


### PR DESCRIPTION
## Summary

Public US storefront checks were compared to **repo** `versionName` / `MARKETING_VERSION`, so runs on `develop` ahead of the store falsely reported failure (e.g. expecting 1.3.22 while iTunes still shows 1.3.21).

## Changes

- **Default expected version** for `verify_public_store_versions.py`: latest **GitHub release tag** via `gh release view` (`--expected-source github_latest_release`, overridable with `--expected-source repo` or explicit `--expected-version`).
- **Evidence strings**: iTunes lookup and Play HTML `141` extractor labeled as **proxies**, not console ground truth.
- **Workflow**: when dispatch input is empty, pass `--expected-source github_latest_release`; input description updated.
- **Docs**: `OPERATIONAL_RELIABILITY.md` storefront semantics; `POSTHOG_ANALYTICS.md` states SDK in-repo ≠ verified production delivery.

## Verification

```bash
python3.12 -m pytest scripts/tests/test_verify_public_store_versions.py scripts/tests/test_verify_play_public_listing.py -q
```

20 passed.

Made with [Cursor](https://cursor.com)