### PR TITLE
fix(ios): ASC lineage must not treat in-review as locked

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -259,7 +259,7 @@ jobs:
             echo "uploadable=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -q "blocked by closed App Store version"; then
+          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -Eq "blocked by (closed|a distribution-locked) App Store version"; then
             reason="$(printf '%s\n' "$output" | tail -n 1)"
             echo "::warning::Skipping automatic iOS TestFlight upload: $reason"
             echo "uploadable=false" >> "$GITHUB_OUTPUT"

--- a/scripts/check_ios_version_lineage.py
+++ b/scripts/check_ios_version_lineage.py
@@ -26,23 +26,19 @@ except ModuleNotFoundError:
 
 
 SEMVER_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)\s*$")
-APP_STORE_CLOSED_STATES = {
-    "ACCEPTED",
-    "APPROVED",
-    "IN_REVIEW",
-    "PENDING_APPLE_RELEASE",
-    "PENDING_DEVELOPER_RELEASE",
-    "PENDING_DEVELOPER_RELEASE_REJECTED",
-    "PENDING_RELEASE",
-    "PREORDER_READY_FOR_SALE",
-    "PROCESSING_FOR_DISTRIBUTION",
-    "READY_FOR_DISTRIBUTION",
-    "READY_FOR_SALE",
-    "REMOVED_FROM_SALE",
-    "REPLACED_WITH_NEW_VERSION",
-    "WAITING_FOR_EXPORT_COMPLIANCE",
-    "WAITING_FOR_REVIEW",
-}
+# Marketing-version "lock" only after the version is in a terminal / distribution state.
+# In-review and pre-submission trains still allow new TestFlight builds for the same
+# marketing version (Apple may reject the new binary for other reasons).
+APP_STORE_VERSION_LOCKED_STATES = frozenset(
+    {
+        "PREORDER_READY_FOR_SALE",
+        "PROCESSING_FOR_DISTRIBUTION",
+        "READY_FOR_DISTRIBUTION",
+        "READY_FOR_SALE",
+        "REMOVED_FROM_SALE",
+        "REPLACED_WITH_NEW_VERSION",
+    }
+)
 
 
 class LineageError(RuntimeError):
@@ -213,11 +209,11 @@ def evaluate_lineage(
     highest_remote_app_store_version, highest_remote_app_store_state = _highest_version_by_state(
         remote_app_store_versions
     )
-    highest_closed_app_store_version, _ = _highest_version_by_state(
+    highest_locked_app_store_version, _ = _highest_version_by_state(
         {
             version: state
             for version, state in remote_app_store_versions.items()
-            if state in APP_STORE_CLOSED_STATES
+            if state in APP_STORE_VERSION_LOCKED_STATES
         }
     )
     highest_remote_version = _highest_semver(
@@ -238,7 +234,7 @@ def evaluate_lineage(
             highest_remote_version=None,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=None,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=True,
@@ -253,7 +249,7 @@ def evaluate_lineage(
             highest_remote_version=highest_remote_version,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
@@ -264,8 +260,8 @@ def evaluate_lineage(
         )
 
     if (
-        highest_closed_app_store_version is not None
-        and _parse_semver(local_version) <= _parse_semver(highest_closed_app_store_version)
+        highest_locked_app_store_version is not None
+        and _parse_semver(local_version) <= _parse_semver(highest_locked_app_store_version)
     ):
         return LineageReport(
             bundle_id=bundle_id,
@@ -274,13 +270,13 @@ def evaluate_lineage(
             highest_remote_version=highest_remote_version,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
             reason=(
-                f"Local iOS marketing version {local_version} is blocked by closed App Store "
-                f"version {highest_closed_app_store_version}; bump the marketing version first"
+                f"Local iOS marketing version {local_version} is blocked by a distribution-locked "
+                f"App Store version {highest_locked_app_store_version}; bump the marketing version first"
             ),
         )
 
@@ -299,7 +295,7 @@ def evaluate_lineage(
         highest_remote_version=highest_remote_version,
         highest_remote_app_store_version=highest_remote_app_store_version,
         highest_remote_app_store_state=highest_remote_app_store_state,
-        highest_closed_app_store_version=highest_closed_app_store_version,
+        highest_closed_app_store_version=highest_locked_app_store_version,
         highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
         highest_remote_build_for_local_version=highest_remote_build_for_local_version,
         passed=True,
@@ -356,7 +352,7 @@ def main() -> int:
         )
     if report.highest_closed_app_store_version is not None:
         print(
-            "ASC highest closed App Store version: "
+            "ASC highest distribution-locked App Store version: "
             f"{report.highest_closed_app_store_version}"
         )
     if report.highest_remote_build_for_highest_version is not None:

--- a/scripts/tests/test_check_ios_version_lineage.py
+++ b/scripts/tests/test_check_ios_version_lineage.py
@@ -61,7 +61,22 @@ def test_evaluate_lineage_rejects_closed_app_store_train_even_when_pre_release_m
 
     assert report.passed is False
     assert report.highest_closed_app_store_version == "1.3.17"
-    assert "closed App Store version 1.3.17" in report.reason
+    assert "distribution-locked" in report.reason
+    assert "1.3.17" in report.reason
+
+
+def test_evaluate_lineage_allows_same_marketing_version_while_waiting_for_review():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.24",
+        local_build=449,
+        remote_versions=["1.3.24"],
+        remote_app_store_versions={"1.3.24": "WAITING_FOR_REVIEW"},
+        remote_builds_by_version={"1.3.24": [451]},
+    )
+
+    assert report.passed is True
+    assert "auto-increment" in report.reason
 
 
 def test_evaluate_lineage_rejects_local_version_behind_higher_app_store_version():

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -120,7 +120,7 @@ def test_internal_distribution_skips_impossible_auto_ios_uploads_without_signoff
 
     assert "uploaded: ${{ steps.ios_lineage.outputs.uploadable }}" in ios_job
     assert "DISTRIBUTION_REASON: ${{ needs.gate.outputs.reason }}" in ios_job
-    assert "blocked by closed App Store version" in ios_job
+    assert "blocked by (closed|a distribution-locked) App Store version" in ios_job
     assert "Skipping automatic iOS TestFlight upload" in ios_job
     assert "Record skipped iOS TestFlight upload" in ios_job
     assert "if: steps.ios_lineage.outputs.uploadable == 'true'" in ios_job


### PR DESCRIPTION
## Problem
Internal Distribution failed on `Guard iOS version lineage against ASC` while App Store version `1.3.24` was `WAITING_FOR_REVIEW`, because `WAITING_FOR_REVIEW` was included in the same bucket as terminal distribution states.

## Change
- Restrict marketing-version lock to terminal / distribution states (e.g. `READY_FOR_DISTRIBUTION`, `READY_FOR_SALE`).
- Regression test: same marketing version + `WAITING_FOR_REVIEW` + higher ASC build passes (auto-increment path).
- `internal-distribution.yml`: skip-path grep accepts both legacy and new wording.

## Evidence
`python3.11 -m pytest scripts/tests/test_check_ios_version_lineage.py scripts/tests/test_growth_workflow_contracts.py::test_internal_distribution_skips_impossible_auto_ios_uploads_without_signoff -q` → 7 passed (local).

Made with [Cursor](https://cursor.com)