### PR TITLE
chore(release): add 1.3.25 release notes

### DIFF
--- a/release-notes/1.3.25.md
+++ b/release-notes/1.3.25.md
@@ -1,0 +1,11 @@
+# Release 1.3.25
+
+## Summary
+Patch release **1.3.25** for **Android** and **iOS** delivering reliability and performance improvements. Same marketing version on both platforms.
+
+## Customer-visible changes
+- Reliability and performance improvements.
+
+## Release operations
+- Android `versionName` **1.3.25**; Play `versionCode` **1774900008** (monotonic with production).
+- iOS `MARKETING_VERSION` **1.3.25**; build number incremented per CI / upload rules.


### PR DESCRIPTION
## Summary
- Add `release-notes/1.3.25.md` required by preflight for the native-release pipeline.
- Mirrors 1.3.24 structure; versionCode 1774900008.

## Test plan
- [x] `internal-distribution.yml` preflight requires versioned release notes; this unblocks 1.3.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)