### PR TITLE
chore(release): merge develop (ASC resolve for in-review submit)

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -259,7 +259,7 @@ jobs:
             echo "uploadable=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -q "blocked by closed App Store version"; then
+          if [[ "$DISTRIBUTION_REASON" != "manual_dispatch" ]] && printf '%s\n' "$output" | grep -Eq "blocked by (closed|a distribution-locked) App Store version"; then
             reason="$(printf '%s\n' "$output" | tail -n 1)"
             echo "::warning::Skipping automatic iOS TestFlight upload: $reason"
             echo "uploadable=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -707,6 +707,7 @@ jobs:
           python scripts/asc/asc_resolve_version.py \
             --preferred-version "$PREFERRED_VERSION" \
             --create-if-needed \
+            --allow-review-locked-preferred \
             --json-out /tmp/asc_version.json
           SELECTED_VERSION=$(python -c 'import json; print(json.load(open("/tmp/asc_version.json"))["selected_version"])')
           SELECTED_VERSION_ID=$(python -c 'import json; print(json.load(open("/tmp/asc_version.json")).get("selected_id") or "")')
@@ -969,7 +970,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -999,29 +999,13 @@ jobs:
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Bumped develop to v${NEW_VERSION}"
 
-      - name: Open pull request for post-release develop bump
-        env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Commit and push version bump to develop
         run: |
-          set -euo pipefail
-          TAG="${{ needs.tag-release.outputs.tag }}"
-          NEW_VER="${{ steps.bump.outputs.new_version }}"
-          BRANCH="chore/post-release-bump-${TAG}-run-${{ github.run_id }}"
           git add native-android/app/build.gradle.kts \
                   native-ios/RandomTimer.xcodeproj/project.pbxproj \
                   native-android/fastlane/metadata/android/en-US/changelogs/ \
                   native-ios/fastlane/metadata/en-US/release_notes.txt
-          if git diff --cached --quiet; then
-            echo "Nothing to commit; skipping PR"
-            exit 0
-          fi
-          git checkout -b "$BRANCH"
-          git commit -m "chore: bump develop to v${NEW_VER} after ${TAG} release"
-          git push origin "HEAD:refs/heads/${BRANCH}"
-          gh pr create \
-            --repo "${GITHUB_REPOSITORY}" \
-            --base develop \
-            --head "$BRANCH" \
-            --title "chore: bump develop to v${NEW_VER} after ${TAG}" \
-            --body "Automated post-release version bump (branch protection blocks direct pushes to \`develop\`). Merge after required checks pass."
-          echo "✅ Opened PR to bump develop to v${NEW_VER}"
+          git diff --cached --quiet && echo "Nothing to commit" && exit 0
+          git commit -m "chore: bump develop to v${{ steps.bump.outputs.new_version }} after ${{ needs.tag-release.outputs.tag }} release [skip ci]"
+          git push origin develop
+          echo "✅ develop is now at v${{ steps.bump.outputs.new_version }}"

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -970,6 +970,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -997,15 +998,41 @@ jobs:
           NEW_VERSION=$(python3 scripts/source_versions.py --repo-root . --format json \
             | python3 -c 'import json,sys; print(json.load(sys.stdin)["android"]["version_name"])')
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Bumped develop to v${NEW_VERSION}"
+          echo "Bumped working tree to v${NEW_VERSION} (will open PR — develop is protected)"
 
-      - name: Commit and push version bump to develop
+      - name: Open pull request for develop version bump
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "❌ ADMIN_TOKEN is required to open the post-release bump PR (direct push to develop is blocked by branch protection)."
+            exit 1
+          fi
+          TAG="${{ needs.tag-release.outputs.tag || 'unknown' }}"
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+          BRANCH="chore/bump-develop-post-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
           git add native-android/app/build.gradle.kts \
                   native-ios/RandomTimer.xcodeproj/project.pbxproj \
                   native-android/fastlane/metadata/android/en-US/changelogs/ \
                   native-ios/fastlane/metadata/en-US/release_notes.txt
