### PR TITLE
Fix stale iOS first-run smoke expectations

### DIFF
--- a/.maestro/activation-first-run-ios.yaml
+++ b/.maestro/activation-first-run-ios.yaml
@@ -12,11 +12,11 @@ appId: com.igorganapolsky.randomtimer
 - assertVisible:
     text: '.*random duration.*'
 
-# Start Timer button should be visible
-- assertVisible: 'Start Timer'
+# Start First Drill button should be visible
+- assertVisible: 'Start First Drill'
 
 # Tap Start — timer starts with new 30s-120s defaults
-- tapOn: 'Start Timer'
+- tapOn: 'Start First Drill'
 
 # Timer screen should appear
 - assertVisible:

--- a/.maestro/ios-smoke-test.yaml
+++ b/.maestro/ios-smoke-test.yaml
@@ -7,10 +7,10 @@ appId: com.igorganapolsky.randomtimer
 - assertVisible: 'Random Tactical Timer'
 - assertVisible:
     text: '.*Timer Range.*'
-- assertVisible: 'Start Timer'
+- assertVisible: 'Start First Drill'
 
 # Start the timer
-- tapOn: 'Start Timer'
+- tapOn: 'Start First Drill'
 
 # End the smoke flow with the app stopped. This avoids a Maestro iOS teardown
 # hang while the animated timer screen is active.

--- a/.maestro/regression-paywall-sticky-cta-ios.yaml
+++ b/.maestro/regression-paywall-sticky-cta-ios.yaml
@@ -3,7 +3,7 @@ appId: com.igorganapolsky.randomtimer
 # Regression: primary CTA + restore stay in sticky chrome after scrolling long paywall content.
 - launchApp:
     clearState: true
-- assertVisible: "Start Timer"
+- assertVisible: "Start First Drill"
 - tapOn:
     text: ".*PRO: 1H.*"
 - extendedWaitUntil:

