### PR TITLE
fix(ios): MATCH_SKIP_CONFIRMATION must be "true" not "1"

### DIFF
--- a/.github/workflows/ios-cert-regen.yml
+++ b/.github/workflows/ios-cert-regen.yml
@@ -98,6 +98,10 @@ jobs:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-          MATCH_SKIP_CONFIRMATION: "1"
+          # MATCH_SKIP_CONFIRMATION must be the literal string "true"/"false";
+          # "1" causes match to reject with `'skip_confirmation' value must be
+          # either true or false! Found String instead.` when the env var
+          # leaks into the subsequent match appstore regen call.
+          MATCH_SKIP_CONFIRMATION: "true"
           FASTLANE_SKIP_UPDATE_CHECK: "1"
         run: fastlane regen_dist_certs


### PR DESCRIPTION
## Critical context
**match repo is currently in an INCOMPLETE state.** Run 24794184997 successfully nuked the dead Distribution cert \`7LTBBL83QC\` and all 4 AppStore profiles from the match repo + Apple portal, then failed on the regen step with:

\`\`\`
[!] 'skip_confirmation' value must be either true or false! Found String instead.
\`\`\`

Until this regen completes, **iOS builds have no cert at all** — the match repo is emptier than when it had the revoked cert.

## Summary
Fastlane's env-var-to-boolean cast accepts literal \`\"true\"\`/\`\"false\"\` but rejects \`\"1\"\`/\`\"0\"\`. Switching \`MATCH_SKIP_CONFIRMATION: \"1\"\` → \`\"true\"\` in the regen workflow.

## Test plan
- [ ] Merge ASAP (match repo in broken state)
- [ ] Re-dispatch \`iOS Cert Regen\`; confirm both match_nuke (no-op since already nuked) + match appstore (fresh cert issued) succeed
- [ ] Re-dispatch Internal Distribution on release/v1.3.26; iOS TestFlight job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)