### PR TITLE
fix(ci): stabilize device-tests (no mid-run cancel, longer iOS bounds)

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -5,9 +5,11 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
+# Do not cancel in-flight device jobs: iOS Maestro + Agent Device often runs 15–25+ minutes.
+# A new push would previously abort mid-flow (looks like a flake, blocks merge, wastes runner time).
 concurrency:
   group: device-tests-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   changes:
@@ -116,7 +118,7 @@ jobs:
     runs-on: macos-15
     permissions:
       contents: read
-    timeout-minutes: 35
+    timeout-minutes: 50
 
     steps:
       - uses: actions/checkout@v6
@@ -203,6 +205,7 @@ jobs:
       - name: Run iOS UI smoke tests on simulator
         env:
           SIMULATOR_UDID: ${{ steps.sim.outputs.sim_id }}
+          MAESTRO_FLOW_TIMEOUT_SECONDS: "180"
         run: bash scripts/device-tests/ci-maestro-ios.sh
 
       - name: Upload iOS device test artifacts

--- a/scripts/device-tests/ci-maestro-ios.sh
+++ b/scripts/device-tests/ci-maestro-ios.sh
@@ -13,7 +13,7 @@ MAESTRO_ARTIFACT_DIR="$NATIVE_IOS_DIR/build/maestro"
 AGENT_DEVICE_ARTIFACT_DIR="$NATIVE_IOS_DIR/build/agent-device"
 LAST_STAGE_FILE="$AGENT_DEVICE_ARTIFACT_DIR/last-stage.txt"
 IOS_BUILD_TIMEOUT_SECONDS="${IOS_BUILD_TIMEOUT_SECONDS:-900}"
-MAESTRO_FLOW_TIMEOUT_SECONDS="${MAESTRO_FLOW_TIMEOUT_SECONDS:-120}"
+MAESTRO_FLOW_TIMEOUT_SECONDS="${MAESTRO_FLOW_TIMEOUT_SECONDS:-180}"
 AGENT_DEVICE_TIMEOUT_SECONDS="${AGENT_DEVICE_TIMEOUT_SECONDS:-120}"
 AGENT_DEVICE_DIAGNOSTIC_TIMEOUT_SECONDS="${AGENT_DEVICE_DIAGNOSTIC_TIMEOUT_SECONDS:-30}"
 SIMCTL_TIMEOUT_SECONDS="${SIMCTL_TIMEOUT_SECONDS:-120}"
@@ -113,10 +113,10 @@ run_maestro_flow() {
   local flow="$2"
   local attempt
   local log_path
-  for attempt in 1 2; do
+  for attempt in 1 2 3; do
     log_path="$MAESTRO_ARTIFACT_DIR/${name}-attempt-${attempt}.log"
     record_stage "maestro ${name} attempt ${attempt}"
-    echo "Maestro ${name}: attempt ${attempt}/2"
+    echo "Maestro ${name}: attempt ${attempt}/3"
     if run_with_timeout "$MAESTRO_FLOW_TIMEOUT_SECONDS" bash -o pipefail -c \
       'maestro test -p ios --device "$1" "$2" | tee "$3"' \
       _ "$SIMULATOR_UDID" "$flow" "$log_path"; then

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -355,6 +355,7 @@ def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
     ios_script = (ROOT / "scripts/device-tests/ci-maestro-ios.sh").read_text(encoding="utf-8")
     trigger_section = source.split("concurrency:", 1)[0]
 
+    assert "cancel-in-progress: false" in source
     assert "pull_request:" in trigger_section
     assert "branches: [develop, main]" in trigger_section
     assert "paths:" not in trigger_section
@@ -378,7 +379,7 @@ def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
     assert "run_maestro_flow" in ios_script
     assert "run_with_timeout \"$IOS_BUILD_TIMEOUT_SECONDS\" xcodebuild build" in ios_script
     assert "run_with_timeout \"$MAESTRO_FLOW_TIMEOUT_SECONDS\" bash -o pipefail -c" in ios_script
-    assert "MAESTRO_FLOW_TIMEOUT_SECONDS:-120" in ios_script
+    assert "MAESTRO_FLOW_TIMEOUT_SECONDS:-180" in ios_script
     assert "xcrun simctl privacy \"$SIMULATOR_UDID\" grant notifications \"$BUNDLE_ID\"" in ios_script
     assert "xcrun simctl terminate \"$SIMULATOR_UDID\" \"$BUNDLE_ID\"" in ios_script
     assert "run_with_timeout \"$seconds\" npx -y agent-device" in ios_script


### PR DESCRIPTION
## Why CI felt unstable
- **`cancel-in-progress: true`** on `device-tests.yml` aborted in-flight **15–25+ minute** iOS Maestro runs whenever a new commit landed on the same PR → **cancelled / flaky** required checks.
- **35m job timeout** vs **xcodebuild (up to 15m)** + **5 Maestro flows** × **2 attempts** × **120s** left little slack on slow `macos-15` runners.

## Changes
- Set **`cancel-in-progress: false`** for device-tests (documented in workflow).
- **iOS job timeout** 35 → **50** minutes; **Maestro per-flow** default **120s → 180s** (workflow env + script default).
- **Maestro** retries per flow **2 → 3** attempts.

## Tests
- `test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device` (growth workflow contracts)

Made with [Cursor](https://cursor.com)