### PR TITLE
feat(ci): iOS Apple-ID fallback uses altool upload (bypasses spaceship)

### DIFF
--- a/.github/workflows/ios-apple-id-release.yml
+++ b/.github/workflows/ios-apple-id-release.yml
@@ -83,25 +83,44 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: fastlane setup
 
-      - name: Build and upload to TestFlight (Apple-ID)
+      - name: Compute build number (timestamp)
+        id: bn
+        run: |
+          set -euo pipefail
+          echo "build_number=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed IPA (no upload)
         working-directory: native-ios
         env:
           CI: "true"
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: "6"
-          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-          FASTLANE_ITC_TEAM_ID: ${{ secrets.FASTLANE_ITC_TEAM_ID }}
           FASTLANE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || 'Internal Testers' }}
-          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
-          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
-        run: fastlane beta
+        run: fastlane build_ipa build_number:${{ steps.bn.outputs.build_number }}
+
+      - name: Upload IPA to TestFlight via altool (app-specific password)
+        working-directory: native-ios
+        env:
+          ALTOOL_USER: ${{ secrets.FASTLANE_USER }}
+          ALTOOL_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ ! -f RandomTimer.ipa ]; then
+            echo "::error::RandomTimer.ipa not found after build"
+            ls -la
+            exit 1
+          fi
+          echo "IPA size: $(du -h RandomTimer.ipa | cut -f1)"
+          xcrun altool --upload-app \
+            --file RandomTimer.ipa \
+            --type ios \
+            --username "$ALTOOL_USER" \
+            --password "$ALTOOL_PASSWORD" \
+            --verbose
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v7

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -195,6 +195,76 @@ platform :ios do
     end
   end
 
+  desc "Build signed IPA only (no upload). Used by Apple-ID fallback workflow; upload handled by xcrun altool."
+  lane :build_ipa do |options|
+    setup_ci if ENV["CI"] == "true"
+
+    marketing_version = get_version_number(
+      xcodeproj: "RandomTimer.xcodeproj",
+      target: "RandomTimer"
+    )
+    current_build_number = get_build_number(
+      xcodeproj: "RandomTimer.xcodeproj"
+    ).to_i
+    next_build_number = options[:build_number] ? options[:build_number].to_i : current_build_number + 1
+
+    UI.message("Using build number #{next_build_number} for version #{marketing_version}")
+    increment_build_number(
+      xcodeproj: "RandomTimer.xcodeproj",
+      build_number: next_build_number
+    )
+
+    if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"]
+      match(
+        type: "appstore",
+        app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
+        readonly: true
+      )
+
+      app_profile = ENV["sigh_com.igorganapolsky.randomtimer_appstore_profile-name"] ||
+                    "match AppStore com.igorganapolsky.randomtimer"
+      widget_profile = ENV["sigh_com.igorganapolsky.randomtimer.widget_appstore_profile-name"] ||
+                       "match AppStore com.igorganapolsky.randomtimer.widget"
+
+      update_code_signing_settings(
+        path: "RandomTimer.xcodeproj",
+        use_automatic_signing: false,
+        targets: ["RandomTimer"],
+        code_sign_identity: "Apple Distribution",
+        profile_name: app_profile
+      )
+
+      update_code_signing_settings(
+        path: "RandomTimer.xcodeproj",
+        use_automatic_signing: false,
+        targets: ["RandomTimerWidgetExtension"],
+        code_sign_identity: "Apple Distribution",
+        profile_name: widget_profile
+      )
+
+      build_opts = {
+        scheme: "RandomTimer",
+        export_method: "app-store",
+        export_options: {
+          signingStyle: "manual",
+          provisioningProfiles: {
+            "com.igorganapolsky.randomtimer" => app_profile,
+            "com.igorganapolsky.randomtimer.widget" => widget_profile
+          }
+        }
+      }
+      build_opts[:xcargs] = "POSTHOG_API_KEY=#{ENV['POSTHOG_API_KEY']}" unless ENV["POSTHOG_API_KEY"].to_s.empty?
+      build_app(**build_opts)
+    else
+      posthog_xcargs = ENV["POSTHOG_API_KEY"].to_s.empty? ? "-allowProvisioningUpdates" : "-allowProvisioningUpdates POSTHOG_API_KEY=#{ENV['POSTHOG_API_KEY']}"
+      build_app(
+        scheme: "RandomTimer",
+        export_method: "app-store",
+        xcargs: posthog_xcargs
+      )
+    end
+  end
+
   desc "Add external beta tester to TestFlight"
   lane :add_tester do |options|
     setup_ci if ENV["CI"] == "true"


### PR DESCRIPTION
## Summary
- Adds Fastfile `build_ipa` lane: build-only, no spaceship-dependent calls
- Splits `ios-apple-id-release.yml` into (1) build IPA via fastlane, (2) upload via `xcrun altool` with app-specific password
- Build number derived from UTC unix timestamp — monotonic, unique across concurrent dispatches, no ASC API call needed

## Why
Prior run 24727446797 failed at `upload_to_testflight` — spaceship login rejected stale `FASTLANE_PASSWORD`. `xcrun altool --upload-app` authenticates via iTMSTransporter using only `FASTLANE_USER` + `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`, bypassing spaceship/web auth entirely.

The `build_app` step already succeeded on macos-26 in the last run (IPA produced in 215s). The remaining blocker is the upload leg, which this PR addresses.

## Test plan
- [ ] Merge → dispatch `ios-apple-id-release.yml` with `ref=release/v1.3.25`
- [ ] Verify `fastlane build_ipa` produces `native-ios/RandomTimer.ipa`
- [ ] Verify `xcrun altool --upload-app` returns success (build appears in ASC TestFlight within ~15 min)
- [ ] Confirm TestFlight processing completes for v1.3.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)