### PR TITLE
fix(voice): first command at 30s; elapsed only on full minutes

### DIFF
--- a/content/pro_audio/runtime/latest.json
+++ b/content/pro_audio/runtime/latest.json
@@ -12,39 +12,9 @@
     "fallbackCommandFilename": "cmd_move_with_a_purpose",
     "elapsedCues": [
       {
-        "second": 15,
-        "filename": "elapsed_15s",
-        "text": "Fifteen seconds elapsed. Move with a purpose."
-      },
-      {
-        "second": 30,
-        "filename": "elapsed_30s",
-        "text": "Thirty seconds elapsed. Stay locked in."
-      },
-      {
-        "second": 45,
-        "filename": "elapsed_45s",
-        "text": "Forty-five seconds elapsed. Keep your bearing."
-      },
-      {
         "second": 60,
         "filename": "elapsed_60s",
         "text": "One minute elapsed. Keep pressure on."
-      },
-      {
-        "second": 75,
-        "filename": "elapsed_75s",
-        "text": "One minute fifteen elapsed. No hesitation. Move."
-      },
-      {
-        "second": 90,
-        "filename": "elapsed_90s",
-        "text": "One minute thirty elapsed. Stay disciplined."
-      },
-      {
-        "second": 105,
-        "filename": "elapsed_105s",
-        "text": "One minute forty-five elapsed. Breathe and press."
       },
       {
         "second": 120,
@@ -52,19 +22,9 @@
         "text": "Two minutes elapsed. Pick it up."
       },
       {
-        "second": 150,
-        "filename": "elapsed_150s",
-        "text": "Two minutes thirty elapsed. Stay sharp and keep driving."
-      },
-      {
         "second": 180,
         "filename": "elapsed_180s",
         "text": "Three minutes elapsed. Sound off and move."
-      },
-      {
-        "second": 210,
-        "filename": "elapsed_210s",
-        "text": "Three minutes thirty elapsed. Do not coast."
       },
       {
         "second": 240,

--- a/native-android/app/src/main/assets/voice_callouts.json
+++ b/native-android/app/src/main/assets/voice_callouts.json
@@ -6,19 +6,9 @@
   "fallbackCommandFilename": "cmd_move_with_a_purpose",
   "elapsedCues": [
     {
-      "second": 30,
-      "filename": "elapsed_30s",
-      "text": "Thirty seconds elapsed. Stay locked in."
-    },
-    {
       "second": 60,
       "filename": "elapsed_60s",
       "text": "One minute elapsed. Keep pressure on."
-    },
-    {
-      "second": 90,
-      "filename": "elapsed_90s",
-      "text": "One minute thirty elapsed. Stay disciplined."
     },
     {
       "second": 120,
@@ -26,19 +16,9 @@
       "text": "Two minutes elapsed. Pick it up."
     },
     {
-      "second": 150,
-      "filename": "elapsed_150s",
-      "text": "Two minutes thirty elapsed. Stay sharp and keep driving."
-    },
-    {
       "second": 180,
       "filename": "elapsed_180s",
       "text": "Three minutes elapsed. Sound off and move."
-    },
-    {
-      "second": 210,
-      "filename": "elapsed_210s",
-      "text": "Three minutes thirty elapsed. Do not coast."
     },
     {
       "second": 240,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -270,7 +270,7 @@ internal fun nextPreviewCueFilename(
 
 internal fun initialFollowupCommandCueSecond(totalDurationSeconds: Int): Int =
     when {
-        totalDurationSeconds <= 29 -> Int.MAX_VALUE
+        totalDurationSeconds <= 30 -> Int.MAX_VALUE
         else -> 30
     }
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -103,7 +103,10 @@ private val fallbackVoiceCueCatalog =
     VoiceCueCatalog(
         previewElapsed = VoiceCue(filename = "preview_elapsed", text = "Thirty seconds elapsed. Move with a purpose."),
         fallbackCommandFilename = "cmd_move_with_a_purpose",
-        elapsedCues = listOf(ElapsedVoiceCue(second = 30, filename = "elapsed_30s", text = "Thirty seconds elapsed. Move with a purpose.")),
+        elapsedCues =
+            listOf(
+                ElapsedVoiceCue(second = 60, filename = "elapsed_60s", text = "One minute elapsed. Keep pressure on."),
+            ),
         commandCues =
             listOf(
                 VoiceCue(filename = "cmd_move_with_a_purpose", text = "Move with a purpose."),
@@ -189,12 +192,19 @@ internal fun runtimeVoiceCueForElapsedSecond(
     return catalog.elapsedCueBySecond[elapsedSeconds]?.let { VoiceCue(filename = it.filename, text = it.text) }
 }
 
+/**
+ * Returns a bundled "time elapsed" announcement only on full-minute marks (60, 120, …).
+ * Sub-minute rows in JSON are ignored here so command coaching stays on its own cadence.
+ */
 internal fun runtimeVoiceCueForElapsedMark(
     elapsedSeconds: Int,
     lastElapsedMilestone: Int,
     catalog: VoiceCueCatalog,
 ): VoiceCue? {
     if (elapsedSeconds <= 0) {
+        return null
+    }
+    if (elapsedSeconds % 60 != 0) {
         return null
     }
     return runtimeVoiceCueForElapsedSecond(
@@ -261,7 +271,7 @@ internal fun nextPreviewCueFilename(
 internal fun initialFollowupCommandCueSecond(totalDurationSeconds: Int): Int =
     when {
         totalDurationSeconds <= 29 -> Int.MAX_VALUE
-        else -> 15
+        else -> 30
     }
 
 @Singleton

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
@@ -149,6 +149,8 @@ class AIVoiceCalloutManagerSelectionTest {
     fun timersAtLeastThirtySecondsScheduleFirstCommandCueAtThirtySeconds() {
         assertThat(initialFollowupCommandCueSecond(12)).isEqualTo(Int.MAX_VALUE)
         assertThat(initialFollowupCommandCueSecond(20)).isEqualTo(Int.MAX_VALUE)
+        assertThat(initialFollowupCommandCueSecond(30)).isEqualTo(Int.MAX_VALUE)
+        assertThat(initialFollowupCommandCueSecond(31)).isEqualTo(30)
         assertThat(initialFollowupCommandCueSecond(40)).isEqualTo(30)
     }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
@@ -38,7 +38,7 @@ class AIVoiceCalloutManagerSelectionTest {
         val path = Paths.get("src/main/assets/voice_callouts.json")
         val catalog = parseVoiceCalloutCatalog(path.toFile().readText())
 
-        assertThat(catalog.elapsedCues.size).isAtLeast(12)
+        assertThat(catalog.elapsedCues.size).isAtLeast(8)
         assertThat(catalog.commandCues.size).isAtLeast(20)
         assertThat(catalog.elapsedCues.all { it.text.contains("elapsed", ignoreCase = true) }).isTrue()
     }
@@ -125,7 +125,7 @@ class AIVoiceCalloutManagerSelectionTest {
     }
 
     @Test
-    fun runtimeVoiceCueForElapsedMarkReturnsConfiguredElapsedAnnouncements() {
+    fun runtimeVoiceCueForElapsedMarkReturnsOnlyFullMinuteElapsedAnnouncements() {
         val catalog =
             VoiceCueCatalog(
                 previewElapsed = VoiceCue(filename = "preview_elapsed", text = "Preview"),
@@ -140,16 +140,16 @@ class AIVoiceCalloutManagerSelectionTest {
             )
 
         assertThat(runtimeVoiceCueForElapsedMark(14, lastElapsedMilestone = 0, catalog = catalog)).isNull()
-        assertThat(runtimeVoiceCueForElapsedMark(15, lastElapsedMilestone = 0, catalog = catalog)?.filename).isEqualTo("elapsed_15s")
-        assertThat(runtimeVoiceCueForElapsedMark(30, lastElapsedMilestone = 0, catalog = catalog)?.filename).isEqualTo("elapsed_30s")
+        assertThat(runtimeVoiceCueForElapsedMark(15, lastElapsedMilestone = 0, catalog = catalog)).isNull()
+        assertThat(runtimeVoiceCueForElapsedMark(30, lastElapsedMilestone = 0, catalog = catalog)).isNull()
         assertThat(runtimeVoiceCueForElapsedMark(60, lastElapsedMilestone = 0, catalog = catalog)?.filename).isEqualTo("elapsed_60s")
     }
 
     @Test
-    fun shortTimersScheduleFollowupCommandCuesEarly() {
+    fun timersAtLeastThirtySecondsScheduleFirstCommandCueAtThirtySeconds() {
         assertThat(initialFollowupCommandCueSecond(12)).isEqualTo(Int.MAX_VALUE)
         assertThat(initialFollowupCommandCueSecond(20)).isEqualTo(Int.MAX_VALUE)
-        assertThat(initialFollowupCommandCueSecond(40)).isEqualTo(15)
+        assertThat(initialFollowupCommandCueSecond(40)).isEqualTo(30)
     }
 
     @Test

--- a/native-ios/RandomTimer/Resources/Audio/female/voice_callouts.json
+++ b/native-ios/RandomTimer/Resources/Audio/female/voice_callouts.json
@@ -6,19 +6,9 @@
   "fallbackCommandFilename": "cmd_move_with_a_purpose",
   "elapsedCues": [
     {
-      "second": 30,
-      "filename": "elapsed_30s",
-      "text": "Thirty seconds elapsed. Stay locked in."
-    },
-    {
       "second": 60,
       "filename": "elapsed_60s",
       "text": "One minute elapsed. Keep pressure on."
-    },
-    {
-      "second": 90,
-      "filename": "elapsed_90s",
-      "text": "One minute thirty elapsed. Stay disciplined."
     },
     {
       "second": 120,
@@ -26,19 +16,9 @@
       "text": "Two minutes elapsed. Pick it up."
     },
     {
-      "second": 150,
-      "filename": "elapsed_150s",
-      "text": "Two minutes thirty elapsed. Stay sharp and keep driving."
-    },
-    {
       "second": 180,
       "filename": "elapsed_180s",
       "text": "Three minutes elapsed. Sound off and move."
-    },
-    {
-      "second": 210,
-      "filename": "elapsed_210s",
-      "text": "Three minutes thirty elapsed. Do not coast."
     },
     {
       "second": 240,

--- a/native-ios/RandomTimer/Resources/Audio/voice_callouts.json
+++ b/native-ios/RandomTimer/Resources/Audio/voice_callouts.json
@@ -6,19 +6,9 @@
   "fallbackCommandFilename": "cmd_move_with_a_purpose",
   "elapsedCues": [
     {
-      "second": 30,
-      "filename": "elapsed_30s",
-      "text": "Thirty seconds elapsed. Stay locked in."
-    },
-    {
       "second": 60,
       "filename": "elapsed_60s",
       "text": "One minute elapsed. Keep pressure on."
-    },
-    {
-      "second": 90,
-      "filename": "elapsed_90s",
-      "text": "One minute thirty elapsed. Stay disciplined."
     },
     {
       "second": 120,
@@ -26,19 +16,9 @@
       "text": "Two minutes elapsed. Pick it up."
     },
     {
-      "second": 150,
-      "filename": "elapsed_150s",
-      "text": "Two minutes thirty elapsed. Stay sharp and keep driving."
-    },
-    {
       "second": 180,
       "filename": "elapsed_180s",
       "text": "Three minutes elapsed. Sound off and move."
-    },
-    {
-      "second": 210,
-      "filename": "elapsed_210s",
-      "text": "Three minutes thirty elapsed. Do not coast."
     },
     {
       "second": 240,

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -76,7 +76,7 @@ private let fallbackVoiceCueCatalog = VoiceCueCatalog(
     ),
     fallbackCommandFilename: "cmd_move_with_a_purpose",
     elapsedCues: [
-        .init(second: 30, filename: "elapsed_30s", text: "Thirty seconds elapsed. Move with a purpose.")
+        .init(second: 60, filename: "elapsed_60s", text: "One minute elapsed. Keep pressure on.")
     ],
     commandCues: [
         .init(filename: "cmd_move_with_a_purpose", text: "Move with a purpose."),
@@ -190,7 +190,7 @@ internal func initialFollowupCommandCueSecond(totalDurationSeconds: Int) -> Int 
     case ...29:
         return .max
     default:
-        return 15
+        return 30
     }
 }
 
@@ -348,8 +348,12 @@ final class AIVoiceCalloutService {
         }
     }
 
+    /// "Time elapsed" lines only on full-minute marks (60, 120, …). Other seconds use command cues only.
     private func elapsedMilestone(for elapsed: Int) -> VoiceCueCatalog.ElapsedCue? {
         let catalog = packStore.voiceCatalog(bundle: bundle)
+        guard elapsed > 0, elapsed % 60 == 0 else {
+            return nil
+        }
         guard let cue = catalog.elapsedCueBySecond[elapsed], elapsed != lastElapsedMilestone else {
             return nil
         }

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -187,7 +187,7 @@ internal func nextPreviewFilename(
 
 internal func initialFollowupCommandCueSecond(totalDurationSeconds: Int) -> Int {
     switch totalDurationSeconds {
-    case ...29:
+    case ...30:
         return .max
     default:
         return 30

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -151,9 +151,9 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
 
     func testResetSessionAllowsElapsedMilestoneToReplay() {
         let sut = makeVoiceCalloutService()
-        sut.triggerCallout(elapsedSeconds: 30)
+        sut.triggerCallout(elapsedSeconds: 60)
         sut.resetSession()
-        sut.triggerCallout(elapsedSeconds: 30)
+        sut.triggerCallout(elapsedSeconds: 60)
     }
 
     func testCommandCueScheduleDoesNotCrashAcrossLongRun() {
@@ -166,7 +166,7 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
     func testCatalogHasVarietyAndClearElapsedLanguage() {
         let catalog = loadVoiceCalloutCatalog(bundle: .main)
 
-        XCTAssertGreaterThanOrEqual(catalog.elapsedCues.count, 12)
+        XCTAssertGreaterThanOrEqual(catalog.elapsedCues.count, 8)
         XCTAssertGreaterThanOrEqual(catalog.commandCues.count, 20)
         XCTAssertTrue(
             catalog.elapsedCues.allSatisfy { $0.text.localizedCaseInsensitiveContains("elapsed") },
@@ -204,8 +204,8 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
             previewElapsed: .init(filename: "preview_elapsed", text: "Repeat me."),
             fallbackCommandFilename: "cmd_primary",
             elapsedCues: [
-                .init(second: 30, filename: "elapsed_primary", text: "Thirty elapsed."),
-                .init(second: 30, filename: "elapsed_duplicate", text: "Thirty elapsed duplicate."),
+                .init(second: 60, filename: "elapsed_primary", text: "Sixty elapsed."),
+                .init(second: 60, filename: "elapsed_duplicate", text: "Sixty elapsed duplicate."),
             ],
             commandCues: [
                 .init(filename: "cmd_primary", text: "Repeat me."),
@@ -213,7 +213,7 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(catalog.elapsedCueBySecond[30]?.filename, "elapsed_primary")
+        XCTAssertEqual(catalog.elapsedCueBySecond[60]?.filename, "elapsed_primary")
         XCTAssertEqual(catalog.filenameByText["Repeat me."], "preview_elapsed")
     }
 
@@ -240,10 +240,10 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertTrue(usedFilenames.contains("cue_c"))
     }
 
-    func testShortTimersScheduleFollowupCommandCuesEarly() {
+    func testTimersAtLeastThirtySecondsScheduleFirstCommandCueAtThirtySeconds() {
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 12), .max)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 20), .max)
-        XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 40), 15)
+        XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 40), 30)
     }
 
     func testPlaybackReactivatesAudioSessionAfterSessionBegin() {
@@ -267,31 +267,25 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         sut.triggerCallout(elapsedSeconds: 14)
         let beforeFirstCommand = sut._stateSnapshotForTesting()
         XCTAssertEqual(beforeFirstCommand.lastElapsedMilestone, 0)
-        XCTAssertEqual(beforeFirstCommand.nextCommandCueAt, 15)
+        XCTAssertEqual(beforeFirstCommand.nextCommandCueAt, 30)
         XCTAssertNil(beforeFirstCommand.lastCommandCueFilename)
-
-        sut.triggerCallout(elapsedSeconds: 15)
-        let atFifteen = sut._stateSnapshotForTesting()
-        XCTAssertEqual(atFifteen.lastElapsedMilestone, 0)
-        XCTAssertEqual(atFifteen.nextCommandCueAt, 45)
-        XCTAssertNotNil(atFifteen.lastCommandCueFilename)
 
         sut.triggerCallout(elapsedSeconds: 30)
         let atThirty = sut._stateSnapshotForTesting()
-        XCTAssertEqual(atThirty.lastElapsedMilestone, 30)
-        XCTAssertEqual(atThirty.nextCommandCueAt, 45)
+        XCTAssertEqual(atThirty.lastElapsedMilestone, 0)
+        XCTAssertEqual(atThirty.nextCommandCueAt, 60)
         XCTAssertNotNil(atThirty.lastCommandCueFilename)
 
         sut.triggerCallout(elapsedSeconds: 45)
         let atFortyFive = sut._stateSnapshotForTesting()
-        XCTAssertEqual(atFortyFive.lastElapsedMilestone, 30)
-        XCTAssertEqual(atFortyFive.nextCommandCueAt, 75)
+        XCTAssertEqual(atFortyFive.lastElapsedMilestone, 0)
+        XCTAssertEqual(atFortyFive.nextCommandCueAt, 60)
         XCTAssertNotNil(atFortyFive.lastCommandCueFilename)
 
         sut.triggerCallout(elapsedSeconds: 60)
         let atSixty = sut._stateSnapshotForTesting()
         XCTAssertEqual(atSixty.lastElapsedMilestone, 60)
-        XCTAssertEqual(atSixty.nextCommandCueAt, 75)
+        XCTAssertEqual(atSixty.nextCommandCueAt, 90)
     }
 
     func testFirstTimedCalloutReactivatesAudioSessionBeforePlayback() {

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -243,6 +243,8 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
     func testTimersAtLeastThirtySecondsScheduleFirstCommandCueAtThirtySeconds() {
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 12), .max)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 20), .max)
+        XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 30), .max)
+        XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 31), 30)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 40), 30)
     }
 

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -254,7 +254,7 @@ def test_android_elapsed_voice_cues_fire_on_configured_marks_and_commands_start_
     android_voice_manager = _read(ANDROID_VOICE_MANAGER)
 
     assert "runtimeVoiceCueForElapsedMark(elapsedSeconds, lastElapsedMilestone, catalog)?.let {" in android_voice_manager
-    assert "else -> 15" in android_voice_manager
+    assert "else -> 30" in android_voice_manager
     assert "nextCommandCueAt = elapsedSeconds + 30" in android_voice_manager
 
 

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -252,10 +252,13 @@ def test_free_sound_arsenal_taps_preview_without_forcing_ios_paywall():
 
 def test_android_elapsed_voice_cues_fire_on_configured_marks_and_commands_start_early():
     android_voice_manager = _read(ANDROID_VOICE_MANAGER)
+    ios_voice_service = _read(IOS_VOICE_SERVICE)
 
     assert "runtimeVoiceCueForElapsedMark(elapsedSeconds, lastElapsedMilestone, catalog)?.let {" in android_voice_manager
     assert "else -> 30" in android_voice_manager
     assert "nextCommandCueAt = elapsedSeconds + 30" in android_voice_manager
+    assert "totalDurationSeconds <= 30 -> Int.MAX_VALUE" in android_voice_manager
+    assert "case ...30:" in ios_voice_service
 
 
 def test_active_timer_loop_badge_shows_round_progress_on_both_platforms():

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -249,7 +249,8 @@ def test_bundled_sound_catalog_pack_id_matches_runtime_manifest():
 def test_ios_voice_catalog_has_clear_elapsed_language_and_more_variety():
     catalog = _load_ios_voice_catalog()
 
-    assert len(catalog["elapsedCues"]) >= 12
+    # Minute-only elapsed rows (60s, 120s, …); bundled list is shorter than legacy half-minute grid.
+    assert len(catalog["elapsedCues"]) >= 8
     assert len(catalog["commandCues"]) >= 20
     assert all("elapsed" in cue["text"].lower() for cue in catalog["elapsedCues"])
     assert catalog["fallbackCommandFilename"] in _ios_catalog_filenames(catalog)


### PR DESCRIPTION
## Summary
- First **command** coaching cue fires at **30s** elapsed (was 15s) on Android and iOS.
- **Time elapsed** announcements (catalog `elapsedCues`) only fire on **full-minute** marks (60, 120, …): enforced in `runtimeVoiceCueForElapsedMark` / `elapsedMilestone`, and non-minute rows removed from bundled JSON + `content/pro_audio/runtime/latest.json`.
- **Command** cues keep the existing **+30s** spacing after each command (and the existing interaction when an elapsed line plays).

## Tests
- `AIVoiceCalloutManagerSelectionTest` (Gradle)
- `AIVoiceCalloutServiceTests` (xcodebuild)
- `scripts/tests/test_mobile_feature_parity.py` assertion updated for `else -> 30`

Made with [Cursor](https://cursor.com)