### PR TITLE
ci: require internal build proof for releases

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -193,6 +193,7 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          TESTFLIGHT_REQUIRED_TESTERS: ${{ vars.TESTFLIGHT_INTERNAL_TESTERS || secrets.TESTFLIGHT_INTERNAL_TESTERS || '' }}
         run: |
           set -euo pipefail
           for name in MATCH_GIT_URL MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION APPSTORE_PRIVATE_KEY APPSTORE_KEY_ID APPSTORE_ISSUER_ID ADMIN_TOKEN; do
@@ -201,6 +202,10 @@ jobs:
               exit 1
             fi
           done
+          if [ -z "${TESTFLIGHT_REQUIRED_TESTERS:-}" ]; then
+            echo "❌ TESTFLIGHT_INTERNAL_TESTERS must include the CEO/TestFlight Apple ID so CI proves the build is visible to that account."
+            exit 1
+          fi
 
       - name: Preflight release checks (iOS)
         run: bash scripts/shell/preflight-release.sh --platform ios --layer 1
@@ -586,6 +591,10 @@ jobs:
               exit 1
             fi
           done
+          if [ -z "${FIREBASE_REQUIRED_TESTER_EMAIL:-}" ]; then
+            echo "❌ FIREBASE_REQUIRED_TESTER_EMAIL must include the CEO Android tester email so CI proves the Firebase build is visible to that account."
+            exit 1
+          fi
           COMBINED_FIREBASE_TESTERS="$(
             python3 - <<'PY'
           import os

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -49,7 +49,7 @@ on:
         required: false
         default: 'false'
       skip_internal_signoff:
-        description: 'Waive internal-signoff/* commit statuses (scheduled monthly release only; release SHA differs from internal build SHA)'
+        description: 'Deprecated/disabled. Releases must have TestFlight/Firebase internal proof on the exact SHA.'
         type: choice
         options:
           - 'false'
@@ -98,8 +98,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${SKIP_INTERNAL}" == "true" ]]; then
-            echo "::warning::internal signoff waived (skip_internal_signoff=true) — use only for scheduled monthly automation"
-            exit 0
+            echo "❌ Internal artifact proof cannot be waived for production release."
+            echo "Every release must have current internal-signoff/testflight and/or internal-signoff/firebase statuses on the exact release SHA."
+            exit 1
           fi
           gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/status" > /tmp/internal-signoff-status.json
           python3 scripts/internal_signoff_gate.py \

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -218,6 +218,8 @@ As of April 7, 2026, production release is blocked until CEO signoff exists for 
 - Android Google Play internal
 - Android Firebase App Distribution
 
+Internal proof is mandatory for every production release. CI must prove the latest TestFlight build is visible to `TESTFLIGHT_INTERNAL_TESTERS` and the latest Firebase APK is visible to `FIREBASE_REQUIRED_TESTER_EMAIL`; production release cannot waive these checks.
+
 Use `target=all_safe` only when Firebase APK delivery must be skipped for explicit debugging reasons.
 
 Target behavior:

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -77,6 +77,7 @@ def test_internal_distribution_workflow_verifies_store_uploads_and_uploads_evide
     assert 'TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"' in source
     assert 'TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"' in source
     assert "TESTFLIGHT_REQUIRED_TESTERS: ${{ vars.TESTFLIGHT_INTERNAL_TESTERS || secrets.TESTFLIGHT_INTERNAL_TESTERS || '' }}" in source
+    assert "TESTFLIGHT_INTERNAL_TESTERS must include the CEO/TestFlight Apple ID" in source
     assert "secrets.FIREBASE_REQUIRED_TESTER_EMAIL" not in source.split("Ensure TestFlight internal distribution visibility", 1)[1].split(
         "Upload IPA artifact", 1
     )[0]
@@ -168,6 +169,7 @@ def test_internal_distribution_workflow_supports_targeted_reruns_and_firebase_de
         "- name: Preflight release checks (Android)", 1
     )[0]
     assert "FIREBASE_REQUIRED_TESTER_EMAIL: ${{ secrets.FIREBASE_REQUIRED_TESTER_EMAIL }}" in firebase_auth_section
+    assert "FIREBASE_REQUIRED_TESTER_EMAIL must include the CEO Android tester email" in firebase_auth_section
     assert "COMBINED_FIREBASE_TESTERS" in firebase_auth_section
     assert 'os.environ.get("FIREBASE_REQUIRED_TESTER_EMAIL", "")' in firebase_auth_section
     assert 'echo "FIREBASE_INTERNAL_TESTERS=${COMBINED_FIREBASE_TESTERS}" >> "$GITHUB_ENV"' in firebase_auth_section
@@ -286,6 +288,8 @@ def test_native_release_workflow_blocks_production_without_internal_signoff_proo
     assert "internal-proof-or-waive:" in source
     assert "skip_internal_signoff:" in source
     assert "skip_production_signoff:" in source
+    assert "Internal artifact proof cannot be waived for production release." in source
+    assert "Every release must have current internal-signoff/testflight and/or internal-signoff/firebase statuses" in source
     assert 'gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/status"' in source
     assert "python3 scripts/internal_signoff_gate.py" in source
     assert "require-production-signoff:" in source


### PR DESCRIPTION
## Summary
- Require TestFlight internal tester proof before iOS internal distribution can pass.
- Require Firebase required tester proof before Android Firebase internal distribution can pass.
- Disable production release waiver for internal artifact proof.
- Document the mandatory TestFlight/Firebase proof requirement.

## Verification
- uv run python -m pytest scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_internal_signoff_gate.py -q
- git diff --check

## Config read-back
- TESTFLIGHT_INTERNAL_TESTERS repo variable set to iganapolsky@gmail.com
- FIREBASE_INTERNAL_TESTERS repo variable already set to iganapolsky@gmail.com
