### PR TITLE
chore(release): merge develop → release/v1.3.25 (altool upload path)

### DIFF
--- a/.github/workflows/ios-apple-id-release.yml
+++ b/.github/workflows/ios-apple-id-release.yml
@@ -83,25 +83,44 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: fastlane setup
 
-      - name: Build and upload to TestFlight (Apple-ID)
+      - name: Compute build number (timestamp)
+        id: bn
+        run: |
+          set -euo pipefail
+          echo "build_number=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed IPA (no upload)
         working-directory: native-ios
         env:
           CI: "true"
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: "6"
-          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-          FASTLANE_ITC_TEAM_ID: ${{ secrets.FASTLANE_ITC_TEAM_ID }}
           FASTLANE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || 'Internal Testers' }}
-          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
-          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
-        run: fastlane beta
+        run: fastlane build_ipa build_number:${{ steps.bn.outputs.build_number }}
+
+      - name: Upload IPA to TestFlight via altool (app-specific password)
+        working-directory: native-ios
+        env:
+          ALTOOL_USER: ${{ secrets.FASTLANE_USER }}
+          ALTOOL_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ ! -f RandomTimer.ipa ]; then
+            echo "::error::RandomTimer.ipa not found after build"
+            ls -la
+            exit 1
+          fi
+          echo "IPA size: $(du -h RandomTimer.ipa | cut -f1)"
+          xcrun altool --upload-app \
+            --file RandomTimer.ipa \
+            --type ios \
+            --username "$ALTOOL_USER" \
+            --password "$ALTOOL_PASSWORD" \
+            --verbose
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ios-apple-id-release.yml
+++ b/.github/workflows/ios-apple-id-release.yml
@@ -1,0 +1,112 @@
+name: iOS Apple-ID Release (ASC JWT fallback)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (branch/tag/SHA)'
+        required: true
+        default: 'release/v1.3.25'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-apple-id-release-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  testflight-upload:
+    name: iOS TestFlight (Apple-ID auth)
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Write GoogleService-Info.plist from secret
+        env:
+          GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
+        working-directory: native-ios
+        run: |
+          set -euo pipefail
+          if [ -n "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
+            printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
+            echo "Wrote GoogleService-Info.plist"
+          fi
+
+      - name: Fail fast on required Apple-ID secrets
+        env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          for name in MATCH_GIT_URL MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION FASTLANE_USER FASTLANE_PASSWORD FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD ADMIN_TOKEN; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required secret: $name"
+              exit 1
+            fi
+          done
+
+      - name: Preflight release checks (iOS)
+        run: bash scripts/shell/preflight-release.sh --platform ios --layer 1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: native-ios
+
+      - name: Install Fastlane
+        working-directory: native-ios
+        run: gem install fastlane
+
+      - name: Configure git credentials for match
+        env:
+          GIT_AUTH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global url."https://x-access-token:${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Setup signing assets (match readonly, no ASC JWT)
+        working-directory: native-ios
+        env:
+          CI: "true"
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        run: fastlane setup
+
+      - name: Build and upload to TestFlight (Apple-ID)
+        working-directory: native-ios
+        env:
+          CI: "true"
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: "6"
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+          FASTLANE_ITC_TEAM_ID: ${{ secrets.FASTLANE_ITC_TEAM_ID }}
+          FASTLANE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || 'Internal Testers' }}
+          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
+        run: fastlane beta
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ios-ipa-apple-id
+          path: native-ios/RandomTimer.ipa
+          if-no-files-found: warn

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -195,6 +195,76 @@ platform :ios do
     end
   end
 
+  desc "Build signed IPA only (no upload). Used by Apple-ID fallback workflow; upload handled by xcrun altool."
+  lane :build_ipa do |options|
+    setup_ci if ENV["CI"] == "true"
+
+    marketing_version = get_version_number(
+      xcodeproj: "RandomTimer.xcodeproj",
+      target: "RandomTimer"
+    )
+    current_build_number = get_build_number(
+      xcodeproj: "RandomTimer.xcodeproj"
+    ).to_i
+    next_build_number = options[:build_number] ? options[:build_number].to_i : current_build_number + 1
+
+    UI.message("Using build number #{next_build_number} for version #{marketing_version}")
+    increment_build_number(
+      xcodeproj: "RandomTimer.xcodeproj",
+      build_number: next_build_number
+    )
+
+    if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"]
+      match(
+        type: "appstore",
+        app_identifier: ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"],
+        readonly: true
+      )
+
+      app_profile = ENV["sigh_com.igorganapolsky.randomtimer_appstore_profile-name"] ||
+                    "match AppStore com.igorganapolsky.randomtimer"
+      widget_profile = ENV["sigh_com.igorganapolsky.randomtimer.widget_appstore_profile-name"] ||
+                       "match AppStore com.igorganapolsky.randomtimer.widget"
+
+      update_code_signing_settings(
+        path: "RandomTimer.xcodeproj",
+        use_automatic_signing: false,
+        targets: ["RandomTimer"],
+        code_sign_identity: "Apple Distribution",
+        profile_name: app_profile
+      )
+
+      update_code_signing_settings(
+        path: "RandomTimer.xcodeproj",
+        use_automatic_signing: false,
+        targets: ["RandomTimerWidgetExtension"],
+        code_sign_identity: "Apple Distribution",
+        profile_name: widget_profile
+      )
+
+      build_opts = {
+        scheme: "RandomTimer",
+        export_method: "app-store",
+        export_options: {
+          signingStyle: "manual",
+          provisioningProfiles: {
+            "com.igorganapolsky.randomtimer" => app_profile,
+            "com.igorganapolsky.randomtimer.widget" => widget_profile
+          }
+        }
+      }
+      build_opts[:xcargs] = "POSTHOG_API_KEY=#{ENV['POSTHOG_API_KEY']}" unless ENV["POSTHOG_API_KEY"].to_s.empty?
+      build_app(**build_opts)
+    else
+      posthog_xcargs = ENV["POSTHOG_API_KEY"].to_s.empty? ? "-allowProvisioningUpdates" : "-allowProvisioningUpdates POSTHOG_API_KEY=#{ENV['POSTHOG_API_KEY']}"
+      build_app(
+        scheme: "RandomTimer",
+        export_method: "app-store",
+        xcargs: posthog_xcargs
+      )
+    end
+  end
+
   desc "Add external beta tester to TestFlight"
   lane :add_tester do |options|
     setup_ci if ENV["CI"] == "true"


### PR DESCRIPTION
Bring altool upload workflow + build_ipa lane into release/v1.3.25 so ios-apple-id-release.yml can ship v1.3.25 to TestFlight via app-specific password (bypasses spaceship login). See #1254.