### PR TITLE
Fix iOS launch bootstrap and App Review resubmission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,14 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             "OTHER_SWIFT_FLAGS=\$(inherited) -D RT_SKIP_FIREBASE_FOR_CI"
 
+      - name: Enforce targeted iOS launch coverage
+        run: |
+          xcrun xccov view --report --json native-ios/build/TestResults.xcresult > native-ios/build/xccov-report.json
+          python3 scripts/check_ios_targeted_coverage.py \
+            --report-json native-ios/build/xccov-report.json \
+            --require native-ios/RandomTimer/Sources/App/AppBootstrap.swift=1.0 \
+            --require native-ios/RandomTimer/Sources/Services/TimerManagerStartupPlan.swift=1.0
+
       - name: Upload iOS xcresult
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -176,12 +176,12 @@ jobs:
           GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
         run: |
           set -euo pipefail
-          if [ -n "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
-            printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
-            echo "✅ Wrote RandomTimer/GoogleService-Info.plist from GOOGLE_SERVICE_INFO_PLIST"
-          else
-            echo "ℹ️ GOOGLE_SERVICE_INFO_PLIST not set; using any plist already in the workspace"
+          if [ -z "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
+            echo "❌ GOOGLE_SERVICE_INFO_PLIST is required for distributed iOS builds"
+            exit 1
           fi
+          printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
+          echo "✅ Wrote RandomTimer/GoogleService-Info.plist from GOOGLE_SERVICE_INFO_PLIST"
         working-directory: native-ios
 
       - name: Fail fast on required iOS distribution secrets

--- a/.github/workflows/ios-apple-id-release.yml
+++ b/.github/workflows/ios-apple-id-release.yml
@@ -30,10 +30,12 @@ jobs:
         working-directory: native-ios
         run: |
           set -euo pipefail
-          if [ -n "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
-            printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
-            echo "Wrote GoogleService-Info.plist"
+          if [ -z "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
+            echo "::error::GOOGLE_SERVICE_INFO_PLIST is required for distributed iOS builds"
+            exit 1
           fi
+          printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
+          echo "Wrote GoogleService-Info.plist"
 
       - name: Fail fast on required Apple-ID secrets
         env:

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -147,12 +147,12 @@ jobs:
           GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
         run: |
           set -euo pipefail
-          if [ -n "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
-            printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
-            echo "✅ Wrote RandomTimer/GoogleService-Info.plist from GOOGLE_SERVICE_INFO_PLIST"
-          else
-            echo "ℹ️ GOOGLE_SERVICE_INFO_PLIST not set; using any plist already in the workspace"
+          if [ -z "${GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
+            echo "❌ GOOGLE_SERVICE_INFO_PLIST is required for distributed iOS builds"
+            exit 1
           fi
+          printf '%s' "$GOOGLE_SERVICE_INFO_PLIST" > RandomTimer/GoogleService-Info.plist
+          echo "✅ Wrote RandomTimer/GoogleService-Info.plist from GOOGLE_SERVICE_INFO_PLIST"
         working-directory: native-ios
 
       - name: Fail fast on required iOS release secrets

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -12,7 +12,7 @@ This document is the **source of truth** for what is **implemented in code** ver
 |------------|-----|---------|--------|
 | **PostHog** (events, identify, funnels) | Yes | Yes | Initializes only when `POSTHOG_API_KEY` is non-empty at build/runtime wiring. |
 | **Session replay** | Yes (SDK config) | Yes (SDK config) | Masking + throttling in code. **Internal** builds / simulators excluded on iOS; Android excludes emulators / debug similarly. **PostHog project** must have session recording enabled if you want replays in the UI. |
-| **Firebase Crashlytics** | Yes | Yes | Release pipelines require real `GoogleService-Info.plist` / `google-services.json` (not committed). iOS debug/test builds can run without a local `GoogleService-Info.plist`; Firebase init is skipped when the plist is not bundled or when CI/test skip flags are set. |
+| **Firebase Crashlytics** | Yes | Yes | Release pipelines require real `GoogleService-Info.plist` / `google-services.json` (not committed). iOS debug/test builds can run without a local `GoogleService-Info.plist`; Firebase init is skipped when the plist is not bundled or when CI/test skip flags are set, and release workflows fail before distribution if the iOS plist secret is missing. |
 | **Firebase Performance** | **No** (SPM product not linked) | **Yes** (Gradle plugin + `firebase-perf` dependency) | iOS auto-instrumentation was removed to stabilize CI; can be re-added later with the same CI skip pattern if validated. |
 | **Firebase Remote Config** | **No** | **No** | Not referenced in app sources; use PostHog feature flags until/unless RC is added. |
 | **PostHog feature flags (in-app)** | Yes | Yes | SDK `isFeatureEnabled` / `reloadFeatureFlags` (see `AnalyticsService` on each platform). Flags load at init with `preloadFeatureFlags` on Android; iOS reloads before paywall when needed. |
@@ -49,7 +49,7 @@ Nothing below should be pasted into chat or committed to git. Use Xcode, Gradle 
 
 ### 2. Firebase (Crashlytics + Android Performance)
 
-- [ ] **iOS release / local Firebase validation:** Download **`GoogleService-Info.plist`** from Firebase Console for `com.iganapolsky.randomtimer`, place at `native-ios/RandomTimer/GoogleService-Info.plist` (file is **gitignored**). Debug/test builds can compile without it, but Firebase/Crashlytics will stay disabled until the real plist is present.
+- [ ] **iOS release / local Firebase validation:** Download **`GoogleService-Info.plist`** from Firebase Console for `com.iganapolsky.randomtimer`, place at `native-ios/RandomTimer/GoogleService-Info.plist` (file is **gitignored**). Debug/test builds can compile without it, but Firebase/Crashlytics will stay disabled until the real plist is present, and distribution workflows now fail fast if `GOOGLE_SERVICE_INFO_PLIST` is unset.
 - [ ] **Android:** **`google-services.json`** in `native-android/app/` for real builds (gitignored in normal dev; CI generates a dummy for builds/tests).
 - [ ] Firebase Console: ensure **Crashlytics** is enabled for the app; **Performance Monitoring** enabled for Android (already depends on Gradle setup).
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		0DDD8A9A4BBA38ABE292B47F /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E4CF9C669D336F6C2FD8E7 /* PrimaryButton.swift */; };
 		1128B196E27E8531DC06D2FF /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE6975376BF7C7C6B14F8BF /* NotificationService.swift */; };
 		1F9A3C44B55D66E77F880011 /* ProSoundCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A3C44B55D66E77F880010 /* ProSoundCatalog.swift */; };
+		1F9A3C44B55D66E77F880013 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A3C44B55D66E77F880012 /* AppBootstrap.swift */; };
+		1F9A3C44B55D66E77F880015 /* TimerManagerStartupPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A3C44B55D66E77F880014 /* TimerManagerStartupPlan.swift */; };
 		17E69C010FAA04EFC0076358 /* TimerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5328BD9D4D105BCDE8D488F4 /* TimerModels.swift */; };
 		1BAE4130DA7DC5758A7F13FE /* StoreReviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48232C2EAE9FAA775617C954 /* StoreReviewManager.swift */; };
 		1DB82123D1FB23AC92C566D7 /* drum_roll.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = F5F3E399050BD30295736FEA /* drum_roll.mp3 */; };
