### PR TITLE
Tighten review gating and paywall intent tracking

### DIFF
--- a/docs/POSTHOG_ANALYTICS.md
+++ b/docs/POSTHOG_ANALYTICS.md
@@ -103,7 +103,7 @@ There are **two** production `analyticsService.track(AnalyticsEvents.TIMER_COMPL
 
 ## Monetization surface parity (Android vs iOS)
 
-Both apps ship the same **subscription paywall** (monthly + annual subscriptions, same product IDs / Play base plans) opened from **feature gates** on the timer setup surface (`range_gate`, `sound_gate` on iOS; `setup_upgrade_cta` on Android for the primary upgrade CTA). **Lifetime / one-time SKUs** may appear on iOS only where the sheet exposes a third plan; Android’s primary sheet is subscription-first. For revenue truth, use store ledgers; for funnel health, use `subscription_funnel_step` + `paywall_*` events with `platform` breakdown.
+Both apps ship the same **subscription paywall** (monthly + annual subscriptions, same product IDs / Play base plans) opened from **feature gates** on the timer setup surface. Current entry points are `range_gate`, `voice_gate`, `repeat_gate`, and `sound_arsenal_gate`, with `unknown` reserved as a fallback when a surface is unmapped. **Lifetime / one-time SKUs** may appear on iOS only where the sheet exposes a third plan; Android’s primary sheet is subscription-first. For revenue truth, use store ledgers; for funnel health, use `subscription_funnel_step` + `paywall_*` events with `platform` breakdown.
 
 ## Store review API counts (Play / App Store Connect)
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/review/StoreReviewManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/review/StoreReviewManager.kt
@@ -10,6 +10,28 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
+internal fun reviewPromptMilestoneForCompletionCount(count: Int): Int? =
+    when {
+        count < 3 -> null
+        count < 10 -> 3
+        count < 25 -> 10
+        else -> 25 + ((count - 25) / 25) * 25
+    }
+
+internal fun isEligibleForReviewPrompt(
+    completionCount: Int,
+    lastPromptMilestone: Int,
+    lastReviewTimestampMillis: Long,
+    nowMillis: Long,
+    minDaysBetweenRequests: Long,
+): Boolean {
+    val milestone = reviewPromptMilestoneForCompletionCount(completionCount) ?: return false
+    if (milestone <= lastPromptMilestone) return false
+    if (lastReviewTimestampMillis == 0L) return true
+    val daysSinceLast = (nowMillis - lastReviewTimestampMillis) / (1000 * 60 * 60 * 24)
+    return daysSinceLast >= minDaysBetweenRequests
+}
+
 @Singleton
 class StoreReviewManager
     @Inject
@@ -25,8 +47,8 @@ class StoreReviewManager
             private const val KEY_LAST_REVIEW_TIMESTAMP = "last_review_timestamp"
             private const val KEY_LAST_REVIEW_VERSION = "last_review_version"
             private const val KEY_PENDING_REVIEW = "pending_review"
+            private const val KEY_LAST_PROMPT_MILESTONE = "last_prompt_milestone"
 
-            private const val COMPLETIONS_BEFORE_REVIEW = 3
             private const val MIN_DAYS_BETWEEN_REQUESTS = 30L
         }
 
@@ -57,24 +79,24 @@ class StoreReviewManager
                         .edit()
                         .putLong(KEY_LAST_REVIEW_TIMESTAMP, System.currentTimeMillis())
                         .putString(KEY_LAST_REVIEW_VERSION, getAppVersion())
-                        .apply()
+                        .putInt(
+                            KEY_LAST_PROMPT_MILESTONE,
+                            reviewPromptMilestoneForCompletionCount(
+                                prefs.getInt(KEY_COMPLETION_COUNT, 0),
+                            ) ?: 0,
+                        ).apply()
                 }
             }
         }
 
-        private fun isEligibleForReview(): Boolean {
-            val count = prefs.getInt(KEY_COMPLETION_COUNT, 0)
-            val lastTimestamp = prefs.getLong(KEY_LAST_REVIEW_TIMESTAMP, 0L)
-            val lastVersion = prefs.getString(KEY_LAST_REVIEW_VERSION, null)
-            val currentVersion = getAppVersion()
-
-            if (count < COMPLETIONS_BEFORE_REVIEW) return false
-            if (lastTimestamp == 0L) return true
-            if (lastVersion != currentVersion) return true
-
-            val daysSinceLast = (System.currentTimeMillis() - lastTimestamp) / (1000 * 60 * 60 * 24)
-            return daysSinceLast >= MIN_DAYS_BETWEEN_REQUESTS
-        }
+        private fun isEligibleForReview(): Boolean =
+            isEligibleForReviewPrompt(
+                completionCount = prefs.getInt(KEY_COMPLETION_COUNT, 0),
+                lastPromptMilestone = prefs.getInt(KEY_LAST_PROMPT_MILESTONE, 0),
+                lastReviewTimestampMillis = prefs.getLong(KEY_LAST_REVIEW_TIMESTAMP, 0L),
+                nowMillis = System.currentTimeMillis(),
+                minDaysBetweenRequests = MIN_DAYS_BETWEEN_REQUESTS,
+            )
 
         private fun getAppVersion(): String =
             try {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -44,8 +44,10 @@ sealed class Screen(
 internal fun paywallEntryPointForFeature(feature: String): String =
     when (feature) {
         "extended_range" -> "range_gate"
-        "voice_callouts", "pro_sounds", "repeat_loop" -> "sound_gate"
-        else -> "setup_upgrade_cta"
+        "voice_callouts" -> "voice_gate"
+        "repeat_loop" -> "repeat_gate"
+        "pro_sounds" -> "sound_arsenal_gate"
+        else -> "unknown"
     }
 
 @Composable
@@ -69,7 +71,7 @@ fun RandomTimerNavHost(
     var showPaywall by remember { mutableStateOf(false) }
     var proPrice by remember { mutableStateOf("$29.99") }
     var monthlyPrice by remember { mutableStateOf("$3.99") }
-    var paywallEntryPoint by remember { mutableStateOf("setup_upgrade_cta") }
+    var paywallEntryPoint by remember { mutableStateOf("unknown") }
     var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
     var paywallDefaultToAnnual by remember { mutableStateOf(false) }
     var paywallValueFramingVariant by remember { mutableStateOf(PaywallValueFraming.CONTROL) }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -1091,17 +1091,6 @@ private fun SoundArsenalCard(
                         color = TimerColors.TextMuted,
                         textAlign = TextAlign.Center,
                     )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = "Unlock Pro",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = TimerColors.AccentPrimary,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier =
-                            Modifier.clickable(onClick = {
-                                onUpgradeTap("pro_sounds")
-                            }),
-                    )
                 }
             }
         }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/review/StoreReviewManagerGateTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/review/StoreReviewManagerGateTest.kt
@@ -1,0 +1,61 @@
+package com.iganapolsky.randomtimer.review
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class StoreReviewManagerGateTest {
+    @Test
+    fun `review milestone advances from 3 to 10 to 25 then every 25 completions`() {
+        assertThat(reviewPromptMilestoneForCompletionCount(2)).isNull()
+        assertThat(reviewPromptMilestoneForCompletionCount(3)).isEqualTo(3)
+        assertThat(reviewPromptMilestoneForCompletionCount(9)).isEqualTo(3)
+        assertThat(reviewPromptMilestoneForCompletionCount(10)).isEqualTo(10)
+        assertThat(reviewPromptMilestoneForCompletionCount(24)).isEqualTo(10)
+        assertThat(reviewPromptMilestoneForCompletionCount(25)).isEqualTo(25)
+        assertThat(reviewPromptMilestoneForCompletionCount(74)).isEqualTo(50)
+    }
+
+    @Test
+    fun `review prompt requires a new milestone`() {
+        val eligible =
+            isEligibleForReviewPrompt(
+                completionCount = 4,
+                lastPromptMilestone = 3,
+                lastReviewTimestampMillis = 0L,
+                nowMillis = 86_400_000L,
+                minDaysBetweenRequests = 30L,
+            )
+
+        assertThat(eligible).isFalse()
+    }
+
+    @Test
+    fun `review prompt respects cooldown even after a new milestone`() {
+        val now = 40L * 86_400_000L
+        val eligible =
+            isEligibleForReviewPrompt(
+                completionCount = 10,
+                lastPromptMilestone = 3,
+                lastReviewTimestampMillis = now - (10L * 86_400_000L),
+                nowMillis = now,
+                minDaysBetweenRequests = 30L,
+            )
+
+        assertThat(eligible).isFalse()
+    }
+
+    @Test
+    fun `review prompt becomes eligible after cooldown and new milestone`() {
+        val now = 40L * 86_400_000L
+        val eligible =
+            isEligibleForReviewPrompt(
+                completionCount = 10,
+                lastPromptMilestone = 3,
+                lastReviewTimestampMillis = now - (31L * 86_400_000L),
+                nowMillis = now,
+                minDaysBetweenRequests = 30L,
+            )
+
+        assertThat(eligible).isTrue()
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
@@ -10,14 +10,14 @@ class NavigationAnalyticsMappingTest {
     }
 
     @Test
-    fun soundAndLoopUpgradesMapToSoundGateEntryPoint() {
-        assertThat(paywallEntryPointForFeature("voice_callouts")).isEqualTo("sound_gate")
-        assertThat(paywallEntryPointForFeature("pro_sounds")).isEqualTo("sound_gate")
-        assertThat(paywallEntryPointForFeature("repeat_loop")).isEqualTo("sound_gate")
+    fun upgradeSurfacesMapToDistinctIntentEntryPoints() {
+        assertThat(paywallEntryPointForFeature("voice_callouts")).isEqualTo("voice_gate")
+        assertThat(paywallEntryPointForFeature("pro_sounds")).isEqualTo("sound_arsenal_gate")
+        assertThat(paywallEntryPointForFeature("repeat_loop")).isEqualTo("repeat_gate")
     }
 
     @Test
-    fun unknownUpgradeFallsBackToSetupCtaEntryPoint() {
-        assertThat(paywallEntryPointForFeature("mystery_feature")).isEqualTo("setup_upgrade_cta")
+    fun unknownUpgradeFallsBackToUnknownEntryPoint() {
+        assertThat(paywallEntryPointForFeature("mystery_feature")).isEqualTo("unknown")
     }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
@@ -138,15 +138,15 @@ class TimerViewModelAnalyticsTest {
 
     @Test
     fun `trackPaywallViewed tracks with entry point and experiment variant`() {
-        viewModel.trackPaywallViewed("setup_upgrade_cta", defaultAnnualExperiment = false)
+        viewModel.trackPaywallViewed("sound_arsenal_gate", defaultAnnualExperiment = false)
         verify {
-            analyticsService.setPaywallSurfaceContext("setup_upgrade_cta", "monthly_default")
+            analyticsService.setPaywallSurfaceContext("sound_arsenal_gate", "monthly_default")
         }
         verify {
             analyticsService.track(
                 AnalyticsEvents.PAYWALL_VIEW,
                 match {
-                    it["entry_point"] == "setup_upgrade_cta" &&
+                    it["entry_point"] == "sound_arsenal_gate" &&
                         it["paywall_experiment_variant"] == "monthly_default" &&
                         it["paywall_value_framing_variant"] == "control"
                 },
@@ -156,7 +156,7 @@ class TimerViewModelAnalyticsTest {
             analyticsService.track(
                 AnalyticsEvents.PAYWALL_VIEWED,
                 match {
-                    it["entry_point"] == "setup_upgrade_cta" &&
+                    it["entry_point"] == "sound_arsenal_gate" &&
                         it["paywall_experiment_variant"] == "monthly_default" &&
                         it["paywall_value_framing_variant"] == "control"
                 },
@@ -172,12 +172,12 @@ class TimerViewModelAnalyticsTest {
 
     @Test
     fun `trackPaywallDismissed tracks with entry point`() {
-        viewModel.trackPaywallDismissed("setup_upgrade_cta")
+        viewModel.trackPaywallDismissed("sound_arsenal_gate")
         verify {
             analyticsService.track(
                 AnalyticsEvents.PAYWALL_DISMISSED,
                 match {
-                    it["entry_point"] == "setup_upgrade_cta" &&
+                    it["entry_point"] == "sound_arsenal_gate" &&
                         it["paywall_value_framing_variant"] == "control"
                 },
             )

--- a/native-ios/RandomTimer/Sources/Services/StoreReviewManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/StoreReviewManager.swift
@@ -1,6 +1,33 @@
 import StoreKit
 import UIKit
 
+func reviewPromptMilestone(for completionCount: Int) -> Int? {
+    switch completionCount {
+    case ..<3:
+        return nil
+    case 3..<10:
+        return 3
+    case 10..<25:
+        return 10
+    default:
+        return 25 + ((completionCount - 25) / 25) * 25
+    }
+}
+
+func isEligibleForReviewPrompt(
+    completionCount: Int,
+    lastPromptMilestone: Int,
+    lastReviewTimestamp: TimeInterval,
+    now: TimeInterval,
+    minDaysBetweenRequests: Int
+) -> Bool {
+    guard let milestone = reviewPromptMilestone(for: completionCount) else { return false }
+    guard milestone > lastPromptMilestone else { return false }
+    guard lastReviewTimestamp != 0 else { return true }
+    let elapsedDays = Int((now - lastReviewTimestamp) / 86_400)
+    return elapsedDays >= minDaysBetweenRequests
+}
+
 @MainActor
 final class StoreReviewManager {
     static let shared = StoreReviewManager()
@@ -9,8 +36,8 @@ final class StoreReviewManager {
     private let lastReviewTimestampKey = "review_last_timestamp"
     private let lastReviewVersionKey = "review_last_version"
     private let pendingReviewKey = "review_pending_prompt"
+    private let lastPromptMilestoneKey = "review_last_prompt_milestone"
 
-    private let completionsBeforeReview = 3
     private let minDaysBetweenRequests = 30
 
     private init() {}
@@ -39,6 +66,10 @@ final class StoreReviewManager {
 
         UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: lastReviewTimestampKey)
         UserDefaults.standard.set(appVersion, forKey: lastReviewVersionKey)
+        UserDefaults.standard.set(
+            reviewPromptMilestone(for: UserDefaults.standard.integer(forKey: completionCountKey)) ?? 0,
+            forKey: lastPromptMilestoneKey
+        )
     }
 
     private var currentWindowScene: UIWindowScene {
@@ -58,15 +89,14 @@ final class StoreReviewManager {
     private func isEligibleToQueueReviewPrompt() -> Bool {
         let count = UserDefaults.standard.integer(forKey: completionCountKey)
         let lastTimestamp = UserDefaults.standard.double(forKey: lastReviewTimestampKey)
-        let lastVersion = UserDefaults.standard.string(forKey: lastReviewVersionKey)
-
-        guard count >= completionsBeforeReview else { return false }
-        guard lastTimestamp != 0 else { return true }
-        if lastVersion != appVersion { return true }
-
-        let lastDate = Date(timeIntervalSince1970: lastTimestamp)
-        let days = Calendar.current.dateComponents([.day], from: lastDate, to: Date()).day ?? 0
-        return days >= minDaysBetweenRequests
+        let lastPromptMilestone = UserDefaults.standard.integer(forKey: lastPromptMilestoneKey)
+        return isEligibleForReviewPrompt(
+            completionCount: count,
+            lastPromptMilestone: lastPromptMilestone,
+            lastReviewTimestamp: lastTimestamp,
+            now: Date().timeIntervalSince1970,
+            minDaysBetweenRequests: minDaysBetweenRequests
+        )
     }
 
     private var appVersion: String {

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -2,14 +2,18 @@ import SwiftUI
 
 enum PaywallEntryPoint: String {
     case rangeGate = "range_gate"
-    case soundGate = "sound_gate"
+    case voiceGate = "voice_gate"
+    case repeatGate = "repeat_gate"
+    case soundArsenalGate = "sound_arsenal_gate"
     case unknown = "unknown"
 
     /// Maps to the analytics feature name for feature_gate_hit events.
     var featureGateName: String {
         switch self {
         case .rangeGate: return "extended_range"
-        case .soundGate: return "pro_sounds"
+        case .voiceGate: return "voice_callouts"
+        case .repeatGate: return "repeat_loop"
+        case .soundArsenalGate: return "pro_sounds"
         case .unknown: return "unknown"
         }
     }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -184,7 +184,7 @@ struct TimerSetupScreen: View {
                                     .accessibilityLabel("Preview Voice Callouts")
 
                                     Button {
-                                        presentPaywall(entryPoint: .soundGate, feature: "voice_callouts")
+                                        presentPaywall(entryPoint: .voiceGate, feature: "voice_callouts")
                                     } label: {
                                         HStack(spacing: 4) {
                                             Text("PRO")
@@ -331,7 +331,7 @@ struct TimerSetupScreen: View {
                                     .labelsHidden()
                                 } else {
                                     Button {
-                                        presentPaywall(entryPoint: .soundGate)
+                                        presentPaywall(entryPoint: .repeatGate, feature: "repeat_loop")
                                     } label: {
                                         HStack(spacing: 4) {
                                             Text("PRO")
@@ -360,7 +360,7 @@ struct TimerSetupScreen: View {
 
                     if !proManager.isPro {
                         Button {
-                            presentPaywall(entryPoint: .soundGate)
+                            presentPaywall(entryPoint: .soundArsenalGate, feature: "pro_sounds")
                         } label: {
                             HStack(spacing: 4) {
                                 Text("PRO")
@@ -447,11 +447,6 @@ struct TimerSetupScreen: View {
                                         .font(.caption2)
                                         .foregroundColor(.textMuted)
 
-                                    Button("Unlock Pro") {
-                                        presentPaywall(entryPoint: .soundGate)
-                                    }
-                                    .font(.caption2.weight(.semibold))
-                                    .foregroundColor(.accentPrimary)
                                 }
                                 .padding(.top, 8)
                             }

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -66,6 +66,54 @@ final class TimerConfigProClampingTests: XCTestCase {
         XCTAssertNil(ProManager.entitlementOverride(forLaunchArguments: ["-ui-test-state", "running"]))
     }
 
+    func testReviewPromptMilestonesAdvancePredictably() {
+        XCTAssertNil(reviewPromptMilestone(for: 2))
+        XCTAssertEqual(reviewPromptMilestone(for: 3), 3)
+        XCTAssertEqual(reviewPromptMilestone(for: 9), 3)
+        XCTAssertEqual(reviewPromptMilestone(for: 10), 10)
+        XCTAssertEqual(reviewPromptMilestone(for: 24), 10)
+        XCTAssertEqual(reviewPromptMilestone(for: 25), 25)
+        XCTAssertEqual(reviewPromptMilestone(for: 74), 50)
+    }
+
+    func testReviewPromptRequiresNewMilestone() {
+        XCTAssertFalse(
+            isEligibleForReviewPrompt(
+                completionCount: 4,
+                lastPromptMilestone: 3,
+                lastReviewTimestamp: 0,
+                now: 86_400,
+                minDaysBetweenRequests: 30
+            )
+        )
+    }
+
+    func testReviewPromptRespectsCooldownAtNewMilestone() {
+        let now: TimeInterval = 40 * 86_400
+        XCTAssertFalse(
+            isEligibleForReviewPrompt(
+                completionCount: 10,
+                lastPromptMilestone: 3,
+                lastReviewTimestamp: now - (10 * 86_400),
+                now: now,
+                minDaysBetweenRequests: 30
+            )
+        )
+    }
+
+    func testReviewPromptAllowsEarnedRepeatAfterCooldown() {
+        let now: TimeInterval = 40 * 86_400
+        XCTAssertTrue(
+            isEligibleForReviewPrompt(
+                completionCount: 10,
+                lastPromptMilestone: 3,
+                lastReviewTimestamp: now - (31 * 86_400),
+                now: now,
+                minDaysBetweenRequests: 30
+            )
+        )
+    }
+
     func testExpiredProUser_maxSecondsAboveFreeLimit_isClamped() {
         let proConfig = RandomTimer.TimerConfig(
             minSeconds: 0,

--- a/scripts/tests/test_pro_lock_parity.py
+++ b/scripts/tests/test_pro_lock_parity.py
@@ -28,7 +28,9 @@ class ProLockParityTest(unittest.TestCase):
     def test_ios_has_pro_lock_for_all_features(self):
         src = IOS_SETUP.read_text()
         self.assertIn("presentPaywall", src, "iOS missing paywall presentation")
-        self.assertIn("soundGate", src, "iOS missing soundGate paywall entry")
+        self.assertIn("voiceGate", src, "iOS missing voiceGate paywall entry")
+        self.assertIn("repeatGate", src, "iOS missing repeatGate paywall entry")
+        self.assertIn("soundArsenalGate", src, "iOS missing soundArsenalGate paywall entry")
         self.assertIn("rangeGate", src, "iOS missing rangeGate paywall entry")
 
     def test_no_legacy_completion_flag_token_in_native_sources(self):

--- a/wiki/Analytics-Events-Reference.md
+++ b/wiki/Analytics-Events-Reference.md
@@ -17,7 +17,7 @@ All events tracked via **PostHog** on both platforms. Firebase Analytics is expl
 | `timer_abandoned` | `TIMER_ABANDONED` | `timerAbandoned` | User cancels before countdown finishes | `target_duration`, `remaining_duration`, `status` |
 | `timer_countdown_finished` | `TIMER_COUNTDOWN_FINISHED` | `timerCountdownFinished` | Countdown reaches zero (before alarm phase) | `target_duration` |
 | `settings_changed` | `SETTINGS_CHANGED` | `settingsChanged` | User modifies timer config | `min_duration`, `max_duration`, `sound_type`, `repeat_enabled` |
-| `review_prompt_requested` | `REVIEW_PROMPT_REQUESTED` | `reviewPromptRequested` | In-app review dialog shown (after ≥3 completions + cooldown; iOS fires when returning to setup after a session, mirroring Android) | — |
+| `review_prompt_requested` | `REVIEW_PROMPT_REQUESTED` | `reviewPromptRequested` | In-app review dialog shown after earned completion milestones (3, 10, 25, then every 25) plus cooldown; iOS fires when returning to setup after a session, mirroring Android | — |
 | `write_review_tapped` | `WRITE_REVIEW_TAPPED` | `writeReviewTapped` | User taps "Write Review" | — |
 
 ## Paywall & monetization

--- a/wiki/Daily-Metrics-Dashboard.md
+++ b/wiki/Daily-Metrics-Dashboard.md
@@ -73,7 +73,7 @@
 | iOS | — | — | — reviews/day |
 | Android | — | — | — reviews/day |
 
-**Prompt Config:** Show after 3 completions, 30 days between prompts
+**Prompt Config:** Show after earned milestones (3, 10, 25, then every 25), 30 days between prompts
 <!-- REVIEWS_END -->
 
 ## Active CRO Experiments

--- a/wiki/Onboarding-Funnel.md
+++ b/wiki/Onboarding-Funnel.md
@@ -35,7 +35,7 @@ First Open  →  First Timer Configured  →  First Timer Completed
 | Store listing clarity | Install → Open rate | CRO screenshot/title experiments |
 | First-use simplicity | Open → Configured rate | Timer setup UX (single screen) |
 | Value delivery | Configured → Completed rate | Alarm quality, loop mode |
-| Review prompts | Completed → Review rate | `StoreReviewManager` (3 completions gate) |
+| Review prompts | Completed → Review rate | `StoreReviewManager` (earned milestone gate: 3, 10, 25, then every 25, plus cooldown) |
 
 <!-- LIVE_DATA_START -->
 ## Latest Funnel Data


### PR DESCRIPTION
## Summary
- tighten store review prompting to earned milestones plus cooldown instead of repeating on any new version after 3 completions
- split paywall intent attribution into `range_gate`, `voice_gate`, `repeat_gate`, and `sound_arsenal_gate`
- remove the redundant bottom-of-card `Unlock Pro` CTA from the free sound arsenal preview
- update Android/iOS tests and repo docs to match the new behavior

## Verification
- `cd native-android && ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.review.StoreReviewManagerGateTest' --tests 'com.iganapolsky.randomtimer.ui.navigation.NavigationAnalyticsMappingTest' --tests 'com.iganapolsky.randomtimer.ui.viewmodel.TimerViewModelAnalyticsTest'`
- `cd native-ios && xcodebuild -scheme RandomTimer test -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=26.4' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -only-testing:RandomTimerTests/TimerConfigProClampingTests`
- `uv run pytest scripts/tests/test_mobile_feature_parity.py scripts/tests/test_pro_lock_parity.py -q`
- `git diff --check`