--- a/native-ios/RandomTimerUITests/RandomTimerUITests.swift
+++ b/native-ios/RandomTimerUITests/RandomTimerUITests.swift
@@ -35,8 +35,8 @@ final class RandomTimerUITests: XCTestCase {
     }
 
     private func ensureSetupScreen(_ app: XCUIApplication, timeout: TimeInterval = 4.0) {
-        let startButton = app.buttons["Start Timer"]
-        if startButton.waitForExistence(timeout: timeout) {
+        let startButton = waitForPrimaryStartButton(in: app, timeout: timeout)
+        if startButton != nil {
             return
         }
 
@@ -44,7 +44,32 @@ final class RandomTimerUITests: XCTestCase {
         if stopButton.waitForExistence(timeout: 2.0) {
             stopButton.tap()
         }
-        XCTAssertTrue(startButton.waitForExistence(timeout: timeout))
+        XCTAssertNotNil(waitForPrimaryStartButton(in: app, timeout: timeout))
+    }
+
+    private func primaryStartButton(in app: XCUIApplication) -> XCUIElement {
+        let firstDrillButton = app.buttons["Start First Drill"]
+        if firstDrillButton.exists {
+            return firstDrillButton
+        }
+        return app.buttons["Start Timer"]
+    }
+
+    private func waitForPrimaryStartButton(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 4.0
+    ) -> XCUIElement? {
+        let firstDrillButton = app.buttons["Start First Drill"]
+        if firstDrillButton.waitForExistence(timeout: timeout) {
+            return firstDrillButton
+        }
+
+        let startTimerButton = app.buttons["Start Timer"]
+        if startTimerButton.waitForExistence(timeout: 0.5) {
+            return startTimerButton
+        }
+
+        return nil
     }
 
     private func scrollUntilVisible(
@@ -66,7 +91,7 @@ final class RandomTimerUITests: XCTestCase {
         let app = launchApp()
         ensureSetupScreen(app)
 
-        let startButton = app.buttons["Start Timer"]
+        let startButton = primaryStartButton(in: app)
         XCTAssertTrue(startButton.waitForExistence(timeout: 3.0))
         XCTAssertTrue(startButton.isHittable)
     }
@@ -79,7 +104,7 @@ final class RandomTimerUITests: XCTestCase {
         XCTAssertTrue(previewButton.waitForExistence(timeout: 3.0))
         previewButton.tap()
 
-        let startButton = app.buttons["Start Timer"]
+        let startButton = primaryStartButton(in: app)
         XCTAssertTrue(
             startButton.waitForExistence(timeout: 3.0),
             "Preview must not crash the app or navigate away from setup."
@@ -162,6 +187,7 @@ final class RandomTimerUITests: XCTestCase {
         let app = launchApp(withState: "running")
         XCTAssertTrue(app.staticTexts["Timer running..."].waitForExistence(timeout: 2.0))
         XCTAssertTrue(app.buttons["Pause"].waitForExistence(timeout: 2.0))
+        XCTAssertFalse(app.buttons["Start First Drill"].exists)
         XCTAssertFalse(app.buttons["Start Timer"].exists)
     }
 
@@ -180,6 +206,7 @@ final class RandomTimerUITests: XCTestCase {
         }
         XCTAssertTrue(app.buttons["Stop"].waitForExistence(timeout: 8.0))
         XCTAssertTrue(app.buttons["Reset"].waitForExistence(timeout: 8.0))
+        XCTAssertFalse(app.buttons["Start First Drill"].exists)
         XCTAssertFalse(app.buttons["Start Timer"].exists)
     }
 
@@ -187,7 +214,7 @@ final class RandomTimerUITests: XCTestCase {
         let app = launchApp()
         ensureSetupScreen(app)
 
-        let startButton = app.buttons["Start Timer"]
+        let startButton = primaryStartButton(in: app)
         XCTAssertTrue(startButton.waitForExistence(timeout: 3.0))
         startButton.tap()
 
@@ -217,6 +244,7 @@ final class RandomTimerUITests: XCTestCase {
         XCTAssertTrue(stopButton.waitForExistence(timeout: 2.0))
         XCTAssertTrue(app.buttons["Reset"].waitForExistence(timeout: 2.0))
         // Should NOT navigate back to setup.
+        XCTAssertFalse(app.buttons["Start First Drill"].exists)
         XCTAssertFalse(app.buttons["Start Timer"].exists)
     }
 
@@ -241,7 +269,7 @@ final class RandomTimerUITests: XCTestCase {
         app.launch()
         captureSetupStorefront(app, isPadCapture: isPadCapture, outputDir: outputDir)
         captureSoundStorefrontIfNeeded(app, isPadCapture: isPadCapture, outputDir: outputDir)
-        let startButton = app.buttons["Start Timer"]
+        let startButton = primaryStartButton(in: app)
         XCTAssertTrue(startButton.waitForExistence(timeout: 3.0))
         startButton.tap()
         captureRunningStorefront(app, isPadCapture: isPadCapture, outputDir: outputDir)

--- a/scripts/device-tests/ci-maestro-ios.sh
+++ b/scripts/device-tests/ci-maestro-ios.sh
@@ -191,7 +191,7 @@ record_stage "agent-device diagnostic snapshot"
 if run_with_timeout "$AGENT_DEVICE_DIAGNOSTIC_TIMEOUT_SECONDS" npx -y agent-device \
   snapshot -i -c --depth 8 --platform ios --udid "$SIMULATOR_UDID" --no-record \
   > "$AGENT_DEVICE_ARTIFACT_DIR/interactive-snapshot.txt"; then
-  if ! grep -Eq "Random Tactical Timer|Start Timer|Timer Range" "$AGENT_DEVICE_ARTIFACT_DIR/interactive-snapshot.txt"; then
+  if ! grep -Eq "Random Tactical Timer|Start First Drill|Start Timer|Timer Range" "$AGENT_DEVICE_ARTIFACT_DIR/interactive-snapshot.txt"; then
     echo "::warning::Agent Device snapshot did not include expected home anchors; preserving diagnostic snapshot."
     sed -n '1,160p' "$AGENT_DEVICE_ARTIFACT_DIR/interactive-snapshot.txt"
   fi

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -398,7 +398,7 @@ def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
     assert "home-pre-agent.png" in ios_script
     assert "Simulator home screenshot was not captured." in ios_script
     assert "retry_agent_device \"wait-home\"" not in ios_script
-    assert "Random Tactical Timer|Start Timer|Timer Range" in ios_script
+    assert "Random Tactical Timer|Start First Drill|Start Timer|Timer Range" in ios_script
     assert ios_script.index("regression-sound-arsenal-paywall-ios.yaml") < ios_script.index("agent-device diagnostic screenshot")
     assert "retry_agent_device_capture \"snapshot\" \"$AGENT_DEVICE_TIMEOUT_SECONDS\"" not in ios_script
     assert "retry_agent_device \"install\" \"$AGENT_DEVICE_TIMEOUT_SECONDS\" install" in ios_script
@@ -443,7 +443,7 @@ def test_ios_maestro_regression_flows_use_bounded_scrolls_and_concrete_lock_anch
 def test_ios_smoke_flow_avoids_flaky_post_start_hierarchy_queries():
     source = IOS_SMOKE_FLOW.read_text(encoding="utf-8")
 
-    assert "- tapOn: 'Start Timer'" in source
+    assert "- tapOn: 'Start First Drill'" in source
     assert "- stopApp" in source
     assert ".*Timer running.*" not in source
     assert "text: 'Pause'" not in source


### PR DESCRIPTION
## Summary
- update iOS first-run Maestro flows to use the current primary CTA copy
- accept both first-run and returning-user start CTA anchors in iOS UI and device-test validation
- keep the growth workflow contract in sync with the shipped smoke flow

## Verification
- uv run pytest scripts/tests/test_growth_workflow_contracts.py -q
- xcodebuild test -project RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=26.4' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -only-testing:RandomTimerUITests/RandomTimerUITests/testSetupStateShowsStartTimer -only-testing:RandomTimerUITests/RandomTimerUITests/testResetShowsRestartedFeedback