### PR TITLE
Improve monetization funnel instrumentation

### DIFF
--- a/marketing/data/paywall_conversion_report.json
+++ b/marketing/data/paywall_conversion_report.json
@@ -1,0 +1,86 @@
+{
+  "generated_at": "2026-04-23T15:20:19+00:00",
+  "window_days": 30,
+  "status": "ok",
+  "reason": "",
+  "funnel": {
+    "views": 783,
+    "offer_selects": 63,
+    "purchase_attempts": 84,
+    "purchase_successes": 1,
+    "view_to_select_rate": 0.0805,
+    "select_to_attempt_rate": 1.3333,
+    "attempt_to_success_rate": 0.0119
+  },
+  "top_failure_reasons": [
+    {
+      "reason": "user_cancelled",
+      "count": 39
+    }
+  ],
+  "entry_points": [
+    {
+      "entry_point": "setup_upgrade_cta",
+      "views": 527,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "unknown",
+      "views": 159,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "sound_gate",
+      "views": 66,
+      "attempts": 43,
+      "successes": 1,
+      "view_to_attempt_rate": 0.6515,
+      "attempt_to_success_rate": 0.0233
+    },
+    {
+      "entry_point": "range_gate",
+      "views": 31,
+      "attempts": 41,
+      "successes": 0,
+      "view_to_attempt_rate": 1.3226,
+      "attempt_to_success_rate": 0.0
+    }
+  ],
+  "leaky_entry_points": [
+    {
+      "entry_point": "setup_upgrade_cta",
+      "views": 527,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "unknown",
+      "views": 159,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    }
+  ],
+  "settings_hotspots": [
+    {
+      "setting_name": "unknown",
+      "changes": 35320,
+      "users": 605
+    }
+  ],
+  "data_quality_warnings": [
+    "purchase_attempts exceed offer_selects; paywall funnel events are inconsistent and need instrumentation review",
+    "unknown paywall entry_point is still receiving meaningful traffic",
+    "settings_changed is still dominated by unknown setting_name rows in live data"
+  ],
+  "query_errors": []
+}

