### PR TITLE
fix(ios): use type:appstore for match_nuke (distribution is CLI alias)

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -484,8 +484,12 @@ platform :ios do
 
     app_ids = ["com.igorganapolsky.randomtimer", "com.igorganapolsky.randomtimer.widget"]
 
+    # match_nuke action accepts only the strict type enum
+    # (appstore/adhoc/development/enterprise/developer_id/…). "distribution"
+    # is a fastlane CLI-only alias that maps to appstore; passing it to the
+    # action throws "Unsupported environment distribution".
     match_nuke(
-      type: "distribution",
+      type: "appstore",
       app_identifier: app_ids,
       api_key: api_key,
       skip_confirmation: true


### PR DESCRIPTION
## Summary
- Run 24792956182 (iOS Cert Regen on develop) failed at step 8: match_nuke rejected type:\"distribution\" with *\"Unsupported environment distribution, must be in appstore, adhoc, development, enterprise, developer_id, mac_installer_distribution, developer_id_installer\"*.
- \"distribution\" is a fastlane **CLI-only** alias; the underlying Ruby action requires the strict enum. Switching to type:\"appstore\" — same category, same cert+profile pair.

## Test plan
- [ ] CI green on this PR (Fastfile-only change)
- [ ] After merge, re-dispatch \`iOS Cert Regen\`; confirm match_nuke + match appstore both succeed and a fresh Distribution cert lands in the match repo
- [ ] Re-dispatch Internal Distribution on release/v1.3.26; confirm iOS TestFlight job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)