### PR TITLE
fix(audio): harden runtime voice callouts and monthly freshness

### DIFF
--- a/.github/workflows/monthly-pro-content-release.yml
+++ b/.github/workflows/monthly-pro-content-release.yml
@@ -51,6 +51,7 @@ jobs:
       content_branch: ${{ steps.commit.outputs.content_branch }}
       new_version: ${{ steps.bump.outputs.new_version }}
       month_label: ${{ steps.meta.outputs.month_label }}
+      release_month: ${{ steps.meta.outputs.release_month }}
       changes_committed: ${{ steps.commit.outputs.changes_committed }}
       content_pr_number: ${{ steps.commit.outputs.content_pr_number }}
 
@@ -81,7 +82,9 @@ jobs:
         id: meta
         run: |
           MONTH_LABEL=$(date -u +"%B-%Y")
+          RELEASE_MONTH=$(date -u +"%Y-%m")
           echo "month_label=${MONTH_LABEL}" >> "$GITHUB_OUTPUT"
+          echo "release_month=${RELEASE_MONTH}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -97,6 +100,7 @@ jobs:
           echo "=== Generating Pro audio content via ElevenLabs ==="
           args=(
             --manifest content/pro_audio/monthly_pro_audio_packs.json
+            --release-month "${{ steps.meta.outputs.release_month }}"
             --voice-id "${ELEVENLABS_VOICE_ID:-DGzg6RaUqxGRTHSBjfgF}"
             --generate-sound-assets
             --sync-android-assets

--- a/.maestro/activation-paywall-from-pro-tap-android.yaml
+++ b/.maestro/activation-paywall-from-pro-tap-android.yaml
@@ -5,11 +5,12 @@ appId: com.iganapolsky.randomtimer
 - launchApp
 
 - assertVisible:
-    text: 'Start Timer'
+    text: 'Start First Drill'
 
 # Extended range PRO affordance — should open paywall
 - tapOn:
     text: 'PRO: 1H'
 
-- assertVisible:
-    text: 'Stop Training With the Brakes On'
+- extendedWaitUntil:
+    visible: 'Restore purchase'
+    timeout: 10000

--- a/.maestro/regression-paywall-sticky-cta-ios.yaml
+++ b/.maestro/regression-paywall-sticky-cta-ios.yaml
@@ -7,7 +7,7 @@ appId: com.igorganapolsky.randomtimer
 - tapOn:
     text: ".*PRO: 1H.*"
 - extendedWaitUntil:
-    visible: "Stop Training With the Brakes On"
+    visible: "Restore purchase"
     timeout: 10000
 - scrollUntilVisible:
     element: "CHOOSE A PLAN"

--- a/.maestro/regression-sound-arsenal-paywall-ios.yaml
+++ b/.maestro/regression-sound-arsenal-paywall-ios.yaml
@@ -10,8 +10,8 @@ appId: com.igorganapolsky.randomtimer
     timeout: 10000
 - assertVisible: "Unlock Sound Arsenal"
 - tapOn: "Unlock Sound Arsenal"
-- assertVisible:
-    text: "Stop Training With the Brakes On"
-    optional: true
+- extendedWaitUntil:
+    visible: "Restore purchase"
+    timeout: 10000
 - takeScreenshot: evidence/ios-sound-arsenal-paywall
 - stopApp

--- a/content/pro_audio/monthly_pro_audio_packs.json
+++ b/content/pro_audio/monthly_pro_audio_packs.json
@@ -271,6 +271,267 @@
           "prompt": "Boxing ring or fight-gym round bell: one bright brass ding with clear pitch and ringing decay, unmistakably a ringside bell, not a school fire alarm or electronic buzzer."
         }
       ]
