### PR TITLE
chore(release): merge develop (iOS ASC lineage gate)

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -259,7 +259,7 @@ jobs:
             echo "uploadable=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -q "blocked by closed App Store version"; then
+          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -Eq "blocked by (closed|a distribution-locked) App Store version"; then
             reason="$(printf '%s\n' "$output" | tail -n 1)"
             echo "::warning::Skipping automatic iOS TestFlight upload: $reason"
             echo "uploadable=false" >> "$GITHUB_OUTPUT"

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1774900007.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1774900007.txt
@@ -1,0 +1,3 @@
+Release 1.3.24:
+- App renamed to Random Tactical Timer on Google Play.
+- Keeps parity with the latest iOS training and paywall experience.

--- a/native-android/fastlane/metadata/android/en-US/title.txt
+++ b/native-android/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Random Timer: Tactical
+Random Tactical Timer

--- a/native-ios/fastlane/metadata/en-US/name.txt
+++ b/native-ios/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-Random Timer: Tactical
+Random Tactical Timer

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,5 +1,5 @@
+• App now appears as Random Tactical Timer on the App Store
 • Clearer Pro upgrade with a readable primary purchase button
 • Paywall tuned for training outcomes; purchase, restore, and legal links stay reachable
 • Monthly and annual Pro subscriptions where available
 • AI voice callouts, Sound Arsenal, and extended range for long tactical sessions
-• Review timing and analytics reliability improvements

--- a/release-notes/1.3.24.md
+++ b/release-notes/1.3.24.md
@@ -1,0 +1,11 @@
+# Release 1.3.24
+
+## Summary
+Unified **1.3.24** release for **Android** and **iOS** with the public app name **Random Tactical Timer** (store listings aligned with App Store Connect and Google Play). Same marketing version on both platforms.
+
+## Customer-visible changes
+- App display name updated to **Random Tactical Timer** on the App Store and Google Play (as processed by each store after submission).
+
+## Release operations
+- Android `versionName` **1.3.24**; Play `versionCode` is computed at upload time to stay monotonic with production.
+- iOS `MARKETING_VERSION` **1.3.24**; build number incremented per CI / upload rules.

--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -240,6 +240,21 @@ def find_or_create_app_store_version(client: ASCClient, app_id: str, version: st
     return vid, state
 
 
+def list_app_store_version_locale_codes(client: ASCClient, version_id: str) -> list[str]:
+    """Return locale codes (e.g. en-US, ja, de-DE) that have an App Store version localization row."""
+    rows = client.get_all(
+        f"/appStoreVersions/{version_id}/appStoreVersionLocalizations",
+        params={"limit": 200},
+    )
+    codes: list[str] = []
+    for row in rows:
+        a = row.get("attributes") or {}
+        loc = (a.get("locale") or "").strip()
+        if loc:
+            codes.append(loc)
+    return sorted(set(codes))
+
+
 def get_version_localization(client: ASCClient, version_id: str, locale: str) -> dict:
     locs = client.get_all(
         f"/appStoreVersions/{version_id}/appStoreVersionLocalizations",
@@ -264,6 +279,8 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
     for field, filename in fastlane_files.items():
         if not (attrs.get(field) or "").strip():
             val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, locale, filename))
+            if field == "whatsNew" and not val and locale != "en-US":
+                val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, "en-US", filename))
             if val:
                 patch[field] = val
 
@@ -300,10 +317,15 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
             loc = refreshed
             attrs = loc.get("attributes") or {}
 
-    # whatsNew ("Release Notes") is not always editable, and is not required for all submissions.
     for field in ("description", "keywords"):
         if not (attrs.get(field) or "").strip():
             die(f"App Store version localization {locale} missing required field: {field}")
+    # App Store Connect rejects submission when any active localization has empty "What's New".
+    if not (attrs.get("whatsNew") or "").strip():
+        die(
+            f"App Store version localization {locale} missing required field: whatsNew "
+            f"(native-ios/fastlane/metadata/{locale}/release_notes.txt, or en-US fallback)"
+        )
     return loc
 
 
@@ -1115,9 +1137,19 @@ def main() -> int:
             info(f"Already submitted: {state}")
             return 0
 
-    loc = get_version_localization(client, version_id, args.locale)
-    loc_id = loc["id"]
-    loc_attrs = loc.get("attributes") or {}
+    locale_codes = list_app_store_version_locale_codes(client, version_id)
+    if not locale_codes:
+        die("No App Store version localizations found for this version.")
+    info(f"Syncing App Store version metadata for locales: {', '.join(locale_codes)}")
+    primary_loc: dict[str, Any] | None = None
+    for code in locale_codes:
+        loc = get_version_localization(client, version_id, code)
+        if code == args.locale:
+            primary_loc = loc
+    if primary_loc is None:
+        die(f"Primary locale {args.locale!r} not found in version localizations: {locale_codes}")
+    loc_id = primary_loc["id"]
+    loc_attrs = primary_loc.get("attributes") or {}
 
     # Support URL may live on App Store version localization (newer ASC API) or on App Info localization
     # (older ASC API). Accept either, but require a non-empty https:// URL.

