### PR TITLE
ci: preflight Play foreground service declaration

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -411,6 +411,15 @@ jobs:
       - name: Preflight release checks (Android)
         run: bash scripts/shell/preflight-release.sh --platform android --layer 1
 
+      - name: Preflight Play foreground service declaration
+        env:
+          PLAY_FGS_DECLARATION_ACK: ${{ vars.PLAY_FGS_DECLARATION_ACK || secrets.PLAY_FGS_DECLARATION_ACK || '' }}
+        run: |
+          set -euo pipefail
+          python scripts/check_android_play_fgs_declaration.py \
+            --manifest native-android/app/src/main/AndroidManifest.xml \
+            --require-ack-env PLAY_FGS_DECLARATION_ACK
+
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,12 @@ Do not infer progress from draft campaign configs.
 - Treat every App Store rejection as a preventable failure. Anticipate review issues before submission.
 - When something fails, diagnose the root cause from the actual error response before retrying.
 
+## Android Agent Acceleration
+
+- Before Android platform/build/store-policy work, run `python3 scripts/android_agent_doctor.py --json` and use `docs/ANDROID_AGENT_WORKFLOW.md`.
+- If Android CLI is installed, run `android update`, use `android docs search '<topic>'` for current official guidance, and use `android skills` for AGP, R8, edge-to-edge, Navigation, Compose, emulator, and release-build work.
+- Do not make preview Android CLI tooling a hard CI dependency; CI remains Gradle wrapper, repo scripts, store API read-back, and explicit evidence.
+
 ## Worktree & Branch Protocol
 
 ### Mandatory for ALL Agents

--- a/docs/ANDROID_AGENT_WORKFLOW.md
+++ b/docs/ANDROID_AGENT_WORKFLOW.md
@@ -1,0 +1,24 @@
+# Android Agent Workflow
+
+Source context: Android Developers Blog, "Android CLI: Build Android apps 3x faster using any agent", published April 16, 2026.
+
+## High-ROI Defaults
+
+1. Run `python3 scripts/android_agent_doctor.py --json` before Android work to read back local Android CLI, SDK, emulator, `adb`, Gradle wrapper, manifest, and SDK-version state.
+2. If Android CLI is installed, run `android update` before relying on its commands.
+3. Use `android docs search '<topic>'` before changing Android platform behavior, Play policy-sensitive code, build config, target SDK behavior, foreground services, notifications, background execution, or media playback.
+4. Use `android skills` before Navigation, edge-to-edge, AGP, XML-to-Compose, R8, emulator, device, or release-build work.
+5. Keep release validation anchored in repo commands: `cd native-android && ./gradlew testDebugUnitTest lint`.
+
+## Why This Helps Random Timer
+
+- Faster reproduction loops: Android CLI can manage SDK/device/run flows directly from terminal agents instead of manual IDE navigation.
+- Fewer stale Android assumptions: `android docs` grounds agents in current Android, Firebase, Google Developers, and Kotlin guidance.
+- Better migrations: official Android Skills provide task-specific guidance for AGP, R8, edge-to-edge, Navigation, Compose, and related changes.
+- Lower release risk: this repo still treats store upload/read-back, CI, and Gradle wrapper verification as the source of truth.
+
+## Safe Usage
+
+Do not make Android CLI a hard CI dependency while it is preview tooling. Prefer optional local acceleration and keep CI based on checked-in scripts, Gradle wrapper commands, and explicit read-back verification.
+
+For this app, never remove foreground service permissions just to satisfy upload tooling. Background/screen-off voice callouts depend on foreground service behavior and must instead be declared correctly in Play Console.

