### PR TITLE
fix(asc): include relationships in reviewSubmissionItems fieldset (unblocks submit-for-review)

### DIFF
--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -786,13 +786,17 @@ def _list_review_submissions(client: ASCClient, app_id: str) -> list[dict[str, A
 
 
 def _list_review_submission_items(client: ASCClient, submission_id: str) -> list[dict[str, Any]]:
+    # JSON:API sparse fieldset: if we list only "state", the server omits the
+    # relationships block, and _find_submission_for_version will never match on
+    # appStoreVersion id — producing STATE_ERROR.ITEM_PART_OF_ANOTHER_SUBMISSION
+    # 409s when the version is silently retained on an older submission.
     data = client.request(
         "GET",
         f"/reviewSubmissions/{submission_id}/items",
         params={
             "limit": 200,
             "include": "appStoreVersion,appCustomProductPageVersion",
-            "fields[reviewSubmissionItems]": "state",
+            "fields[reviewSubmissionItems]": "state,appStoreVersion,appCustomProductPageVersion",
         },
     )
     return data.get("data") or []

--- a/scripts/tests/test_asc_submit_for_review_list_items_sparse_fieldset.py
+++ b/scripts/tests/test_asc_submit_for_review_list_items_sparse_fieldset.py
@@ -1,0 +1,87 @@
+"""
+Regression test for HTTP 409 ITEM_PART_OF_ANOTHER_SUBMISSION in iOS submit-for-review.
+
+_list_review_submission_items must request relationships in fields[reviewSubmissionItems]
+so _find_submission_for_version can match an existing submission by appStoreVersion id.
+
+If sparse fieldset omits relationships (JSON:API spec), relationships collapse to None,
+the function returns (None, None), and the caller ends up creating/reusing a different
+submission while the version is still attached to the original one — producing a 409.
+"""
+import unittest
+
+from scripts.tests.router_client import RouterClient
+
+
+class ListReviewSubmissionItemsSparseFieldsetTests(unittest.TestCase):
+    def test_list_review_submission_items_requests_appstoreversion_relationship_in_fields(self):
+        from scripts.asc.asc_submit_for_review import _list_review_submission_items
+
+        submission_id = "sub-1"
+        client = RouterClient(
+            {
+                ("GET", f"/reviewSubmissions/{submission_id}/items"): {"data": []},
+            }
+        )
+
+        _list_review_submission_items(client, submission_id)
+
+        self.assertEqual(len(client.calls), 1)
+        params = client.calls[0]["params"] or {}
+        fields = params.get("fields[reviewSubmissionItems]", "")
+        self.assertIn(
+            "appStoreVersion",
+            fields,
+            "fields[reviewSubmissionItems] must request appStoreVersion so "
+            "_find_submission_for_version can locate the owning submission.",
+        )
+
+    def test_find_submission_for_version_matches_by_relationship_when_response_includes_it(self):
+        """End-to-end: when the endpoint returns relationships (as it will after fix),
+        the existing submission holding the version is found and the code does NOT
+        try to create a duplicate submission item (which would 409)."""
+        from scripts.asc.asc_submit_for_review import _find_submission_for_version
+
+        submission_id = "d3ce3d68"
+        version_id = "884770007"
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/reviewSubmissions"): {
+                    "data": [
+                        {
+                            "id": submission_id,
+                            "type": "reviewSubmissions",
+                            "attributes": {"state": "READY_FOR_REVIEW"},
+                        }
+                    ]
+                },
+                ("GET", f"/reviewSubmissions/{submission_id}/items"): {
+                    "data": [
+                        {
+                            "id": "item-1",
+                            "type": "reviewSubmissionItems",
+                            "attributes": {"state": "READY_FOR_REVIEW"},
+                            "relationships": {
+                                "appStoreVersion": {
+                                    "data": {"type": "appStoreVersions", "id": version_id}
+                                }
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+
+        found_submission, found_item = _find_submission_for_version(
+            client, app_id="app-1", version_id=version_id
+        )
+
+        self.assertIsNotNone(found_submission)
+        self.assertEqual(found_submission["id"], submission_id)
+        self.assertIsNotNone(found_item)
+        self.assertEqual(found_item["id"], "item-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- \`_list_review_submission_items\` requested \`fields[reviewSubmissionItems]=state\`, which per JSON:API spec omits the \`relationships\` block.
- As a result, \`_find_submission_for_version\` could never match an existing submission by \`appStoreVersion\` id, so it would fall through to \`_find_reusable_empty_submission\` and try to attach the version to a different submission.
- When a prior (non-empty) submission still held the version, ASC returned **HTTP 409 STATE_ERROR.ITEM_PART_OF_ANOTHER_SUBMISSION**, failing the release.

## Evidence

- v1.3.27 native-release run [24899474650](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/24899474650) — \`ios-testflight\` green (IPA uploaded), \`ios-submit-review\` failed.
- Log excerpt:
  \`\`\`
  HTTP 409 ... code STATE_ERROR.ENTITY_STATE_INVALID
  appStoreVersions with id '884770007' is not in valid state.
  Item is already present in another reviewSubmission
  appStoreVersions with id 884770007 was already added to another reviewSubmission with id d3ce3d68-cf57-4204-9d3a-44fdc69a4ef4
  \`\`\`

## Fix

- Expand \`fields[reviewSubmissionItems]\` to include \`appStoreVersion,appCustomProductPageVersion\` so JSON:API returns the relationships.
- Added regression test \`test_asc_submit_for_review_list_items_sparse_fieldset\` — failing before, green after.

## Test plan

- [x] Added regression test (fails on main, passes with fix)
- [x] Existing submission-flow tests still green
- [ ] Post-merge: re-dispatch \`ios-submit-review.yml\` with \`version=1.3.27\` off \`develop\` to finish the recovery release

🤖 Generated with [Claude Code](https://claude.com/claude-code)