### PR TITLE
fix: tighten timer indicator and voice callouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,10 @@ fix-ios-device:
 
 # Install git hooks
 install-hooks:
-	@cp scripts/pre-commit .git/hooks/pre-commit
-	@chmod +x .git/hooks/pre-commit
-	@echo "✅ Pre-commit hook installed"
+	@./scripts/shell/bootstrap_git_config.sh
+	@echo "✅ Git bootstrap complete"
+
+bootstrap-git: install-hooks
 
 # Verify (unit tests + builds)
 verify: verify-android verify-ios

--- a/README.md
+++ b/README.md
@@ -98,8 +98,11 @@ flowchart TB
 Entry point: **[`Makefile`](Makefile)**.
 
 ```bash
+make bootstrap-git
 make verify
 ```
+
+`make bootstrap-git` is worktree-safe. On Git `2.54+`, it configures the repo pre-commit hook via `hook.*` config and enables `git status` comparisons against both `@{upstream}` and `@{push}`. On older Git versions, it falls back to a managed hook wrapper in the resolved hooks directory.
 
 Details: iOS `native-ios/` (`xcodebuild`), Android `native-android/` (`./gradlew …`). See Makefile targets for simulators, Maestro, and platform-specific checks.
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -64,21 +64,46 @@ internal fun selectPreferredVoice(candidates: List<VoiceCandidate>): VoiceCandid
         }
 
 private const val VOICE_CATALOG_ASSET = "voice_callouts.json"
+internal const val MIN_VOICE_CALLOUT_SPACING_SECONDS = 30
+
+private val maleCombatCommandFilenames =
+    setOf(
+        "cmd_stay_locked_in",
+        "cmd_no_hesitation_move",
+        "cmd_sound_off_and_drive",
+        "cmd_eyes_up_keep_moving",
+        "cmd_keep_pressure_on",
+        "cmd_sharp_movement_sharp_focus",
+        "cmd_stay_in_the_fight",
+        "cmd_drive_through_it",
+        "cmd_reset_and_attack",
+        "cmd_strong_feet_strong_pace",
+        "cmd_move_fast_stay_precise",
+        "cmd_instant_response_go",
+        "cmd_snap_back_and_drive",
+        "cmd_drive_forward",
+        "cmd_keep_pressure",
+        "cmd_move_now",
+        "cmd_push_through",
+        "cmd_stay_sharp",
+    )
+
+private val malePreviewCommandFilenames =
+    listOf(
+        "cmd_stay_locked_in",
+        "cmd_no_hesitation_move",
+        "cmd_sound_off_and_drive",
+        "cmd_snap_back_and_drive",
+        "cmd_stay_in_the_fight",
+        "cmd_reset_and_attack",
+        "cmd_drive_through_it",
+        "cmd_drive_forward",
+        "cmd_keep_pressure_on",
+        "cmd_instant_response_go",
+    )
 
 private object VoicePreviewSampleCatalog {
-    val maleCommandFilenames =
-        listOf(
-            "cmd_move_with_a_purpose",
-            "cmd_stay_locked_in",
-            "cmd_no_hesitation_move",
-            "cmd_sound_off_and_drive",
-            "cmd_snap_back_and_drive",
-            "cmd_stay_disciplined",
-            "cmd_keep_your_bearing",
-            "cmd_reset_and_attack",
-            "cmd_sharp_movement_sharp_focus",
-            "cmd_stay_in_the_fight",
-        )
+    val maleCommandFilenames = malePreviewCommandFilenames
 
     const val maleElapsedFilename = "preview_elapsed"
 
@@ -274,6 +299,32 @@ internal fun initialFollowupCommandCueSecond(totalDurationSeconds: Int): Int =
         else -> 30
     }
 
+internal fun hasMetVoiceCalloutCooldown(
+    elapsedSeconds: Int,
+    lastCueSecond: Int,
+): Boolean = lastCueSecond <= 0 || elapsedSeconds - lastCueSecond >= MIN_VOICE_CALLOUT_SPACING_SECONDS
+
+internal fun commandCueRepeatFamilyKey(filename: String): String =
+    when (filename) {
+        "cmd_move_with_a_purpose", "cmd_most_ricky_tick" -> "move_with_a_purpose"
+        "cmd_stay_in_the_fight", "cmd_push_through" -> "stay_in_the_fight"
+        "cmd_keep_pressure_on", "cmd_keep_pressure" -> "keep_pressure"
+        "cmd_no_hesitation_move", "cmd_drive_forward" -> "no_hesitation"
+        else -> filename
+    }
+
+internal fun commandCuePoolForGender(
+    cues: List<VoiceCue>,
+    gender: VoiceGender,
+): List<VoiceCue> {
+    if (gender != VoiceGender.MALE) {
+        return cues
+    }
+
+    val combatPool = cues.filter { it.filename in maleCombatCommandFilenames }
+    return combatPool.ifEmpty { cues.filter { it.filename != "cmd_most_ricky_tick" }.ifEmpty { cues } }
+}
+
 @Singleton
 class AIVoiceCalloutManager
     @Inject