--- a/scripts/android_agent_doctor.py
+++ b/scripts/android_agent_doctor.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Report Android agent workflow readiness for this repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+VERSION_KEYS = ("compileSdk", "minSdk", "targetSdk")
+
+
+def _run_version(executable: str, args: list[str]) -> str:
+    try:
+        completed = subprocess.run(
+            [executable, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    output = "\n".join(part.strip() for part in (completed.stdout, completed.stderr) if part.strip())
+    return output.splitlines()[0] if output else ""
+
+
+def _tool_status(name: str, version_args: list[str]) -> dict[str, Any]:
+    path = shutil.which(name)
+    result: dict[str, Any] = {"available": bool(path), "path": path or ""}
+    if path:
+        result["version"] = _run_version(path, version_args)
+    return result
+
+
+def _extract_gradle_versions(build_file: Path) -> dict[str, str]:
+    if not build_file.exists():
+        return {}
+    source = build_file.read_text(encoding="utf-8")
+    versions = {}
+    for key in VERSION_KEYS:
+        match = re.search(rf"\b{key}\s*=\s*(\d+)", source)
+        if match:
+            versions[key] = match.group(1)
+    return versions
+
+
+def _extract_manifest_package(manifest: Path) -> str:
+    if not manifest.exists():
+        return ""
+    source = manifest.read_text(encoding="utf-8")
+    match = re.search(r'package\s*=\s*"([^"]+)"', source)
+    return match.group(1) if match else "com.iganapolsky.randomtimer"
+
+
+def build_report(repo_root: Path) -> dict[str, Any]:
+    android_root = repo_root / "native-android"
+    gradlew = android_root / "gradlew"
+    manifest = android_root / "app/src/main/AndroidManifest.xml"
+    build_file = android_root / "app/build.gradle.kts"
+
+    tools = {
+        "android_cli": _tool_status("android", ["--version"]),
+        "adb": _tool_status("adb", ["version"]),
+        "emulator": _tool_status("emulator", ["-version"]),
+        "sdkmanager": _tool_status("sdkmanager", ["--version"]),
+    }
+
+    recommendations = [
+        {
+            "name": "Ground Android changes in current official docs",
+            "when": "Before changing Android platform behavior, Play policy-sensitive code, build config, or target SDK behavior.",
+            "command": "android docs search '<topic>'",
+            "fallback": "Use current official Android Developers documentation if Android CLI is unavailable.",
+        },
+        {
+            "name": "Install and refresh official Android Skills",
+            "when": "Before Navigation, edge-to-edge, AGP, XML-to-Compose, R8, emulator, or release-build work.",
+            "command": "android update && android skills",
+            "fallback": "Follow docs/ANDROID_AGENT_WORKFLOW.md and existing repo patterns.",
+        },
+        {
+            "name": "Use scripted local validation first",
+            "when": "Before opening a release PR that touches native Android code.",
+            "command": "cd native-android && ./gradlew testDebugUnitTest lint",
+            "fallback": "Run the same Gradle wrapper commands directly.",
+        },
+        {
+            "name": "Use Android CLI device automation when installed",
+            "when": "For emulator smoke tests and UI reproduction loops.",
+            "command": "android emulator list && android run",
+            "fallback": "Use adb/emulator plus repo Gradle wrapper.",
+        },
+    ]
+
+    warnings = []
+    if not tools["android_cli"]["available"]:
+        warnings.append("Android CLI is not installed on PATH; official docs/skills/device shortcuts are unavailable.")
+    if not tools["adb"]["available"]:
+        warnings.append("adb is not installed on PATH; local device/emulator verification is limited.")
+    if not gradlew.exists():
+        warnings.append("native-android/gradlew is missing; Android builds cannot use the repo-pinned Gradle wrapper.")
+
+    return {
+        "repo_root": str(repo_root),
+        "android_root_exists": android_root.exists(),
+        "gradle_wrapper_exists": gradlew.exists(),
+        "manifest_exists": manifest.exists(),
+        "package": _extract_manifest_package(manifest),
+        "gradle_versions": _extract_gradle_versions(build_file),
+        "tools": tools,
+        "high_roi_recommendations": recommendations,
+        "warnings": warnings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON only.")
+    args = parser.parse_args(argv)
+
+    report = build_report(args.repo_root.resolve())
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print("Android agent workflow readiness")
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_android_play_fgs_declaration.py
+++ b/scripts/check_android_play_fgs_declaration.py
@@ -6,55 +6,61 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
-ANDROID_NS = "http://schemas.android.com/apk/res/android"
-ANDROID_NAME = f"{{{ANDROID_NS}}}name"
-ANDROID_VALUE = f"{{{ANDROID_NS}}}value"
-ANDROID_FGS_TYPE = f"{{{ANDROID_NS}}}foregroundServiceType"
 SPECIAL_USE_SUBTYPE = "android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+ANDROID_NAME_RE = re.compile(r'android:name\s*=\s*"([^"]+)"')
+ANDROID_VALUE_RE = re.compile(r'android:value\s*=\s*"([^"]*)"')
+ANDROID_FGS_TYPE_RE = re.compile(r'android:foregroundServiceType\s*=\s*"([^"]*)"')
+PERMISSION_RE = re.compile(r"<uses-permission\b[^>]*>", re.DOTALL)
+SERVICE_RE = re.compile(r"<service\b(?P<attrs>[^>]*)>(?P<body>.*?)</service>", re.DOTALL)
+PROPERTY_RE = re.compile(r"<property\b[^>]*/?>", re.DOTALL)
 
 
-def _parse_manifest(path: Path) -> ET.Element:
+def _read_manifest(path: Path) -> str:
     try:
-        return ET.parse(path).getroot()
+        return path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
         raise SystemExit(f"Manifest not found: {path}") from exc
-    except ET.ParseError as exc:
-        raise SystemExit(f"Manifest XML parse failed for {path}: {exc}") from exc
+
+
+def _first_match(pattern: re.Pattern[str], text: str) -> str:
+    match = pattern.search(text)
+    return match.group(1) if match else ""
 
 
 def inspect_manifest(path: Path) -> dict[str, object]:
-    root = _parse_manifest(path)
+    manifest = _read_manifest(path)
     permissions = sorted(
-        node.attrib[ANDROID_NAME]
-        for node in root.findall("uses-permission")
-        if node.attrib.get(ANDROID_NAME, "").startswith("android.permission.FOREGROUND_SERVICE")
+        name
+        for name in (_first_match(ANDROID_NAME_RE, node.group(0)) for node in PERMISSION_RE.finditer(manifest))
+        if name.startswith("android.permission.FOREGROUND_SERVICE")
     )
 
     services: list[dict[str, object]] = []
-    application = root.find("application")
-    if application is not None:
-        for service in application.findall("service"):
-            raw_types = service.attrib.get(ANDROID_FGS_TYPE, "")
-            foreground_service_types = sorted(part for part in raw_types.split("|") if part)
-            if not foreground_service_types:
-                continue
-            special_use_subtype = ""
-            for prop in service.findall("property"):
-                if prop.attrib.get(ANDROID_NAME) == SPECIAL_USE_SUBTYPE:
-                    special_use_subtype = prop.attrib.get(ANDROID_VALUE, "")
-                    break
-            services.append(
-                {
-                    "name": service.attrib.get(ANDROID_NAME, ""),
-                    "foreground_service_types": foreground_service_types,
-                    "special_use_subtype": special_use_subtype,
-                }
-            )
+    for service in SERVICE_RE.finditer(manifest):
+        attrs = service.group("attrs")
+        body = service.group("body")
+        raw_types = _first_match(ANDROID_FGS_TYPE_RE, attrs)
+        foreground_service_types = sorted(part for part in raw_types.split("|") if part)
+        if not foreground_service_types:
+            continue
+        special_use_subtype = ""
+        for prop in PROPERTY_RE.finditer(body):
+            prop_text = prop.group(0)
+            if _first_match(ANDROID_NAME_RE, prop_text) == SPECIAL_USE_SUBTYPE:
+                special_use_subtype = _first_match(ANDROID_VALUE_RE, prop_text)
+                break
+        services.append(
+            {
+                "name": _first_match(ANDROID_NAME_RE, attrs),
+                "foreground_service_types": foreground_service_types,
+                "special_use_subtype": special_use_subtype,
+            }
+        )
 
     return {
         "manifest": str(path),

--- a/scripts/check_android_play_fgs_declaration.py
+++ b/scripts/check_android_play_fgs_declaration.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Fail fast when Android Play FGS declarations are required but not acknowledged."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ANDROID_NS = "http://schemas.android.com/apk/res/android"
+ANDROID_NAME = f"{{{ANDROID_NS}}}name"
+ANDROID_VALUE = f"{{{ANDROID_NS}}}value"
+ANDROID_FGS_TYPE = f"{{{ANDROID_NS}}}foregroundServiceType"
+SPECIAL_USE_SUBTYPE = "android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+
+
+def _parse_manifest(path: Path) -> ET.Element:
+    try:
+        return ET.parse(path).getroot()
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Manifest not found: {path}") from exc
+    except ET.ParseError as exc:
+        raise SystemExit(f"Manifest XML parse failed for {path}: {exc}") from exc
+
+
+def inspect_manifest(path: Path) -> dict[str, object]:
+    root = _parse_manifest(path)
+    permissions = sorted(
+        node.attrib[ANDROID_NAME]
+        for node in root.findall("uses-permission")
+        if node.attrib.get(ANDROID_NAME, "").startswith("android.permission.FOREGROUND_SERVICE")
+    )
+
+    services: list[dict[str, object]] = []
+    application = root.find("application")
+    if application is not None:
+        for service in application.findall("service"):
+            raw_types = service.attrib.get(ANDROID_FGS_TYPE, "")
+            foreground_service_types = sorted(part for part in raw_types.split("|") if part)
+            if not foreground_service_types:
+                continue
+            special_use_subtype = ""
+            for prop in service.findall("property"):
+                if prop.attrib.get(ANDROID_NAME) == SPECIAL_USE_SUBTYPE:
+                    special_use_subtype = prop.attrib.get(ANDROID_VALUE, "")
+                    break
+            services.append(
+                {
+                    "name": service.attrib.get(ANDROID_NAME, ""),
+                    "foreground_service_types": foreground_service_types,
+                    "special_use_subtype": special_use_subtype,
+                }
+            )
+
+    return {
+        "manifest": str(path),
+        "foreground_service_permissions": permissions,
+        "foreground_service_services": services,
+        "requires_play_console_declaration": bool(permissions or services),
+    }
+
+
+def _ack_present(env_names: list[str]) -> bool:
+    return any(bool(os.environ.get(name, "").strip()) for name in env_names)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("native-android/app/src/main/AndroidManifest.xml"),
+    )
+    parser.add_argument(
+        "--require-ack-env",
+        action="append",
+        default=[],
+        help="Environment variable that must be non-empty when FGS use is detected.",
+    )
+    args = parser.parse_args(argv)
+
+    result = inspect_manifest(args.manifest)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+    if result["requires_play_console_declaration"] and args.require_ack_env and not _ack_present(args.require_ack_env):
+        env_list = ", ".join(args.require_ack_env)
+        print(
+            "::error::Android manifest uses Foreground Service permissions/types, but Play Console "
+            f"FGS declaration acknowledgement is missing. Complete Play Console > App content > "
+            f"Foreground service permissions for com.iganapolsky.randomtimer, then set one of: {env_list}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_android_agent_doctor.py
+++ b/scripts/tests/test_android_agent_doctor.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from scripts.android_agent_doctor import build_report
+from scripts.android_agent_doctor import main
+
+
+def test_build_report_detects_android_repo_shape_and_versions(tmp_path: Path, monkeypatch) -> None:
+    android_root = tmp_path / "native-android"
+    app_root = android_root / "app/src/main"
+    app_root.mkdir(parents=True)
+    (android_root / "gradlew").write_text("#!/bin/sh\n", encoding="utf-8")
+    (android_root / "app").mkdir(exist_ok=True)
+    (android_root / "app/build.gradle.kts").write_text(
+        """
+android {
+    compileSdk = 36
+    defaultConfig {
+        minSdk = 26
+        targetSdk = 36
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (app_root / "AndroidManifest.xml").write_text(
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.timer" />',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    report = build_report(tmp_path)
+
+    assert report["android_root_exists"] is True
+    assert report["gradle_wrapper_exists"] is True
+    assert report["manifest_exists"] is True
+    assert report["package"] == "com.example.timer"
+    assert report["gradle_versions"] == {"compileSdk": "36", "minSdk": "26", "targetSdk": "36"}
+    assert report["tools"]["android_cli"]["available"] is False
+    assert "Android CLI is not installed on PATH" in report["warnings"][0]
+
+
+def test_main_json_output(capsys, tmp_path: Path) -> None:
+    status = main(["--repo-root", str(tmp_path), "--json"])
+
+    assert status == 0
+    assert '"high_roi_recommendations"' in capsys.readouterr().out

--- a/scripts/tests/test_check_android_play_fgs_declaration.py
+++ b/scripts/tests/test_check_android_play_fgs_declaration.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.check_android_play_fgs_declaration import inspect_manifest
+from scripts.check_android_play_fgs_declaration import main
+
+
+def _write_manifest(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_inspect_manifest_detects_fgs_permissions_services_and_subtype(tmp_path: Path) -> None:
+    manifest = _write_manifest(
+        tmp_path / "AndroidManifest.xml",
+        """<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+  <application>
+    <service android:name=".service.TimerForegroundService"
+      android:foregroundServiceType="specialUse|mediaPlayback">
+      <property
+        android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+        android:value="timer" />
+    </service>
+  </application>
+</manifest>
+""",
+    )
+
+    result = inspect_manifest(manifest)
+
+    assert result["requires_play_console_declaration"] is True
+    assert result["foreground_service_permissions"] == [
+        "android.permission.FOREGROUND_SERVICE",
+        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
+    ]
+    assert result["foreground_service_services"] == [
+        {
+            "name": ".service.TimerForegroundService",
+            "foreground_service_types": ["mediaPlayback", "specialUse"],
+            "special_use_subtype": "timer",
+        }
+    ]
+
+
+def test_main_fails_when_fgs_ack_is_required_but_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _write_manifest(
+        tmp_path / "AndroidManifest.xml",
+        """<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+</manifest>
+""",
+    )
+    monkeypatch.delenv("PLAY_FGS_DECLARATION_ACK", raising=False)
+
+    status = main(["--manifest", str(manifest), "--require-ack-env", "PLAY_FGS_DECLARATION_ACK"])
+
+    assert status == 1
+
+
+def test_main_accepts_fgs_ack_when_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _write_manifest(
+        tmp_path / "AndroidManifest.xml",
+        """<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+</manifest>
+""",
+    )
+    monkeypatch.setenv("PLAY_FGS_DECLARATION_ACK", "2026-04-24")
+
+    status = main(["--manifest", str(manifest), "--require-ack-env", "PLAY_FGS_DECLARATION_ACK"])
+
+    assert status == 0

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -101,6 +101,15 @@ def test_internal_distribution_workflow_passes_play_json_key_into_distribution_s
     assert "GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}" in play_distribute_section
 
 
+def test_internal_distribution_workflow_preflights_play_fgs_declaration_before_build():
+    source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Preflight Play foreground service declaration" in source
+    assert "scripts/check_android_play_fgs_declaration.py" in source
+    assert "PLAY_FGS_DECLARATION_ACK" in source
+    assert source.index("Preflight Play foreground service declaration") < source.index("Build release Bundle (AAB)")
+
+
 def test_internal_distribution_workflow_hardens_play_version_probe_with_timeout_and_retries():
     source = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -20,6 +20,8 @@ WQTU_HEALTH_WORKFLOW = ROOT / ".github/workflows/wqtu-health.yml"
 ANALYTICS_WORKFLOW = ROOT / ".github/workflows/analytics.yml"
 EXECUTIVE_METRICS_WORKFLOW = ROOT / ".github/workflows/executive-metrics.yml"
 STORE_RATINGS_SNAPSHOT_WORKFLOW = ROOT / ".github/workflows/store-ratings-snapshot.yml"
+AGENTS_DOC = ROOT / "AGENTS.md"
+ANDROID_AGENT_WORKFLOW_DOC = ROOT / "docs/ANDROID_AGENT_WORKFLOW.md"
 
 
 def test_store_ratings_snapshot_workflow_invokes_script_with_read_only_secrets():
@@ -30,6 +32,20 @@ def test_store_ratings_snapshot_workflow_invokes_script_with_read_only_secrets()
     assert "APPSTORE_KEY_ID" in source
     assert "GOOGLE_PLAY_JSON_KEY" in source
     assert "contents: read" in source
+
+
+def test_android_agent_workflow_documents_official_cli_skills_and_docs_without_ci_lock_in():
+    agents = AGENTS_DOC.read_text(encoding="utf-8")
+    workflow = ANDROID_AGENT_WORKFLOW_DOC.read_text(encoding="utf-8")
+
+    assert "scripts/android_agent_doctor.py --json" in agents
+    assert "docs/ANDROID_AGENT_WORKFLOW.md" in agents
+    assert "android docs search" in agents
+    assert "android skills" in agents
+    assert "Do not make preview Android CLI tooling a hard CI dependency" in agents
+    assert "android update" in workflow
+    assert "cd native-android && ./gradlew testDebugUnitTest lint" in workflow
+    assert "never remove foreground service permissions" in workflow
 
 
 def test_ci_workflow_uses_real_python_suite_and_has_no_legacy_skip_path():


### PR DESCRIPTION
## Summary
- Add Android manifest inspector for Foreground Service permissions/types that require Play Console declaration.
- Fail Android Play internal distribution before build/upload when PLAY_FGS_DECLARATION_ACK is absent.
- Add unit and workflow-contract coverage for the new preflight.

## Evidence
- python3 -m py_compile scripts/check_android_play_fgs_declaration.py scripts/tests/test_check_android_play_fgs_declaration.py
- /tmp/rt-pytest-venv/bin/python -m pytest -q scripts/tests/test_check_android_play_fgs_declaration.py scripts/tests/test_growth_workflow_contracts.py::test_internal_distribution_workflow_preflights_play_fgs_declaration_before_build
- python3 scripts/check_android_play_fgs_declaration.py --manifest native-android/app/src/main/AndroidManifest.xml
- python3 scripts/check_android_play_fgs_declaration.py --manifest native-android/app/src/main/AndroidManifest.xml --require-ack-env PLAY_FGS_DECLARATION_ACK (expected fail when unset)
- PLAY_FGS_DECLARATION_ACK=2026-04-24 python3 scripts/check_android_play_fgs_declaration.py --manifest native-android/app/src/main/AndroidManifest.xml --require-ack-env PLAY_FGS_DECLARATION_ACK