--- a/marketing/data/paywall_conversion_report.md
+++ b/marketing/data/paywall_conversion_report.md
@@ -1,0 +1,40 @@
+# Paywall Conversion Report
+
+Generated: 2026-04-23T15:20:19+00:00
+Window (days): 30
+
+## Funnel
+- Views: **783**
+- Offer Selects: **63**
+- Purchase Attempts: **84**
+- Purchase Successes: **1**
+- View -> Offer Select: **8.1%**
+- Select -> Purchase Attempt: **133.3%**
+- Attempt -> Purchase Success: **1.2%**
+
+## Top Failure Reasons
+| Reason | Count |
+|--------|-------|
+| user_cancelled | 39 |
+
+## Entry Point Funnel
+| Entry Point | Views | Attempts | Successes | View->Attempt | Attempt->Success |
+|-------------|-------|----------|-----------|---------------|------------------|
+| setup_upgrade_cta | 527 | 0 | 0 | 0.0% | 0.0% |
+| unknown | 159 | 0 | 0 | 0.0% | 0.0% |
+| sound_gate | 66 | 43 | 1 | 65.1% | 2.3% |
+| range_gate | 31 | 41 | 0 | 132.3% | 0.0% |
+
+## Leaky Entry Points
+- `setup_upgrade_cta` had **527** views and **0** purchase attempts.
+- `unknown` had **159** views and **0** purchase attempts.
+
+## Settings Hotspots
+| Setting | Changes | Users |
+|---------|---------|-------|
+| unknown | 35320 | 605 |
+
+## Data Quality Warnings
+- purchase_attempts exceed offer_selects; paywall funnel events are inconsistent and need instrumentation review
+- unknown paywall entry_point is still receiving meaningful traffic
+- settings_changed is still dominated by unknown setting_name rows in live data

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -351,11 +351,11 @@ class AnalyticsService
         }
 
         companion object {
-            private const val PREFS_NAME = "random_timer_analytics"
+            const val PREFS_NAME = "random_timer_analytics"
             private const val KEY_DISTINCT_ID = "posthog_distinct_id"
             private const val KEY_HAS_OPENED = "has_first_opened"
             private const val KEY_HAS_CONFIGURED = "has_first_configured"
-            private const val KEY_HAS_COMPLETED = "has_first_completed"
+            const val KEY_HAS_COMPLETED = "has_first_completed"
             private const val KEY_HAS_TRACKED_APPLICATION_INSTALLED = "has_tracked_application_installed"
             private val UTM_KEYS =
                 listOf(
@@ -428,6 +428,9 @@ object AnalyticsProperties {
     /** Mirrors iOS; consumed by executive_metrics_snapshot PRAGMATIC filter. */
     const val DISTRIBUTION_CHANNEL = "distribution_channel"
 
+    const val SETTING_NAME = "setting_name"
+    const val SETTING_VALUE = "setting_value"
+    const val PREVIOUS_VALUE = "previous_value"
     const val ENTRY_POINT = "entry_point"
     const val RESULT = "result"
     const val SUCCESS = "success"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -41,6 +41,13 @@ sealed class Screen(
     data object ActiveTimer : Screen("active_timer")
 }
 
+internal fun paywallEntryPointForFeature(feature: String): String =
+    when (feature) {
+        "extended_range" -> "range_gate"
+        "voice_callouts", "pro_sounds", "repeat_loop" -> "sound_gate"
+        else -> "setup_upgrade_cta"
+    }
+
 @Composable
 fun RandomTimerNavHost(
     navController: NavHostController = rememberNavController(),
@@ -132,7 +139,7 @@ fun RandomTimerNavHost(
                     scope.launch {
                         proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
                         monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
-                        paywallEntryPoint = "setup_upgrade_cta"
+                        paywallEntryPoint = paywallEntryPointForFeature(feature)
                         paywallTrialEligibilityByProductId =
                             mapOf(
                                 ProManager.MONTHLY_PRODUCT_ID to

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -50,19 +50,20 @@ import com.iganapolsky.randomtimer.ui.theme.TimerColors
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal const val HIDDEN_UNLOCK_HOLD_DURATION_MS = 8_000L
-internal const val PAYWALL_HEADLINE = "Stop Training With the Brakes On"
-internal const val PAYWALL_SUBHEADLINE = "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library built for pressure drills."
-internal const val PAYWALL_HEADLINE_OUTCOMES_FIRST = "Finish Strong When the Clock Attacks"
+internal const val PAYWALL_HEADLINE = "Unlock Full Fight-Ready Training"
+internal const val PAYWALL_SUBHEADLINE =
+    "Unlock 60-minute random windows, combat voice callouts, round-capped loops, and the full sound arsenal built for pressure drills."
+internal const val PAYWALL_HEADLINE_OUTCOMES_FIRST = "Finish Strong With Full Random Pressure"
 internal const val PAYWALL_SUBHEADLINE_OUTCOMES_FIRST =
-    "Unlimited sessions, live voice callouts, and a full sound library — built so every rep feels like match pressure."
+    "Longer random windows, combat callouts, and full-spectrum sounds — built so every rep feels closer to live pressure."
 internal const val PAYWALL_PRICING_FOOTER = "Cancel anytime. Subscription auto-renews until cancelled."
 internal val PAYWALL_FEATURE_ROWS =
     listOf(
-        "Full-length sessions — up to 60 minutes, no cutoffs",
-        "Live voice callouts keep you sharp under pressure",
-        "Loop drills with round limits — just like competition",
-        "Full sound arsenal — real bells, horns, and sirens",
-        "Verified audio drops when new packs are ready",
+        "60-minute random windows for full-length drills",
+        "Combat and MMA voice callouts with live time checks",
+        "Round-capped loops for pad work, sparring, and circuits",
+        "Full sound arsenal — bells, horns, sirens, and more",
+        "Fresh pro audio drops when new packs land",
     )
 
 /** Identifies which subscription plan the user has selected on the paywall. */
@@ -141,7 +142,10 @@ fun PaywallSheet(
                     Spacer(modifier = Modifier.height(12.dp))
                     PrimaryButton(
                         text = ctaLabel,
-                        onClick = { onPurchase(purchaseProductId) },
+                        onClick = {
+                            onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId)
+                            onPurchase(purchaseProductId)
+                        },
                         modifier =
                             Modifier
                                 .fillMaxWidth()
@@ -313,6 +317,12 @@ internal fun productIdForPlan(plan: SubscriptionPlanSelection): String =
     when (plan) {
         SubscriptionPlanSelection.MONTHLY -> ProManager.MONTHLY_PRODUCT_ID
         SubscriptionPlanSelection.ANNUAL -> ProManager.ELITE_PRODUCT_ID
+    }
+
+internal fun planNameForSelection(plan: SubscriptionPlanSelection): String =
+    when (plan) {
+        SubscriptionPlanSelection.MONTHLY -> "monthly"
+        SubscriptionPlanSelection.ANNUAL -> "annual"
     }
 
 internal fun ctaLabelForPlan(

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -1,5 +1,6 @@
 package com.iganapolsky.randomtimer.ui.screens
 
+import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -57,6 +58,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -81,6 +83,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.domain.model.RangeToggleProfiles
 import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimeRangeAdjuster
@@ -133,6 +139,25 @@ private object SetupSpacing {
         )
 }
 
+internal fun primaryStartButtonText(hasFirstCompleted: Boolean): String =
+    if (hasFirstCompleted) {
+        "Start Timer"
+    } else {
+        "Start First Drill"
+    }
+
+internal fun primaryStartButtonCaption(hasFirstCompleted: Boolean): String? =
+    if (hasFirstCompleted) {
+        null
+    } else {
+        "Quick start: the default drill fires in 5-30 seconds."
+    }
+
+internal fun readHasFirstCompleted(context: Context): Boolean =
+    context
+        .getSharedPreferences(AnalyticsService.PREFS_NAME, Context.MODE_PRIVATE)
+        .getBoolean(AnalyticsService.KEY_HAS_COMPLETED, false)
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TimerSetupScreen(
@@ -152,6 +177,8 @@ fun TimerSetupScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var hasFirstCompleted by remember(context) { mutableStateOf(readHasFirstCompleted(context)) }
     val haptic = LocalHapticFeedback.current
     var showArsenal by remember { mutableStateOf(!isPro) }
     var storedFreeMinSeconds by rememberSaveable { mutableIntStateOf(TimerConfig.DEFAULT.minSeconds) }
@@ -161,6 +188,17 @@ fun TimerSetupScreen(
 
     LaunchedEffect(isPro) {
         showArsenal = true
+    }
+
+    DisposableEffect(lifecycleOwner, context) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    hasFirstCompleted = readHasFirstCompleted(context)
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     LaunchedEffect(
@@ -255,21 +293,37 @@ fun TimerSetupScreen(
                 }
             },
             bottomBar = {
-                PrimaryButton(
-                    text = "Start Timer",
-                    onClick = onStartTimer,
+                Column(
                     modifier =
                         Modifier
-                            .semantics { testTagsAsResourceId = true }
-                            .testTag("start_timer")
+                            .fillMaxWidth()
                             .padding(horizontal = spacing.outerHorizontal)
                             .padding(bottom = 16.dp, top = 8.dp)
-                            .navigationBarsPadding()
-                            .graphicsLayer {
-                                scaleX = 1.02f
-                                scaleY = 1.02f
-                            },
-                )
+                            .navigationBarsPadding(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    primaryStartButtonCaption(hasFirstCompleted)?.let { caption ->
+                        Text(
+                            text = caption,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TimerColors.TextMuted,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                    }
+                    PrimaryButton(
+                        text = primaryStartButtonText(hasFirstCompleted),
+                        onClick = onStartTimer,
+                        modifier =
+                            Modifier
+                                .semantics { testTagsAsResourceId = true }
+                                .testTag("start_timer")
+                                .graphicsLayer {
+                                    scaleX = 1.02f
+                                    scaleY = 1.02f
+                                },
+                    )
+                }
             },
             containerColor = TimerColors.BackgroundDark,
             modifier = Modifier.fillMaxSize(),

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -103,18 +103,7 @@ class TimerViewModel
         }
 
         fun updateConfig(newConfig: TimerConfig) {
-            analyticsService.track(
-                AnalyticsEvents.SETTINGS_CHANGED,
-                mapOf(
-                    "min_duration" to newConfig.minSeconds,
-                    "max_duration" to newConfig.maxSeconds,
-                    "sound_type" to newConfig.soundType.name,
-                    "repeat_enabled" to newConfig.repeatEnabled,
-                    AnalyticsProperties.ENTITLEMENT_LEVEL to
-                        proManager.entitlementLevel.value.name
-                            .lowercase(),
-                ),
-            )
+            trackSettingsChanges(config.value, newConfig)
             viewModelScope.launch {
                 repository.saveTimerConfig(newConfig)
             }
@@ -209,18 +198,7 @@ class TimerViewModel
                     repeatRounds = current.repeatRounds,
                 )
             _timerState.value = _timerState.value?.copy(config = updatedConfig)
-            analyticsService.track(
-                AnalyticsEvents.SETTINGS_CHANGED,
-                mapOf(
-                    "min_duration" to updatedConfig.minSeconds,
-                    "max_duration" to updatedConfig.maxSeconds,
-                    "sound_type" to updatedConfig.soundType.name,
-                    "repeat_enabled" to updatedConfig.repeatEnabled,
-                    AnalyticsProperties.ENTITLEMENT_LEVEL to
-                        proManager.entitlementLevel.value.name
-                            .lowercase(),
-                ),
-            )
+            trackSettingsChanges(current, updatedConfig)
             viewModelScope.launch {
                 repository.saveTimerConfig(updatedConfig)
                 serviceController.updateLoop(enabled)
@@ -237,23 +215,52 @@ class TimerViewModel
                     repeatRounds = current.repeatRounds,
                 )
             _timerState.value = _timerState.value?.copy(config = updatedConfig)
-            analyticsService.track(
-                AnalyticsEvents.SETTINGS_CHANGED,
-                mapOf(
-                    "min_duration" to updatedConfig.minSeconds,
-                    "max_duration" to updatedConfig.maxSeconds,
-                    "sound_type" to updatedConfig.soundType.name,
-                    "repeat_enabled" to updatedConfig.repeatEnabled,
-                    "voice_callouts_enabled" to updatedConfig.voiceEnabled,
-                    AnalyticsProperties.ENTITLEMENT_LEVEL to
-                        proManager.entitlementLevel.value.name
-                            .lowercase(),
-                ),
-            )
+            trackSettingsChanges(current, updatedConfig)
             viewModelScope.launch {
                 repository.saveTimerConfig(updatedConfig)
                 serviceController.updateVoiceEnabled(enabled)
             }
+        }
+
+        private fun trackSettingsChanges(
+            previousConfig: TimerConfig,
+            updatedConfig: TimerConfig,
+        ) {
+            val baseProperties =
+                mapOf(
+                    AnalyticsProperties.ENTITLEMENT_LEVEL to
+                        proManager.entitlementLevel.value.name
+                            .lowercase(),
+                )
+
+            fun emit(
+                name: String,
+                previousValue: Any,
+                updatedValue: Any,
+            ) {
+                if (previousValue.toString() == updatedValue.toString()) return
+                analyticsService.track(
+                    AnalyticsEvents.SETTINGS_CHANGED,
+                    baseProperties +
+                        mapOf(
+                            AnalyticsProperties.SETTING_NAME to name,
+                            AnalyticsProperties.PREVIOUS_VALUE to previousValue,
+                            AnalyticsProperties.SETTING_VALUE to updatedValue,
+                        ),
+                )
+            }
+
+            emit("min_seconds", previousConfig.minSeconds, updatedConfig.minSeconds)
+            emit("max_seconds", previousConfig.maxSeconds, updatedConfig.maxSeconds)
+            emit("alarm_duration", previousConfig.alarmDuration, updatedConfig.alarmDuration)
+            emit("repeat_enabled", previousConfig.repeatEnabled, updatedConfig.repeatEnabled)
+            emit("sound_type", previousConfig.soundType.name.lowercase(), updatedConfig.soundType.name.lowercase())
+            emit("volume", previousConfig.volume, updatedConfig.volume)
+            emit("vibration_enabled", previousConfig.vibrationEnabled, updatedConfig.vibrationEnabled)
+            emit("use_extended_range", previousConfig.useExtendedRange, updatedConfig.useExtendedRange)
+            emit("voice_callouts_enabled", previousConfig.voiceEnabled, updatedConfig.voiceEnabled)
+            emit("voice_gender", previousConfig.voiceGender.name.lowercase(), updatedConfig.voiceGender.name.lowercase())
+            emit("repeat_rounds", previousConfig.repeatRounds, updatedConfig.repeatRounds)
         }
 
         fun trackScreen(screen: String) {

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
@@ -1,0 +1,23 @@
+package com.iganapolsky.randomtimer.ui.navigation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NavigationAnalyticsMappingTest {
+    @Test
+    fun rangeUpgradeMapsToRangeGateEntryPoint() {
+        assertThat(paywallEntryPointForFeature("extended_range")).isEqualTo("range_gate")
+    }
+
+    @Test
+    fun soundAndLoopUpgradesMapToSoundGateEntryPoint() {
+        assertThat(paywallEntryPointForFeature("voice_callouts")).isEqualTo("sound_gate")
+        assertThat(paywallEntryPointForFeature("pro_sounds")).isEqualTo("sound_gate")
+        assertThat(paywallEntryPointForFeature("repeat_loop")).isEqualTo("sound_gate")
+    }
+
+    @Test
+    fun unknownUpgradeFallsBackToSetupCtaEntryPoint() {
+        assertThat(paywallEntryPointForFeature("mystery_feature")).isEqualTo("setup_upgrade_cta")
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -12,19 +12,19 @@ class PaywallSheetTest {
 
     @Test
     fun `paywall copy focuses on training outcomes`() {
-        assertEquals("Stop Training With the Brakes On", PAYWALL_HEADLINE)
+        assertEquals("Unlock Full Fight-Ready Training", PAYWALL_HEADLINE)
         assertEquals(
-            "Go unlimited — sessions up to 60 minutes, live voice callouts, and a full sound library built for pressure drills.",
+            "Unlock 60-minute random windows, combat voice callouts, round-capped loops, and the full sound arsenal built for pressure drills.",
             PAYWALL_SUBHEADLINE,
         )
         assertEquals("Cancel anytime. Subscription auto-renews until cancelled.", PAYWALL_PRICING_FOOTER)
         assertEquals(
             listOf(
-                "Full-length sessions — up to 60 minutes, no cutoffs",
-                "Live voice callouts keep you sharp under pressure",
-                "Loop drills with round limits — just like competition",
-                "Full sound arsenal — real bells, horns, and sirens",
-                "Verified audio drops when new packs are ready",
+                "60-minute random windows for full-length drills",
+                "Combat and MMA voice callouts with live time checks",
+                "Round-capped loops for pad work, sparring, and circuits",
+                "Full sound arsenal — bells, horns, sirens, and more",
+                "Fresh pro audio drops when new packs land",
             ),
             PAYWALL_FEATURE_ROWS,
         )
@@ -51,6 +51,8 @@ class PaywallSheetTest {
         val annual = SubscriptionPlanSelection.ANNUAL
         assertEquals(SubscriptionPlanSelection.MONTHLY, monthly)
         assertEquals(SubscriptionPlanSelection.ANNUAL, annual)
+        assertEquals("monthly", planNameForSelection(monthly))
+        assertEquals("annual", planNameForSelection(annual))
     }
 
     @Test

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
@@ -1,6 +1,11 @@
 package com.iganapolsky.randomtimer.ui.screens
 
+import android.content.Context
+import android.content.SharedPreferences
 import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Test
 
 class TimerSetupScreenTextTest {
@@ -23,5 +28,32 @@ class TimerSetupScreenTextTest {
     fun repeatLoopDetailSummaryExplainsFreeTierLockClearly() {
         assertThat(repeatLoopDetailSummary(isPro = false, repeatRounds = 0))
             .isEqualTo("Infinite Loop (Pro: set 1–100 rounds)")
+    }
+
+    @Test
+    fun startButtonUsesFirstSessionCopyBeforeFirstCompletion() {
+        assertThat(primaryStartButtonText(hasFirstCompleted = false)).isEqualTo("Start First Drill")
+        assertThat(primaryStartButtonCaption(hasFirstCompleted = false))
+            .isEqualTo("Quick start: the default drill fires in 5-30 seconds.")
+    }
+
+    @Test
+    fun startButtonUsesGenericCopyAfterFirstCompletion() {
+        assertThat(primaryStartButtonText(hasFirstCompleted = true)).isEqualTo("Start Timer")
+        assertThat(primaryStartButtonCaption(hasFirstCompleted = true)).isNull()
+    }
+
+    @Test
+    fun readsFirstCompletionFlagFromAnalyticsPreferences() {
+        val context = mockk<Context>()
+        val prefs = mockk<SharedPreferences>()
+        every {
+            context.getSharedPreferences(AnalyticsService.PREFS_NAME, Context.MODE_PRIVATE)
+        } returns prefs
+        every {
+            prefs.getBoolean(AnalyticsService.KEY_HAS_COMPLETED, false)
+        } returns true
+
+        assertThat(readHasFirstCompleted(context)).isTrue()
     }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
@@ -2,6 +2,7 @@ package com.iganapolsky.randomtimer.ui.viewmodel
 
 import com.google.common.truth.Truth.assertThat
 import com.iganapolsky.randomtimer.analytics.AnalyticsEvents
+import com.iganapolsky.randomtimer.analytics.AnalyticsProperties
 import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.analytics.SubscriptionFunnelSteps
 import com.iganapolsky.randomtimer.billing.ProManager
@@ -178,6 +179,45 @@ class TimerViewModelAnalyticsTest {
                 match {
                     it["entry_point"] == "setup_upgrade_cta" &&
                         it["paywall_value_framing_variant"] == "control"
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `updateConfig emits per-setting analytics with setting_name`() {
+        val updated = TimerConfig.DEFAULT.copy(minSeconds = 10, maxSeconds = 45, voiceEnabled = true)
+
+        viewModel.updateConfig(updated)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.SETTINGS_CHANGED,
+                match {
+                    it[AnalyticsProperties.SETTING_NAME] == "min_seconds" &&
+                        it[AnalyticsProperties.PREVIOUS_VALUE] == 5 &&
+                        it[AnalyticsProperties.SETTING_VALUE] == 10
+                },
+            )
+        }
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.SETTINGS_CHANGED,
+                match {
+                    it[AnalyticsProperties.SETTING_NAME] == "max_seconds" &&
+                        it[AnalyticsProperties.PREVIOUS_VALUE] == 30 &&
+                        it[AnalyticsProperties.SETTING_VALUE] == 45
+                },
+            )
+        }
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.SETTINGS_CHANGED,
+                match {
+                    it[AnalyticsProperties.SETTING_NAME] == "voice_callouts_enabled" &&
+                        it[AnalyticsProperties.PREVIOUS_VALUE] == false &&
+                        it[AnalyticsProperties.SETTING_VALUE] == true
                 },
             )
         }

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		840C3EEAD4E35D7D202C1C68 /* TimerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B55AFED96FE157EA7D0BF85 /* TimerModelsTests.swift */; };
 		A1C100112233445566778899 /* Audio in Resources */ = {isa = PBXBuildFile; fileRef = A1C1001122334455667788BB /* Audio */; };
 		A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */; };
+		ACTD00112233445566778802 /* ActivationDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACTD00112233445566778801 /* ActivationDefaultsTests.swift */; };
 		PRVT001122334455AABB0002 /* ProValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRVT001122334455AABB0001 /* ProValidationTests.swift */; };
 		85ABA1B34E3D14E790434638 /* ProManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A3DD46F85A68522E1B0902 /* ProManager.swift */; };
 		AIVC00112233445566778899 /* AIVoiceCalloutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AIVC00112233445566778800 /* AIVoiceCalloutService.swift */; };
@@ -169,6 +170,7 @@
 		A1B2C3D4E5F60718A1B2C3D5 /* CircularTimerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularTimerViewTests.swift; sourceTree = "<group>"; };
 		A1C1001122334455667788BB /* Audio */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Audio; path = RandomTimer/Resources/Audio; sourceTree = "<group>"; };
 		A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIVoiceCalloutServiceTests.swift; sourceTree = "<group>"; };
+		ACTD00112233445566778801 /* ActivationDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationDefaultsTests.swift; sourceTree = "<group>"; };
 		A5A3DD46F85A68522E1B0902 /* ProManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProManager.swift; sourceTree = "<group>"; };
 		AIVC00112233445566778800 /* AIVoiceCalloutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIVoiceCalloutService.swift; sourceTree = "<group>"; };
 		AAA529E7A224C8E8728DAE7A /* TimerSetupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSetupScreen.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 		4A083F7CAA823D4930153B06 /* RandomTimerTests */ = {
 			isa = PBXGroup;
 			children = (
+				ACTD00112233445566778801 /* ActivationDefaultsTests.swift */,
 				DISTCH00112233445566778801 /* DistributionChannelResolverTests.swift */,
 				A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */,
 				A1B2C3D4E5F60718A1B2C3D5 /* CircularTimerViewTests.swift */,
@@ -649,6 +652,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACTD00112233445566778802 /* ActivationDefaultsTests.swift in Sources */,
 				DISTCH00112233445566778802 /* DistributionChannelResolverTests.swift in Sources */,
 				A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */,
 				A1B2C3D4E5F60718A1B2C3D4 /* CircularTimerViewTests.swift in Sources */,

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -559,6 +559,9 @@ enum AnalyticsEvents {
 
 enum AnalyticsProperties {
     static let distributionChannel = "distribution_channel"
+    static let settingName = "setting_name"
+    static let settingValue = "setting_value"
+    static let previousValue = "previous_value"
     static let entryPoint = "entry_point"
     static let result = "result"
     static let abandonReason = "abandon_reason"

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -95,6 +95,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
     }
 
     func updateConfig(_ newConfig: TimerConfig) {
+        let previousConfig = config
         config = newConfig
 
         // Sync config into running timer state so alarmTick sees the change
@@ -103,18 +104,38 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
             timerState = state
         }
 
-        AnalyticsService.shared.track(AnalyticsEvents.settingsChanged, properties: [
-            "min_duration": newConfig.minDuration,
-            "max_duration": newConfig.maxDuration,
-            "sound_type": String(describing: newConfig.soundType),
-            "repeat_enabled": newConfig.repeatEnabled,
-            "voice_callouts_enabled": newConfig.voiceEnabled,
-            AnalyticsProperties.entitlementLevel: ProManager.shared.entitlementLevel.rawValue,
-        ])
+        trackSettingsChanges(from: previousConfig, to: newConfig)
 
         Task {
             await storageService.saveConfig(newConfig)
         }
+    }
+
+    private func trackSettingsChanges(from oldConfig: TimerConfig, to newConfig: TimerConfig) {
+        let baseProperties: [String: Any] = [
+            AnalyticsProperties.entitlementLevel: ProManager.shared.entitlementLevel.rawValue,
+        ]
+
+        func emit(_ name: String, previousValue: Any, newValue: Any) {
+            guard String(describing: previousValue) != String(describing: newValue) else { return }
+            AnalyticsService.shared.track(AnalyticsEvents.settingsChanged, properties: baseProperties.merging([
+                AnalyticsProperties.settingName: name,
+                AnalyticsProperties.previousValue: previousValue,
+                AnalyticsProperties.settingValue: newValue,
+            ]) { _, new in new })
+        }
+
+        emit("min_seconds", previousValue: oldConfig.minSeconds, newValue: newConfig.minSeconds)
+        emit("max_seconds", previousValue: oldConfig.maxSeconds, newValue: newConfig.maxSeconds)
+        emit("alarm_duration", previousValue: oldConfig.alarmDuration, newValue: newConfig.alarmDuration)
+        emit("repeat_enabled", previousValue: oldConfig.repeatEnabled, newValue: newConfig.repeatEnabled)
+        emit("sound_type", previousValue: oldConfig.soundType.rawValue, newValue: newConfig.soundType.rawValue)
+        emit("volume", previousValue: oldConfig.volume, newValue: newConfig.volume)
+        emit("vibration_enabled", previousValue: oldConfig.vibrationEnabled, newValue: newConfig.vibrationEnabled)
+        emit("use_extended_range", previousValue: oldConfig.useExtendedRange, newValue: newConfig.useExtendedRange)
+        emit("voice_callouts_enabled", previousValue: oldConfig.voiceEnabled, newValue: newConfig.voiceEnabled)
+        emit("voice_gender", previousValue: oldConfig.voiceGender.rawValue, newValue: newConfig.voiceGender.rawValue)
+        emit("repeat_rounds", previousValue: oldConfig.repeatRounds, newValue: newConfig.repeatRounds)
     }
 
     func startTimer(roundCount: Int = 1) async {

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -24,24 +24,24 @@ enum PaywallPlanSelection {
 
 struct PaywallSheet: View {
     static let hiddenUnlockHoldDuration: TimeInterval = 8.0
-    static let headline = "Stop Training With the Brakes On"
-    static let headlineOutcomesFirst = "Finish Strong When the Clock Attacks"
+    static let headline = "Unlock Full Fight-Ready Training"
+    static let headlineOutcomesFirst = "Finish Strong With Full Random Pressure"
     static let subheadline =
-        "Go unlimited — sessions up to 60 minutes, live voice callouts, "
-        + "and a full sound library built for pressure drills."
+        "Unlock 60-minute random windows, combat voice callouts, round-capped loops, "
+        + "and the full sound arsenal built for pressure drills."
     static let subheadlineOutcomesFirst =
-        "Unlimited sessions, live voice callouts, and a full sound library — "
-        + "built so every rep feels like match pressure."
+        "Longer random windows, combat callouts, and full-spectrum sounds — "
+        + "built so every rep feels closer to live pressure."
     static let subscriptionFooter =
         "Cancel anytime. Subscription auto-renews until cancelled. "
         + "Price shown on Apple's confirmation sheet."
     static let featureTitle = "PRO FEATURES"
     static let featureRows = [
-        "Full-length sessions — up to 60 minutes, no cutoffs",
-        "Live voice callouts keep you sharp under pressure",
-        "Loop drills with round limits — just like competition",
-        "Full sound arsenal — real bells, horns, and sirens",
-        "Verified audio drops when new packs are ready",
+        "60-minute random windows for full-length drills",
+        "Combat and MMA voice callouts with live time checks",
+        "Round-capped loops for pad work, sparring, and circuits",
+        "Full sound arsenal — bells, horns, sirens, and more",
+        "Fresh pro audio drops when new packs land",
     ]
 
     @EnvironmentObject var proManager: ProManager
@@ -227,6 +227,7 @@ struct PaywallSheet: View {
         VStack(spacing: 12) {
             PrimaryButton(title: ctaButtonTitle) {
                 Task {
+                    trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)
                     await purchase(productID: selectedProductID)
                 }
             }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+func primaryStartButtonTitle(hasFirstCompleted: Bool) -> String {
+    hasFirstCompleted ? "Start Timer" : "Start First Drill"
+}
+
+func primaryStartButtonCaption(hasFirstCompleted: Bool) -> String? {
+    hasFirstCompleted ? nil : "Quick start: the default drill fires in 5-30 seconds."
+}
+
 /// Initial screen for configuring and starting a timer
 struct TimerSetupScreen: View {
     @EnvironmentObject var timerManager: TimerManager
@@ -10,6 +18,7 @@ struct TimerSetupScreen: View {
     @State private var paywallEntryPoint: PaywallEntryPoint = .unknown
     @State private var showArsenal = true
     @State private var screenAppearedAt: Date?
+    @AppStorage("has_first_completed") private var hasFirstCompleted = false
     @AppStorage("timer_range_free_min") private var storedFreeMinSeconds = TimerConfig.minimumFloorSeconds
     @AppStorage("timer_range_free_max") private var storedFreeMaxSeconds = TimerConfig.maxSecondsFree
     @AppStorage("timer_range_extended_min") private var storedExtendedMinSeconds = TimerConfig.minimumFloorSeconds
@@ -457,9 +466,16 @@ struct TimerSetupScreen: View {
             .padding(.horizontal, 24)
         }
         .safeAreaInset(edge: .bottom) {
-            PrimaryButton(title: "Start Timer") {
-                Task {
-                    await timerManager.startTimer()
+            VStack(spacing: 8) {
+                if let caption = primaryStartButtonCaption(hasFirstCompleted: hasFirstCompleted) {
+                    Text(caption)
+                        .font(.caption)
+                        .foregroundColor(.textMuted)
+                }
+                PrimaryButton(title: primaryStartButtonTitle(hasFirstCompleted: hasFirstCompleted)) {
+                    Task {
+                        await timerManager.startTimer()
+                    }
                 }
             }
             .scaleEffect(1.02)

--- a/native-ios/RandomTimerTests/ActivationDefaultsTests.swift
+++ b/native-ios/RandomTimerTests/ActivationDefaultsTests.swift
@@ -61,4 +61,17 @@ final class ActivationDefaultsTests: XCTestCase {
     func testMaxSecondsProUnchangedAt3600() {
         XCTAssertEqual(TimerConfig.maxSecondsPro, 3600)
     }
+
+    func testPrimaryStartButtonUsesFirstSessionCopyBeforeFirstCompletion() {
+        XCTAssertEqual(primaryStartButtonTitle(hasFirstCompleted: false), "Start First Drill")
+        XCTAssertEqual(
+            primaryStartButtonCaption(hasFirstCompleted: false),
+            "Quick start: the default drill fires in 5-30 seconds."
+        )
+    }
+
+    func testPrimaryStartButtonFallsBackToGenericCopyAfterFirstCompletion() {
+        XCTAssertEqual(primaryStartButtonTitle(hasFirstCompleted: true), "Start Timer")
+        XCTAssertNil(primaryStartButtonCaption(hasFirstCompleted: true))
+    }
 }

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -9,11 +9,11 @@ final class TimerConfigProClampingTests: XCTestCase {
 
     @MainActor
     func testPaywallCopyFocusesOnTrainingOutcomes() {
-        XCTAssertEqual(PaywallSheet.headline, "Stop Training With the Brakes On")
+        XCTAssertEqual(PaywallSheet.headline, "Unlock Full Fight-Ready Training")
         XCTAssertEqual(
             PaywallSheet.subheadline,
-            "Go unlimited — sessions up to 60 minutes, live voice callouts, "
-                + "and a full sound library built for pressure drills."
+            "Unlock 60-minute random windows, combat voice callouts, round-capped loops, "
+                + "and the full sound arsenal built for pressure drills."
         )
         let expectedFooter =
             "Cancel anytime. Subscription auto-renews until cancelled. "
@@ -22,11 +22,11 @@ final class TimerConfigProClampingTests: XCTestCase {
         XCTAssertEqual(
             PaywallSheet.featureRows,
             [
-                "Full-length sessions — up to 60 minutes, no cutoffs",
-                "Live voice callouts keep you sharp under pressure",
-                "Loop drills with round limits — just like competition",
-                "Full sound arsenal — real bells, horns, and sirens",
-                "Verified audio drops when new packs are ready",
+                "60-minute random windows for full-length drills",
+                "Combat and MMA voice callouts with live time checks",
+                "Round-capped loops for pad work, sparring, and circuits",
+                "Full sound arsenal — bells, horns, sirens, and more",
+                "Fresh pro audio drops when new packs land",
             ]
         )
     }
@@ -40,7 +40,7 @@ final class TimerConfigProClampingTests: XCTestCase {
 
     @MainActor
     func testPaywallOutcomesFirstHeadlineMatchesAndroidExperimentCopy() {
-        XCTAssertEqual(PaywallSheet.headlineOutcomesFirst, "Finish Strong When the Clock Attacks")
+        XCTAssertEqual(PaywallSheet.headlineOutcomesFirst, "Finish Strong With Full Random Pressure")
     }
 
     func testPaywallUsesApprovedAppStoreConnectProductId() {

--- a/scripts/paywall_conversion_report.py
+++ b/scripts/paywall_conversion_report.py
@@ -182,6 +182,72 @@ def _entry_point_funnel(api_key: str, project_id: str, days: int, errors: List[s
     return out
 
 
+def _settings_hotspots(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
+    win = f"{days} day"
+    rows = _table(
+        f"""
+        SELECT
+          coalesce(toString(properties.setting_name), 'unknown') AS setting_name,
+          count() AS changes,
+          count(DISTINCT person_id) AS users
+        FROM events
+        WHERE event = 'settings_changed'
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        GROUP BY setting_name
+        ORDER BY changes DESC
+        LIMIT 15
+        /* settings_hotspots */
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    return [
+        {
+            "setting_name": str(row[0] or "unknown"),
+            "changes": _safe_int(row[1]),
+            "users": _safe_int(row[2]),
+        }
+        for row in rows
+    ]
+
+
+def _leaky_entry_points(entry_points: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in entry_points
+        if _safe_int(row.get("views")) >= 20 and _safe_int(row.get("attempts")) == 0
+    ]
+
+
+def _data_quality_warnings(
+    counts: dict[str, int],
+    entry_points: list[dict[str, Any]],
+    settings_hotspots: list[dict[str, Any]],
+) -> list[str]:
+    warnings: list[str] = []
+    offer_selects = _safe_int(counts.get("offer_selects"))
+    attempts = _safe_int(counts.get("purchase_attempts"))
+    views = _safe_int(counts.get("views"))
+
+    if attempts > offer_selects and offer_selects > 0:
+        warnings.append(
+            "purchase_attempts exceed offer_selects; paywall funnel events are inconsistent and need instrumentation review"
+        )
+    if attempts > views and views > 0:
+        warnings.append(
+            "purchase_attempts exceed paywall views; entry or purchase attempt events are being emitted without matching impressions"
+        )
+    if any(str(row.get("entry_point")) == "unknown" and _safe_int(row.get("views")) >= 20 for row in entry_points):
+        warnings.append("unknown paywall entry_point is still receiving meaningful traffic")
+    if settings_hotspots:
+        top = settings_hotspots[0]
+        if str(top.get("setting_name")) == "unknown" and _safe_int(top.get("changes")) >= 100:
+            warnings.append("settings_changed is still dominated by unknown setting_name rows in live data")
+    return warnings
+
+
 def build_markdown(payload: Dict[str, Any]) -> str:
     funnel = payload.get("funnel", {})
     lines = [
@@ -224,6 +290,46 @@ def build_markdown(payload: Dict[str, Any]) -> str:
         )
     if not payload.get("entry_points"):
         lines.append("| (none) | 0 | 0 | 0 | 0.0% | 0.0% |")
+
+    lines.extend(
+        [
+            "",
+            "## Leaky Entry Points",
+        ]
+    )
+    for row in payload.get("leaky_entry_points", []):
+        lines.append(
+            f"- `{row.get('entry_point', 'unknown')}` had **{row.get('views', 0)}** views and "
+            f"**0** purchase attempts."
+        )
+    if not payload.get("leaky_entry_points"):
+        lines.append("- None")
+
+    lines.extend(
+        [
+            "",
+            "## Settings Hotspots",
+            "| Setting | Changes | Users |",
+            "|---------|---------|-------|",
+        ]
+    )
+    for row in payload.get("settings_hotspots", []):
+        lines.append(
+            f"| {row.get('setting_name', 'unknown')} | {row.get('changes', 0)} | {row.get('users', 0)} |"
+        )
+    if not payload.get("settings_hotspots"):
+        lines.append("| (none) | 0 | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Data Quality Warnings",
+        ]
+    )
+    for warning in payload.get("data_quality_warnings", []):
+        lines.append(f"- {warning}")
+    if not payload.get("data_quality_warnings"):
+        lines.append("- None")
 
     if payload.get("query_errors"):
         lines.extend(
@@ -268,6 +374,9 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         },
         "top_failure_reasons": [],
         "entry_points": [],
+        "leaky_entry_points": [],
+        "settings_hotspots": [],
+        "data_quality_warnings": [],
         "query_errors": [],
     }
 
@@ -282,6 +391,7 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
     counts = _funnel_counts(api_key, project_id, days, errors)
     failures = _failure_reasons(api_key, project_id, days, errors)
     entry_points = _entry_point_funnel(api_key, project_id, days, errors)
+    settings_hotspots = _settings_hotspots(api_key, project_id, days, errors)
 
     payload["funnel"] = {
         **counts,
@@ -291,6 +401,13 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
     }
     payload["top_failure_reasons"] = failures
     payload["entry_points"] = entry_points
+    payload["leaky_entry_points"] = _leaky_entry_points(entry_points)
+    payload["settings_hotspots"] = settings_hotspots
+    payload["data_quality_warnings"] = _data_quality_warnings(
+        payload["funnel"],
+        entry_points,
+        settings_hotspots,
+    )
     payload["query_errors"] = errors
     if errors:
         payload["status"] = "degraded"

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -64,9 +64,9 @@ def test_paywall_hidden_unlock_is_on_title_and_unlocks_pro_not_elite():
     android_source = _read(ANDROID_PAYWALL)
     ios_paywall = _read(IOS_PAYWALL)
 
-    assert "Stop Training With the Brakes On" in android_source and "holdForHiddenUnlock" in android_source
+    assert "Unlock Full Fight-Ready Training" in android_source and "holdForHiddenUnlock" in android_source
     assert "8_000L" in android_source
-    assert "Stop Training With the Brakes On" in ios_paywall and "highPriorityGesture" in ios_paywall
+    assert "Unlock Full Fight-Ready Training" in ios_paywall and "highPriorityGesture" in ios_paywall
     assert "LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration" in ios_paywall
     assert "triggerDebugUnlock()" in ios_paywall
     assert "unlockProForDebug" in ios_paywall
@@ -78,16 +78,32 @@ def test_paywall_single_offer_parity():
     ios_paywall = _read(IOS_PAYWALL)
 
     assert "Elite Tactical" not in android_paywall
-    assert "Stop Training With the Brakes On" in android_paywall
-    assert "Stop Training With the Brakes On" in ios_paywall
-    assert "Go unlimited" in android_paywall
-    assert "Go unlimited" in ios_paywall
-    assert "Cancel anytime" in android_paywall
+    assert "Unlock Full Fight-Ready Training" in android_paywall
+    assert "Unlock Full Fight-Ready Training" in ios_paywall
+    assert "Unlock 60-minute random windows" in android_paywall
+    assert "Unlock 60-minute random windows" in ios_paywall
     assert "Start Monthly" in android_paywall
     assert "Start Annual" in android_paywall
     assert "Start Monthly" in ios_paywall
     assert "Start Annual" in ios_paywall
     assert "Unlock Lifetime" in ios_paywall
+
+
+def test_paywall_purchase_cta_reemits_current_plan_selection_before_purchase():
+    android_paywall = _read(ANDROID_PAYWALL)
+    ios_paywall = _read(IOS_PAYWALL)
+
+    assert "onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId)" in android_paywall
+    assert "onPurchase(purchaseProductId)" in android_paywall
+    assert android_paywall.index("onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId)") < android_paywall.index(
+        "onPurchase(purchaseProductId)"
+    )
+
+    assert "trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)" in ios_paywall
+    assert "await purchase(productID: selectedProductID)" in ios_paywall
+    assert ios_paywall.index("trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)") < ios_paywall.index(
+        "await purchase(productID: selectedProductID)"
+    )
 
 
 def test_ios_paywall_uses_scrollable_large_presentation_to_avoid_clipped_actions():
@@ -220,11 +236,11 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert '.accessibilityLabel("Unlock Sound Arsenal")' in ios_setup
     android_paywall_norm = _android_paywall_em_dash_normalized(android_paywall)
     for expected in (
-        "Full-length sessions — up to 60 minutes, no cutoffs",
-        "Live voice callouts keep you sharp under pressure",
-        "Loop drills with round limits — just like competition",
-        "Full sound arsenal — real bells, horns, and sirens",
-        "Verified audio drops when new packs are ready",
+        "60-minute random windows for full-length drills",
+        "Combat and MMA voice callouts with live time checks",
+        "Round-capped loops for pad work, sparring, and circuits",
+        "Full sound arsenal — bells, horns, sirens, and more",
+        "Fresh pro audio drops when new packs land",
     ):
         assert expected in android_paywall_norm
         assert expected in ios_paywall
@@ -302,7 +318,7 @@ def test_active_timer_voice_badge_is_visible_and_live_toggleable_on_both_platfor
     assert "onVoiceToggle: (Boolean) -> Unit" in android_active
     assert "onVoiceToggle = viewModel::updateVoiceSetting" in android_nav
     assert "fun updateVoiceSetting(enabled: Boolean)" in android_viewmodel
-    assert '"voice_callouts_enabled" to updatedConfig.voiceEnabled' in android_viewmodel
+    assert 'emit("voice_callouts_enabled", previousConfig.voiceEnabled, updatedConfig.voiceEnabled)' in android_viewmodel
     assert "fun updateVoiceEnabled(enabled: Boolean)" in android_controller
     assert "ACTION_UPDATE_VOICE" in android_service
     assert "updateVoiceSetting(voiceEnabled)" in android_service
@@ -311,8 +327,11 @@ def test_active_timer_voice_badge_is_visible_and_live_toggleable_on_both_platfor
 def test_android_setup_screen_has_single_start_timer_cta_and_clear_free_loop_copy():
     android_setup = _read(ANDROID_SETUP)
 
-    start_cta_count = len(re.findall(r'PrimaryButton\(\s*text\s*=\s*"Start Timer"', android_setup, re.MULTILINE))
-    assert start_cta_count == 1, "Android setup screen should expose exactly one Start Timer CTA"
+    assert "internal fun primaryStartButtonText(hasFirstCompleted: Boolean)" in android_setup
+    assert 'if (hasFirstCompleted)' in android_setup
+    assert '"Start First Drill"' in android_setup
+    assert '"Start Timer"' in android_setup
+    assert "PrimaryButton(" in android_setup and "text = primaryStartButtonText(hasFirstCompleted)" in android_setup
     assert 'repeatLoopDetailTitle(isPro = isPro)' in android_setup
     assert 'repeatLoopDetailSummary(' in android_setup
     assert 'Infinite Loop (Pro: set 1–100 rounds)' in android_setup
@@ -323,7 +342,10 @@ def test_ios_setup_screen_keeps_start_timer_in_sticky_bottom_inset():
     ios_setup = _read(IOS_SETUP)
 
     assert ".safeAreaInset(edge: .bottom)" in ios_setup
-    assert 'PrimaryButton(title: "Start Timer")' in ios_setup
+    assert 'func primaryStartButtonTitle(hasFirstCompleted: Bool)' in ios_setup
+    assert '"Start First Drill"' in ios_setup
+    assert '"Start Timer"' in ios_setup
+    assert 'PrimaryButton(title: primaryStartButtonTitle(hasFirstCompleted: hasFirstCompleted))' in ios_setup
     assert "Spacer(minLength: 140)" in ios_setup
 
 

--- a/scripts/tests/test_paywall_conversion_report.py
+++ b/scripts/tests/test_paywall_conversion_report.py
@@ -5,6 +5,29 @@ from pathlib import Path
 from unittest import mock
 
 
+def run_report_with_mocked_posthog(report, scalar_rows, table_rows):
+    scalar_results = iter(scalar_rows)
+    table_results = iter(table_rows)
+
+    def fake_posthog_query(_query: str, _api_key: str, _project_id: str, _errors):
+        if "top_failure_reasons" in _query:
+            return {"results": next(table_results)}
+        if "entry_point_funnel" in _query:
+            return {"results": next(table_results)}
+        if "settings_hotspots" in _query:
+            return {"results": next(table_results)}
+        return {"results": next(scalar_results)}
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        with mock.patch.dict(
+            "os.environ",
+            {"POSTHOG_PERSONAL_API_KEY": "phx", "POSTHOG_PROJECT_ID": "123"},
+            clear=True,
+        ), mock.patch.object(report, "posthog_query", side_effect=fake_posthog_query):
+            return report.run(root, days=30)
+
+
 class PaywallConversionReportTests(unittest.TestCase):
     def test_build_markdown_includes_funnel_and_failure_reasons(self):
         from scripts import paywall_conversion_report as report
@@ -26,6 +49,16 @@ class PaywallConversionReportTests(unittest.TestCase):
             ],
             "entry_points": [
                 {"entry_point": "setup_upgrade_cta", "views": 70, "attempts": 15, "successes": 2},
+                {"entry_point": "unknown", "views": 25, "attempts": 0, "successes": 0},
+            ],
+            "leaky_entry_points": [
+                {"entry_point": "unknown", "views": 25, "attempts": 0, "successes": 0},
+            ],
+            "settings_hotspots": [
+                {"setting_name": "voice_callouts_enabled", "changes": 42, "users": 18},
+            ],
+            "data_quality_warnings": [
+                "unknown paywall entry_point is still receiving meaningful traffic",
             ],
         }
 
@@ -35,6 +68,9 @@ class PaywallConversionReportTests(unittest.TestCase):
         self.assertIn("View -> Offer Select", markdown)
         self.assertIn("user_cancelled", markdown)
         self.assertIn("setup_upgrade_cta", markdown)
+        self.assertIn("Leaky Entry Points", markdown)
+        self.assertIn("voice_callouts_enabled", markdown)
+        self.assertIn("Data Quality Warnings", markdown)
 
     def test_run_writes_reports_when_credentials_missing(self):
         from scripts import paywall_conversion_report as report
@@ -65,42 +101,76 @@ class PaywallConversionReportTests(unittest.TestCase):
     def test_run_populates_funnel_from_posthog_queries(self):
         from scripts import paywall_conversion_report as report
 
-        scalar_results = iter(
+        result = run_report_with_mocked_posthog(
+            report,
             [
                 [[120]],  # views
                 [[60]],   # offer selects
                 [[24]],   # attempts
                 [[6]],    # successes
-            ]
-        )
-        table_results = iter(
+            ],
             [
                 [["user_cancelled", 10], ["network_error", 3]],
                 [["setup_upgrade_cta", 80, 16, 4], ["sound_gate", 40, 8, 2]],
-            ]
+                [["voice_callouts_enabled", 31, 14], ["repeat_enabled", 15, 9]],
+            ],
         )
 
-        def fake_posthog_query(_query: str, _api_key: str, _project_id: str, _errors):
-            if "top_failure_reasons" in _query:
-                return {"results": next(table_results)}
-            if "entry_point_funnel" in _query:
-                return {"results": next(table_results)}
-            return {"results": next(scalar_results)}
+        self.assertEqual("ok", result["status"])
+        self.assertEqual(120, result["funnel"]["views"])
+        self.assertEqual(6, result["funnel"]["purchase_successes"])
+        self.assertAlmostEqual(0.5, result["funnel"]["view_to_select_rate"], places=4)
+        self.assertEqual("user_cancelled", result["top_failure_reasons"][0]["reason"])
+        self.assertEqual("voice_callouts_enabled", result["settings_hotspots"][0]["setting_name"])
+        self.assertEqual([], result["leaky_entry_points"])
+        self.assertEqual([], result["data_quality_warnings"])
 
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            with mock.patch.dict(
-                "os.environ",
-                {"POSTHOG_PERSONAL_API_KEY": "phx", "POSTHOG_PROJECT_ID": "123"},
-                clear=True,
-            ), mock.patch.object(report, "posthog_query", side_effect=fake_posthog_query):
-                result = report.run(root, days=30)
+    def test_run_flags_entry_points_with_views_but_zero_attempts(self):
+        from scripts import paywall_conversion_report as report
 
-            self.assertEqual("ok", result["status"])
-            self.assertEqual(120, result["funnel"]["views"])
-            self.assertEqual(6, result["funnel"]["purchase_successes"])
-            self.assertAlmostEqual(0.5, result["funnel"]["view_to_select_rate"], places=4)
-            self.assertEqual("user_cancelled", result["top_failure_reasons"][0]["reason"])
+        result = run_report_with_mocked_posthog(
+            report,
+            [
+                [[120]],
+                [[60]],
+                [[24]],
+                [[6]],
+            ],
+            [
+                [["user_cancelled", 10]],
+                [["setup_upgrade_cta", 90, 0, 0], ["sound_gate", 40, 8, 2]],
+                [["voice_callouts_enabled", 31, 14]],
+            ],
+        )
+
+        self.assertEqual("setup_upgrade_cta", result["leaky_entry_points"][0]["entry_point"])
+        self.assertEqual(90, result["leaky_entry_points"][0]["views"])
+
+    def test_run_flags_funnel_and_settings_data_quality_problems(self):
+        from scripts import paywall_conversion_report as report
+
+        result = run_report_with_mocked_posthog(
+            report,
+            [
+                [[120]],
+                [[60]],
+                [[85]],
+                [[1]],
+            ],
+            [
+                [["user_cancelled", 10]],
+                [["unknown", 159, 0, 0], ["sound_gate", 68, 44, 1]],
+                [["unknown", 34847, 601]],
+            ],
+        )
+
+        self.assertIn("purchase_attempts exceed offer_selects", result["data_quality_warnings"][0])
+        self.assertTrue(
+            any("unknown paywall entry_point" in warning for warning in result["data_quality_warnings"])
+        )
+        self.assertTrue(
+            any("settings_changed is still dominated by unknown" in warning for warning in result["data_quality_warnings"])
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -158,9 +158,9 @@ def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():
     android_navigation = ANDROID_NAVIGATION.read_text(encoding="utf-8")
     ios_paywall = IOS_PAYWALL.read_text(encoding="utf-8")
 
-    assert "Stop Training With the Brakes On" in android_paywall
+    assert "Unlock Full Fight-Ready Training" in android_paywall
     assert "holdForHiddenUnlock" in android_paywall and "8_000" in android_paywall
-    assert "Stop Training With the Brakes On" in ios_paywall
+    assert "Unlock Full Fight-Ready Training" in ios_paywall
     assert "highPriorityGesture" in ios_paywall
     assert "LongPressGesture(minimumDuration: Self.hiddenUnlockHoldDuration" in ios_paywall
     assert "triggerDebugUnlock()" in ios_paywall


### PR DESCRIPTION
## Summary
- Fix first-session CTA state on Android/iOS so setup uses `Start First Drill` until the first completion is actually recorded.
- Add paywall entry-point attribution and offer-selection tracking before purchase attempts.
- Emit per-setting `settings_changed` analytics with previous/current values on Android and iOS.
- Refresh combat-focused paywall copy and add live paywall conversion report warnings for leaky funnel instrumentation.

## Evidence
- `./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.ui.screens.PaywallSheetTest --tests com.iganapolsky.randomtimer.ui.screens.TimerSetupScreenTextTest --tests com.iganapolsky.randomtimer.ui.navigation.NavigationAnalyticsMappingTest --tests com.iganapolsky.randomtimer.ui.viewmodel.TimerViewModelAnalyticsTest --console=plain` -> BUILD SUCCESSFUL
- `python3 -m unittest scripts.tests.test_paywall_conversion_report` -> 5 tests passed
- `uv run pytest scripts/tests/test_mobile_feature_parity.py scripts/tests/test_timer_defaults_parity.py scripts/tests/test_mobile_analytics_parity.py -q` -> 47 passed
- `git diff --check` -> clean
- `xcodebuild -project RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 16' -skip-testing:RandomTimerUITests test` -> TEST SUCCEEDED, 98 tests, 0 failures
- Changed-file secret scan -> scanned 22 files, 0 matches

## Live Report Read-Back
- `marketing/data/paywall_conversion_report.json` generated at `2026-04-23T15:20:19+00:00`
- `paywall_view`: 783
- `paywall_offer_select`: 63
- `purchase_attempt`: 84
- `purchase_success`: 1
- warnings include purchase attempts exceeding offer selects and unknown entry points/settings names needing cleanup
