### PR TITLE
Fix Android setup smoke test copy

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -23,13 +23,13 @@ class TimerSetupSmokeTest {
     fun setupScreenRendersCoreControls() {
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule
-                .onAllNodesWithText("Start Timer")
+                .onAllNodesWithText("Start First Drill")
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
 
         composeRule
-            .onNodeWithText("Start Timer")
+            .onNodeWithText("Start First Drill")
             .assertExists()
 
         composeRule
@@ -54,7 +54,7 @@ class TimerSetupSmokeTest {
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule
-                .onAllNodesWithText("Stop Training With the Brakes On")
+                .onAllNodesWithText("Unlock Full Fight-Ready Training")
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }


### PR DESCRIPTION
## Summary
- Update Android setup smoke test expectations to match the merged first-session CTA copy (`Start First Drill`).
- Update the paywall smoke assertion to match the merged paywall headline (`Unlock Full Fight-Ready Training`).

## Evidence
- `./gradlew assembleDebug assembleDebugAndroidTest --console=plain` -> BUILD SUCCESSFUL
- `python3 -m unittest scripts.tests.test_paywall_conversion_report` -> 5 tests passed
- `uv run pytest scripts/tests/test_mobile_feature_parity.py scripts/tests/test_timer_defaults_parity.py scripts/tests/test_mobile_analytics_parity.py -q` -> 47 passed
- `git diff --check` -> clean
- Changed-file secret scan -> scanned 1 file, 0 matches

## Context
PR #1272 merged before the non-required Android device job finished. That job later failed because this smoke test still waited for old UI copy.
