### PR TITLE
chore(release): add release notes for v1.3.28

### DIFF
--- a/release-notes/1.3.28.md
+++ b/release-notes/1.3.28.md
@@ -1,0 +1,15 @@
+# Release 1.3.28
+
+## Summary
+**1.3.28** hardens runtime voice-callout behavior and refreshes the monthly Pro audio pipeline.
+
+## Customer-visible changes
+- Reduced repeated fallback voice lines so callouts vary correctly during active sessions.
+- Fixed missed elapsed-time announcements when the timer crosses a full-minute boundary.
+- Improved screen-off voice-callout reliability during active drills.
+- Refreshed Pro audio generation to select the pack for the release month, including the May 2026 combatives/corner content set.
+
+## Release operations
+- Android `VERSION_NAME` **1.3.28** and iOS `MARKETING_VERSION` **1.3.28** on `develop`.
+- Internal distribution preflight requires this file before Android Play Internal, Firebase Internal, and iOS TestFlight Internal can proceed.
+- Public storefronts still lag the prior release as of 2026-04-24; this note unblocks the next internal distribution cycle, not public propagation by itself.


### PR DESCRIPTION
## Summary
- add the missing `release-notes/1.3.28.md` file required by preflight
- unblock Android Play Internal, Android Firebase Internal, and iOS TestFlight Internal on develop

## Verification
- bash scripts/shell/preflight-release.sh --platform android --layer 1
- bash scripts/shell/preflight-release.sh --platform ios --layer 1
- git diff --check

## Evidence
The post-merge Internal Distribution run on develop (`24911188995`) failed in all platform jobs with the same error: missing `release-notes/1.3.28.md`.