@@ -285,6 +336,7 @@ class AIVoiceCalloutManager
         private var mediaPlayer: MediaPlayer? = null
         private var currentVolume: Float = 1.0f
         private var lastCommandCueFilename: String? = null
+        private var lastCommandCueFamilyKey: String? = null
         private val usedCommandCueFilenames = mutableSetOf<String>()
         private val lastPreviewCommandFilenameByGender = mutableMapOf<VoiceGender, String?>()
         private val usedPreviewCommandFilenamesByGender =
@@ -293,6 +345,7 @@ class AIVoiceCalloutManager
                 VoiceGender.FEMALE to mutableSetOf<String>(),
             )
         private var nextCommandCueAt = 0
+        private var lastSpokenCueAt = 0
 
         /** Current voice gender for the active session. */
         var currentGender: VoiceGender = VoiceGender.MALE
@@ -325,25 +378,24 @@ class AIVoiceCalloutManager
             val mappedFilename = catalog.filenameByText[text]
             val baseFilename = mappedFilename ?: catalog.fallbackCommandCue.filename
             val filename = genderedVoiceFilename(baseFilename, currentGender)
-            val directResId = context.resources.getIdentifier(filename, "raw", context.packageName)
-            val fallbackFilename = genderedVoiceFilename(catalog.fallbackCommandCue.filename, currentGender)
-            val fallbackResId = context.resources.getIdentifier(fallbackFilename, "raw", context.packageName)
-            val resId = directResId.takeIf { it != 0 } ?: fallbackResId.takeIf { it != 0 } ?: voiceResIdOrFallback(context, text, catalog)
+            val fallbackResId = if (mappedFilename == null) voiceResIdOrFallback(context, text, catalog) else 0
             if (mappedFilename == null) {
                 Log.w("AIVoiceCallout", "Unmapped cue requested, using bundled fallback: $text")
             }
 
-            playVoiceFile(filename = filename, fallbackResId = resId, cueText = text)
+            playVoiceFile(filename = filename, fallbackResId = fallbackResId, cueText = text)
         }
 
         fun resetSession() {
             stopPlayback()
             lastElapsedMilestone = 0
             lastCommandCueFilename = null
+            lastCommandCueFamilyKey = null
             usedCommandCueFilenames.clear()
             lastPreviewCommandFilenameByGender.clear()
             usedPreviewCommandFilenamesByGender.values.forEach { it.clear() }
             nextCommandCueAt = 0
+            lastSpokenCueAt = 0
             currentGender = VoiceGender.MALE
         }
 
@@ -501,11 +553,16 @@ class AIVoiceCalloutManager
 
         fun triggerCallout(elapsedSeconds: Int) {
             val catalog = packStore.voiceCatalog()
-            runtimeVoiceCueForElapsedMark(elapsedSeconds, lastElapsedMilestone, catalog)?.let {
-                speak(it.text)
+            runtimeVoiceCueForElapsedMark(elapsedSeconds, lastElapsedMilestone, catalog)?.let { cue ->
+                if (!hasMetVoiceCalloutCooldown(elapsedSeconds, lastSpokenCueAt)) {
+                    return@let
+                }
+
+                speak(cue.text)
                 lastElapsedMilestone = elapsedSeconds
+                lastSpokenCueAt = elapsedSeconds
                 if (nextCommandCueAt <= elapsedSeconds) {
-                    nextCommandCueAt = elapsedSeconds + 30
+                    nextCommandCueAt = elapsedSeconds + MIN_VOICE_CALLOUT_SPACING_SECONDS
                 }
                 return
             }
@@ -513,36 +570,47 @@ class AIVoiceCalloutManager
                 val cue = randomCommandCue()
                 speak(cue.text)
                 lastCommandCueFilename = cue.filename
-                nextCommandCueAt = elapsedSeconds + 30
+                lastSpokenCueAt = elapsedSeconds
+                nextCommandCueAt = elapsedSeconds + MIN_VOICE_CALLOUT_SPACING_SECONDS
             }
         }
 
         private fun shouldFireCommandCue(elapsedSeconds: Int): Boolean {
             if (nextCommandCueAt == 0) {
-                nextCommandCueAt = 30
+                nextCommandCueAt = MIN_VOICE_CALLOUT_SPACING_SECONDS
             }
             if (nextCommandCueAt == Int.MAX_VALUE) {
                 return false
             }
-            return elapsedSeconds >= nextCommandCueAt
+            return elapsedSeconds >= nextCommandCueAt && hasMetVoiceCalloutCooldown(elapsedSeconds, lastSpokenCueAt)
         }
 
         private fun randomCommandCue(): VoiceCue {
             val catalog = packStore.voiceCatalog()
-            val available = catalog.commandCues.filter { it.filename !in usedCommandCueFilenames }
+            val curated = commandCuePoolForGender(catalog.commandCues, currentGender)
+            val available =
+                curated.filter { cue ->
+                    cue.filename !in usedCommandCueFilenames &&
+                        commandCueRepeatFamilyKey(cue.filename) != lastCommandCueFamilyKey
+                }
             val pool =
                 available.ifEmpty {
                     // All cues used — reset and exclude only the last one
                     usedCommandCueFilenames.clear()
-                    catalog.commandCues
-                        .filter { it.filename != lastCommandCueFilename }
-                        .ifEmpty { catalog.commandCues }
+                    curated
+                        .filter { commandCueRepeatFamilyKey(it.filename) != lastCommandCueFamilyKey }
+                        .ifEmpty {
+                            curated
+                                .filter { it.filename != lastCommandCueFilename }
+                                .ifEmpty { curated }
+                        }
                 }
             val cue =
                 nextCommandCue(pool, lastCommandCueFilename) { upperBound ->
                     Random.nextInt(upperBound)
                 }
             lastCommandCueFilename = cue.filename
+            lastCommandCueFamilyKey = commandCueRepeatFamilyKey(cue.filename)
             usedCommandCueFilenames.add(cue.filename)
             return cue
         }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/CircularTimer.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/CircularTimer.kt
