### PR TITLE
chore(release): add release notes for v1.3.27

### DIFF
--- a/release-notes/1.3.27.md
+++ b/release-notes/1.3.27.md
@@ -1,0 +1,13 @@
+# Release 1.3.27
+
+## Summary
+**1.3.27** is an iOS recovery release after Apple Review rejected v1.3.25 and v1.3.26 on consecutive submissions. Binary rebuilt from `develop` with the merged iOS launch-bootstrap hardening (PR #1265) to eliminate the Firebase-missing crash path that likely triggered the reviewer rejections.
+
+## Customer-visible changes
+- No new user-facing features vs 1.3.26.
+- iOS launch is now resilient when Firebase config is unavailable (prevents cold-start crash that Apple Review may have hit).
+
+## Release operations
+- Android: no new publish required. v1.3.26 is LIVE on Google Play public storefront as of 2026-04-22.
+- iOS `MARKETING_VERSION` **1.3.27**; build number incremented per CI / upload rules.
+- Submission via `native-release.yml` (platform=ios) then `iOS Submit For Review`.


### PR DESCRIPTION
## Summary
- Add `release-notes/1.3.27.md` to unblock `scripts/shell/preflight-release.sh` which fails with `❌ Versioned release notes missing: release-notes/1.3.27.md` on `iOS Submit For Review` workflow dispatch.
- Blocks iOS recovery submission after consecutive App Review rejections of v1.3.25 and v1.3.26.

## Context
- Android v1.3.26: LIVE on public storefront.
- iOS v1.3.26: REJECTED by Apple Review at 2026-04-24 03:20 UTC (after ~3h IN_REVIEW). Second consecutive rejection.
- Develop already bumped to `MARKETING_VERSION=1.3.27` by PR #1268 but release notes file was never added.
- PR #1265 (iOS launch bootstrap fix) was merged to develop — this is the likely fix for what reviewers hit.

## Test plan
- [x] File matches format of prior `release-notes/1.3.24.md`
- [ ] Preflight passes on next `iOS Submit For Review` dispatch
🤖 Generated with [Claude Code](https://claude.com/claude-code)