### PR TITLE
docs(release): add 1.3.26 release notes

### DIFF
--- a/release-notes/1.3.26.md
+++ b/release-notes/1.3.26.md
@@ -1,0 +1,16 @@
+# Release 1.3.26
+
+## Summary
+Unified **1.3.26** release for **Android** and **iOS** under the public name **Random Tactical Timer**. Focus: fix two UX bugs in the voice-callout experience and expand the coaching library with MMA combatives cues.
+
+## Customer-visible changes
+- **No more ring leaks.** The timer ring no longer visually encodes elapsed progress, restoring the "random" promise (ring used to narrow as time advanced, telegraphing the interval).
+- **Voice callouts no longer repeat.** Fixed a dedup bug where the same cue (e.g. "Move with a purpose") could fire twice in the same session.
+- **30-second cooldown between callouts.** Cooldown is now measured in elapsed session-seconds, so it works correctly when the app is backgrounded or the device sleeps.
+- **15 new MMA combatives voice cues** (male + female voices): check stance, jab and circle, footwork, hands high, pressure the cage, double leg, sprawl and brawl, mix strikes, control the center, snap that jab, feint and fire, wall and pound, takedown defense, chain wrestling, finish on the feet.
+
+## Release operations
+- Android `versionName` **1.3.26**; Play `versionCode` **1774900009** (monotonic with prior production).
+- iOS `MARKETING_VERSION` **1.3.26**; build number incremented per CI / upload rules.
+- Audio assets rendered via ElevenLabs (`eleven_multilingual_v2`, male voice `DGzg6RaUqxGRTHSBjfgF`, female `EXAVITQu4vr4xnSDxMaL`). 60 new mp3s bundled (15 cues × male + female × iOS + Android mirror).
+- `generate-base-voice-callouts` workflow fix: stage-then-diff so newly rendered (untracked) mp3s aren't silently dropped from the auto-PR.


### PR DESCRIPTION
## Summary

- Adds `release-notes/1.3.26.md` (required by `preflight-release.sh` — Internal Distribution run `24786608926` failed on Android Firebase + Google Play jobs with: "Versioned release notes missing: release-notes/1.3.26.md").

## Test plan

- [x] Preflight passes locally (missing file was only error reported)
- [ ] Android Firebase + Play internal jobs succeed on re-dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)