### PR TITLE
fix(ui): align Sound Arsenal Pro lock with other Pro chips

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Card
@@ -850,22 +849,32 @@ fun TimerSetupScreen(
                             )
 
                             if (!isPro) {
-                                IconButton(
+                                Surface(
                                     onClick = {
                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         onUpgradeTap("pro_sounds")
                                     },
+                                    shape = RoundedCornerShape(4.dp),
+                                    color = TimerColors.AccentPrimary.copy(alpha = 0.1f),
                                     modifier =
-                                        Modifier
-                                            .size(28.dp)
-                                            .semantics { contentDescription = "Unlock Sound Arsenal" },
+                                        Modifier.semantics { contentDescription = "Unlock Sound Arsenal" },
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Filled.Lock,
-                                        contentDescription = null,
-                                        tint = TimerColors.TextMuted,
-                                        modifier = Modifier.size(14.dp),
-                                    )
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            text = "PRO ",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            fontWeight = FontWeight.Bold,
+                                            color = TimerColors.AccentPrimary,
+                                        )
+                                        Text(
+                                            text = "\uD83D\uDD12",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = TimerColors.AccentPrimary,
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -353,9 +353,16 @@ struct TimerSetupScreen: View {
                         Button {
                             presentPaywall(entryPoint: .soundGate)
                         } label: {
-                            Image(systemName: "lock.fill")
-                                .font(.caption2)
-                                .foregroundColor(.textMuted)
+                            HStack(spacing: 4) {
+                                Text("PRO")
+                                Image(systemName: "lock.fill")
+                            }
+                            .font(.caption2.weight(.bold))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.accentPrimary.opacity(0.1))
+                            .foregroundColor(.accentPrimary)
+                            .cornerRadius(4)
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel("Unlock Sound Arsenal")

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -216,7 +216,7 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert "Preview Sounds" in android_setup
     assert "Preview Sounds" in ios_setup
     assert 'contentDescription = "Unlock Sound Arsenal"' in android_setup
-    assert "Icons.Filled.Lock" in android_setup
+    assert 'onUpgradeTap("pro_sounds")' in android_setup
     assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     android_paywall_norm = _android_paywall_em_dash_normalized(android_paywall)
     for expected in (


### PR DESCRIPTION
Sound Arsenal used a different Pro affordance than Voice Callouts and Repeat Loop (standalone lock vs PRO chip). This PR matches the existing chip pattern on iOS and Android and updates the parity test that previously required `Icons.Filled.Lock` for Sound Arsenal.

Made with [Cursor](https://cursor.com)