@@ -48,6 +50,8 @@
 		69A55EE7F47BF51A55C13896 /* RandomTimerLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACBE63218A7CEC69F1E5422 /* RandomTimerLiveActivity.swift */; };
 		7333136EFF1A48ADABA95895 /* bell.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 75387774E2DAB72906B19DCD /* bell.mp3 */; };
 		840C3EEAD4E35D7D202C1C68 /* TimerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B55AFED96FE157EA7D0BF85 /* TimerModelsTests.swift */; };
+		840C3EEAD4E35D7D202C1C69 /* AppBootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840C3EEAD4E35D7D202C1C67 /* AppBootstrapTests.swift */; };
+		840C3EEAD4E35D7D202C1C70 /* TimerManagerStartupPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840C3EEAD4E35D7D202C1C71 /* TimerManagerStartupPlanTests.swift */; };
 		A1C100112233445566778899 /* Audio in Resources */ = {isa = PBXBuildFile; fileRef = A1C1001122334455667788BB /* Audio */; };
 		A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */; };
 		PRVT001122334455AABB0002 /* ProValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRVT001122334455AABB0001 /* ProValidationTests.swift */; };
@@ -144,6 +148,8 @@
 		368C8F93B37D3B244F271919 /* RandomTimerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomTimerApp.swift; sourceTree = "<group>"; };
 		3BE6975376BF7C7C6B14F8BF /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		1F9A3C44B55D66E77F880010 /* ProSoundCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProSoundCatalog.swift; sourceTree = "<group>"; };
+		1F9A3C44B55D66E77F880012 /* AppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrap.swift; sourceTree = "<group>"; };
+		1F9A3C44B55D66E77F880014 /* TimerManagerStartupPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManagerStartupPlan.swift; sourceTree = "<group>"; };
 		48232C2EAE9FAA775617C954 /* StoreReviewManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreReviewManager.swift; sourceTree = "<group>"; };
 		4C626B57059C6BDF97711A5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4EB219B60074D5E0130A3D15 /* ServiceProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ServiceProtocols.swift; sourceTree = "<group>"; };
@@ -154,6 +160,8 @@
 		75387774E2DAB72906B19DCD /* bell.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = bell.mp3; sourceTree = "<group>"; };
 		7810CC4BC51B69F8B2799FF7 /* CircularTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularTimerView.swift; sourceTree = "<group>"; };
 		7B55AFED96FE157EA7D0BF85 /* TimerModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerModelsTests.swift; sourceTree = "<group>"; };
+		840C3EEAD4E35D7D202C1C67 /* AppBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrapTests.swift; sourceTree = "<group>"; };
+		840C3EEAD4E35D7D202C1C71 /* TimerManagerStartupPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManagerStartupPlanTests.swift; sourceTree = "<group>"; };
 		7CA1C5AD670D6527A669A21F /* RangeSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSliderView.swift; sourceTree = "<group>"; };
 		808390B0F0B9EE36AC342E7A /* PaywallSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallSheet.swift; sourceTree = "<group>"; };
 		8E92FED72459C5B7A18BEE3D /* buzzer.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = buzzer.mp3; sourceTree = "<group>"; };
@@ -218,6 +226,7 @@
 		3F3001C89372688DF388B3EA /* App */ = {
 			isa = PBXGroup;
 			children = (
+				1F9A3C44B55D66E77F880012 /* AppBootstrap.swift */,
 				368C8F93B37D3B244F271919 /* RandomTimerApp.swift */,
 			);
 			path = App;
@@ -226,6 +235,8 @@
 		4A083F7CAA823D4930153B06 /* RandomTimerTests */ = {
 			isa = PBXGroup;
 			children = (
+				840C3EEAD4E35D7D202C1C67 /* AppBootstrapTests.swift */,
+				840C3EEAD4E35D7D202C1C71 /* TimerManagerStartupPlanTests.swift */,
 				DISTCH00112233445566778801 /* DistributionChannelResolverTests.swift */,
 				A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */,
 				A1B2C3D4E5F60718A1B2C3D5 /* CircularTimerViewTests.swift */,
@@ -271,6 +282,7 @@
 				A1B2C3D400000002DEADBEEF /* Logger.swift */,
 				3BE6975376BF7C7C6B14F8BF /* NotificationService.swift */,
 				1F9A3C44B55D66E77F880010 /* ProSoundCatalog.swift */,
+				1F9A3C44B55D66E77F880014 /* TimerManagerStartupPlan.swift */,
 				8EEB9F4FF4ED4C88A5232642 /* LiveActivityService.swift */,
 				D4045FE32D7D1E2F9D4C423C /* StorageService.swift */,
 				CE62A2F6E881E0CCA7DF2361 /* TimerManager.swift */,
@@ -619,6 +631,8 @@
 				E1DD7FFA2F3044B7A5F461C1 /* LiveActivityService.swift in Sources */,
 				0DDD8A9A4BBA38ABE292B47F /* PrimaryButton.swift in Sources */,
 				4ED9D921707F80E1AC5501F3 /* RandomTimerApp.swift in Sources */,
+				1F9A3C44B55D66E77F880013 /* AppBootstrap.swift in Sources */,
+				1F9A3C44B55D66E77F880015 /* TimerManagerStartupPlan.swift in Sources */,
 				E479E3D609A46B2F93C1BD2C /* RangeSliderView.swift in Sources */,
 				A1B2C3D400000004SHARE01 /* ShareSheet.swift in Sources */,
 				D8BFD3BC04A1001EE7329508 /* StorageService.swift in Sources */,
@@ -649,6 +663,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				840C3EEAD4E35D7D202C1C69 /* AppBootstrapTests.swift in Sources */,
+				840C3EEAD4E35D7D202C1C70 /* TimerManagerStartupPlanTests.swift in Sources */,
 				DISTCH00112233445566778802 /* DistributionChannelResolverTests.swift in Sources */,
 				A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */,
 				A1B2C3D4E5F60718A1B2C3D4 /* CircularTimerViewTests.swift in Sources */,

--- a/native-ios/RandomTimer/Sources/App/AppBootstrap.swift
+++ b/native-ios/RandomTimer/Sources/App/AppBootstrap.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct AppBootstrapPlan: Equatable {
+    let shouldInitializeFirebase: Bool
+    let shouldInitializeAnalytics: Bool
+    let logMessage: String?
+
+    static func resolve(
+        skipHostedTests: Bool,
+        hasBundledFirebaseConfig: Bool,
+    ) -> Self {
+        if skipHostedTests {
+            return Self(
+                shouldInitializeFirebase: false,
+                shouldInitializeAnalytics: false,
+                logMessage: "Skipping Firebase and analytics initialization for hosted tests."
+            )
+        }
+
+        if !hasBundledFirebaseConfig {
+            return Self(
+                shouldInitializeFirebase: false,
+                shouldInitializeAnalytics: true,
+                logMessage: "Skipping Firebase initialization because GoogleService-Info.plist is not bundled."
+            )
+        }
+
+        return Self(
+            shouldInitializeFirebase: true,
+            shouldInitializeAnalytics: true,
+            logMessage: nil
+        )
+    }
+}

--- a/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
+++ b/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
@@ -29,18 +29,23 @@ struct RandomTimerApp: App {
     }
 
     init() {
-        guard !Self.shouldSkipFirebaseForHostedTests else { return }
-        guard Self.hasBundledFirebaseConfig else {
-            #if DEBUG
-            Self.logger.warning("Skipping Firebase initialization because GoogleService-Info.plist is not bundled.")
-            return
-            #else
-            preconditionFailure("Missing bundled GoogleService-Info.plist in release build.")
-            #endif
+        let bootstrapPlan = AppBootstrapPlan.resolve(
+            skipHostedTests: Self.shouldSkipFirebaseForHostedTests,
+            hasBundledFirebaseConfig: Self.hasBundledFirebaseConfig,
+        )
+
+        if let logMessage = bootstrapPlan.logMessage {
+            Self.logger.warning("\(logMessage, privacy: .public)")
         }
-        FirebaseApp.configure()
-        CrashReportingService.shared.initialize()
-        AnalyticsService.shared.initialize()
+
+        if bootstrapPlan.shouldInitializeFirebase {
+            FirebaseApp.configure()
+            CrashReportingService.shared.initialize()
+        }
+
+        if bootstrapPlan.shouldInitializeAnalytics {
+            AnalyticsService.shared.initialize()
+        }
     }
 
     var body: some Scene {

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -30,10 +30,12 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         self.notificationService = notificationService
         self.liveActivityService = liveActivityService
 
-        // Load config synchronously from storage to avoid UI flicker.
-        // Clamp to current Pro entitlement so expired Pro users don't retain Pro-only values.
-        let rawConfig = storageService.loadConfigSync() ?? .default
-        self.config = rawConfig.clamped(isPro: ProManager.shared.isPro)
+        let startupPlan = TimerManagerStartupPlan.resolve(
+            rawConfig: storageService.loadConfigSync(),
+            persistedTimerState: storageService.loadTimerStateSync(),
+            isPro: ProManager.shared.isPro
+        )
+        self.config = startupPlan.initialConfig
 
         // Wire Bluetooth/CarPlay media button and notification action callbacks.
         // Media button behavior must match timer-circle tap (silence + stay on timer screen).
@@ -59,18 +61,12 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         notificationService.stopAlarmSound()
         notificationService.stopVibration()
 
-        // Check synchronously if there's a stale alarm/complete state and clear it
-        // This prevents showing the alarm screen when reopening after force close
-        if let savedState = storageService.loadTimerStateSync() {
-            if savedState.status == .alarm || savedState.status == .complete {
-                storageService.clearTimerStateSync()
-                // timerState stays nil - go to home screen
-            } else {
-                // There's an active timer - restore it async
-                Task {
-                    await endAllLiveActivities()
-                    await restoreActiveTimer()
-                }
+        if startupPlan.shouldClearPersistedTimerState {
+            storageService.clearTimerStateSync()
+        } else if startupPlan.shouldRestoreActiveTimer {
+            Task {
+                await endAllLiveActivities()
+                await restoreActiveTimer()
             }
         }
 

--- a/native-ios/RandomTimer/Sources/Services/TimerManagerStartupPlan.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManagerStartupPlan.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct TimerManagerStartupPlan: Equatable {
+    let initialConfig: TimerConfig
+    let shouldClearPersistedTimerState: Bool
+    let shouldRestoreActiveTimer: Bool
+
+    static func resolve(
+        rawConfig: TimerConfig?,
+        persistedTimerState: TimerState?,
+        isPro: Bool
+    ) -> Self {
+        let initialConfig = (rawConfig ?? .default).clamped(isPro: isPro)
+
+        guard let persistedTimerState else {
+            return Self(
+                initialConfig: initialConfig,
+                shouldClearPersistedTimerState: false,
+                shouldRestoreActiveTimer: false
+            )
+        }
+
+        switch persistedTimerState.status {
+        case .alarm, .complete:
+            return Self(
+                initialConfig: initialConfig,
+                shouldClearPersistedTimerState: true,
+                shouldRestoreActiveTimer: false
+            )
+        default:
+            return Self(
+                initialConfig: initialConfig,
+                shouldClearPersistedTimerState: false,
+                shouldRestoreActiveTimer: true
+            )
+        }
+    }
+}

--- a/native-ios/RandomTimerTests/AppBootstrapTests.swift
+++ b/native-ios/RandomTimerTests/AppBootstrapTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import RandomTimer
+
+final class AppBootstrapTests: XCTestCase {
+    func testHostedTestsSkipFirebaseAndAnalyticsEvenWhenConfigExists() {
+        let plan = AppBootstrapPlan.resolve(
+            skipHostedTests: true,
+            hasBundledFirebaseConfig: true,
+        )
+
+        XCTAssertFalse(plan.shouldInitializeFirebase)
+        XCTAssertFalse(plan.shouldInitializeAnalytics)
+        XCTAssertEqual(plan.logMessage, "Skipping Firebase and analytics initialization for hosted tests.")
+    }
+
+    func testMissingFirebaseConfigSkipsFirebaseButKeepsAnalytics() {
+        let plan = AppBootstrapPlan.resolve(
+            skipHostedTests: false,
+            hasBundledFirebaseConfig: false,
+        )
+
+        XCTAssertFalse(plan.shouldInitializeFirebase)
+        XCTAssertTrue(plan.shouldInitializeAnalytics)
+        XCTAssertEqual(
+            plan.logMessage,
+            "Skipping Firebase initialization because GoogleService-Info.plist is not bundled."
+        )
+    }
+
+    func testBundledFirebaseConfigInitializesFullObservabilityStack() {
+        let plan = AppBootstrapPlan.resolve(
+            skipHostedTests: false,
+            hasBundledFirebaseConfig: true,
+        )
+
+        XCTAssertTrue(plan.shouldInitializeFirebase)
+        XCTAssertTrue(plan.shouldInitializeAnalytics)
+        XCTAssertNil(plan.logMessage)
+    }
+}

--- a/native-ios/RandomTimerTests/TimerManagerStartupPlanTests.swift
+++ b/native-ios/RandomTimerTests/TimerManagerStartupPlanTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import RandomTimer
+
+final class TimerManagerStartupPlanTests: XCTestCase {
+    private func makeConfig(
+        minSeconds: Int = 5,
+        maxSeconds: Int = 300,
+        useExtendedRange: Bool = false
+    ) -> RandomTimer.TimerConfig {
+        RandomTimer.TimerConfig(
+            minSeconds: minSeconds,
+            maxSeconds: maxSeconds,
+            alarmDuration: 10,
+            hiddenMode: false,
+            repeatEnabled: false,
+            soundType: .intense,
+            volume: 0.5,
+            vibrationEnabled: false,
+            useExtendedRange: useExtendedRange
+        )
+    }
+
+    private func makeState(status: RandomTimer.TimerStatus) -> RandomTimer.TimerState {
+        RandomTimer.TimerState(
+            config: makeConfig(),
+            targetDuration: 30,
+            startedAt: Date(),
+            remainingDuration: 10,
+            status: status
+        )
+    }
+
+    func testResolveUsesDefaultConfigWhenNothingPersisted() {
+        let plan = TimerManagerStartupPlan.resolve(
+            rawConfig: nil,
+            persistedTimerState: nil,
+            isPro: false
+        )
+
+        XCTAssertEqual(plan.initialConfig.minSeconds, RandomTimer.TimerConfig.default.minSeconds)
+        XCTAssertEqual(plan.initialConfig.maxSeconds, RandomTimer.TimerConfig.default.maxSeconds)
+        XCTAssertFalse(plan.shouldClearPersistedTimerState)
+        XCTAssertFalse(plan.shouldRestoreActiveTimer)
+    }
+
+    func testResolveClearsPersistedAlarmState() {
+        let plan = TimerManagerStartupPlan.resolve(
+            rawConfig: makeConfig(),
+            persistedTimerState: makeState(status: .alarm),
+            isPro: false
+        )
+
+        XCTAssertTrue(plan.shouldClearPersistedTimerState)
+        XCTAssertFalse(plan.shouldRestoreActiveTimer)
+    }
+
+    func testResolveClearsPersistedCompleteState() {
+        let plan = TimerManagerStartupPlan.resolve(
+            rawConfig: makeConfig(),
+            persistedTimerState: makeState(status: .complete),
+            isPro: false
+        )
+
+        XCTAssertTrue(plan.shouldClearPersistedTimerState)
+        XCTAssertFalse(plan.shouldRestoreActiveTimer)
+    }
+
+    func testResolveRestoresPersistedRunningState() {
+        let plan = TimerManagerStartupPlan.resolve(
+            rawConfig: makeConfig(),
+            persistedTimerState: makeState(status: .running),
+            isPro: false
+        )
+
+        XCTAssertFalse(plan.shouldClearPersistedTimerState)
+        XCTAssertTrue(plan.shouldRestoreActiveTimer)
+    }
+
+    func testResolveClampsProOnlyRangeForFreeUsers() {
+        let plan = TimerManagerStartupPlan.resolve(
+            rawConfig: makeConfig(minSeconds: 5, maxSeconds: 3600, useExtendedRange: true),
+            persistedTimerState: nil,
+            isPro: false
+        )
+
+        XCTAssertEqual(plan.initialConfig.maxSeconds, RandomTimer.TimerConfig.maxSecondsFree)
+        XCTAssertFalse(plan.initialConfig.useExtendedRange)
+    }
+}

--- a/native-ios/RandomTimerUITests/RandomTimerUITests.swift
+++ b/native-ios/RandomTimerUITests/RandomTimerUITests.swift
@@ -264,11 +264,13 @@ final class RandomTimerUITests: XCTestCase {
     }
 }
 
+@MainActor
 private func saveScreenshot(_ screenshot: XCUIScreenshot, named name: String, outputDir: String) {
     let path = "\(outputDir)/\(name)"
     FileManager.default.createFile(atPath: path, contents: screenshot.pngRepresentation)
 }
 
+@MainActor
 private func captureSetupStorefront(_ app: XCUIApplication, isPadCapture: Bool, outputDir: String) {
     let loopToggle = app.switches["Loop Enabled"]
     if loopToggle.waitForExistence(timeout: 3.0) && loopToggle.value as? String == "0" {
@@ -282,6 +284,7 @@ private func captureSetupStorefront(_ app: XCUIApplication, isPadCapture: Bool, 
     )
 }
 
+@MainActor
 private func captureSoundStorefrontIfNeeded(_ app: XCUIApplication, isPadCapture: Bool, outputDir: String) {
     guard !isPadCapture else { return }
 
@@ -296,6 +299,7 @@ private func captureSoundStorefrontIfNeeded(_ app: XCUIApplication, isPadCapture
     sleep(1)
 }
 
+@MainActor
 private func captureRunningStorefront(_ app: XCUIApplication, isPadCapture: Bool, outputDir: String) {
     sleep(1)
     app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
@@ -307,6 +311,7 @@ private func captureRunningStorefront(_ app: XCUIApplication, isPadCapture: Bool
     )
 }
 
+@MainActor
 private func capturePausedStorefront(_ app: XCUIApplication, isPadCapture: Bool, outputDir: String) {
     let pauseButton = app.buttons["Pause"]
     if pauseButton.waitForExistence(timeout: 3.0) {

--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -541,34 +541,18 @@ def verify_pricing(client: ASCClient, app_id: str) -> None:
     schedule_id: str | None = None
     base_territory_id: str | None = None
 
-    # Current API: some accounts expose a singular schedule relationship off the app.
+    # Current API: price schedule is exposed as a singular relationship off the app.
     try:
         data = client.request(
             "GET",
             f"/apps/{app_id}/appPriceSchedule",
-            params={"include": "baseTerritory", "limit": 10},
+            params={"include": "baseTerritory"},
         )
         candidate = data.get("data")
         if isinstance(candidate, dict) and candidate.get("id"):
             schedule = candidate
     except Exception:
         schedule = None
-
-    # Common API: schedules are top-level resources filtered by app.
-    if not schedule:
-        try:
-            data = client.request(
-                "GET",
-                "/appPriceSchedules",
-                params={"filter[app]": app_id, "include": "baseTerritory", "limit": 10},
-            )
-            schedule_list = data.get("data") or []
-            for item in schedule_list:
-                if isinstance(item, dict) and item.get("id"):
-                    schedule = item
-                    break
-        except Exception:
-            schedule = None
 
     if schedule and schedule.get("id"):
         schedule_id = schedule["id"]

--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -8,6 +8,7 @@ It performs hard preflight checks and reads back state before reporting success.
 from __future__ import annotations
 
 import argparse
+import re
 import os
 import sys
 import time
@@ -795,7 +796,30 @@ def _list_review_submission_items(client: ASCClient, submission_id: str) -> list
             "fields[reviewSubmissionItems]": "state",
         },
     )
-    return data.get("data") or []
+    items = data.get("data") or []
+    if not isinstance(items, list):
+        return []
+
+    included_versions = [
+        inc
+        for inc in (data.get("included") or [])
+        if isinstance(inc, dict) and inc.get("type") == "appStoreVersions" and inc.get("id")
+    ]
+    if len(included_versions) == 1:
+        version_id = included_versions[0]["id"]
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            relationships = item.setdefault("relationships", {})
+            if not isinstance(relationships, dict):
+                item["relationships"] = {}
+                relationships = item["relationships"]
+            app_store_version = relationships.get("appStoreVersion")
+            if app_store_version:
+                continue
+            relationships["appStoreVersion"] = {"data": {"type": "appStoreVersions", "id": version_id}}
+
+    return [item for item in items if isinstance(item, dict)]
 
 
 def _find_submission_for_version(
@@ -850,6 +874,52 @@ def _create_review_submission_item(client: ASCClient, *, submission_id: str, ver
         }
     }
     return client.request("POST", "/reviewSubmissionItems", payload=payload).get("data") or {}
+
+
+def _extract_submission_id_from_item_conflict(exc: Exception) -> str | None:
+    msg = str(exc)
+    if "ITEM_PART_OF_ANOTHER_SUBMISSION" not in msg:
+        return None
+    match = re.search(r"another reviewSubmission with id ([A-Za-z0-9-]+)", msg)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _get_review_submission(client: ASCClient, submission_id: str) -> dict[str, Any]:
+    return client.request(
+        "GET",
+        f"/reviewSubmissions/{submission_id}",
+        params={"fields[reviewSubmissions]": "platform,state,submittedDate"},
+    ).get("data") or {}
+
+
+def _recover_submission_from_item_conflict(
+    client: ASCClient,
+    *,
+    submission_id: str,
+    version_id: str,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    submission = _get_review_submission(client, submission_id)
+    item: dict[str, Any] | None = None
+    items = _list_review_submission_items(client, submission_id)
+    for candidate in items:
+        rel_version = ((candidate.get("relationships") or {}).get("appStoreVersion") or {}).get("data") or {}
+        if rel_version.get("id") == version_id:
+            item = candidate
+            break
+    if item is None and len(items) == 1:
+        only_item = items[0]
+        if ((only_item.get("relationships") or {}).get("appStoreVersion") or {}).get("data"):
+            item = only_item
+    if not submission:
+        die(f"Conflict referenced missing review submission {submission_id}.")
+    if item is None:
+        die(
+            "Conflict referenced an existing review submission, but its App Store version item "
+            f"could not be recovered: submission_id={submission_id} version_id={version_id}"
+        )
+    return submission, item
 
 
 def _create_subscription_review_item(client: ASCClient, *, submission_id: str, subscription_id: str) -> dict[str, Any]:
@@ -1035,13 +1105,43 @@ def submit_for_review(client: ASCClient, app_id: str, version_id: str, *, attach
         submission_id = str(submission.get("id") or "")
         if not submission_id:
             die("Failed to create review submission (missing submission id in response).")
-        item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
+        try:
+            item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
+        except Exception as exc:
+            conflicting_submission_id = _extract_submission_id_from_item_conflict(exc)
+            if not conflicting_submission_id:
+                raise
+            info(
+                "App Store version is already attached to another review submission; "
+                f"recovering submission {conflicting_submission_id}."
+            )
+            submission, item = _recover_submission_from_item_conflict(
+                client,
+                submission_id=conflicting_submission_id,
+                version_id=version_id,
+            )
+            submission_id = str(submission.get("id") or conflicting_submission_id)
     else:
         submission_id = str(submission.get("id") or "")
         if not submission_id:
             die("Existing review submission is missing an id.")
         if not item:
-            item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
+            try:
+                item = _create_review_submission_item(client, submission_id=submission_id, version_id=version_id)
+            except Exception as exc:
+                conflicting_submission_id = _extract_submission_id_from_item_conflict(exc)
+                if not conflicting_submission_id:
+                    raise
+                info(
+                    "App Store version is already attached to another review submission; "
+                    f"recovering submission {conflicting_submission_id}."
+                )
+                submission, item = _recover_submission_from_item_conflict(
+                    client,
+                    submission_id=conflicting_submission_id,
+                    version_id=version_id,
+                )
+                submission_id = str(submission.get("id") or conflicting_submission_id)
 
     item_id = str((item or {}).get("id") or "")
     item_state = ((item or {}).get("attributes") or {}).get("state", "UNKNOWN")

--- a/scripts/asc/asc_verify_ready.py
+++ b/scripts/asc/asc_verify_ready.py
@@ -203,13 +203,74 @@ def _get_app_review_details(client: AscClient, app_store_version_id: str) -> Dic
     return data if isinstance(data, dict) else {}
 
 
-def _get_app_price_schedules(client: AscClient, app_id: str) -> List[Dict[str, Any]]:
-    # If pricing is not set, this list tends to be empty.
-    payload = client.get(
-        f"/apps/{app_id}/appPriceSchedules",
-        params={"limit": "10"},
-    )
-    return payload.get("data", []) or []
+def _get_app_pricing_summary(client: AscClient, app_id: str) -> Dict[str, Any]:
+    # Pricing verification needs read-back evidence, not "best effort" skips.
+    # Prefer the current price-schedule model, but accept legacy /prices when present.
+    try:
+        legacy = client.get(f"/apps/{app_id}/prices", params={"limit": "1"})
+        legacy_data = legacy.get("data") or []
+        if legacy_data:
+            return {
+                "source": "legacy_prices",
+                "schedule_count": len(legacy_data),
+                "manual_price_count": len(legacy_data),
+                "automatic_price_count": 0,
+            }
+    except Exception:
+        pass
+
+    schedule: Dict[str, Any] | None = None
+    schedule_id: str | None = None
+    errors: List[str] = []
+
+    try:
+        payload = client.get(
+            f"/apps/{app_id}/appPriceSchedule",
+            params={"include": "baseTerritory"},
+        )
+        candidate = payload.get("data")
+        if isinstance(candidate, dict) and candidate.get("id"):
+            schedule = candidate
+            schedule_id = str(candidate["id"])
+    except Exception as exc:
+        errors.append(f"/apps/{app_id}/appPriceSchedule: {exc}")
+
+    if not schedule_id:
+        detail = "; ".join(errors) if errors else "no price schedule resource found"
+        raise AscClientError(f"Could not verify pricing: {detail}")
+
+    manual_prices = []
+    automatic_prices = []
+    manual_error: Exception | None = None
+    automatic_error: Exception | None = None
+
+    try:
+        payload = client.get(f"/appPriceSchedules/{schedule_id}/manualPrices", params={"limit": "10"})
+        manual_prices = payload.get("data") or []
+    except Exception as exc:
+        manual_error = exc
+
+    try:
+        payload = client.get(f"/appPriceSchedules/{schedule_id}/automaticPrices", params={"limit": "10"})
+        automatic_prices = payload.get("data") or []
+    except Exception as exc:
+        automatic_error = exc
+
+    if not manual_prices and not automatic_prices:
+        detail_parts = [f"schedule_id={schedule_id}"]
+        if manual_error is not None:
+            detail_parts.append(f"manualPrices={manual_error}")
+        if automatic_error is not None:
+            detail_parts.append(f"automaticPrices={automatic_error}")
+        raise AscClientError("Could not verify pricing: " + "; ".join(detail_parts))
+
+    return {
+        "source": "price_schedule",
+        "schedule_count": 1 if schedule else 0,
+        "schedule_id": schedule_id,
+        "manual_price_count": len(manual_prices),
+        "automatic_price_count": len(automatic_prices),
+    }
 
 
 def _get_age_rating_declaration(
@@ -464,24 +525,27 @@ def verify_ready(
             )
         )
 
-    # Pricing (App Price Schedule exists)
+    # Pricing
     try:
-        schedules = _get_app_price_schedules(client, app_id)
+        pricing = _get_app_pricing_summary(client, app_id)
         checks.append(
             Check(
                 name="Pricing Set",
-                passed=len(schedules) > 0,
-                details=f"appPriceSchedules={len(schedules)}",
-                evidence={"appPriceSchedules_count": len(schedules)},
+                passed=True,
+                details=(
+                    f"source={pricing['source']} schedule_id={pricing.get('schedule_id', '') or 'legacy'} "
+                    f"manualPrices={pricing['manual_price_count']} "
+                    f"automaticPrices={pricing['automatic_price_count']}"
+                ),
+                evidence=pricing,
             )
         )
     except AscClientError as exc:
         checks.append(
             Check(
                 name="Pricing Set",
-                passed=True,
-                details=f"Skipped check (endpoint/API unavailable): {exc}",
-                evidence={"skipped": True},
+                passed=False,
+                details=str(exc),
             )
         )
     except Exception as exc:

--- a/scripts/check_ios_targeted_coverage.py
+++ b/scripts/check_ios_targeted_coverage.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _iter_file_coverages(node: object):
+    if isinstance(node, dict):
+        path = node.get("path")
+        line_coverage = node.get("lineCoverage")
+        if isinstance(path, str) and isinstance(line_coverage, (int, float)):
+            yield path, float(line_coverage)
+        for key in ("targets", "files"):
+            children = node.get(key)
+            if isinstance(children, list):
+                for child in children:
+                    yield from _iter_file_coverages(child)
+    elif isinstance(node, list):
+        for child in node:
+            yield from _iter_file_coverages(child)
+
+
+def load_coverages(report_json: Path) -> dict[str, float]:
+    payload = json.loads(report_json.read_text(encoding="utf-8"))
+    return {path: coverage for path, coverage in _iter_file_coverages(payload)}
+
+
+def parse_requirement(raw: str) -> tuple[str, float]:
+    suffix, sep, threshold = raw.rpartition("=")
+    if not sep:
+        raise argparse.ArgumentTypeError("coverage requirement must look like path/suffix.swift=1.0")
+    return suffix, float(threshold)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fail if targeted iOS source files are below the required line coverage.")
+    parser.add_argument("--report-json", required=True, help="Path to xccov --json report")
+    parser.add_argument(
+        "--require",
+        action="append",
+        type=parse_requirement,
+        default=[],
+        help="Coverage requirement in the form path/suffix.swift=1.0",
+    )
+    args = parser.parse_args()
+
+    coverages = load_coverages(Path(args.report_json))
+    if not args.require:
+        raise SystemExit("No --require entries provided.")
+
+    failures: list[str] = []
+    for suffix, threshold in args.require:
+        matches = [(path, coverage) for path, coverage in coverages.items() if path.endswith(suffix)]
+        if not matches:
+            failures.append(f"missing coverage entry for suffix: {suffix}")
+            continue
+        if len(matches) > 1:
+            failures.append(f"ambiguous coverage suffix {suffix}: {[path for path, _ in matches]}")
+            continue
+        path, coverage = matches[0]
+        print(f"{path}: {coverage:.3%} (required {threshold:.1%})")
+        if coverage + 1e-9 < threshold:
+            failures.append(f"{path} covered at {coverage:.3%}, below required {threshold:.1%}")
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print("iOS targeted coverage check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -231,6 +231,7 @@ def check_voice_contract(repo_root: Path, errors: list[str]) -> None:
 
 def check_ios_firebase_contract(repo_root: Path, errors: list[str]) -> None:
     app_source = _read(repo_root, "native-ios/RandomTimer/Sources/App/RandomTimerApp.swift")
+    bootstrap_source = _read(repo_root, "native-ios/RandomTimer/Sources/App/AppBootstrap.swift")
     pbxproj = _read(repo_root, "native-ios/RandomTimer.xcodeproj/project.pbxproj")
     observability = _read(repo_root, "docs/OBSERVABILITY.md")
 
@@ -241,14 +242,14 @@ def check_ios_firebase_contract(repo_root: Path, errors: list[str]) -> None:
         label="RandomTimerApp.swift",
     )
     _assert_contains(
-        app_source,
+        bootstrap_source,
         "Skipping Firebase initialization because GoogleService-Info.plist is not bundled.",
         errors=errors,
-        label="RandomTimerApp.swift",
+        label="AppBootstrap.swift",
     )
-    _assert_contains(
+    _assert_not_contains(
         app_source,
-        "Missing bundled GoogleService-Info.plist in release build.",
+        "preconditionFailure(\"Missing bundled GoogleService-Info.plist in release build.\")",
         errors=errors,
         label="RandomTimerApp.swift",
     )
@@ -273,6 +274,12 @@ def check_ios_firebase_contract(repo_root: Path, errors: list[str]) -> None:
     _assert_contains(
         observability,
         "iOS debug/test builds can run without a local `GoogleService-Info.plist`",
+        errors=errors,
+        label="docs/OBSERVABILITY.md",
+    )
+    _assert_contains(
+        observability,
+        "release workflows fail before distribution if the iOS plist secret is missing",
         errors=errors,
         label="docs/OBSERVABILITY.md",
     )

--- a/scripts/tests/test_asc_submit_for_review_pricing.py
+++ b/scripts/tests/test_asc_submit_for_review_pricing.py
@@ -13,14 +13,29 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
             {
                 ("GET", "/apps/app1/prices"): RuntimeError("404"),
                 ("GET", "/apps/app1/appPriceSchedule"): RuntimeError("404"),
-                ("GET", "/appPriceSchedules"): {"data": [{"id": "sched1", "type": "appPriceSchedules"}]},
-                ("GET", "/appPriceSchedules/sched1/manualPrices"): {"data": [{"id": "mp1", "type": "appPrices"}]},
+                (
+                    "GET",
+                    "/apps/app1/appPricePoints",
+                ): {
+                    "data": [
+                        {"id": "pp1", "type": "appPricePoints", "attributes": {"customerPrice": "0.00"}},
+                        {"id": "pp2", "type": "appPricePoints", "attributes": {"customerPrice": "0.99"}},
+                    ]
+                },
+                ("POST", "/appPriceSchedules"): {"data": {"id": "sched1", "type": "appPriceSchedules"}},
+                ("GET", "/appPriceSchedules/sched1"): {"data": {"id": "sched1", "type": "appPriceSchedules"}},
             }
         )
         verify_pricing(client, "app1")
         self.assertEqual(
             [c["path"] for c in client.calls],
-            ["/apps/app1/prices", "/apps/app1/appPriceSchedule", "/appPriceSchedules", "/appPriceSchedules/sched1/manualPrices"],
+            [
+                "/apps/app1/prices",
+                "/apps/app1/appPriceSchedule",
+                "/apps/app1/appPricePoints",
+                "/appPriceSchedules",
+                "/appPriceSchedules/sched1",
+            ],
         )
 
     def test_verify_pricing_falls_back_to_singular_schedule_endpoint(self):
@@ -44,7 +59,6 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
 
         client = RouterClient(
             {
-                ("GET", "/appPriceSchedules"): {"data": []},
                 ("GET", "/apps/app1/appPriceSchedule"): RuntimeError("404"),
                 ("GET", "/apps/app1/prices"): RuntimeError("404"),
                 (
@@ -65,7 +79,6 @@ class AscSubmitForReviewVerifyPricingTests(unittest.TestCase):
             verify_pricing(client, "app1")
 
         paths = [c["path"] for c in client.calls]
-        self.assertIn("/appPriceSchedules", paths)
         self.assertIn("/apps/app1/appPricePoints", paths)
         self.assertIn("/appPriceSchedules/sched1", paths)
         post = next((c for c in client.calls if c["method"] == "POST" and c["path"] == "/appPriceSchedules"), None)

--- a/scripts/tests/test_asc_submit_for_review_submission_flow.py
+++ b/scripts/tests/test_asc_submit_for_review_submission_flow.py
@@ -199,6 +199,90 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
             ],
         )
 
+    def test_submit_for_review_recovers_existing_rejected_submission_from_item_conflict(self):
+        from scripts.asc.asc_submit_for_review import submit_for_review
+
+        existing_submission_id = "d3ce3d68-cf57-4204-9d3a-44fdc69a4ef4"
+        conflict_shell_id = "sub-empty"
+        version_id = "ver-1"
+        item_id = "item-existing"
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/subscriptionGroups"): {"data": []},
+                ("GET", "/apps/app-1/reviewSubmissions"): {
+                    "data": [
+                        {
+                            "id": conflict_shell_id,
+                            "type": "reviewSubmissions",
+                            "attributes": {"state": "READY_FOR_REVIEW", "submittedDate": None},
+                        }
+                    ]
+                },
+                ("GET", f"/reviewSubmissions/{conflict_shell_id}/items"): {"data": []},
+                ("POST", "/reviewSubmissionItems"): RuntimeError(
+                    "POST /reviewSubmissionItems failed: HTTP 409 {'errors': [{'code': "
+                    "'STATE_ERROR.ITEM_PART_OF_ANOTHER_SUBMISSION', 'detail': "
+                    "'appStoreVersions with id 884770007 was already added to another "
+                    f"reviewSubmission with id {existing_submission_id}'}}]"
+                ),
+                ("GET", f"/reviewSubmissions/{existing_submission_id}"): {
+                    "data": {
+                        "id": existing_submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "UNRESOLVED_ISSUES"},
+                    }
+                },
+                ("GET", f"/reviewSubmissions/{existing_submission_id}/items"): {
+                    "data": [
+                        {
+                            "id": item_id,
+                            "type": "reviewSubmissionItems",
+                            "attributes": {"state": "REJECTED"},
+                        }
+                    ],
+                    "included": [
+                        {
+                            "id": version_id,
+                            "type": "appStoreVersions",
+                        }
+                    ],
+                },
+                ("PATCH", f"/reviewSubmissionItems/{item_id}"): {
+                    "data": {
+                        "id": item_id,
+                        "type": "reviewSubmissionItems",
+                        "attributes": {"state": "READY_FOR_REVIEW"},
+                    }
+                },
+                ("PATCH", f"/reviewSubmissions/{existing_submission_id}"): {
+                    "data": {
+                        "id": existing_submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "WAITING_FOR_REVIEW"},
+                    }
+                },
+            }
+        )
+
+        submit_for_review(client, "app-1", version_id)
+
+        self.assertEqual(
+            [call["path"] for call in client.calls],
+            [
+                "/apps/app-1/subscriptionGroups",
+                "/apps/app-1/reviewSubmissions",
+                f"/reviewSubmissions/{conflict_shell_id}/items",
+                "/apps/app-1/reviewSubmissions",
+                f"/reviewSubmissions/{conflict_shell_id}/items",
+                "/reviewSubmissionItems",
+                f"/reviewSubmissions/{existing_submission_id}",
+                f"/reviewSubmissions/{existing_submission_id}/items",
+                f"/reviewSubmissionItems/{item_id}",
+                f"/reviewSubmissions/{existing_submission_id}",
+            ],
+        )
+
     def test_submit_for_review_with_attach_subscriptions_skips_existing_waiting_submission_when_none_pending(self):
         from scripts.asc.asc_submit_for_review import submit_for_review
 

--- a/scripts/tests/test_asc_verify_ready.py
+++ b/scripts/tests/test_asc_verify_ready.py
@@ -80,8 +80,14 @@ class _FakeAscClient:
                 }
             }
 
-        if path == "/apps/app1/appPriceSchedules":
-            return {"data": [{"id": "price1", "type": "appPriceSchedules"}]}
+        if path == "/apps/app1/appPriceSchedule":
+            return {"data": {"id": "price1", "type": "appPriceSchedules"}}
+
+        if path == "/appPriceSchedules/price1/manualPrices":
+            return {"data": [{"id": "manual1", "type": "appPrices"}]}
+
+        if path == "/appPriceSchedules/price1/automaticPrices":
+            return {"data": []}
 
         if path == "/appInfos/info1/ageRatingDeclaration":
             return {"data": {"id": "age1", "type": "appStoreAgeRatingDeclarations"}}
@@ -205,6 +211,44 @@ class AscVerifyReadyScreenshotStateTests(unittest.TestCase):
         self.assertFalse(passed)
         terms_check = next(c for c in report["checks"] if c["name"] == "Terms of Use Link")
         self.assertFalse(terms_check["passed"])
+
+    def test_verify_ready_fails_when_pricing_cannot_be_verified(self):
+        from scripts.asc import asc_verify_ready
+
+        fake = _FakeAscClient(
+            app_screenshots_by_set={
+                "set_iphone": self._shots(["COMPLETE", "COMPLETE", "COMPLETE"], "ph"),
+                "set_ipad": self._shots(["COMPLETE", "COMPLETE", "COMPLETE"], "pd"),
+            }
+        )
+
+        original_get = fake.get
+
+        def patched_get(path, params=None):
+            if path in {
+                "/apps/app1/prices",
+                "/apps/app1/appPriceSchedule",
+                "/appPriceSchedules",
+            }:
+                raise RuntimeError("pricing endpoint unavailable")
+            return original_get(path, params)
+
+        fake.get = patched_get
+
+        with mock.patch("scripts.asc.asc_verify_ready.AscClient", return_value=fake):
+            passed, report = asc_verify_ready.verify_ready(
+                bundle_id="com.igorganapolsky.randomtimer",
+                version="1.1.1",
+                locale="en-US",
+                min_iphone=3,
+                min_ipad=3,
+                require_build=True,
+            )
+
+        self.assertFalse(passed)
+        pricing_check = next(c for c in report["checks"] if c["name"] == "Pricing Set")
+        self.assertFalse(pricing_check["passed"])
+        self.assertIn("Could not verify pricing", pricing_check["details"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_ios_targeted_coverage.py
+++ b/scripts/tests/test_check_ios_targeted_coverage.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_ios_targeted_coverage import load_coverages
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_ios_targeted_coverage.py"
+
+
+def test_load_coverages_walks_nested_targets_and_files(tmp_path: Path):
+    report = tmp_path / "xccov.json"
+    report.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {
+                        "name": "RandomTimer",
+                        "files": [
+                            {
+                                "path": "/tmp/RandomTimer/Sources/App/AppBootstrap.swift",
+                                "lineCoverage": 1.0,
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    coverages = load_coverages(report)
+
+    assert coverages["/tmp/RandomTimer/Sources/App/AppBootstrap.swift"] == 1.0
+
+
+def test_cli_fails_when_target_file_is_below_threshold(tmp_path: Path):
+    report = tmp_path / "xccov.json"
+    report.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {
+                        "files": [
+                            {
+                                "path": "/tmp/RandomTimer/Sources/App/AppBootstrap.swift",
+                                "lineCoverage": 0.8,
+                            }
+                        ]
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--report-json",
+            str(report),
+            "--require",
+            "Sources/App/AppBootstrap.swift=1.0",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "below required 100.0%" in result.stdout
+
+
+def test_cli_passes_when_target_file_meets_threshold(tmp_path: Path):
+    report = tmp_path / "xccov.json"
+    report.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {
+                        "files": [
+                            {
+                                "path": "/tmp/RandomTimer/Sources/App/AppBootstrap.swift",
+                                "lineCoverage": 1.0,
+                            }
+                        ]
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--report-json",
+            str(report),
+            "--require",
+            "Sources/App/AppBootstrap.swift=1.0",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "iOS targeted coverage check passed." in result.stdout

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -6,6 +6,7 @@ CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 INTERNAL_DISTRIBUTION_WORKFLOW = ROOT / ".github/workflows/internal-distribution.yml"
 IOS_METADATA_SYNC_WORKFLOW = ROOT / ".github/workflows/ios-metadata-sync.yml"
 IOS_INTERNAL_RETRY_WORKFLOW = ROOT / ".github/workflows/ios-internal-retry.yml"
+IOS_APPLE_ID_RELEASE_WORKFLOW = ROOT / ".github/workflows/ios-apple-id-release.yml"
 IOS_SUBMIT_REVIEW_WORKFLOW = ROOT / ".github/workflows/ios-submit-review.yml"
 NATIVE_RELEASE_WORKFLOW = ROOT / ".github/workflows/native-release.yml"
 ANDROID_PRODUCTION_RETRY_WORKFLOW = ROOT / ".github/workflows/android-production-retry.yml"
@@ -44,6 +45,14 @@ def test_ci_workflow_covers_release_and_hotfix_branches():
     source = CI_WORKFLOW.read_text(encoding="utf-8")
 
     assert "branches: [develop, main, 'release/**', 'hotfix/**']" in source
+
+
+def test_ci_workflow_enforces_targeted_ios_launch_coverage():
+    source = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "check_ios_targeted_coverage.py" in source
+    assert "--require native-ios/RandomTimer/Sources/App/AppBootstrap.swift=1.0" in source
+    assert "--require native-ios/RandomTimer/Sources/Services/TimerManagerStartupPlan.swift=1.0" in source
 
 
 def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evidence():
@@ -216,6 +225,17 @@ def test_native_release_workflow_disables_hidden_play_fallback_and_verifies_requ
     assert "(inputs.platform == 'both' && needs.ios-testflight.result == 'success' && needs.android-release.result == 'success')" in source
     assert "(inputs.platform == 'ios' && needs.ios-testflight.result == 'success')" in source
     assert "(inputs.platform == 'android' && needs.android-release.result == 'success')" in source
+
+
+def test_distributed_ios_workflows_require_google_service_info_secret():
+    for workflow in (
+        NATIVE_RELEASE_WORKFLOW,
+        INTERNAL_DISTRIBUTION_WORKFLOW,
+        IOS_APPLE_ID_RELEASE_WORKFLOW,
+    ):
+        source = workflow.read_text(encoding="utf-8")
+        assert "GOOGLE_SERVICE_INFO_PLIST" in source
+        assert "required for distributed iOS builds" in source
 
 
 def test_native_release_workflow_keeps_ios_review_submission_opt_in():

--- a/scripts/tests/test_verify_release.py
+++ b/scripts/tests/test_verify_release.py
@@ -130,6 +130,23 @@ def test_google_play_verify_api_error(monkeypatch):
     assert result["status"] == "ERROR"
 
 
+def test_google_play_verify_production_clarifies_backend_only(monkeypatch):
+    gp = vr.GooglePlayVerifier()
+    mock_edits = MagicMock()
+    mock_edits.insert.return_value.execute.return_value = {"id": "edit-1"}
+    mock_edits.tracks.return_value.get.return_value.execute.return_value = {
+        "releases": [{"versionCodes": ["42"], "status": "completed"}]
+    }
+    mock_edits.delete.return_value.execute.return_value = {}
+    gp.service = MagicMock(edits=lambda: mock_edits)
+
+    result = gp.verify("production", 42)
+
+    assert result["passed"] is True
+    assert result["status"] == "completed"
+    assert "backend track state only" in result["details"]
+
+
 def test_appstore_verifier_verify_build_found(monkeypatch):
     asc = vr.AppStoreVerifier()
     monkeypatch.setattr(asc, "_get_app_id", lambda: "app-123")

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -164,13 +164,19 @@ class GooglePlayVerifier:
                 codes = [int(c) for c in release.get("versionCodes", [])]
                 if version_code in codes:
                     status = release.get("status", "unknown")
+                    details = (
+                        f"versionCode {version_code} found on '{track}' "
+                        f"track with status '{status}'"
+                    )
+                    if track == "production":
+                        details += (
+                            "; this proves backend track state only, not public storefront visibility. "
+                            "Managed publishing or storefront propagation can still delay public availability."
+                        )
                     return {
                         "passed": status in ("completed", "inProgress", "draft", "halted"),
                         "status": status,
-                        "details": (
-                            f"versionCode {version_code} found on '{track}' "
-                            f"track with status '{status}'"
-                        ),
+                        "details": details,
                     }
 
             # Not found on any release in this track


### PR DESCRIPTION
## Summary\n- remove the hard iOS launch crash when Firebase config is missing and make startup behavior testable\n- enforce targeted 100% coverage for the crash-critical startup paths in CI\n- harden ASC resubmission automation to recover rejected review submissions that keep the version attached to the old submission shell\n\n## Verification\n- uv run pytest scripts/tests/test_check_ios_targeted_coverage.py scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_asc_submit_for_review_submission_flow.py -q\n- xcodebuild test -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 16' -skip-testing:RandomTimerUITests -quiet CODE_SIGNING_ALLOWED=NO 'OTHER_SWIFT_FLAGS= -D RT_SKIP_FIREBASE_FOR_CI'\n- python3 scripts/check_ios_targeted_coverage.py --report-json native-ios/build/xccov-report.json --require native-ios/RandomTimer/Sources/App/AppBootstrap.swift=1.0 --require native-ios/RandomTimer/Sources/Services/TimerManagerStartupPlan.swift=1.0\n- live ASC resubmission of iOS 1.3.26 -> WAITING_FOR_REVIEW