### PR TITLE
fix(ci): store release watcher — pass ASC private key to poll step

### DIFF
--- a/.github/workflows/store-release-watcher.yml
+++ b/.github/workflows/store-release-watcher.yml
@@ -50,10 +50,11 @@ jobs:
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          STATE_JSON="$(python scripts/asc/asc_poll_version_state.py --version "$TARGET_VERSION" --json 2>/dev/null || echo '{}')"
+          STATE_JSON="$(python scripts/asc/asc_poll_version_state.py --version "$TARGET_VERSION" --json || echo '{}')"
           STATE="$(echo "$STATE_JSON" | python -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print(d.get("state","UNKNOWN"))')"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
           echo "json=$STATE_JSON" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
First run (24685735048) logged `state=UNKNOWN` because `APPSTORE_PRIVATE_KEY` wasn't exposed to the Poll ASC state step, so `ASCAuth.from_env()` raised and the previous `2>/dev/null` swallowed it.

## Changes
- Add `APPSTORE_PRIVATE_KEY` env to Poll ASC state step
- Drop the stderr redirect so future failures are visible

## Test plan
- [ ] Re-dispatch after merge; issue body should show iOS state = `WAITING_FOR_REVIEW` (not `UNKNOWN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)