--- a/scripts/check_ios_version_lineage.py
+++ b/scripts/check_ios_version_lineage.py
@@ -26,23 +26,19 @@ except ModuleNotFoundError:
 
 
 SEMVER_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)\s*$")
-APP_STORE_CLOSED_STATES = {
-    "ACCEPTED",
-    "APPROVED",
-    "IN_REVIEW",
-    "PENDING_APPLE_RELEASE",
-    "PENDING_DEVELOPER_RELEASE",
-    "PENDING_DEVELOPER_RELEASE_REJECTED",
-    "PENDING_RELEASE",
-    "PREORDER_READY_FOR_SALE",
-    "PROCESSING_FOR_DISTRIBUTION",
-    "READY_FOR_DISTRIBUTION",
-    "READY_FOR_SALE",
-    "REMOVED_FROM_SALE",
-    "REPLACED_WITH_NEW_VERSION",
-    "WAITING_FOR_EXPORT_COMPLIANCE",
-    "WAITING_FOR_REVIEW",
-}
+# Marketing-version "lock" only after the version is in a terminal / distribution state.
+# In-review and pre-submission trains still allow new TestFlight builds for the same
+# marketing version (Apple may reject the new binary for other reasons).
+APP_STORE_VERSION_LOCKED_STATES = frozenset(
+    {
+        "PREORDER_READY_FOR_SALE",
+        "PROCESSING_FOR_DISTRIBUTION",
+        "READY_FOR_DISTRIBUTION",
+        "READY_FOR_SALE",
+        "REMOVED_FROM_SALE",
+        "REPLACED_WITH_NEW_VERSION",
+    }
+)
 
 
 class LineageError(RuntimeError):
