### PR TITLE
fix: ignore terminal ASC review submissions

### DIFF
--- a/scripts/asc/asc_submit_for_review.py
+++ b/scripts/asc/asc_submit_for_review.py
@@ -832,6 +832,14 @@ def _find_reusable_empty_submission(client: ASCClient, *, app_id: str) -> dict[s
     return None
 
 
+def _is_terminal_review_submission_state(state: str) -> bool:
+    return state.upper() in {
+        "CANCELED",
+        "CANCELLED",
+        "COMPLETE",
+    }
+
+
 def _create_review_submission(client: ASCClient, *, app_id: str) -> dict[str, Any]:
     payload = {
         "data": {
@@ -1014,7 +1022,14 @@ def submit_for_review(client: ASCClient, app_id: str, version_id: str, *, attach
     if submission:
         sub_state = (submission.get("attributes") or {}).get("state", "UNKNOWN")
         info(f"Found existing review submission {submission.get('id')} (state={sub_state}).")
-        if attach_subscriptions and sub_state in ("WAITING_FOR_REVIEW", "IN_REVIEW"):
+        if _is_terminal_review_submission_state(str(sub_state)):
+            info(
+                f"Ignoring terminal review submission {submission.get('id')} "
+                f"(state={sub_state}); creating a fresh submission for this version."
+            )
+            submission = None
+            item = None
+        elif attach_subscriptions and sub_state in ("WAITING_FOR_REVIEW", "IN_REVIEW"):
             if pending_subs:
                 pending_names = ", ".join(name or sub_id for sub_id, name in pending_subs)
                 die(

--- a/scripts/tests/test_asc_submit_for_review_submission_flow.py
+++ b/scripts/tests/test_asc_submit_for_review_submission_flow.py
@@ -148,6 +148,75 @@ class AscSubmitForReviewSubmissionFlowTests(unittest.TestCase):
             },
         )
 
+    def test_submit_for_review_ignores_terminal_complete_submission_and_creates_fresh_one(self):
+        from scripts.asc.asc_submit_for_review import submit_for_review
+
+        old_submission_id = "sub-complete"
+        new_submission_id = "sub-new"
+        version_id = "ver-1"
+
+        client = RouterClient(
+            {
+                ("GET", "/apps/app-1/subscriptionGroups"): {"data": []},
+                ("GET", "/apps/app-1/reviewSubmissions"): {
+                    "data": [
+                        {
+                            "id": old_submission_id,
+                            "type": "reviewSubmissions",
+                            "attributes": {"state": "COMPLETE"},
+                        }
+                    ]
+                },
+                ("GET", f"/reviewSubmissions/{old_submission_id}/items"): {
+                    "data": [
+                        {
+                            "id": "item-old",
+                            "type": "reviewSubmissionItems",
+                            "attributes": {"state": "READY_FOR_REVIEW"},
+                            "relationships": {
+                                "appStoreVersion": {"data": {"type": "appStoreVersions", "id": version_id}}
+                            },
+                        }
+                    ]
+                },
+                ("POST", "/reviewSubmissions"): {
+                    "data": {
+                        "id": new_submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "READY_FOR_REVIEW"},
+                    }
+                },
+                ("POST", "/reviewSubmissionItems"): {
+                    "data": {
+                        "id": "item-new",
+                        "type": "reviewSubmissionItems",
+                        "attributes": {"state": "READY_FOR_REVIEW"},
+                    }
+                },
+                ("PATCH", f"/reviewSubmissions/{new_submission_id}"): {
+                    "data": {
+                        "id": new_submission_id,
+                        "type": "reviewSubmissions",
+                        "attributes": {"state": "WAITING_FOR_REVIEW"},
+                    }
+                },
+            }
+        )
+
+        submit_for_review(client, "app-1", version_id)
+
+        self.assertEqual(
+            [call["path"] for call in client.calls],
+            [
+                "/apps/app-1/subscriptionGroups",
+                "/apps/app-1/reviewSubmissions",
+                f"/reviewSubmissions/{old_submission_id}/items",
+                "/reviewSubmissions",
+                "/reviewSubmissionItems",
+                f"/reviewSubmissions/{new_submission_id}",
+            ],
+        )
+
     def test_submit_for_review_reuses_empty_ready_for_review_submission_when_limit_shell_exists(self):
         from scripts.asc.asc_submit_for_review import submit_for_review
 


### PR DESCRIPTION
## Summary
- Ignore terminal App Store Connect review submissions such as COMPLETE when submitting a new app version review
- Create a fresh review submission instead of PATCHing historical submissions that Apple rejects with STATE_ERROR.ENTITY_STATE_INVALID
- Add regression coverage for the exact terminal COMPLETE submission reuse failure

## Verification
- uv run python -m pytest scripts/tests/test_asc_submit_for_review_submission_flow.py scripts/tests/test_asc_submit_for_review_list_items_sparse_fieldset.py -q
- uv run python -m pytest scripts/tests/test_asc_submit_for_review_submission_flow.py scripts/tests/test_asc_submit_for_review_list_items_sparse_fieldset.py scripts/tests/test_asc_verify_ready.py scripts/tests/test_asc_resolve_version.py scripts/tests/test_asc_remove_from_review.py scripts/tests/test_asc_poll_version_state.py -q
- uv run python -m pytest  -q
- git diff --check