-          git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "chore: bump develop to v${{ steps.bump.outputs.new_version }} after ${{ needs.tag-release.outputs.tag }} release [skip ci]"
-          git push origin develop
-          echo "✅ develop is now at v${{ steps.bump.outputs.new_version }}"
+          if git diff --cached --quiet; then
+            echo "Nothing to commit — skipping PR."
+            exit 0
+          fi
+          git commit -m "chore: bump develop to v${NEW_VERSION} after ${TAG} release [skip ci]"
+          git push -u origin "$BRANCH"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Automated post-release version bump after tag \`${TAG}\`."
+            echo ""
+            echo "develop rejects direct pushes; merge this PR to align develop with the next patch train."
+            echo ""
+            echo "Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > "$BODY_FILE"
+          gh pr create --repo "${{ github.repository }}" --base develop --head "$BRANCH" \
+            --title "chore: bump develop to v${NEW_VERSION} after ${TAG}" \
+            --body-file "$BODY_FILE"
+          rm -f "$BODY_FILE"
+          echo "✅ Opened PR for develop version bump (branch ${BRANCH})"

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1774900007.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1774900007.txt
@@ -1,0 +1,3 @@
+Release 1.3.24:
+- App renamed to Random Tactical Timer on Google Play.
+- Keeps parity with the latest iOS training and paywall experience.

--- a/native-android/fastlane/metadata/android/en-US/title.txt
+++ b/native-android/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Random Timer: Tactical
+Random Tactical Timer

--- a/native-ios/fastlane/metadata/en-US/name.txt
+++ b/native-ios/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-Random Timer: Tactical
+Random Tactical Timer

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,5 +1,5 @@
+• App now appears as Random Tactical Timer on the App Store
 • Clearer Pro upgrade with a readable primary purchase button
 • Paywall tuned for training outcomes; purchase, restore, and legal links stay reachable
 • Monthly and annual Pro subscriptions where available
 • AI voice callouts, Sound Arsenal, and extended range for long tactical sessions
-• Review timing and analytics reliability improvements

--- a/release-notes/1.3.24.md
+++ b/release-notes/1.3.24.md
@@ -1,0 +1,11 @@
+# Release 1.3.24
+
+## Summary
+Unified **1.3.24** release for **Android** and **iOS** with the public app name **Random Tactical Timer** (store listings aligned with App Store Connect and Google Play). Same marketing version on both platforms.
+
+## Customer-visible changes
+- App display name updated to **Random Tactical Timer** on the App Store and Google Play (as processed by each store after submission).
+
+## Release operations
+- Android `versionName` **1.3.24**; Play `versionCode` is computed at upload time to stay monotonic with production.
+- iOS `MARKETING_VERSION` **1.3.24**; build number incremented per CI / upload rules.

--- a/scripts/asc/asc_resolve_version.py
+++ b/scripts/asc/asc_resolve_version.py
@@ -168,6 +168,7 @@ def resolve_version(
     preferred_version: str,
     create_if_needed: bool,
     auto_next_patch: bool,
+    allow_review_locked_preferred: bool = False,
 ) -> Resolution:
     versions = _list_ios_versions(client, app_id)
     highest_editable = _pick_highest_editable_version(versions)
@@ -213,6 +214,16 @@ def resolve_version(
                 selected_state=state,
                 created=False,
                 reason="preferred_version_editable",
+                selected_id=str(current.get("id") or ""),
+                preferred_version=preferred_version,
+            )
+
+        if allow_review_locked_preferred and state in ("WAITING_FOR_REVIEW", "IN_REVIEW"):
+            return Resolution(
+                selected_version=preferred_version,
+                selected_state=state,
+                created=False,
+                reason="preferred_version_review_locked_api_target",
                 selected_id=str(current.get("id") or ""),
                 preferred_version=preferred_version,
             )
@@ -366,6 +377,14 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--preferred-version", required=True, help="Preferred marketing version (X.Y.Z).")
     p.add_argument("--create-if-needed", action="store_true", help="Create target version when missing.")
     p.add_argument("--auto-next-patch", action="store_true", help="If preferred version is not editable, target next patch.")
+    p.add_argument(
+        "--allow-review-locked-preferred",
+        action="store_true",
+        help=(
+            "If the preferred version exists in WAITING_FOR_REVIEW or IN_REVIEW, still return it for "
+            "API-only steps (e.g. localization / What's New patches). Unsafe for naive Fastlane storefront uploads."
+        ),
+    )
     p.add_argument("--json-out", help="Write JSON resolution payload to this path.")
     return p.parse_args()
 
@@ -392,6 +411,7 @@ def main() -> int:
         preferred_version=args.preferred_version,
         create_if_needed=args.create_if_needed,
         auto_next_patch=args.auto_next_patch,
+        allow_review_locked_preferred=args.allow_review_locked_preferred,
     )
     payload = {
         "bundle_id": args.bundle_id,

--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -240,6 +240,21 @@ def find_or_create_app_store_version(client: ASCClient, app_id: str, version: st
     return vid, state
 
 
+def list_app_store_version_locale_codes(client: ASCClient, version_id: str) -> list[str]:
+    """Return locale codes (e.g. en-US, ja, de-DE) that have an App Store version localization row."""
+    rows = client.get_all(
+        f"/appStoreVersions/{version_id}/appStoreVersionLocalizations",
+        params={"limit": 200},
+    )
+    codes: list[str] = []
+    for row in rows:
+        a = row.get("attributes") or {}
+        loc = (a.get("locale") or "").strip()
+        if loc:
+            codes.append(loc)
+    return sorted(set(codes))
+
+
 def get_version_localization(client: ASCClient, version_id: str, locale: str) -> dict:
     locs = client.get_all(
         f"/appStoreVersions/{version_id}/appStoreVersionLocalizations",
@@ -264,6 +279,8 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
     for field, filename in fastlane_files.items():
         if not (attrs.get(field) or "").strip():
             val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, locale, filename))
+            if field == "whatsNew" and not val and locale != "en-US":
+                val = _read_text_file(os.path.join(FASTLANE_METADATA_DIR, "en-US", filename))
             if val:
                 patch[field] = val
 
@@ -300,10 +317,15 @@ def get_version_localization(client: ASCClient, version_id: str, locale: str) ->
             loc = refreshed
             attrs = loc.get("attributes") or {}
 
-    # whatsNew ("Release Notes") is not always editable, and is not required for all submissions.
     for field in ("description", "keywords"):
         if not (attrs.get(field) or "").strip():
             die(f"App Store version localization {locale} missing required field: {field}")
+    # App Store Connect rejects submission when any active localization has empty "What's New".
+    if not (attrs.get("whatsNew") or "").strip():
+        die(
+            f"App Store version localization {locale} missing required field: whatsNew "
+            f"(native-ios/fastlane/metadata/{locale}/release_notes.txt, or en-US fallback)"
+        )
     return loc
 
 
@@ -1115,9 +1137,19 @@ def main() -> int:
             info(f"Already submitted: {state}")
             return 0
 
-    loc = get_version_localization(client, version_id, args.locale)
-    loc_id = loc["id"]
-    loc_attrs = loc.get("attributes") or {}
+    locale_codes = list_app_store_version_locale_codes(client, version_id)
+    if not locale_codes:
+        die("No App Store version localizations found for this version.")
+    info(f"Syncing App Store version metadata for locales: {', '.join(locale_codes)}")
+    primary_loc: dict[str, Any] | None = None
+    for code in locale_codes:
+        loc = get_version_localization(client, version_id, code)
+        if code == args.locale:
+            primary_loc = loc
+    if primary_loc is None:
+        die(f"Primary locale {args.locale!r} not found in version localizations: {locale_codes}")
+    loc_id = primary_loc["id"]
+    loc_attrs = primary_loc.get("attributes") or {}
 
     # Support URL may live on App Store version localization (newer ASC API) or on App Info localization
     # (older ASC API). Accept either, but require a non-empty https:// URL.

--- a/scripts/check_ios_version_lineage.py
+++ b/scripts/check_ios_version_lineage.py
@@ -26,23 +26,19 @@ except ModuleNotFoundError:
 
 
 SEMVER_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)\s*$")
-APP_STORE_CLOSED_STATES = {
-    "ACCEPTED",
-    "APPROVED",
-    "IN_REVIEW",
-    "PENDING_APPLE_RELEASE",
-    "PENDING_DEVELOPER_RELEASE",
-    "PENDING_DEVELOPER_RELEASE_REJECTED",
-    "PENDING_RELEASE",
-    "PREORDER_READY_FOR_SALE",
-    "PROCESSING_FOR_DISTRIBUTION",
-    "READY_FOR_DISTRIBUTION",
-    "READY_FOR_SALE",
-    "REMOVED_FROM_SALE",
-    "REPLACED_WITH_NEW_VERSION",
-    "WAITING_FOR_EXPORT_COMPLIANCE",
-    "WAITING_FOR_REVIEW",
-}
+# Marketing-version "lock" only after the version is in a terminal / distribution state.
+# In-review and pre-submission trains still allow new TestFlight builds for the same
+# marketing version (Apple may reject the new binary for other reasons).
+APP_STORE_VERSION_LOCKED_STATES = frozenset(
+    {
+        "PREORDER_READY_FOR_SALE",
+        "PROCESSING_FOR_DISTRIBUTION",
+        "READY_FOR_DISTRIBUTION",
+        "READY_FOR_SALE",
+        "REMOVED_FROM_SALE",
+        "REPLACED_WITH_NEW_VERSION",
+    }
+)
 
 
 class LineageError(RuntimeError):
@@ -213,11 +209,11 @@ def evaluate_lineage(
     highest_remote_app_store_version, highest_remote_app_store_state = _highest_version_by_state(
         remote_app_store_versions
     )
-    highest_closed_app_store_version, _ = _highest_version_by_state(
+    highest_locked_app_store_version, _ = _highest_version_by_state(
         {
             version: state
             for version, state in remote_app_store_versions.items()
-            if state in APP_STORE_CLOSED_STATES
+            if state in APP_STORE_VERSION_LOCKED_STATES
         }
     )
     highest_remote_version = _highest_semver(
@@ -238,7 +234,7 @@ def evaluate_lineage(
             highest_remote_version=None,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=None,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=True,
@@ -253,7 +249,7 @@ def evaluate_lineage(
             highest_remote_version=highest_remote_version,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
@@ -264,8 +260,8 @@ def evaluate_lineage(
         )
 
     if (
-        highest_closed_app_store_version is not None
-        and _parse_semver(local_version) <= _parse_semver(highest_closed_app_store_version)
+        highest_locked_app_store_version is not None
+        and _parse_semver(local_version) <= _parse_semver(highest_locked_app_store_version)
     ):
         return LineageReport(
             bundle_id=bundle_id,
@@ -274,13 +270,13 @@ def evaluate_lineage(
             highest_remote_version=highest_remote_version,
             highest_remote_app_store_version=highest_remote_app_store_version,
             highest_remote_app_store_state=highest_remote_app_store_state,
-            highest_closed_app_store_version=highest_closed_app_store_version,
+            highest_closed_app_store_version=highest_locked_app_store_version,
             highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
             highest_remote_build_for_local_version=highest_remote_build_for_local_version,
             passed=False,
             reason=(
-                f"Local iOS marketing version {local_version} is blocked by closed App Store "
-                f"version {highest_closed_app_store_version}; bump the marketing version first"
+                f"Local iOS marketing version {local_version} is blocked by a distribution-locked "
+                f"App Store version {highest_locked_app_store_version}; bump the marketing version first"
             ),
         )
 
@@ -299,7 +295,7 @@ def evaluate_lineage(
         highest_remote_version=highest_remote_version,
         highest_remote_app_store_version=highest_remote_app_store_version,
         highest_remote_app_store_state=highest_remote_app_store_state,
-        highest_closed_app_store_version=highest_closed_app_store_version,
+        highest_closed_app_store_version=highest_locked_app_store_version,
         highest_remote_build_for_highest_version=highest_remote_build_for_highest_version,
         highest_remote_build_for_local_version=highest_remote_build_for_local_version,
         passed=True,
@@ -356,7 +352,7 @@ def main() -> int:
         )
     if report.highest_closed_app_store_version is not None:
         print(
-            "ASC highest closed App Store version: "
+            "ASC highest distribution-locked App Store version: "
             f"{report.highest_closed_app_store_version}"
         )
     if report.highest_remote_build_for_highest_version is not None:

--- a/scripts/tests/router_client.py
+++ b/scripts/tests/router_client.py
@@ -22,3 +22,11 @@ class RouterClient:
             return value()
         return value
 
+    def get_all(self, path: str, *, params=None):
+        """Match ASCClient.get_all: one GET returning data[] (optionally paginated)."""
+        data = self.request("GET", path, params=params or {})
+        if not isinstance(data, dict):
+            return []
+        chunk = data.get("data") or []
+        return chunk if isinstance(chunk, list) else []
+

--- a/scripts/tests/test_asc_resolve_version.py
+++ b/scripts/tests/test_asc_resolve_version.py
@@ -80,6 +80,33 @@ class AscResolveVersionUnitTests(unittest.TestCase):
         self.assertFalse(result.created)
         self.assertEqual(result.reason, "preferred_version_editable")
 
+    def test_review_locked_preferred_exits_without_escape_hatch(self):
+        client = _FakeClient([_version("1.3.24", "WAITING_FOR_REVIEW")])
+        with self.assertRaises(SystemExit) as ctx:
+            resolve_version(
+                client=client,
+                app_id="app1",
+                preferred_version="1.3.24",
+                create_if_needed=True,
+                auto_next_patch=False,
+            )
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_allow_review_locked_preferred_returns_in_review_train(self):
+        client = _FakeClient([_version("1.3.24", "WAITING_FOR_REVIEW", vid="ver-wfr")])
+        result = resolve_version(
+            client=client,
+            app_id="app1",
+            preferred_version="1.3.24",
+            create_if_needed=True,
+            auto_next_patch=False,
+            allow_review_locked_preferred=True,
+        )
+        self.assertEqual(result.selected_version, "1.3.24")
+        self.assertEqual(result.selected_id, "ver-wfr")
+        self.assertEqual(result.selected_state, "WAITING_FOR_REVIEW")
+        self.assertEqual(result.reason, "preferred_version_review_locked_api_target")
+
     def test_creates_next_patch_when_preferred_is_live(self):
         client = _FakeClient([_version("1.1.1", "READY_FOR_SALE")])
         result = resolve_version(

--- a/scripts/tests/test_asc_submit_for_review_version_localization.py
+++ b/scripts/tests/test_asc_submit_for_review_version_localization.py
@@ -68,7 +68,8 @@ class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
     def test_get_version_localization_ignores_whats_new_state_error(self):
         import scripts.asc.asc_submit_for_review as asc
 
-        client = _FakeClient(patch_error=_WHATS_NEW_STATE_ERROR, refreshed_whats_new="")
+        # API refuses PATCH for whatsNew (STATE_ERROR), but GET read-back still shows prior text.
+        client = _FakeClient(patch_error=_WHATS_NEW_STATE_ERROR, refreshed_whats_new="Hello")
 
         with tempfile.TemporaryDirectory() as td:
             os.makedirs(os.path.join(td, "en-US"), exist_ok=True)
@@ -82,10 +83,9 @@ class AscSubmitForReviewVersionLocalizationAutofillTests(unittest.TestCase):
             finally:
                 asc.FASTLANE_METADATA_DIR = prev
 
-        # Should not raise, and should not require whatsNew to be present.
         self.assertEqual((loc.get("attributes") or {}).get("description"), "desc")
         self.assertEqual((loc.get("attributes") or {}).get("keywords"), "kw")
-        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "")
+        self.assertEqual((loc.get("attributes") or {}).get("whatsNew"), "Hello")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_asc_submit_multilocale.py
+++ b/scripts/tests/test_asc_submit_multilocale.py
@@ -1,0 +1,41 @@
+"""Tests for multi-locale App Store version localization listing."""
+
+import unittest
+
+from scripts.tests.router_client import RouterClient
+
+
+class AscSubmitMultilocaleTests(unittest.TestCase):
+    def test_list_app_store_version_locale_codes_returns_sorted_unique(self):
+        from scripts.asc.asc_submit_for_review import list_app_store_version_locale_codes
+
+        client = RouterClient(
+            {
+                (
+                    "GET",
+                    "/appStoreVersions/ver-1/appStoreVersionLocalizations",
+                ): {
+                    "data": [
+                        {
+                            "id": "loc-ko",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "ko"},
+                        },
+                        {
+                            "id": "loc-en",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "en-US"},
+                        },
+                        {
+                            "id": "loc-ja",
+                            "type": "appStoreVersionLocalizations",
+                            "attributes": {"locale": "ja"},
+                        },
+                    ],
+                    "links": {},
+                },
+            }
+        )
+
+        codes = list_app_store_version_locale_codes(client, "ver-1")
+        self.assertEqual(codes, ["en-US", "ja", "ko"])

--- a/scripts/tests/test_check_ios_version_lineage.py
+++ b/scripts/tests/test_check_ios_version_lineage.py
@@ -61,7 +61,22 @@ def test_evaluate_lineage_rejects_closed_app_store_train_even_when_pre_release_m
 
     assert report.passed is False
     assert report.highest_closed_app_store_version == "1.3.17"
-    assert "closed App Store version 1.3.17" in report.reason
+    assert "distribution-locked" in report.reason
+    assert "1.3.17" in report.reason
+
+
+def test_evaluate_lineage_allows_same_marketing_version_while_waiting_for_review():
+    report = evaluate_lineage(
+        bundle_id="com.igorganapolsky.randomtimer",
+        local_version="1.3.24",
+        local_build=449,
+        remote_versions=["1.3.24"],
+        remote_app_store_versions={"1.3.24": "WAITING_FOR_REVIEW"},
+        remote_builds_by_version={"1.3.24": [451]},
+    )
+
+    assert report.passed is True
+    assert "auto-increment" in report.reason
 
 
 def test_evaluate_lineage_rejects_local_version_behind_higher_app_store_version():

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -225,6 +225,16 @@ def test_native_release_workflow_keeps_ios_review_submission_opt_in():
     assert "default: 'false'" in submit_review_block
 
 
+def test_native_release_ios_submit_review_resolves_version_even_when_review_locked():
+    source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    resolve_block = source.split("- name: Resolve editable App Store version", 1)[1].split(
+        "- name: Write App Store Connect key (for API)", 1
+    )[0]
+    assert "asc_resolve_version.py" in resolve_block
+    assert "--allow-review-locked-preferred" in resolve_block
+
+
 def test_native_release_workflow_marks_android_firebase_mirror_input_deprecated():
     source = NATIVE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -120,7 +120,7 @@ def test_internal_distribution_skips_impossible_auto_ios_uploads_without_signoff
 
     assert "uploaded: ${{ steps.ios_lineage.outputs.uploadable }}" in ios_job
     assert "DISTRIBUTION_REASON: ${{ needs.gate.outputs.reason }}" in ios_job
-    assert "blocked by closed App Store version" in ios_job
+    assert "blocked by (closed|a distribution-locked) App Store version" in ios_job
     assert "Skipping automatic iOS TestFlight upload" in ios_job
     assert "Record skipped iOS TestFlight upload" in ios_job
     assert "if: steps.ios_lineage.outputs.uploadable == 'true'" in ios_job

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -159,3 +159,11 @@ def test_security_sensitive_workflows_pin_third_party_actions() -> None:
         path = keyed_path.split("#", 1)[0]
         contents = workflow_cache.setdefault(path, _read(path))
         assert pinned_ref in contents, f"{path} is missing {pinned_ref}"
+
+
+def test_native_release_post_tag_bump_opens_pr_not_direct_push_to_develop() -> None:
+    contents = _read(".github/workflows/native-release.yml")
+    bump_block = contents.split("bump-develop-version:", 1)[1]
+    assert "git push origin develop" not in bump_block
+    assert "gh pr create" in bump_block
+    assert "pull-requests: write" in bump_block


### PR DESCRIPTION
Brings #1242 onto `release/v1.3.24` so `ios-submit-review` in Native App Release can resolve App Store version `1.3.24` while `WAITING_FOR_REVIEW`.

Evidence: prior run `24678630692` failed `ios-submit-review` with `asc_resolve_version` non-editable error.

Made with [Cursor](https://cursor.com)