### PR TITLE
chore: bump develop to v1.3.27 after v1.3.26 ship

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1774900007
-        versionName = "1.3.24"
+        versionCode = ciVersionCode ?: 1774900010
+        versionName = "1.3.27"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -712,7 +712,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.24;
+				MARKETING_VERSION = 1.3.27;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -734,7 +734,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.24;
+				MARKETING_VERSION = 1.3.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -822,7 +822,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.24;
+				MARKETING_VERSION = 1.3.27;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -844,7 +844,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.24;
+				MARKETING_VERSION = 1.3.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Summary
- Skipping rejected v1.3.25 and shipped v1.3.26 — next release cut from develop must be v1.3.27
- iOS `MARKETING_VERSION` 1.3.24 → 1.3.27 (4 occurrences in project.pbxproj)
- Android `versionCode` 1774900007 → 1774900010 (next after shipped 1774900009)
- Android `versionName` 1.3.24 → 1.3.27

## Context
- v1.3.26 just shipped 2026-04-22 via Native Release run [24797724625](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/24797724625); Apple state=WAITING_FOR_REVIEW, Play production=completed
- Supersedes closed PRs #1241, #1252, #1266 (all were bumping to 1.3.25 which is no longer valid)

## Test plan
- [ ] Required CI checks pass
- [ ] Merge to unblock v1.3.27 release work

🤖 Generated with [Claude Code](https://claude.com/claude-code)