@@ -2,7 +2,6 @@ package com.iganapolsky.randomtimer.ui.components
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
@@ -46,9 +45,6 @@ import kotlin.time.Duration
  * iOS uses SwiftUI withAnimation with these same durations.
  */
 object CircularTimerAnimationConfig {
-    /** Ball orbit: one full 360° rotation in milliseconds (LinearEasing, Restart) */
-    const val SHIMMER_ORBIT_MS = 3000
-
     /** Circle pulse: one-way duration in ms (default easing, Reverse). Full cycle = 2x */
     const val CIRCLE_PULSE_ONE_WAY_MS = 1500
 
@@ -73,8 +69,10 @@ object CircularTimerAnimationConfig {
 internal fun shouldBreatheText(status: TimerStatus): Boolean =
     status == TimerStatus.RUNNING || status == TimerStatus.WARNING || status == TimerStatus.DANGER
 
-internal fun effectiveTrackAlpha(status: TimerStatus, pulseAlpha: Float): Float =
-    if (status == TimerStatus.PAUSED) 0.45f else pulseAlpha
+internal fun effectiveTrackAlpha(
+    status: TimerStatus,
+    pulseAlpha: Float,
+): Float = if (status == TimerStatus.PAUSED) 0.45f else pulseAlpha
 
 @Composable
 fun CircularTimer(
@@ -144,22 +142,6 @@ fun CircularTimer(
     }
     val circlePulseAlpha = circlePulseAlphaAnim.value
 
-    // Orbiting shimmer dot
-    val shimmerAngleAnim = remember { Animatable(0f) }
-    LaunchedEffect(isActivelyRunning) {
-        if (isActivelyRunning) {
-            shimmerAngleAnim.animateTo(
-                targetValue = shimmerAngleAnim.value + 360f,
-                animationSpec =
-                    infiniteRepeatable(
-                        animation = tween(durationMillis = CircularTimerAnimationConfig.SHIMMER_ORBIT_MS, easing = LinearEasing),
-                        repeatMode = RepeatMode.Restart,
-                    ),
-            )
-        }
-    }
-    val shimmerAngle = shimmerAngleAnim.value
-
     // Accessibility: only expose status and range, never timing data
     val accessibilityText =
         when (status) {
@@ -188,27 +170,6 @@ fun CircularTimer(
                 radius = radius - strokePx / 2,
                 style = Stroke(width = strokePx, cap = StrokeCap.Round),
             )
-
-            // Orbiting shimmer dot (only when actively running, not paused/complete)
-            if (isActivelyRunning) {
-                val shimmerAngleRad = Math.toRadians((shimmerAngle - 90).toDouble())
-                val arcRadius = radius - strokePx / 2
-                val shimmerX = (radius + arcRadius * kotlin.math.cos(shimmerAngleRad)).toFloat()
-                val shimmerY = (radius + arcRadius * kotlin.math.sin(shimmerAngleRad)).toFloat()
-
-                // Outer glow (large, soft)
-                drawCircle(
-                    color = Color.White.copy(alpha = 0.15f),
-                    radius = strokePx * 2.5f,
-                    center = Offset(shimmerX, shimmerY),
-                )
-                // Inner bright spot
-                drawCircle(
-                    color = Color.White.copy(alpha = 0.5f),
-                    radius = strokePx,
-                    center = Offset(shimmerX, shimmerY),
-                )
-            }
 
             // Progress arc
             val sweepAngle = 360f * animatedProgress
@@ -243,19 +204,12 @@ fun CircularTimer(
                 )
             }
 
-            // Tracking dot at the start of progress (like iOS)
+            // Keep the start marker to a single dot so the ring never looks like a countdown.
             if (animatedProgress > 0f && animatedProgress < 1f) {
                 val startAngle = Math.toRadians(-90.0)
                 val trackDotX = (radius + (radius - strokePx / 2) * kotlin.math.cos(startAngle)).toFloat()
                 val trackDotY = (radius + (radius - strokePx / 2) * kotlin.math.sin(startAngle)).toFloat()
 
-                // Outer glow
-                drawCircle(
-                    color = animatedColor.copy(alpha = 0.3f),
-                    radius = strokePx * 1.5f,
-                    center = Offset(trackDotX, trackDotY),
-                )
-                // Inner dot
                 drawCircle(
                     color = animatedColor.copy(alpha = 0.6f),
                     radius = strokePx * 0.8f,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
@@ -110,6 +110,28 @@ class AIVoiceCalloutManagerSelectionTest {
     }
 
     @Test
+    fun commandCueRepeatFamilyGroupsMoveWithAPurposeVariants() {
+        assertThat(commandCueRepeatFamilyKey("cmd_move_with_a_purpose")).isEqualTo("move_with_a_purpose")
+        assertThat(commandCueRepeatFamilyKey("cmd_most_ricky_tick")).isEqualTo("move_with_a_purpose")
+        assertThat(commandCueRepeatFamilyKey("cmd_stay_locked_in")).isEqualTo("cmd_stay_locked_in")
+    }
+
+    @Test
+    fun maleCommandCuePoolPrefersCombatStyleLinesAndDropsMostRickyTick() {
+        val cues =
+            listOf(
+                VoiceCue(filename = "cmd_most_ricky_tick", text = "Most ricky tick. Move with a purpose."),
+                VoiceCue(filename = "cmd_stay_in_the_fight", text = "Stay in the fight."),
+                VoiceCue(filename = "cmd_drive_forward", text = "Drive forward. No hesitation."),
+                VoiceCue(filename = "cmd_keep_tempo_high", text = "Keep the tempo high."),
+            )
+
+        val selected = commandCuePoolForGender(cues, VoiceGender.MALE)
+
+        assertThat(selected.map { it.filename }).containsExactly("cmd_stay_in_the_fight", "cmd_drive_forward")
+    }
+
+    @Test
     fun nextPreviewCueFilenameAvoidsImmediateRepeatsAndCyclesUnusedSamples() {
         val used = linkedSetOf("cue_a")
 
@@ -152,6 +174,14 @@ class AIVoiceCalloutManagerSelectionTest {
         assertThat(initialFollowupCommandCueSecond(30)).isEqualTo(Int.MAX_VALUE)
         assertThat(initialFollowupCommandCueSecond(31)).isEqualTo(30)
         assertThat(initialFollowupCommandCueSecond(40)).isEqualTo(30)
+    }
+
+    @Test
+    fun calloutCooldownRequiresThirtySecondsBetweenSpokenCues() {
+        assertThat(hasMetVoiceCalloutCooldown(elapsedSeconds = 29, lastCueSecond = 1)).isFalse()
+        assertThat(hasMetVoiceCalloutCooldown(elapsedSeconds = 30, lastCueSecond = 1)).isFalse()
+        assertThat(hasMetVoiceCalloutCooldown(elapsedSeconds = 31, lastCueSecond = 1)).isTrue()
+        assertThat(hasMetVoiceCalloutCooldown(elapsedSeconds = 60, lastCueSecond = 30)).isTrue()
     }
 
     @Test

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/components/CircularTimerTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/components/CircularTimerTest.kt
@@ -9,13 +9,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class CircularTimerTest {
-
     // -- Animation timing parity tests (must match iOS CircularTimerView) --
-
-    @Test
-    fun `shimmer orbit is 3 seconds`() {
-        assertThat(CircularTimerAnimationConfig.SHIMMER_ORBIT_MS).isEqualTo(3000)
-    }
 
     @Test
     fun `circle pulse full cycle is 3 seconds`() {

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -51,13 +51,44 @@ internal struct VoiceCueCatalog: Codable {
 }
 
 internal let voiceCatalogResourceName = "voice_callouts"
+internal let minVoiceCalloutSpacingSeconds = 30
+
+private let maleCombatCommandFilenames: Set<String> = [
+    "cmd_stay_locked_in",
+    "cmd_no_hesitation_move",
+    "cmd_sound_off_and_drive",
+    "cmd_eyes_up_keep_moving",
+    "cmd_keep_pressure_on",
+    "cmd_sharp_movement_sharp_focus",
+    "cmd_stay_in_the_fight",
+    "cmd_drive_through_it",
+    "cmd_reset_and_attack",
+    "cmd_strong_feet_strong_pace",
+    "cmd_move_fast_stay_precise",
+    "cmd_instant_response_go",
+    "cmd_snap_back_and_drive",
+    "cmd_drive_forward",
+    "cmd_keep_pressure",
+    "cmd_move_now",
+    "cmd_push_through",
+    "cmd_stay_sharp",
+]
+
+private let malePreviewCommandFilenames = [
+    "cmd_stay_locked_in",
+    "cmd_no_hesitation_move",
+    "cmd_sound_off_and_drive",
+    "cmd_snap_back_and_drive",
+    "cmd_stay_in_the_fight",
+    "cmd_reset_and_attack",
+    "cmd_drive_through_it",
+    "cmd_drive_forward",
+    "cmd_keep_pressure_on",
+    "cmd_instant_response_go",
+]
 
 private enum VoicePreviewSampleCatalog {
-    static let maleCommandFilenames = [
-        "cmd_move_with_a_purpose", "cmd_stay_locked_in", "cmd_no_hesitation_move", "cmd_sound_off_and_drive",
-        "cmd_snap_back_and_drive", "cmd_stay_disciplined", "cmd_keep_your_bearing", "cmd_reset_and_attack",
-        "cmd_sharp_movement_sharp_focus", "cmd_stay_in_the_fight",
-    ]
+    static let maleCommandFilenames = malePreviewCommandFilenames
     static let maleElapsedFilename = "preview_elapsed"
     static let femaleCommandFilenames = [
         "female/cmd_move_with_a_purpose", "female/cmd_no_hesitation_move", "female/cmd_stay_in_the_fight",
@@ -194,12 +225,41 @@ internal func initialFollowupCommandCueSecond(totalDurationSeconds: Int) -> Int 
     }
 }
 
+internal func hasMetVoiceCalloutCooldown(elapsedSeconds: Int, lastCueSecond: Int) -> Bool {
+    lastCueSecond <= 0 || elapsedSeconds - lastCueSecond >= minVoiceCalloutSpacingSeconds
+}
+
+internal func commandCueRepeatFamilyKey(_ filename: String) -> String {
+    switch filename {
+    case "cmd_move_with_a_purpose", "cmd_most_ricky_tick":
+        return "move_with_a_purpose"
+    case "cmd_stay_in_the_fight", "cmd_push_through":
+        return "stay_in_the_fight"
+    case "cmd_keep_pressure_on", "cmd_keep_pressure":
+        return "keep_pressure"
+    case "cmd_no_hesitation_move", "cmd_drive_forward":
+        return "no_hesitation"
+    default:
+        return filename
+    }
+}
+
+internal func commandCuePool(for cues: [VoiceCueCatalog.Cue], gender: VoiceGender) -> [VoiceCueCatalog.Cue] {
+    guard gender == .male else {
+        return cues
+    }
+
+    let combatPool = cues.filter { maleCombatCommandFilenames.contains($0.filename) }
+    return combatPool.isEmpty ? cues.filter { $0.filename != "cmd_most_ricky_tick" } : combatPool
+}
+
 @MainActor
 final class AIVoiceCalloutService {
     struct StateSnapshot {
         let lastElapsedMilestone: Int
         let nextCommandCueAt: Int
         let lastCommandCueFilename: String?
+        let lastSpokenCueAt: Int
     }
 
     typealias AudioSessionActivator = @MainActor () -> Void
@@ -207,7 +267,7 @@ final class AIVoiceCalloutService {
     static let shared = AIVoiceCalloutService()
 
     /// Current voice gender preference, set from TimerManager based on config.
-    /// Male = drill sergeant, Female = HIIT instructor.
+    /// Male = mixed combatives coach, Female = HIIT instructor.
     var currentGender: VoiceGender = .male
 
     private static let log = Logger(subsystem: "com.iganapolsky.randomtimer", category: "voice")
@@ -227,6 +287,8 @@ final class AIVoiceCalloutService {
     private var lastElapsedMilestone = 0
     private var nextCommandCueAt = 0
     private var lastCommandCueFilename: String?
+    private var lastCommandCueFamilyKey: String?
+    private var lastSpokenCueAt = 0
     private var usedCommandCueFilenames: Set<String> = []
     private var lastPreviewCommandFilenameByGender: [VoiceGender: String] = [:]
     private var usedPreviewCommandFilenamesByGender: [VoiceGender: Set<String>] = [:]
@@ -263,6 +325,8 @@ final class AIVoiceCalloutService {
         lastElapsedMilestone = 0
         nextCommandCueAt = 0
         lastCommandCueFilename = nil
+        lastCommandCueFamilyKey = nil
+        lastSpokenCueAt = 0
         usedCommandCueFilenames.removeAll()
         lastPreviewCommandFilenameByGender.removeAll()
         usedPreviewCommandFilenamesByGender.removeAll()
@@ -332,10 +396,14 @@ final class AIVoiceCalloutService {
 
     func triggerCallout(elapsedSeconds: Int) {
         if let callout = elapsedMilestone(for: elapsedSeconds) {
+            guard hasMetVoiceCalloutCooldown(elapsedSeconds: elapsedSeconds, lastCueSecond: lastSpokenCueAt) else {
+                return
+            }
             speak(callout.text)
             lastElapsedMilestone = elapsedSeconds
+            lastSpokenCueAt = elapsedSeconds
             if nextCommandCueAt <= elapsedSeconds {
-                nextCommandCueAt = elapsedSeconds + 30
+                nextCommandCueAt = elapsedSeconds + minVoiceCalloutSpacingSeconds
             }
             return
         }
@@ -344,7 +412,8 @@ final class AIVoiceCalloutService {
             let cue = randomCommandCue()
             speak(cue.text)
             lastCommandCueFilename = cue.filename
-            nextCommandCueAt = elapsedSeconds + 30
+            lastSpokenCueAt = elapsedSeconds
+            nextCommandCueAt = elapsedSeconds + minVoiceCalloutSpacingSeconds
         }
     }
 
@@ -362,27 +431,36 @@ final class AIVoiceCalloutService {
 
     private func shouldFireCommandCue(elapsedSeconds: Int) -> Bool {
         if nextCommandCueAt == 0 {
-            nextCommandCueAt = 30
+            nextCommandCueAt = minVoiceCalloutSpacingSeconds
         }
         if nextCommandCueAt == .max {
             return false
         }
         return elapsedSeconds >= nextCommandCueAt
+            && hasMetVoiceCalloutCooldown(elapsedSeconds: elapsedSeconds, lastCueSecond: lastSpokenCueAt)
     }
 
     private func randomCommandCue() -> VoiceCueCatalog.Cue {
         let catalog = packStore.voiceCatalog(bundle: bundle)
-        var pool = catalog.commandCues.filter { !usedCommandCueFilenames.contains($0.filename) }
+        let curated = commandCuePool(for: catalog.commandCues, gender: currentGender)
+        var pool = curated.filter {
+            !usedCommandCueFilenames.contains($0.filename)
+                && commandCueRepeatFamilyKey($0.filename) != lastCommandCueFamilyKey
+        }
         if pool.isEmpty {
             // All cues used — reset and exclude only the last one
             usedCommandCueFilenames.removeAll()
-            pool = catalog.commandCues.filter { $0.filename != lastCommandCueFilename }
-            if pool.isEmpty { pool = catalog.commandCues }
+            pool = curated.filter { commandCueRepeatFamilyKey($0.filename) != lastCommandCueFamilyKey }
+            if pool.isEmpty {
+                pool = curated.filter { $0.filename != lastCommandCueFilename }
+            }
+            if pool.isEmpty { pool = curated }
         }
         let cue = nextCommandCue(from: pool, lastFilename: lastCommandCueFilename) { upperBound in
             secureRandomInt(in: 0...(upperBound - 1))
         }
         lastCommandCueFilename = cue.filename
+        lastCommandCueFamilyKey = commandCueRepeatFamilyKey(cue.filename)
         usedCommandCueFilenames.insert(cue.filename)
         return cue
     }
@@ -403,7 +481,8 @@ final class AIVoiceCalloutService {
         StateSnapshot(
             lastElapsedMilestone: lastElapsedMilestone,
             nextCommandCueAt: nextCommandCueAt,
-            lastCommandCueFilename: lastCommandCueFilename
+            lastCommandCueFilename: lastCommandCueFilename,
+            lastSpokenCueAt: lastSpokenCueAt
         )
     }
 }

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -227,6 +227,25 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertEqual(selected.filename, "cue_b")
     }
 
+    func testCommandCueRepeatFamilyGroupsMoveWithAPurposeVariants() {
+        XCTAssertEqual(commandCueRepeatFamilyKey("cmd_move_with_a_purpose"), "move_with_a_purpose")
+        XCTAssertEqual(commandCueRepeatFamilyKey("cmd_most_ricky_tick"), "move_with_a_purpose")
+        XCTAssertEqual(commandCueRepeatFamilyKey("cmd_stay_locked_in"), "cmd_stay_locked_in")
+    }
+
+    func testMaleCommandCuePoolPrefersCombatStyleLinesAndDropsMostRickyTick() {
+        let cues = [
+            VoiceCueCatalog.Cue(filename: "cmd_most_ricky_tick", text: "Most ricky tick. Move with a purpose."),
+            VoiceCueCatalog.Cue(filename: "cmd_stay_in_the_fight", text: "Stay in the fight."),
+            VoiceCueCatalog.Cue(filename: "cmd_drive_forward", text: "Drive forward. No hesitation."),
+            VoiceCueCatalog.Cue(filename: "cmd_keep_tempo_high", text: "Keep the tempo high."),
+        ]
+
+        let selected = commandCuePool(for: cues, gender: .male)
+
+        XCTAssertEqual(selected.map(\.filename), ["cmd_stay_in_the_fight", "cmd_drive_forward"])
+    }
+
     func testNextPreviewFilenameAvoidsImmediateRepeatWhenPossible() {
         var usedFilenames: Set<String> = ["cue_a"]
 
@@ -246,6 +265,13 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 30), .max)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 31), 30)
         XCTAssertEqual(initialFollowupCommandCueSecond(totalDurationSeconds: 40), 30)
+    }
+
+    func testVoiceCalloutCooldownRequiresThirtySecondsBetweenSpokenCues() {
+        XCTAssertFalse(hasMetVoiceCalloutCooldown(elapsedSeconds: 29, lastCueSecond: 1))
+        XCTAssertFalse(hasMetVoiceCalloutCooldown(elapsedSeconds: 30, lastCueSecond: 1))
+        XCTAssertTrue(hasMetVoiceCalloutCooldown(elapsedSeconds: 31, lastCueSecond: 1))
+        XCTAssertTrue(hasMetVoiceCalloutCooldown(elapsedSeconds: 60, lastCueSecond: 30))
     }
 
     func testPlaybackReactivatesAudioSessionAfterSessionBegin() {
@@ -277,17 +303,20 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertEqual(atThirty.lastElapsedMilestone, 0)
         XCTAssertEqual(atThirty.nextCommandCueAt, 60)
         XCTAssertNotNil(atThirty.lastCommandCueFilename)
+        XCTAssertEqual(atThirty.lastSpokenCueAt, 30)
 
         sut.triggerCallout(elapsedSeconds: 45)
         let atFortyFive = sut._stateSnapshotForTesting()
         XCTAssertEqual(atFortyFive.lastElapsedMilestone, 0)
         XCTAssertEqual(atFortyFive.nextCommandCueAt, 60)
         XCTAssertNotNil(atFortyFive.lastCommandCueFilename)
+        XCTAssertEqual(atFortyFive.lastSpokenCueAt, 30)
 
         sut.triggerCallout(elapsedSeconds: 60)
         let atSixty = sut._stateSnapshotForTesting()
         XCTAssertEqual(atSixty.lastElapsedMilestone, 60)
         XCTAssertEqual(atSixty.nextCommandCueAt, 90)
+        XCTAssertEqual(atSixty.lastSpokenCueAt, 60)
     }
 
     func testFirstTimedCalloutReactivatesAudioSessionBeforePlayback() {

--- a/scripts/shell/bootstrap_git_config.sh
+++ b/scripts/shell/bootstrap_git_config.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+hooks_dir="$(git rev-parse --git-path hooks)"
+managed_hook="$hooks_dir/pre-commit"
+managed_marker="# random-timer-managed-hook"
+precommit_script="$repo_root/scripts/pre-commit"
+hook_name="random-timer-pre-commit"
+
+git_version="$(git version | awk '{print $3}')"
+
+version_ge() {
+  local left="$1"
+  local right="$2"
+  local first
+  first="$(printf '%s\n%s\n' "$left" "$right" | sort -V | head -n1)"
+  [[ "$first" == "$right" ]]
+}
+
+remove_managed_hook_wrapper() {
+  if [[ ! -f "$managed_hook" ]]; then
+    return
+  fi
+
+  if grep -q "$managed_marker" "$managed_hook"; then
+    rm -f "$managed_hook"
+    return
+  fi
+
+  if grep -Fq 'exec ./scripts/pre-commit "$@"' "$managed_hook"; then
+    rm -f "$managed_hook"
+    return
+  fi
+
+  if cmp -s "$managed_hook" "$precommit_script"; then
+    rm -f "$managed_hook"
+  fi
+}
+
+install_managed_hook_wrapper() {
+  mkdir -p "$hooks_dir"
+  cat >"$managed_hook" <<EOF
+#!/usr/bin/env bash
+$managed_marker
+exec "$precommit_script" "\$@"
+EOF
+  chmod +x "$managed_hook"
+  echo "Installed worktree-safe pre-commit wrapper at $managed_hook"
+}
+
+configure_hook_via_git_254() {
+  git config --local --unset-all "hook.$hook_name.event" 2>/dev/null || true
+  git config --local --unset-all "hook.$hook_name.command" 2>/dev/null || true
+  git config --local "hook.$hook_name.command" "$precommit_script"
+  git config --local --add "hook.$hook_name.event" pre-commit
+  git config --local "hook.$hook_name.enabled" true
+  remove_managed_hook_wrapper
+  echo "Configured pre-commit via hook.$hook_name.* repo-local config"
+}
+
+configure_compare_branches_via_git_254() {
+  git config --local status.compareBranches "@{upstream} @{push}"
+  echo "Configured git status branch comparisons for @{upstream} and @{push}"
+}
+
+main() {
+  if [[ ! -x "$precommit_script" ]]; then
+    echo "Missing executable pre-commit script at $precommit_script" >&2
+    exit 1
+  fi
+
+  if version_ge "$git_version" "2.54.0"; then
+    configure_hook_via_git_254
+    configure_compare_branches_via_git_254
+  else
+    install_managed_hook_wrapper
+    echo "Git $git_version does not support config-defined hooks or status.compareBranches yet; skipped 2.54-only setup"
+  fi
+}
+
+main "$@"

--- a/scripts/tests/test_git_bootstrap_contracts.py
+++ b/scripts/tests/test_git_bootstrap_contracts.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+import os
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = ROOT / "Makefile"
+README = ROOT / "README.md"
+BOOTSTRAP = ROOT / "scripts" / "shell" / "bootstrap_git_config.sh"
+
+
+class GitBootstrapContractsTests(unittest.TestCase):
+    def test_makefile_bootstrap_target_uses_git_bootstrap_script(self) -> None:
+        source = MAKEFILE.read_text(encoding="utf-8")
+
+        self.assertIn("./scripts/shell/bootstrap_git_config.sh", source)
+        self.assertIn("bootstrap-git: install-hooks", source)
+
+    def test_readme_documents_bootstrap_git_and_status_compare_branches(self) -> None:
+        source = README.read_text(encoding="utf-8")
+
+        self.assertIn("make bootstrap-git", source)
+        self.assertIn("status` comparisons against both `@{upstream}` and `@{push}`", source)
+
+    def test_bootstrap_script_configures_git_254_repo_without_hookdir_pre_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            env = os.environ.copy()
+            env["GIT_CONFIG_GLOBAL"] = os.devnull
+            env["GIT_CONFIG_NOSYSTEM"] = "1"
+
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True, env=env)
+
+            scripts_dir = repo / "scripts"
+            shell_dir = scripts_dir / "shell"
+            shell_dir.mkdir(parents=True)
+
+            managed_pre_commit = scripts_dir / "pre-commit"
+            managed_pre_commit.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            managed_pre_commit.chmod(managed_pre_commit.stat().st_mode | stat.S_IXUSR)
+
+            copied_bootstrap = shell_dir / "bootstrap_git_config.sh"
+            shutil.copy2(BOOTSTRAP, copied_bootstrap)
+            copied_bootstrap.chmod(copied_bootstrap.stat().st_mode | stat.S_IXUSR)
+
+            subprocess.run([str(copied_bootstrap)], cwd=repo, check=True, capture_output=True, text=True, env=env)
+
+            configured_hook = subprocess.run(
+                ["git", "config", "--local", "--get", "hook.random-timer-pre-commit.command"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            ).stdout.strip()
+            self.assertEqual(Path(configured_hook).resolve(), managed_pre_commit.resolve())
+
+            configured_events = subprocess.run(
+                ["git", "config", "--local", "--get-all", "hook.random-timer-pre-commit.event"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            ).stdout.splitlines()
+            self.assertEqual(configured_events, ["pre-commit"])
+
+            compare_branches = subprocess.run(
+                ["git", "config", "--local", "--get", "status.compareBranches"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            ).stdout.strip()
+            self.assertEqual(compare_branches, "@{upstream} @{push}")
+
+            hooks_dir = subprocess.run(
+                ["git", "rev-parse", "--git-path", "hooks"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            ).stdout.strip()
+            self.assertFalse((repo / hooks_dir / "pre-commit").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove the extra Android timer indicator marker
- enforce a 30-second minimum gap between voice callouts and reduce male callout repetition
- add worktree-safe Git bootstrap automation and automated contract coverage

## Verification
- python3 -m unittest scripts.tests.test_git_bootstrap_contracts
- cd native-android && ./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest --tests com.iganapolsky.randomtimer.ui.components.CircularTimerTest
- xcodebuild -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination "platform=iOS Simulator,name=iPhone 16" -only-testing:RandomTimerTests/AIVoiceCalloutServiceTests test