### PR TITLE
revert(android): drop FOREGROUND_SERVICE_MEDIA_PLAYBACK (unblocks v1.3.27 Play upload)

### DIFF
--- a/native-android/app/src/main/AndroidManifest.xml
+++ b/native-android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <!-- Foreground Service for active timer -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <!-- Keep screen on during alarm -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -80,12 +79,11 @@
             </intent-filter>
         </activity>
 
-        <!-- Timer Foreground Service. mediaPlayback FGS type is required so voice
-             callouts continue when screen is off; specialUse covers the timer semantics. -->
+        <!-- Timer Foreground Service -->
         <service
             android:name=".service.TimerForegroundService"
             android:exported="false"
-            android:foregroundServiceType="specialUse|mediaPlayback">
+            android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="timer" />


### PR DESCRIPTION
## Summary

Google Play upload for v1.3.27 failed with HTTP 403:

\`\`\`
"You must let us know whether your app uses any Foreground Service permissions."
\`\`\`

Adding \`FOREGROUND_SERVICE_MEDIA_PLAYBACK\` triggered a Play Console policy-declaration form that has no API and must be filled manually via Play Console UI. Reverting to the manifest state that's already live (v1.3.26) unblocks the Android ship.

## Evidence

- Android failure: run [24908838593](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/24908838593), \`android-release\` job, \"Upload to Google Play (track)\" step.
- v1.3.26 live on Play since 2026-04-22 22:47 UTC with \`specialUse\` only — proven working.

## Platform trade-off

- iOS v1.3.27 ships \`UIBackgroundModes=audio\` (verified root cause of screen-off voice bug on iOS — confirmed missing via \`grep\` earlier today).
- Android screen-off voice enhancement is deferred; Android bug #2 may have a different root cause we can investigate in v1.3.28. Play Console declaration must be completed out-of-band before re-introducing \`mediaPlayback\`.

## Test plan

- [x] Diff matches pre-PR-1277 Android manifest (live v1.3.26 state)
- [ ] Re-dispatch \`native-release.yml\` \`platform=android\` after merge → expect successful Play production upload
- [ ] Phase B (v1.3.28): fill Play Console FGS declaration via \`scripts/complete_all_declarations.py\`, re-add mediaPlayback

🤖 Generated with [Claude Code](https://claude.com/claude-code)