### PR TITLE
fix(asc): fill What's New for all App Store locales before submit

### DIFF
--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -240,6 +240,21 @@ def find_or_create_app_store_version(client: ASCClient, app_id: str, version: st
     return vid, state
 
 
+def list_app_store_version_locale_codes(client: ASCClient, version_id: str) -> list[str]:
+    """Return locale codes (e.g. en-US, ja, de-DE) that have an App Store version localization row."""
+    rows = client.get_all(
+        f"/appStoreVersions/{version_id}/appStoreVersionLocalizations",
+        params={"limit": 200},
+    )
+    codes: list[str] = []
+    for row in rows:
+        a = row.get("attributes") or {}
+        loc = (a.get("locale") or "").strip()
+        if loc:
+            codes.append(loc)
+    return sorted(set(codes))
+
+
 def get_version_localization(client: ASCClient, version_id: str, locale: str) -> dict:
     locs = client.get_all(
         f"/appStoreVersions/{version_id}/appStoreVersionLocalizations",
@@ -264,6 +279,8 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
     for field, filename in fastlane_files.items():
         if not (attrs.get(field) or "").strip():
             val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, locale, filename))
+            if field == "whatsNew" and not val and locale != "en-US":
+                val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, "en-US", filename))
             if val:
                 patch[field] = val
 
@@ -300,10 +317,15 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
             loc = refreshed
             attrs = loc.get("attributes") or {}
 
-    # whatsNew ("Release Notes") is not always editable, and is not required for all submissions.
     for field in ("description", "keywords"):
         if not (attrs.get(field) or "").strip():
             die(f"App Store version localization {locale} missing required field: {field}")
+    # App Store Connect rejects submission when any active localization has empty "What's New".
+    if not (attrs.get("whatsNew") or "").strip():
+        die(
+            f"App Store version localization {locale} missing required field: whatsNew "
+            f"(native-ios/fastlane/metadata/{locale}/release_notes.txt, or en-US fallback)"
+        )
     return loc
 
 
@@ -1115,9 +1137,19 @@ def main() -> int:
             info(f"Already submitted: {state}")
             return 0
 
-    loc = get_version_localization(client, version_id, args.locale)
-    loc_id = loc["id"]
-    loc_attrs = loc.get("attributes") or {}
+    locale_codes = list_app_store_version_locale_codes(client, version_id)
+    if not locale_codes:
+        die("No App Store version localizations found for this version.")
+    info(f"Syncing App Store version metadata for locales: {', '.join(locale_codes)}")
+    primary_loc: dict[str, Any] | None = None
+    for code in locale_codes:
+        loc = get_version_localization(client, version_id, code)
+        if code == args.locale:
+            primary_loc = loc
+    if primary_loc is None:
+        die(f"Primary locale {args.locale!r} not found in version localizations: {locale_codes}")
+    loc_id = primary_loc["id"]
+    loc_attrs = primary_loc.get("attributes") or {}
 
     # Support URL may live on App Store version localization (newer ASC API) or on App Info localization
     # (older ASC API). Accept either, but require a non-empty https:// URL.

--- a/scripts/tests/router_client.py
+++ b/scripts/tests/router_client.py
@@ -22,3 +22,11 @@ class RouterClient:
             return value()
         return value
 
+    def get_all(self, path: str, *, params=None):
+        """Match ASCClient.get_all: one GET returning data[] (optionally paginated)."""
+        data = self.request("GET", path, params=params or {})
+        if not isinstance(data, dict):
+            return []
+        chunk = data.get("data") or []
+        return chunk if isinstance(chunk, list) else []
+

--- a/scripts/tests/test_asc_submit_for_review_version_localization.py
+++ b/scripts/tests/test_asc_submit_for_review_version_localization.py
@@ -68,7 +68,8 @@ class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
     def test_get_version_localization_ignores_whats_new_state_error(self):
         import scripts.asc.asc_submit_for_review as asc
 
-        client = _FakeClient(patch_error=_WHATS_NEW_STATE_ERROR, refreshed_whats_new="")
+        # API refuses PATCH for whatsNew (STATE_ERROR), but GET read-back still shows prior text.
+        client = _FakeClient(patch_error=_WHATS_NEW_STATE_ERROR, refreshed_whats_new="Hello")
 
         with tempfile.TemporaryDirectory() as td:
             os.makedirs(os.path.join(td, "en-US"), exist_ok=True)
@@ -82,10 +83,9 @@ class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
             finally:
                 asc.FASTLANE_METADATA_DIR = prev
 
-        # Should not raise, and should not require whatsNew to be present.
         self.assertEqual((loc.get("attributes") or {}).get("description"), "desc")
         self.assertEqual((loc.get("attributes") or {}).get("keywords"), "kw")
-        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "")
+        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "Hello")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_asc_submit_multilocale.py
+++ b/scripts/tests/test_asc_submit_multilocale.py
@@ -1,0 +1,41 @@
+"""Tests for multi-locale App Store version localization listing."""
+
+import unittest
+
+from scripts.tests.router_client import RouterClient
+
+
+class AscSubmitMultilocaleTests(unittest.TestCase):
+    def test_list_app_store_version_locale_codes_returns_sorted_unique(self):
+        from scripts.asc.asc_submit_for_review import list_app_store_version_locale_codes
+
+        client = RouterClient(
+            {
+                (
+                    "GET",
+                    "/appStoreVersions/ver-1/appStoreVersionLocalizations",
+                ): {
+                    "data": [
+                        {
+                            "id": "loc-ko",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "ko"},
+                        },
+                        {
+                            "id": "loc-en",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "en-US"},
+                        },
+                        {
+                            "id": "loc-ja",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "ja"},
+                        },
+                    ],
+                    "links": {},
+                },
+            }
+        )
+
+        codes = list_app_store_version_locale_codes(client, "ver-1")
+        self.assertEqual(codes, ["en-US", "ja", "ko"])


### PR DESCRIPTION
Resolves ASC rejection when **en-US**, **ja**, **de-DE**, and **ko** had empty **What's New**: `asc_submit_for_review.py` only synced **`--locale`** (default en-US). Now lists every `appStoreVersionLocalization` for the version and applies `release_notes.txt` per locale, with **en-US fallback** for empty `whatsNew` files. Fails fast if `whatsNew` is still blank after sync.

**Tests:** `scripts/tests/test_asc_submit_multilocale.py`, updated localization test, `RouterClient.get_all`.

Made with [Cursor](https://cursor.com)