+    },
+    {
+      "id": "2026-05_combatives_corner",
+      "releaseMonth": "2026-05",
+      "theme": "Combatives corner (May content window)",
+      "voiceNamePattern": "fighter|coach|combat|corner|operator|drill|sergeant",
+      "voiceModelId": "eleven_v3",
+      "voiceSettings": {
+        "stability": 0.52,
+        "similarity_boost": 0.82,
+        "style": 0.74,
+        "use_speaker_boost": true,
+        "speed": 1.02
+      },
+      "previewElapsed": {
+        "filename": "preview_elapsed",
+        "text": "Thirty seconds elapsed. Stay sharp and keep working."
+      },
+      "fallbackCommandFilename": "cmd_stay_locked_in",
+      "elapsedCues": [
+        {
+          "second": 15,
+          "filename": "elapsed_15s",
+          "text": "Fifteen seconds elapsed. Find your rhythm."
+        },
+        {
+          "second": 30,
+          "filename": "elapsed_30s",
+          "text": "Thirty seconds elapsed. Stay sharp and keep working."
+        },
+        {
+          "second": 45,
+          "filename": "elapsed_45s",
+          "text": "Forty-five seconds elapsed. Keep your feet alive."
+        },
+        {
+          "second": 60,
+          "filename": "elapsed_60s",
+          "text": "One minute elapsed. Breathe and stay dangerous."
+        },
+        {
+          "second": 75,
+          "filename": "elapsed_75s",
+          "text": "One minute fifteen elapsed. Win the next exchange."
+        },
+        {
+          "second": 90,
+          "filename": "elapsed_90s",
+          "text": "One minute thirty elapsed. Stay composed under pace."
+        },
+        {
+          "second": 105,
+          "filename": "elapsed_105s",
+          "text": "One minute forty-five elapsed. Pressure, angle, reset."
+        },
+        {
+          "second": 120,
+          "filename": "elapsed_120s",
+          "text": "Two minutes elapsed. Keep the tempo honest."
+        },
+        {
+          "second": 150,
+          "filename": "elapsed_150s",
+          "text": "Two minutes thirty elapsed. Own the center and keep firing."
+        },
+        {
+          "second": 180,
+          "filename": "elapsed_180s",
+          "text": "Three minutes elapsed. Dig in and close strong."
+        },
+        {
+          "second": 210,
+          "filename": "elapsed_210s",
+          "text": "Three minutes thirty elapsed. No drifting. Stay on offense."
+        },
+        {
+          "second": 240,
+          "filename": "elapsed_240s",
+          "text": "Four minutes elapsed. Smooth breathing. Violent pace."
+        },
+        {
+          "second": 300,
+          "filename": "elapsed_300s",
+          "text": "Five minutes elapsed. Championship pace now."
+        },
+        {
+          "second": 420,
+          "filename": "elapsed_420s",
+          "text": "Seven minutes elapsed. Your form still matters. Keep it clean."
+        },
+        {
+          "second": 540,
+          "filename": "elapsed_540s",
+          "text": "Nine minutes elapsed. Compete for every second."
+        },
+        {
+          "second": 600,
+          "filename": "elapsed_600s",
+          "text": "Ten minutes elapsed. You are still in it. Finish with intent."
+        }
+      ],
+      "commandCues": [
+        {
+          "filename": "cmd_move_with_a_purpose",
+          "text": "Cut the angle and go."
+        },
+        {
+          "filename": "cmd_pick_it_up",
+          "text": "Pick up the pace. Stay clean."
+        },
+        {
+          "filename": "cmd_stay_locked_in",
+          "text": "Stay locked in. Read and react."
+        },
+        {
+          "filename": "cmd_no_hesitation_move",
+          "text": "No hesitation. First move wins."
+        },
+        {
+          "filename": "cmd_keep_your_bearing",
+          "text": "Stay balanced. Stay ready."
+        },
+        {
+          "filename": "cmd_sound_off_and_drive",
+          "text": "Drive forward. Do not fade."
+        },
+        {
+          "filename": "cmd_eyes_up_keep_moving",
+          "text": "Eyes up. Find the opening."
+        },
+        {
+          "filename": "cmd_stay_disciplined",
+          "text": "Discipline over panic. Work the plan."
+        },
+        {
+          "filename": "cmd_breathe_recover_press",
+          "text": "Breathe once. Then pressure."
+        },
+        {
+          "filename": "cmd_do_not_coast",
+          "text": "Do not coast. Compete."
+        },
+        {
+          "filename": "cmd_own_this_rep",
+          "text": "Own the exchange."
+        },
+        {
+          "filename": "cmd_keep_pressure_on",
+          "text": "Keep them reacting."
+        },
+        {
+          "filename": "cmd_sharp_movement_sharp_focus",
+          "text": "Sharp feet. Sharp reads."
+        },
+        {
+          "filename": "cmd_stay_in_the_fight",
+          "text": "Stay in the pocket and work."
+        },
+        {
+          "filename": "cmd_drive_through_it",
+          "text": "Drive through the fatigue."
+        },
+        {
+          "filename": "cmd_reset_and_attack",
+          "text": "Reset your stance and attack."
+        },
+        {
+          "filename": "cmd_strong_feet_strong_pace",
+          "text": "Light feet. Hard pace."
+        },
+        {
+          "filename": "cmd_move_fast_stay_precise",
+          "text": "Fast hands. Precise decisions."
+        },
+        {
+          "filename": "cmd_keep_tempo_high",
+          "text": "Tempo stays high. Stay composed."
+        },
+        {
+          "filename": "cmd_most_ricky_tick",
+          "text": "Win this beat. Win the next."
+        },
+        {
+          "filename": "cmd_instant_response_go",
+          "text": "Instant reaction. Go now."
+        },
+        {
+          "filename": "cmd_maintain_your_interval",
+          "text": "Manage distance. Re-enter on your terms."
+        },
+        {
+          "filename": "cmd_snap_back_and_drive",
+          "text": "Snap back, re-center, fire."
+        },
+        {
+          "filename": "cmd_finish_rep_keep_pushing",
+          "text": "Finish the round like it counts."
+        }
+      ],
+      "soundArsenal": [
+        {
+          "soundType": "intense",
+          "filename": "alarm",
+          "durationSeconds": 4.0,
+          "prompt": "Fight-camp alarm hit, aggressive transient, compact loop, no melody, immediate urgency."
+        },
+        {
+          "soundType": "gentle",
+          "filename": "gentle-chime",
+          "durationSeconds": 4.0,
+          "prompt": "Clean coaching chime for interval transition, polished attack, restrained tail, no ambience."
+        },
+        {
+          "soundType": "klaxon",
+          "filename": "klaxon",
+          "durationSeconds": 4.0,
+          "prompt": "Arena-ready warning klaxon, tight and forceful, no crowd, loopable."
+        },
+        {
+          "soundType": "whistle",
+          "filename": "whistle",
+          "durationSeconds": 3.0,
+          "prompt": "Coach whistle with hard stop, gym-floor clarity, no crowd noise."
+        },
+        {
+          "soundType": "buzzer",
+          "filename": "buzzer",
+          "durationSeconds": 3.0,
+          "prompt": "Competition buzzer, clean electronic snap, assertive but not comedic."
+        },
+        {
+          "soundType": "gong",
+          "filename": "gong",
+          "durationSeconds": 5.0,
+          "prompt": "Large fight-night gong with bright metallic sustain, powerful center hit, no temple ambience."
+        },
+        {
+          "soundType": "airhorn",
+          "filename": "airhorn",
+          "durationSeconds": 3.0,
+          "prompt": "Short airhorn burst for sprint interval turnover, compressed and controlled."
+        },
+        {
+          "soundType": "drumRoll",
+          "filename": "drum_roll",
+          "durationSeconds": 4.0,
+          "prompt": "Snare build with competition tension, dry room, crisp finish."
+        },
+        {
+          "soundType": "siren",
+          "filename": "siren",
+          "durationSeconds": 4.0,
+          "prompt": "Compact rotating siren with combat-gym urgency, no ambience, clean loop."
+        },
+        {
+          "soundType": "bell",
+          "filename": "bell",
+          "durationSeconds": 4.0,
+          "prompt": "Authentic boxing round bell, bright brass strike, unmistakable ringside identity, no crowd."
+        }
+      ]
     }
   ]
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -187,31 +187,29 @@ internal fun runtimeVoiceCueForElapsedSecond(
     elapsedSeconds: Int,
     lastElapsedMilestone: Int,
     catalog: VoiceCueCatalog,
-): VoiceCue? {
-    if (elapsedSeconds == lastElapsedMilestone) return null
-    return catalog.elapsedCueBySecond[elapsedSeconds]?.let { VoiceCue(filename = it.filename, text = it.text) }
-}
+): ElapsedVoiceCue? =
+    catalog.elapsedCues
+        .asSequence()
+        .filter { it.second > lastElapsedMilestone && it.second <= elapsedSeconds }
+        .maxByOrNull { it.second }
 
 /**
- * Returns a bundled "time elapsed" announcement only on full-minute marks (60, 120, …).
+ * Returns the latest crossed bundled "time elapsed" announcement on full-minute marks (60, 120, …).
  * Sub-minute rows in JSON are ignored here so command coaching stays on its own cadence.
  */
 internal fun runtimeVoiceCueForElapsedMark(
     elapsedSeconds: Int,
     lastElapsedMilestone: Int,
     catalog: VoiceCueCatalog,
-): VoiceCue? {
+): ElapsedVoiceCue? {
     if (elapsedSeconds <= 0) {
-        return null
-    }
-    if (elapsedSeconds % 60 != 0) {
         return null
     }
     return runtimeVoiceCueForElapsedSecond(
         elapsedSeconds = elapsedSeconds,
         lastElapsedMilestone = lastElapsedMilestone,
         catalog = catalog,
-    )
+    )?.takeIf { it.second % 60 == 0 }
 }
 
 internal fun nextCommandCue(
@@ -324,16 +322,26 @@ class AIVoiceCalloutManager
             val catalog = packStore.voiceCatalog()
             val mappedFilename = catalog.filenameByText[text]
             val baseFilename = mappedFilename ?: catalog.fallbackCommandCue.filename
-            val filename = genderedVoiceFilename(baseFilename, currentGender)
+            speak(
+                VoiceCue(
+                    filename = baseFilename,
+                    text = text,
+                ),
+            )
+        }
+
+        private fun speak(cue: VoiceCue) {
+            val filename = genderedVoiceFilename(cue.filename, currentGender)
             val directResId = context.resources.getIdentifier(filename, "raw", context.packageName)
+            val catalog = packStore.voiceCatalog()
             val fallbackFilename = genderedVoiceFilename(catalog.fallbackCommandCue.filename, currentGender)
             val fallbackResId = context.resources.getIdentifier(fallbackFilename, "raw", context.packageName)
-            val resId = directResId.takeIf { it != 0 } ?: fallbackResId.takeIf { it != 0 } ?: voiceResIdOrFallback(context, text, catalog)
-            if (mappedFilename == null) {
-                Log.w("AIVoiceCallout", "Unmapped cue requested, using bundled fallback: $text")
+            val resId = directResId.takeIf { it != 0 } ?: fallbackResId.takeIf { it != 0 } ?: voiceResIdOrFallback(context, cue.text, catalog)
+            if (catalog.filenameByText[cue.text] == null) {
+                Log.w("AIVoiceCallout", "Unmapped cue requested, using bundled fallback: ${cue.text}")
             }
 
-            playVoiceFile(filename = filename, fallbackResId = resId, cueText = text)
+            playVoiceFile(filename = filename, fallbackResId = resId, cueText = cue.text)
         }
 
         fun resetSession() {
@@ -507,8 +515,13 @@ class AIVoiceCalloutManager
 
             val catalog = packStore.voiceCatalog()
             runtimeVoiceCueForElapsedMark(elapsedSeconds, lastElapsedMilestone, catalog)?.let {
-                speak(it.text)
-                lastElapsedMilestone = elapsedSeconds
+                speak(
+                    VoiceCue(
+                        filename = it.filename,
+                        text = it.text,
+                    ),
+                )
+                lastElapsedMilestone = it.second
                 lastCueFiredAtElapsed = elapsedSeconds
                 if (nextCommandCueAt <= elapsedSeconds) {
                     nextCommandCueAt = elapsedSeconds + 30
@@ -517,7 +530,7 @@ class AIVoiceCalloutManager
             }
             if (shouldFireCommandCue(elapsedSeconds)) {
                 val cue = randomCommandCue()
-                speak(cue.text)
+                speak(cue)
                 lastCommandCueFilename = cue.filename
                 nextCommandCueAt = elapsedSeconds + 30
                 lastCueFiredAtElapsed = elapsedSeconds

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -336,7 +336,8 @@ class AIVoiceCalloutManager
             val catalog = packStore.voiceCatalog()
             val fallbackFilename = genderedVoiceFilename(catalog.fallbackCommandCue.filename, currentGender)
             val fallbackResId = context.resources.getIdentifier(fallbackFilename, "raw", context.packageName)
-            val resId = directResId.takeIf { it != 0 } ?: fallbackResId.takeIf { it != 0 } ?: voiceResIdOrFallback(context, cue.text, catalog)
+            val resId =
+                directResId.takeIf { it != 0 } ?: fallbackResId.takeIf { it != 0 } ?: voiceResIdOrFallback(context, cue.text, catalog)
             if (catalog.filenameByText[cue.text] == null) {
                 Log.w("AIVoiceCallout", "Unmapped cue requested, using bundled fallback: ${cue.text}")
             }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
@@ -17,6 +17,7 @@ import android.media.RingtoneManager
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -80,6 +81,7 @@ class TimerForegroundService : Service() {
     private var audioFocusRequest: AudioFocusRequest? = null
     private var vibrator: Vibrator? = null
     private var screenOffReceiver: ScreenOffReceiver? = null
+    private var wakeLock: PowerManager.WakeLock? = null
 
     inner class LocalBinder : Binder() {
         fun getService(): TimerForegroundService = this@TimerForegroundService
@@ -211,6 +213,7 @@ class TimerForegroundService : Service() {
         stopAlarmSound()
         stopVibration()
         unregisterScreenOffReceiver()
+        releaseTimerWakeLock()
         voiceCalloutManager.shutdown()
         serviceScope.cancel()
     }
@@ -274,6 +277,7 @@ class TimerForegroundService : Service() {
     }
 
     private fun startTimer(initialState: TimerState) {
+        acquireTimerWakeLock()
         _timerState.value = initialState
         updateNotification(initialState)
         voiceCalloutManager.resetSession()
@@ -343,6 +347,7 @@ class TimerForegroundService : Service() {
         stopAlarmSound()
         stopVibration()
         unregisterScreenOffReceiver()
+        releaseTimerWakeLock()
         _timerState.value = null
         removeForegroundNotification()
         stopSelf()
@@ -374,6 +379,7 @@ class TimerForegroundService : Service() {
 
     private fun pauseTimer() {
         timerJob?.cancel()
+        releaseTimerWakeLock()
         _timerState.value?.let { state ->
             if (state.status != TimerStatus.PAUSED) {
                 val pausedState = state.copy(status = TimerStatus.PAUSED)
@@ -445,6 +451,7 @@ class TimerForegroundService : Service() {
         stopAlarmSound()
         stopVibration()
         unregisterScreenOffReceiver()
+        releaseTimerWakeLock()
 
         _timerState.value?.let { current ->
             if (current.status == TimerStatus.ALARM) {
@@ -459,6 +466,7 @@ class TimerForegroundService : Service() {
     }
 
     private fun triggerAlarm(state: TimerState) {
+        acquireTimerWakeLock()
         // Update status to ALARM
         _timerState.value =
             state.copy(
@@ -523,6 +531,7 @@ class TimerForegroundService : Service() {
                             // Auto-restart timer
                             restartTimerInternal()
                         } else {
+                            releaseTimerWakeLock()
                             // Loop limit reached - keep state as COMPLETE
                             _timerState.value =
                                 currentState.copy(
@@ -533,6 +542,7 @@ class TimerForegroundService : Service() {
                             _timerState.value?.let { updateNotification(it) }
                         }
                     } else {
+                        releaseTimerWakeLock()
                         // Alarm sound finished — keep state as COMPLETE (iOS parity)
                         // User must manually Stop or Reset from the ActiveTimerScreen
                         _timerState.value =
@@ -576,6 +586,41 @@ class TimerForegroundService : Service() {
             )
 
         startTimer(newState)
+    }
+
+    private fun acquireTimerWakeLock() {
+        val existing = wakeLock
+        if (existing?.isHeld == true) {
+            return
+        }
+
+        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+        wakeLock =
+            existing
+                ?: powerManager.newWakeLock(
+                    PowerManager.PARTIAL_WAKE_LOCK,
+                    "$packageName:active_timer",
+                ).apply {
+                    setReferenceCounted(false)
+                }
+
+        runCatching {
+            wakeLock?.acquire()
+        }.onFailure { error ->
+            Log.w("TimerForegroundService", "Failed to acquire timer wake lock", error)
+        }
+    }
+
+    private fun releaseTimerWakeLock() {
+        val current = wakeLock ?: return
+        if (!current.isHeld) {
+            return
+        }
+        runCatching {
+            current.release()
+        }.onFailure { error ->
+            Log.w("TimerForegroundService", "Failed to release timer wake lock", error)
+        }
     }
 
     private fun createNotificationChannels() {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
@@ -597,12 +597,13 @@ class TimerForegroundService : Service() {
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock =
             existing
-                ?: powerManager.newWakeLock(
-                    PowerManager.PARTIAL_WAKE_LOCK,
-                    "$packageName:active_timer",
-                ).apply {
-                    setReferenceCounted(false)
-                }
+                ?: powerManager
+                    .newWakeLock(
+                        PowerManager.PARTIAL_WAKE_LOCK,
+                        "$packageName:active_timer",
+                    ).apply {
+                        setReferenceCounted(false)
+                    }
 
         runCatching {
             wakeLock?.acquire()

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
@@ -135,6 +135,7 @@ class AIVoiceCalloutManagerSelectionTest {
                         ElapsedVoiceCue(second = 15, filename = "elapsed_15s", text = "Fifteen seconds elapsed."),
                         ElapsedVoiceCue(second = 30, filename = "elapsed_30s", text = "Thirty seconds elapsed."),
                         ElapsedVoiceCue(second = 60, filename = "elapsed_60s", text = "One minute elapsed."),
+                        ElapsedVoiceCue(second = 120, filename = "elapsed_120s", text = "Two minutes elapsed."),
                     ),
                 commandCues = listOf(VoiceCue(filename = "cmd_a", text = "Move.")),
             )
@@ -143,6 +144,8 @@ class AIVoiceCalloutManagerSelectionTest {
         assertThat(runtimeVoiceCueForElapsedMark(15, lastElapsedMilestone = 0, catalog = catalog)).isNull()
         assertThat(runtimeVoiceCueForElapsedMark(30, lastElapsedMilestone = 0, catalog = catalog)).isNull()
         assertThat(runtimeVoiceCueForElapsedMark(60, lastElapsedMilestone = 0, catalog = catalog)?.filename).isEqualTo("elapsed_60s")
+        assertThat(runtimeVoiceCueForElapsedMark(61, lastElapsedMilestone = 0, catalog = catalog)?.filename).isEqualTo("elapsed_60s")
+        assertThat(runtimeVoiceCueForElapsedMark(121, lastElapsedMilestone = 60, catalog = catalog)?.filename).isEqualTo("elapsed_120s")
     }
 
     @Test

--- a/native-ios/RandomTimer/Info.plist
+++ b/native-ios/RandomTimer/Info.plist
@@ -37,6 +37,10 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -258,6 +258,13 @@ final class AIVoiceCalloutService {
         playVoiceFile(named: filename, cueText: text)
     }
 
+    private func speak(_ cue: VoiceCueCatalog.Cue) {
+        activateAudioSession()
+
+        let filename = genderedVoiceFilename(cue.filename, gender: currentGender)
+        playVoiceFile(named: filename, cueText: cue.text)
+    }
+
     func resetSession() {
         audioPlayer?.stop()
         audioPlayer = nil
@@ -338,8 +345,8 @@ final class AIVoiceCalloutService {
         }
 
         if let callout = elapsedMilestone(for: elapsedSeconds) {
-            speak(callout.text)
-            lastElapsedMilestone = elapsedSeconds
+            speak(.init(filename: callout.filename, text: callout.text))
+            lastElapsedMilestone = callout.second
             if nextCommandCueAt <= elapsedSeconds {
                 nextCommandCueAt = elapsedSeconds + 30
             }
@@ -349,23 +356,20 @@ final class AIVoiceCalloutService {
 
         if shouldFireCommandCue(elapsedSeconds: elapsedSeconds) {
             let cue = randomCommandCue()
-            speak(cue.text)
+            speak(cue)
             lastCommandCueFilename = cue.filename
             nextCommandCueAt = elapsedSeconds + 30
             lastCueFiredAtElapsed = elapsedSeconds
         }
     }
 
-    /// "Time elapsed" lines only on full-minute marks (60, 120, …). Other seconds use command cues only.
+    /// Returns the latest crossed "time elapsed" line on full-minute marks (60, 120, …).
+    /// Sub-minute elapsed rows stay out of runtime so command coaching keeps its own cadence.
     private func elapsedMilestone(for elapsed: Int) -> VoiceCueCatalog.ElapsedCue? {
         let catalog = packStore.voiceCatalog(bundle: bundle)
-        guard elapsed > 0, elapsed % 60 == 0 else {
-            return nil
-        }
-        guard let cue = catalog.elapsedCueBySecond[elapsed], elapsed != lastElapsedMilestone else {
-            return nil
-        }
-        return cue
+        return catalog.elapsedCues
+            .filter { $0.second > lastElapsedMilestone && $0.second <= elapsed && $0.second.isMultiple(of: 60) }
+            .max(by: { $0.second < $1.second })
     }
 
     private func shouldFireCommandCue(elapsedSeconds: Int) -> Bool {

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -194,6 +194,111 @@ internal func initialFollowupCommandCueSecond(totalDurationSeconds: Int) -> Int 
     }
 }
 
+internal protocol BackgroundVoiceKeepAliveEngine: AnyObject {
+    var isRunning: Bool { get }
+    var mainMixerNode: AVAudioMixerNode { get }
+    func attach(_ node: AVAudioNode)
+    func connect(_ node1: AVAudioNode, to node2: AVAudioNode, format: AVAudioFormat?)
+    func prepare()
+    func start() throws
+    func stop()
+    func reset()
+}
+
+extension AVAudioEngine: BackgroundVoiceKeepAliveEngine {}
+
+@MainActor
+final class BackgroundVoiceKeepAliveService: BackgroundVoiceKeepAliveHandling {
+    typealias AudioSessionActivator = @MainActor () -> Void
+    typealias AudioSessionDeactivator = @MainActor () -> Void
+    typealias EngineFactory = @MainActor () -> BackgroundVoiceKeepAliveEngine
+
+    static let shared = BackgroundVoiceKeepAliveService()
+
+    private static let log = Logger(subsystem: "com.iganapolsky.randomtimer", category: "voice-keepalive")
+
+    private static func activateBackgroundAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            log.error("Background voice audio session setup failed: \(error.localizedDescription)")
+        }
+    }
+
+    private static func deactivateBackgroundAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            log.error("Background voice audio session teardown failed: \(error.localizedDescription)")
+        }
+    }
+
+    private let makeEngine: EngineFactory
+    private let activateAudioSession: AudioSessionActivator
+    private let deactivateAudioSession: AudioSessionDeactivator
+    private var audioEngine: BackgroundVoiceKeepAliveEngine?
+    private var sourceNode: AVAudioSourceNode?
+
+    var isActive: Bool {
+        audioEngine?.isRunning == true
+    }
+
+    init(
+        makeEngine: @escaping EngineFactory = { AVAudioEngine() },
+        activateAudioSession: @escaping AudioSessionActivator =
+            BackgroundVoiceKeepAliveService.activateBackgroundAudioSession,
+        deactivateAudioSession: @escaping AudioSessionDeactivator =
+            BackgroundVoiceKeepAliveService.deactivateBackgroundAudioSession
+    ) {
+        self.makeEngine = makeEngine
+        self.activateAudioSession = activateAudioSession
+        self.deactivateAudioSession = deactivateAudioSession
+    }
+
+    func start() {
+        guard !isActive else { return }
+
+        activateAudioSession()
+
+        let engine = makeEngine()
+        let format = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1)
+        let silenceSource = AVAudioSourceNode { _, _, _, audioBufferList -> OSStatus in
+            let buffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+            for buffer in buffers {
+                if let data = buffer.mData {
+                    memset(data, 0, Int(buffer.mDataByteSize))
+                }
+            }
+            return 0
+        }
+
+        engine.attach(silenceSource)
+        engine.connect(silenceSource, to: engine.mainMixerNode, format: format)
+        engine.mainMixerNode.outputVolume = 0
+        engine.prepare()
+
+        do {
+            try engine.start()
+            audioEngine = engine
+            sourceNode = silenceSource
+        } catch {
+            Self.log.error("Background voice keepalive failed to start: \(error.localizedDescription)")
+            sourceNode = nil
+            audioEngine = nil
+            deactivateAudioSession()
+        }
+    }
+
+    func stop() {
+        sourceNode = nil
+        audioEngine?.stop()
+        audioEngine?.reset()
+        audioEngine = nil
+        deactivateAudioSession()
+    }
+}
+
 @MainActor
 final class AIVoiceCalloutService {
     struct StateSnapshot {

--- a/native-ios/RandomTimer/Sources/Services/ServiceProtocols.swift
+++ b/native-ios/RandomTimer/Sources/Services/ServiceProtocols.swift
@@ -39,3 +39,10 @@ protocol TimerLiveActivityHandling {
     func end() async
     func endAll() async
 }
+
+@MainActor
+protocol BackgroundVoiceKeepAliveHandling {
+    var isActive: Bool { get }
+    func start()
+    func stop()
+}

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -18,17 +18,21 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
     nonisolated private let storageService: TimerStorage
     private let notificationService: TimerNotificationHandling
     private let liveActivityService: TimerLiveActivityHandling
+    private let backgroundVoiceKeepAliveService: BackgroundVoiceKeepAliveHandling
+    private var isAppBackgrounded = false
 
     // MARK: - Initialization
 
     init(
         storageService: TimerStorage = StorageService(),
         notificationService: TimerNotificationHandling = NotificationService(),
-        liveActivityService: TimerLiveActivityHandling = LiveActivityService()
+        liveActivityService: TimerLiveActivityHandling = LiveActivityService(),
+        backgroundVoiceKeepAliveService: BackgroundVoiceKeepAliveHandling = BackgroundVoiceKeepAliveService.shared
     ) {
         self.storageService = storageService
         self.notificationService = notificationService
         self.liveActivityService = liveActivityService
+        self.backgroundVoiceKeepAliveService = backgroundVoiceKeepAliveService
 
         // Load config synchronously from storage to avoid UI flicker.
         // Clamp to current Pro entitlement so expired Pro users don't retain Pro-only values.
@@ -105,6 +109,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         }
 
         trackSettingsChanges(from: previousConfig, to: newConfig)
+        updateBackgroundVoiceKeepAliveIfNeeded()
 
         Task {
             await storageService.saveConfig(newConfig)
@@ -167,6 +172,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
                 gender: state.config.voiceGender
             )
         }
+        updateBackgroundVoiceKeepAliveIfNeeded()
 
         AnalyticsService.shared.track(AnalyticsEvents.timerStarted, properties: [
             "min_duration": config.minDuration,
@@ -203,6 +209,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         stopCountdown()
         AIVoiceCalloutService.shared.resetSession()
         timerState = nil
+        updateBackgroundVoiceKeepAliveIfNeeded()
 
         await storageService.clearTimerState()
         await endLiveActivity()
@@ -249,6 +256,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         stopCountdown()
         state.status = .paused
         timerState = state
+        updateBackgroundVoiceKeepAliveIfNeeded()
     }
 
     func resumeTimer() {
@@ -259,6 +267,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
             currentStatus: .running
         )
         timerState = state
+        updateBackgroundVoiceKeepAliveIfNeeded()
         startCountdown()
     }
 
@@ -282,6 +291,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
     /// Treats backgrounding during alarm as a silence action (like Android's ScreenOffReceiver)
     /// so the alarm does NOT restart when returning to foreground.
     func handleBackground() {
+        isAppBackgrounded = true
         // When a running timer is backgrounded, the countdown continues and the alarm will still
         // fire via the scheduled notification. This is NOT abandonment — fire timer_backgrounded
         // (informational only) so we can measure background rate without inflating abandon rate.
@@ -294,6 +304,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
                 "status": state.status.rawValue,
             ])
         }
+        updateBackgroundVoiceKeepAliveIfNeeded()
 
         guard let state = timerState, state.status == .alarm else { return }
         // Silence alarm — stops sound/vibration AND marks as silenced so
@@ -325,6 +336,8 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
     }
 
     func handleForeground() async {
+        isAppBackgrounded = false
+        updateBackgroundVoiceKeepAliveIfNeeded()
         // User is back — cancel any pending re-engagement reminders
         notificationService.cancelReengagementReminders()
 
@@ -510,6 +523,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         )
 
         timerState = newState
+        updateBackgroundVoiceKeepAliveIfNeeded()
 
         // Save state for recovery
         await storageService.saveTimerState(newState)
@@ -672,6 +686,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
             state.alarmTimeRemaining = TimeInterval(state.config.alarmDuration)
             state.alarmStartedAt = Date()
             timerState = state
+            updateBackgroundVoiceKeepAliveIfNeeded()
 
             // Save alarm state so we can detect it on app restart
             await storageService.saveTimerState(state)
@@ -707,6 +722,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
                 currentStatus: state.status
             )
             timerState = state
+            updateBackgroundVoiceKeepAliveIfNeeded()
 
             await storageService.saveTimerState(state)
             await updateLiveActivity(state: state)
@@ -735,6 +751,7 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
             state.alarmTimeRemaining = 0
             state.status = .complete
             timerState = state
+            updateBackgroundVoiceKeepAliveIfNeeded()
 
             stopCountdown()
             notificationService.stopAlarmSound()
@@ -764,6 +781,20 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
         } else {
             timerState = state
         }
+    }
+
+    private func updateBackgroundVoiceKeepAliveIfNeeded() {
+        guard shouldKeepBackgroundVoiceAlive else {
+            backgroundVoiceKeepAliveService.stop()
+            return
+        }
+        backgroundVoiceKeepAliveService.start()
+    }
+
+    private var shouldKeepBackgroundVoiceAlive: Bool {
+        guard isAppBackgrounded, ProManager.shared.isPro, let state = timerState else { return false }
+        guard state.config.voiceEnabled else { return false }
+        return [.running, .warning, .danger].contains(state.status)
     }
 
     // MARK: - Live Activity Handling

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -1,9 +1,51 @@
 import XCTest
 import CryptoKit
+import AVFoundation
 @testable import RandomTimer
 
 private final class CounterBox {
     var value = 0
+}
+
+private final class FakeBackgroundVoiceKeepAliveEngine: BackgroundVoiceKeepAliveEngine {
+    let mainMixerNode = AVAudioMixerNode()
+    private(set) var isRunning = false
+    private(set) var attachedNodes = 0
+    private(set) var connectedNodes = 0
+    private(set) var prepareCalls = 0
+    private(set) var startCalls = 0
+    private(set) var stopCalls = 0
+    private(set) var resetCalls = 0
+    var startError: Error?
+
+    func attach(_ node: AVAudioNode) {
+        attachedNodes += 1
+    }
+
+    func connect(_ node1: AVAudioNode, to node2: AVAudioNode, format: AVAudioFormat?) {
+        connectedNodes += 1
+    }
+
+    func prepare() {
+        prepareCalls += 1
+    }
+
+    func start() throws {
+        startCalls += 1
+        if let startError {
+            throw startError
+        }
+        isRunning = true
+    }
+
+    func stop() {
+        stopCalls += 1
+        isRunning = false
+    }
+
+    func reset() {
+        resetCalls += 1
+    }
 }
 
 private func makeUnusedTestAssetURL(filename: String) -> URL {
@@ -343,5 +385,64 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
             try Data(contentsOf: XCTUnwrap(store.soundAudioURL(for: .intense, bundle: .main))),
             soundPayload
         )
+    }
+
+    func testBackgroundVoiceKeepAliveStartIsIdempotent() {
+        let engine = FakeBackgroundVoiceKeepAliveEngine()
+        let activations = CounterBox()
+        let deactivations = CounterBox()
+        let sut = BackgroundVoiceKeepAliveService(
+            makeEngine: { engine },
+            activateAudioSession: { activations.value += 1 },
+            deactivateAudioSession: { deactivations.value += 1 }
+        )
+
+        sut.start()
+        sut.start()
+
+        XCTAssertTrue(sut.isActive)
+        XCTAssertEqual(activations.value, 1)
+        XCTAssertEqual(engine.startCalls, 1)
+        XCTAssertEqual(engine.attachedNodes, 1)
+        XCTAssertEqual(engine.connectedNodes, 1)
+        XCTAssertEqual(engine.prepareCalls, 1)
+        XCTAssertEqual(deactivations.value, 0)
+    }
+
+    func testBackgroundVoiceKeepAliveStopTearsDownEngineAndSession() {
+        let engine = FakeBackgroundVoiceKeepAliveEngine()
+        let deactivations = CounterBox()
+        let sut = BackgroundVoiceKeepAliveService(
+            makeEngine: { engine },
+            activateAudioSession: {},
+            deactivateAudioSession: { deactivations.value += 1 }
+        )
+
+        sut.start()
+        sut.stop()
+
+        XCTAssertFalse(sut.isActive)
+        XCTAssertEqual(engine.stopCalls, 1)
+        XCTAssertEqual(engine.resetCalls, 1)
+        XCTAssertEqual(deactivations.value, 1)
+    }
+
+    func testBackgroundVoiceKeepAliveDeactivatesSessionWhenEngineStartFails() {
+        struct StartFailure: Error {}
+
+        let engine = FakeBackgroundVoiceKeepAliveEngine()
+        engine.startError = StartFailure()
+        let deactivations = CounterBox()
+        let sut = BackgroundVoiceKeepAliveService(
+            makeEngine: { engine },
+            activateAudioSession: {},
+            deactivateAudioSession: { deactivations.value += 1 }
+        )
+
+        sut.start()
+
+        XCTAssertFalse(sut.isActive)
+        XCTAssertEqual(engine.startCalls, 1)
+        XCTAssertEqual(deactivations.value, 1)
     }
 }

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -290,6 +290,17 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertEqual(atSixty.nextCommandCueAt, 90)
     }
 
+    func testElapsedMinuteAnnouncementCatchesUpAfterSkippedSecond() {
+        let sut = makeVoiceCalloutService()
+
+        sut.beginSession(totalDurationSeconds: 180)
+        sut.triggerCallout(elapsedSeconds: 61)
+
+        let snapshot = sut._stateSnapshotForTesting()
+        XCTAssertEqual(snapshot.lastElapsedMilestone, 60)
+        XCTAssertEqual(snapshot.nextCommandCueAt, 91)
+    }
+
     func testFirstTimedCalloutReactivatesAudioSessionBeforePlayback() {
         let counter = CounterBox()
         let sut = makeVoiceCalloutService(counter: counter)

--- a/scripts/generate_pro_audio_content.py
+++ b/scripts/generate_pro_audio_content.py
@@ -96,8 +96,31 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     return json.loads(_resolve_repo_path(path, must_exist=True).read_text(encoding="utf-8"))
 
 
-def _select_pack(manifest: dict[str, Any], pack_id: str | None) -> dict[str, Any]:
-    resolved_id = pack_id or manifest["activePackId"]
+def _select_pack(
+    manifest: dict[str, Any],
+    pack_id: str | None,
+    release_month: str | None = None,
+) -> dict[str, Any]:
+    if pack_id:
+        for pack in manifest["packs"]:
+            if pack["id"] == pack_id:
+                return pack
+        raise SystemExit(f"Could not find audio pack {pack_id!r}.")
+
+    if release_month:
+        matches = [pack for pack in manifest["packs"] if pack.get("releaseMonth") == release_month]
+        if len(matches) == 1:
+            return matches[0]
+        if matches:
+            raise SystemExit(
+                f"Found multiple audio packs for releaseMonth {release_month!r}; use --pack-id to disambiguate."
+            )
+        raise SystemExit(
+            f"Could not find an audio pack scheduled for releaseMonth {release_month!r}. "
+            "Add a fresh monthly pack before running the release."
+        )
+
+    resolved_id = manifest["activePackId"]
     for pack in manifest["packs"]:
         if pack["id"] == resolved_id:
             return pack
@@ -274,7 +297,7 @@ def _resolve_generation_api_key(args: argparse.Namespace) -> str:
 def _generate_voice_assets_if_requested(
     args: argparse.Namespace,
     api_key: str,
-    defaults: dict[str, Any],
+    voice_settings_defaults: dict[str, Any],
     voice_lines: list[tuple[str, str]],
     expected_voice_stems: set[str],
     model_id: str,
@@ -290,7 +313,7 @@ def _generate_voice_assets_if_requested(
         voices = _list_voices(api_key)
         voice = _resolve_voice(voices, None, voice_name_query)
 
-    voice_settings = _load_voice_settings(api_key, voice["voice_id"], defaults["voiceSettings"])
+    voice_settings = _load_voice_settings(api_key, voice["voice_id"], voice_settings_defaults)
     _generate_voice_assets(
         api_key=api_key,
         voice_id=voice["voice_id"],
@@ -507,6 +530,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--pack-id", default="", help="Optional explicit pack ID. Defaults to the active pack.")
     parser.add_argument(
+        "--release-month",
+        default="",
+        help="Optional YYYY-MM release window. When set, selects the pack for that month instead of activePackId.",
+    )
+    parser.add_argument(
         "--ios-audio-dir",
         type=Path,
         default=Path("native-ios/RandomTimer/Resources/Audio"),
@@ -565,15 +593,20 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _resolve_output_paths(parse_args())
     manifest = _load_manifest(args.manifest)
-    pack = _select_pack(manifest, args.pack_id.strip() or None)
+    pack = _select_pack(
+        manifest,
+        args.pack_id.strip() or None,
+        args.release_month.strip() or None,
+    )
     defaults = manifest["defaults"]
     entitlement = defaults["entitlement"]
     voice_catalog = _voice_catalog(pack)
     sound_catalog = _sound_catalog(pack, entitlement)
     voice_lines = _voice_lines(voice_catalog)
     sound_lines = _sound_entries(pack)
-    model_id = args.model_id.strip() or defaults["voiceModelId"]
-    voice_name_pattern = args.voice_name_pattern.strip() or defaults["voiceNamePattern"]
+    voice_settings_defaults = pack.get("voiceSettings") or defaults["voiceSettings"]
+    model_id = args.model_id.strip() or pack.get("voiceModelId") or defaults["voiceModelId"]
+    voice_name_pattern = args.voice_name_pattern.strip() or pack.get("voiceNamePattern") or defaults["voiceNamePattern"]
 
     estimate = {
         "pack_id": pack["id"],
@@ -602,7 +635,7 @@ def main() -> None:
     _generate_voice_assets_if_requested(
         args=args,
         api_key=api_key,
-        defaults=defaults,
+        voice_settings_defaults=voice_settings_defaults,
         voice_lines=voice_lines,
         expected_voice_stems=expected_voice_stems,
         model_id=model_id,

--- a/scripts/tests/test_audio_asset_regressions.py
+++ b/scripts/tests/test_audio_asset_regressions.py
@@ -74,5 +74,6 @@ def test_session_voice_playback_routes_to_gendered_assets() -> None:
 
     assert "genderedVoiceFilename(baseFilename, gender: currentGender)" in ios_voice_service
     assert 'return "female/\\(filename)"' in ios_voice_service
-    assert "val filename = genderedVoiceFilename(baseFilename, currentGender)" in android_voice_manager
+    assert "private fun speak(cue: VoiceCue)" in android_voice_manager
+    assert "val filename = genderedVoiceFilename(cue.filename, currentGender)" in android_voice_manager
     assert 'VoiceGender.FEMALE -> if (filename.startsWith("female_")) filename else "female_$filename"' in android_voice_manager

--- a/scripts/tests/test_generate_pro_audio_content.py
+++ b/scripts/tests/test_generate_pro_audio_content.py
@@ -25,6 +25,28 @@ def test_select_pack_uses_active_pack_by_default():
     assert pack["id"] == manifest["activePackId"]
 
 
+def test_select_pack_can_target_release_month() -> None:
+    module = _load_module()
+    manifest = module._load_manifest(MANIFEST_PATH)
+    expected = next(pack for pack in manifest["packs"] if pack["releaseMonth"] == "2026-04")
+
+    pack = module._select_pack(manifest, None, "2026-04")
+
+    assert pack["id"] == expected["id"]
+
+
+def test_select_pack_fails_when_release_month_is_missing() -> None:
+    module = _load_module()
+    manifest = module._load_manifest(MANIFEST_PATH)
+
+    try:
+        module._select_pack(manifest, None, "2099-12")
+    except SystemExit as error:
+        assert "releaseMonth '2099-12'" in str(error)
+    else:
+        raise AssertionError("Expected missing releaseMonth to fail fast")
+
+
 def test_voice_catalog_contains_preview_elapsed_elapsed_and_command_cues():
     module = _load_module()
     manifest = module._load_manifest(MANIFEST_PATH)

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -141,6 +141,7 @@ def test_voice_callouts_are_gated_as_pro_on_both_platforms():
     android_service = ANDROID_FOREGROUND_SERVICE.read_text(encoding="utf-8")
     ios_setup = IOS_SETUP_SCREEN.read_text(encoding="utf-8")
     ios_timer_manager = IOS_TIMER_MANAGER.read_text(encoding="utf-8")
+    ios_info_plist = IOS_INFO_PLIST.read_text(encoding="utf-8")
     android_config = ANDROID_CONFIG.read_text(encoding="utf-8")
     ios_models = IOS_MODELS.read_text(encoding="utf-8")
 
@@ -151,6 +152,10 @@ def test_voice_callouts_are_gated_as_pro_on_both_platforms():
     assert "voiceEnabled" in android_service and "isPro" in android_service
     assert "ProManager.shared.isPro && state.config.voiceEnabled" in ios_timer_manager
     assert "triggerCallout(elapsedSeconds: elapsedSeconds)" in ios_timer_manager
+    assert "backgroundVoiceKeepAliveService" in ios_timer_manager
+    assert "updateBackgroundVoiceKeepAliveIfNeeded()" in ios_timer_manager
+    assert "<key>UIBackgroundModes</key>" in ios_info_plist
+    assert "<string>audio</string>" in ios_info_plist
 
 
 def test_hidden_debug_unlock_holds_for_8_seconds_and_unlocks_pro():

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -63,6 +63,7 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert contents.count("timeout-minutes:") >= 4
     assert "actions: write" in contents
     assert "--body \"Auto-generated monthly Pro content update." in contents
+    assert '--release-month "${{ steps.meta.outputs.release_month }}"' in contents
     assert "git push origin develop" not in contents
     assert 'gh pr comment "${CONTENT_PR_NUMBER}"' in contents
     assert "/trunk merge" in contents


### PR DESCRIPTION
## Summary
- stop runtime callouts from collapsing back to the same fallback line and catch crossed full-minute elapsed announcements
- hold an Android partial wake lock while the timer/alarm is active so screen-off voice cadence stays alive
- make monthly Pro audio generation select the pack for the current release month and add a May 2026 combatives/corner pack for ElevenLabs generation

## Verification
- ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest'
- uv run pytest scripts/tests/test_generate_pro_audio_content.py scripts/tests/test_workflow_security_contracts.py -q
- git diff --check
- python3 -m json.tool content/pro_audio/monthly_pro_audio_packs.json >/dev/null

## Notes
- Local iOS xcodebuild verification was attempted twice but hung in Swift package fetching ( dependency resolution), so iOS runtime changes are covered by code review and unit-test updates but not a completed local simulator run in this session.