### PR TITLE
fix(ios): add match nuke + regen workflow for revoked Distribution cert

### DIFF
--- a/.github/workflows/ios-cert-regen.yml
+++ b/.github/workflows/ios-cert-regen.yml
@@ -1,0 +1,103 @@
+name: iOS Cert Regen (match nuke + regen Distribution)
+
+# One-off maintenance workflow. Run when the Apple Distribution cert stored in
+# the fastlane match repo has been revoked at Apple's portal and every release
+# build fails with "Signing certificate is invalid ... It may have been revoked
+# or expired." Uses the live ASC JWT (APPSTORE_* secrets) so the operation is
+# non-interactive — no Apple-ID 2FA required.
+#
+# Effect:
+#   1. `fastlane match nuke distribution` revokes the stored cert at Apple's
+#      portal (no-op if already revoked) and deletes it from the match git repo
+#      along with every App Store provisioning profile for the two bundle IDs.
+#   2. `fastlane match appstore` generates a fresh Distribution cert + App Store
+#      profiles and commits them back to the match repo.
+# After this runs, re-dispatch Internal Distribution / Native App Release on
+# the target release branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to check out (match ops are ref-agnostic; default develop)"
+        required: false
+        default: develop
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-cert-regen
+  cancel-in-progress: false
+
+jobs:
+  regen:
+    name: Nuke + regenerate Apple Distribution cert
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Fail fast on required secrets
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          for name in APPSTORE_KEY_ID APPSTORE_ISSUER_ID APPSTORE_PRIVATE_KEY APPLE_TEAM_ID MATCH_GIT_URL MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION ADMIN_TOKEN; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required secret: $name"
+              exit 1
+            fi
+          done
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: native-ios
+
+      - name: Install Fastlane
+        working-directory: native-ios
+        run: gem install fastlane
+
+      - name: Configure git credentials for match
+        env:
+          GIT_AUTH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global url."https://x-access-token:${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Write ASC private key
+        env:
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+          chmod 600 ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+
+      - name: Match nuke + regenerate Distribution cert
+        working-directory: native-ios
+        env:
+          CI: "true"
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          FASTLANE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_SKIP_CONFIRMATION: "1"
+          FASTLANE_SKIP_UPDATE_CHECK: "1"
+        run: fastlane regen_dist_certs

--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -461,10 +461,42 @@ platform :ios do
   lane :deploy do
     # Setup for CI
     setup_ci if ENV["CI"]
-    
+
     # Build and upload to TestFlight using the same logic as beta lane
     beta
-    
+
     # The Firebase upload is already handled in the beta lane
+  end
+
+  desc "Nuke revoked Apple Distribution cert and regenerate via match (ASC JWT, non-interactive)"
+  lane :regen_dist_certs do
+    setup_ci if ENV["CI"] == "true"
+
+    UI.user_error!("APPSTORE_KEY_ID required") if ENV["APPSTORE_KEY_ID"].to_s.empty?
+    UI.user_error!("APPSTORE_ISSUER_ID required") if ENV["APPSTORE_ISSUER_ID"].to_s.empty?
+    UI.user_error!("MATCH_GIT_URL required") if ENV["MATCH_GIT_URL"].to_s.empty?
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APPSTORE_KEY_ID"],
+      issuer_id: ENV["APPSTORE_ISSUER_ID"],
+      key_filepath: File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{ENV['APPSTORE_KEY_ID']}.p8")
+    )
+
+    app_ids = ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"]
+
+    match_nuke(
+      type: "distribution",
+      app_identifier: app_ids,
+      api_key: api_key,
+      skip_confirmation: true
+    )
+
+    match(
+      type: "appstore",
+      app_identifier: app_ids,
+      readonly: false,
+      force: true,
+      api_key: api_key
+    )
   end
 end


### PR DESCRIPTION
## Summary
- **Blocker:** Apple Distribution cert `4707A7D2DDD3FA09233F62F8477B7FD` (team `9GMM26JC5X`) was revoked at Apple's portal. Every iOS release build currently fails at codesign: *"Signing certificate is invalid … It may have been revoked or expired."* This blocks v1.3.26 TestFlight uploads on `release/v1.3.26`.
- The existing `ios-apple-id-release.yml` fallback does **not** help — it uses the same `fastlane match readonly` and fetches the same dead cert from the match git repo.
- Adds a one-off `workflow_dispatch` workflow (`.github/workflows/ios-cert-regen.yml`) plus a Fastfile lane (`regen_dist_certs`) that use the live ASC JWT secrets (`APPSTORE_KEY_ID`/`APPSTORE_ISSUER_ID`/`APPSTORE_PRIVATE_KEY`, rotated 2026-04-21) to run `match nuke distribution` + `match appstore` **non-interactively** for both `com.igorganapolsky.randomtimer` and `com.igorganapolsky.randomtimer.widget`.

## Post-merge runbook
1. Dispatch `iOS Cert Regen` on `develop` (or any ref).
2. Verify the run succeeds and the match repo has a new `distribution` cert.
3. Re-dispatch **Internal Distribution** on `release/v1.3.26`.
4. Once internal signoff statuses land, re-dispatch **Native App Release** on `release/v1.3.26`.

## Test plan
- [ ] CI green on this PR (no app code changed — only a Fastfile lane + a new workflow file)
- [ ] After merge, manually dispatch `iOS Cert Regen`; confirm `match nuke` + `match appstore` complete and a fresh cert appears in the match git repo
- [ ] Re-dispatch `Internal Distribution` on `release/v1.3.26`; confirm iOS TestFlight job passes (no cert error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)