### PR TITLE
fix(ios): force readonly:false on match_nuke

### DIFF
--- a/native-ios/fastlane/Fastfile
+++ b/native-ios/fastlane/Fastfile
@@ -488,9 +488,14 @@ platform :ios do
     # (appstore/adhoc/development/enterprise/developer_id/…). "distribution"
     # is a fastlane CLI-only alias that maps to appstore; passing it to the
     # action throws "Unsupported environment distribution".
+    # Explicit readonly:false — fastlane's Matchfile / setup_ci can otherwise
+    # default match_nuke to readonly, producing a dry-run that refuses with
+    # "fastlane match nuke doesn't delete anything when running with
+    # --readonly enabled".
     match_nuke(
       type: "appstore",
       app_identifier: app_ids,
+      readonly: false,
       api_key: api_key,
       skip_confirmation: true
     )


### PR DESCRIPTION
## Summary
Run 24793525661 (cert regen on develop, SHA c95cec662) failed with:

\`\`\`
[!] fastlane match nuke doesn't delete anything when running with --readonly enabled
\`\`\`

match_nuke correctly identified the 4 App Store profiles (all marked **INVALID** at Apple) and the distribution cert files (\`7LTBBL83QC.cer\`/\`.p12\`) that it would delete — then refused to act because readonly was enabled, likely inherited from \`setup_ci\` or CI env defaults. The regenerate step never ran.

Explicit \`readonly: false\` on match_nuke forces the delete. The subsequent \`match(type: \"appstore\", readonly: false, force: true, ...)\` call already had the right flag; match_nuke was the gap.

## Test plan
- [ ] CI green on this PR (Fastfile-only)
- [ ] After merge, re-dispatch \`iOS Cert Regen\`; confirm match_nuke deletes the old cert + profiles and match appstore issues fresh ones
- [ ] Re-dispatch Internal Distribution on release/v1.3.26; iOS TestFlight job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)