@@ -213,11 +209,11 @@ def evaluate_lineage(
     highest_remote_app_store_version, highest_remote_app_store_state = _highest_version_by_state(
         remote_app_store_versions
     )
-    highest_closed_app_store_version, _ = _highest_version_by_state(
+    highest_locked_app_store_version, _ = _highest_version_by_state(
         {
             version: state
             for version, state in remote_app_store_versions.items()
-            if state in APP_STORE_CLOSED_STATES
+            if state in APP_STORE_VERSION_LOCKED_STATES
         }
     )
     highest_remote_version = _highest_semver(
@@ -238,7 +234,7 @@ def evaluate_lineage(
             highest_remote_version=None,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=None,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=True,
@@ -253,7 +249,7 @@ def evaluate_lineage(
             highest_remote_version=highest_remote_version,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
@@ -264,8 +260,8 @@ def evaluate_lineage(
         )
 
     if (
-        highest_closed_app_store_version is not None
-        and _parse_semver(local_version) <= _parse_semver(highest_closed_app_store_version)
+        highest_locked_app_store_version is not None
+        and _parse_semver(local_version) <= _parse_semver(highest_locked_app_store_version)
     ):
         return LineageReport(
             bundle_id=bundle_id,
@@ -274,13 +270,13 @@ def evaluate_lineage(
             highest_remote_version=highest_remote_version,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
             reason=(
-                f"Local iOS marketing version {local_version} is blocked by closed App Store "
-                f"version {highest_closed_app_store_version}; bump the marketing version first"
+                f"Local iOS marketing version {local_version} is blocked by a distribution-locked "
+                f"App Store version {highest_locked_app_store_version}; bump the marketing version first"
             ),
         )
 
@@ -299,7 +295,7 @@ def evaluate_lineage(
         highest_remote_version=highest_remote_version,
         highest_remote_app_store_version=highest_remote_app_store_version,
         highest_remote_app_store_state=highest_remote_app_store_state,
-        highest_closed_app_store_version=highest_closed_app_store_version,
+        highest_closed_app_store_version=highest_locked_app_store_version,
         highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
         highest_remote_build_for_local_version=highest_remote_build_for_local_version,
         passed=True,
@@ -356,7 +352,7 @@ def main() -> int:
         )
     if report.highest_closed_app_store_version is not None:
         print(
-            "ASC highest closed App Store version: "
+            "ASC highest distribution-locked App Store version: "
             f"{report.highest_closed_app_store_version}"
         )
     if report.highest_remote_build_for_highest_version is not None:

--- a/scripts/tests/router_client.py
+++ b/scripts/tests/router_client.py
@@ -22,3 +22,11 @@ class RouterClient:
             return value()
         return value
 
+    def get_all(self, path: str, *, params=None):
+        """Match ASCClient.get_all: one GET returning data[] (optionally paginated)."""
+        data = self.request("GET", path, params=params or {})
+        if not isinstance(data, dict):
+            return []
+        chunk = data.get("data") or []
+        return chunk if isinstance(chunk, list) else []
+

--- a/scripts/tests/test_asc_submit_for_review_version_localization.py
+++ b/scripts/tests/test_asc_submit_for_review_version_localization.py
@@ -68,7 +68,8 @@ class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
     def test_get_version_localization_ignores_whats_new_state_error(self):
         import scripts.asc.asc_submit_for_review as asc
 
-        client = _FakeClient(patch_error=_WHATS_NEW_STATE_ERROR, refreshed_whats_new="")
+        # API refuses PATCH for whatsNew (STATE_ERROR), but GET read-back still shows prior text.
+        client = _FakeClient(patch_error=_WHATS_NEW_STATE_ERROR, refreshed_whats_new="Hello")
 
         with tempfile.TemporaryDirectory() as td:
             os.makedirs(os.path.join(td, "en-US"), exist_ok=True)
@@ -82,10 +83,9 @@ class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
             finally:
                 asc.FASTLANE_METADATA_DIR = prev
 
-        # Should not raise, and should not require whatsNew to be present.
         self.assertEqual((loc.get("attributes") or {}).get("description"), "desc")
         self.assertEqual((loc.get("attributes") or {}).get("keywords"), "kw")
-        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "")
+        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "Hello")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_asc_submit_multilocale.py
+++ b/scripts/tests/test_asc_submit_multilocale.py
@@ -1,0 +1,41 @@
+"""Tests for multi-locale App Store version localization listing."""
+
+import unittest
+
+from scripts.tests.router_client import RouterClient
+
+
+class AscSubmitMultilocaleTests(unittest.TestCase):
+    def test_list_app_store_version_locale_codes_returns_sorted_unique(self):
+        from scripts.asc.asc_submit_for_review import list_app_store_version_locale_codes
+
+        client = RouterClient(
+            {
+                (
+                    "GET",
+                    "/appStoreVersions/ver-1/appStoreVersionLocalizations",
+                ): {
+                    "data": [
+                        {
+                            "id": "loc-ko",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "ko"},
+                        },
+                        {
+                            "id": "loc-en",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "en-US"},
+                        },
+                        {
+                            "id": "loc-ja",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "ja"},
+                        },
+                    ],
+                    "links": {},
+                },
+            }
+        )
+
+        codes = list_app_store_version_locale_codes(client, "ver-1")
+        self.assertEqual(codes, ["en-US", "ja", "ko"])

--- a/scripts/tests/test_check_ios_version_lineage.py
+++ b/scripts/tests/test_check_ios_version_lineage.py
@@ -61,7 +61,22 @@ def test_evaluate_lineage_rejects_closed_app_store_train_even_when_pre_release_m
 
     assert report.passed is False
     assert report.highest_closed_app_store_version == "1.3.17"
-    assert "closed App Store version 1.3.17" in report.reason
+    assert "distribution-locked" in report.reason
+    assert "1.3.17" in report.reason
+
+
+def test_evaluate_lineage_allows_same_marketing_version_while_waiting_for_review():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.24",
+        local_build=449,
+        remote_versions=["1.3.24"],
+        remote_app_store_versions={"1.3.24": "WAITING_FOR_REVIEW"},
+        remote_builds_by_version={"1.3.24": [451]},
+    )
+
+    assert report.passed is True
+    assert "auto-increment" in report.reason
 
 
 def test_evaluate_lineage_rejects_local_version_behind_higher_app_store_version():

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -120,7 +120,7 @@ def test_internal_distribution_skips_impossible_auto_ios_uploads_without_signoff
 
     assert "uploaded: ${{ steps.ios_lineage.outputs.uploadable }}" in ios_job
     assert "DISTRIBUTION_REASON: ${{ needs.gate.outputs.reason }}" in ios_job
-    assert "blocked by closed App Store version" in ios_job
+    assert "blocked by (closed|a distribution-locked) App Store version" in ios_job
     assert "Skipping automatic iOS TestFlight upload" in ios_job
     assert "Record skipped iOS TestFlight upload" in ios_job
     assert "if: steps.ios_lineage.outputs.uploadable == 'true'" in ios_job


### PR DESCRIPTION
Brings #1237 onto `release/v1.3.24` so Internal Distribution iOS lineage passes while `1.3.24` is `WAITING_FOR_REVIEW`, unblocking `internal-signoff/testflight` for Native App Release.

Evidence: Native App Release run 24669755201 failed on missing internal signoff statuses; Internal Distribution iOS job showed lineage block on `cdf3c236`.

Made with [Cursor](https://cursor.com)