### PR TITLE
chore(release-notes): sync 1.3.24.md to develop

### DIFF
--- a/release-notes/1.3.24.md
+++ b/release-notes/1.3.24.md
@@ -1,0 +1,11 @@
+# Release 1.3.24
+
+## Summary
+Unified **1.3.24** release for **Android** and **iOS** with the public app name **Random Tactical Timer** (store listings aligned with App Store Connect and Google Play). Same marketing version on both platforms.
+
+## Customer-visible changes
+- App display name updated to **Random Tactical Timer** on the App Store and Google Play (as processed by each store after submission).
+
+## Release operations
+- Android `versionName` **1.3.24**; Play `versionCode` is computed at upload time to stay monotonic with production.
+- iOS `MARKETING_VERSION` **1.3.24**; build number incremented per CI / upload rules.


### PR DESCRIPTION
develop lacked `release-notes/1.3.24.md` while `release/v1.3.24` had it after #1235, causing Internal Distribution preflight to fail on PRs from `develop`. Copy from `release/v1.3.24` tip.

Made with [Cursor](https://cursor.com)