### PR TITLE
fix(ci): post-release develop bump via pull request

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -1016,7 +1016,7 @@ jobs:
             exit 0
           fi
           git checkout -b "$BRANCH"
-          git commit -m "chore: bump develop to v${NEW_VER} after ${TAG} release [skip ci]"
+          git commit -m "chore: bump develop to v${NEW_VER} after ${TAG} release"
           git push origin "HEAD:refs/heads/${BRANCH}"
           gh pr create \
             --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -969,6 +969,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -998,13 +999,29 @@ jobs:
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Bumped develop to v${NEW_VERSION}"
 
-      - name: Commit and push version bump to develop
+      - name: Open pull request for post-release develop bump
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          TAG="${{ needs.tag-release.outputs.tag }}"
+          NEW_VER="${{ steps.bump.outputs.new_version }}"
+          BRANCH="chore/post-release-bump-${TAG}-run-${{ github.run_id }}"
           git add native-android/app/build.gradle.kts \
                   native-ios/RandomTimer.xcodeproj/project.pbxproj \
                   native-android/fastlane/metadata/android/en-US/changelogs/ \
                   native-ios/fastlane/metadata/en-US/release_notes.txt
-          git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "chore: bump develop to v${{ steps.bump.outputs.new_version }} after ${{ needs.tag-release.outputs.tag }} release [skip ci]"
-          git push origin develop
-          echo "✅ develop is now at v${{ steps.bump.outputs.new_version }}"
+          if git diff --cached --quiet; then
+            echo "Nothing to commit; skipping PR"
+            exit 0
+          fi
+          git checkout -b "$BRANCH"
+          git commit -m "chore: bump develop to v${NEW_VER} after ${TAG} release [skip ci]"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+          gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: bump develop to v${NEW_VER} after ${TAG}" \
+            --body "Automated post-release version bump (branch protection blocks direct pushes to \`develop\`). Merge after required checks pass."
+          echo "✅ Opened PR to bump develop to v${NEW_VER}"

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1774900006
-        versionName = "1.3.23"
+        versionCode = ciVersionCode ?: 1774900007
+        versionName = "1.3.24"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -712,7 +712,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.23;
+				MARKETING_VERSION = 1.3.24;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.23;
+				MARKETING_VERSION = 1.3.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -822,7 +822,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.23;
+				MARKETING_VERSION = 1.3.24;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -844,7 +844,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.23;
+				MARKETING_VERSION = 1.3.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Replaces direct `git push origin develop` in `native-release.yml` `bump-develop-version` with a branch + `gh pr create`, satisfying repository rules (GH013). Adds `pull-requests: write`.

Made with [Cursor](https://cursor.com)