### PR TITLE
ci: add flaky test evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,28 @@ jobs:
             --tests 'com.iganapolsky.randomtimer.data.repository.TimerRepositoryImplTest' \
             --tests 'com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest'
 
+      - name: Summarize Android regression JUnit evidence
+        if: always()
+        run: |
+          python scripts/ci_junit_summary.py \
+            'native-android/app/build/test-results/testDebugUnitTest/**/*.xml' \
+            --json-out /tmp/android-regression-junit-summary.json \
+            --markdown-out /tmp/android-regression-junit-summary.md \
+            --github-annotations
+          cat /tmp/android-regression-junit-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Android regression test evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-regression-junit-evidence
+          path: |
+            native-android/app/build/test-results/testDebugUnitTest
+            native-android/app/build/reports/tests/testDebugUnitTest
+            /tmp/android-regression-junit-summary.json
+            /tmp/android-regression-junit-summary.md
+          if-no-files-found: warn
+
   android:
     name: Autonomous Android Tests
     needs: changes
@@ -292,6 +314,17 @@ jobs:
       - name: Run unit tests with coverage
         run: ./gradlew testDebugUnitTest jacocoDebugUnitTestReport --no-daemon
 
+      - name: Summarize Android JUnit evidence
+        if: always()
+        working-directory: .
+        run: |
+          python scripts/ci_junit_summary.py \
+            'native-android/app/build/test-results/testDebugUnitTest/**/*.xml' \
+            --json-out /tmp/android-junit-summary.json \
+            --markdown-out /tmp/android-junit-summary.md \
+            --github-annotations
+          cat /tmp/android-junit-summary.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build debug APK
         run: ./gradlew assembleDebug --no-daemon
 
@@ -307,9 +340,13 @@ jobs:
         with:
           name: android-unit-coverage
           path: |
+            native-android/app/build/test-results/testDebugUnitTest
             native-android/app/build/reports/tests/testDebugUnitTest
             native-android/app/build/reports/jacoco/jacocoDebugUnitTestReport
             native-android/app/build/jacoco/testDebugUnitTest.exec
+            /tmp/android-junit-summary.json
+            /tmp/android-junit-summary.md
+          if-no-files-found: warn
 
   ios:
     name: Autonomous iOS Build Check
@@ -503,7 +540,28 @@ jobs:
         run: python -m pip install --upgrade pip pytest==8.4.2 pytest-cov==7.0.0 pillow==11.3.0 google-auth==2.43.0 requests==2.32.5 PyYAML==6.0.2
 
       - name: Run unit tests
-        run: python -m pytest scripts/tests/ -q --cov=scripts --cov-report=term --cov-report=xml:coverage-python.xml
+        run: python -m pytest scripts/tests/ -q --junitxml=python-test-results.xml --cov=scripts --cov-report=term --cov-report=xml:coverage-python.xml
+
+      - name: Summarize Python JUnit evidence
+        if: always()
+        run: |
+          python scripts/ci_junit_summary.py \
+            'python-test-results.xml' \
+            --json-out /tmp/python-junit-summary.json \
+            --markdown-out /tmp/python-junit-summary.md \
+            --github-annotations
+          cat /tmp/python-junit-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Python JUnit evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-junit-evidence
+          path: |
+            python-test-results.xml
+            /tmp/python-junit-summary.json
+            /tmp/python-junit-summary.md
+          if-no-files-found: warn
 
       - name: Upload Python coverage artifact
         if: always()

--- a/.github/workflows/flaky-test-audit.yml
+++ b/.github/workflows/flaky-test-audit.yml
@@ -1,0 +1,144 @@
+name: Flaky Test Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 10 * * 1"
+
+concurrency:
+  group: flaky-test-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-flaky-audit:
+    name: Python Flaky Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest==8.4.2 pytest-cov==7.0.0 pillow==11.3.0 google-auth==2.43.0 requests==2.32.5 PyYAML==6.0.2
+
+      - name: Run Python tests three times
+        id: audit
+        run: |
+          set +e
+          mkdir -p /tmp/flaky-junit/python
+          failed=0
+          for run in 1 2 3; do
+            echo "Python flaky audit run ${run}/3"
+            python -m pytest scripts/tests/ -q --junitxml="/tmp/flaky-junit/python/run-${run}.xml"
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              failed=1
+            fi
+          done
+          echo "failed=${failed}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Summarize Python flaky evidence
+        if: always()
+        run: |
+          python scripts/ci_junit_summary.py \
+            '/tmp/flaky-junit/python/*.xml' \
+            --json-out /tmp/python-flaky-summary.json \
+            --markdown-out /tmp/python-flaky-summary.md \
+            --github-annotations \
+            --require-files
+          cat /tmp/python-flaky-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Python flaky evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-flaky-evidence
+          path: |
+            /tmp/flaky-junit/python
+            /tmp/python-flaky-summary.json
+            /tmp/python-flaky-summary.md
+          if-no-files-found: error
+
+      - name: Fail on Python flaky audit failures
+        if: steps.audit.outputs.failed != '0'
+        run: exit 1
+
+  android-flaky-audit:
+    name: Android Flaky Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission
+        run: chmod +x native-android/gradlew
+
+      - name: Create dummy google-services.json for CI
+        run: |
+          cat > native-android/app/google-services.json << 'GSEOF'
+          {
+            "project_info": { "project_number": "000000000000", "project_id": "random-timer-ci", "storage_bucket": "random-timer-ci.appspot.com" },
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.iganapolsky.randomtimer" } }, "api_key": [{ "current_key": "CI_PLACEHOLDER" }] }],
+            "configuration_version": "1"
+          }
+          GSEOF
+
+      - name: Run Android unit tests three times
+        id: audit
+        working-directory: native-android
+        run: |
+          set +e
+          failed=0
+          for run in 1 2 3; do
+            echo "Android flaky audit run ${run}/3"
+            ./gradlew testDebugUnitTest --no-daemon
+            status=$?
+            mkdir -p "/tmp/flaky-junit/android/run-${run}"
+            cp -R app/build/test-results/testDebugUnitTest/. "/tmp/flaky-junit/android/run-${run}/" 2>/dev/null || true
+            if [ "$status" -ne 0 ]; then
+              failed=1
+            fi
+          done
+          echo "failed=${failed}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Summarize Android flaky evidence
+        if: always()
+        run: |
+          python scripts/ci_junit_summary.py \
+            '/tmp/flaky-junit/android/**/*.xml' \
+            --json-out /tmp/android-flaky-summary.json \
+            --markdown-out /tmp/android-flaky-summary.md \
+            --github-annotations \
+            --require-files
+          cat /tmp/android-flaky-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Android flaky evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-flaky-evidence
+          path: |
+            /tmp/flaky-junit/android
+            /tmp/android-flaky-summary.json
+            /tmp/android-flaky-summary.md
+          if-no-files-found: error
+
+      - name: Fail on Android flaky audit failures
+        if: steps.audit.outputs.failed != '0'
+        run: exit 1

--- a/scripts/ci_junit_summary.py
+++ b/scripts/ci_junit_summary.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def _case_status(case: ET.Element) -> str:
+    if case.findall("error"):
+        return "error"
+    if case.findall("failure"):
+        return "failed"
+    if case.findall("skipped"):
+        return "skipped"
+    return "passed"
+
+
+def _message(case: ET.Element) -> str:
+    for tag in ("error", "failure", "skipped"):
+        node = case.find(tag)
+        if node is not None:
+            message = node.attrib.get("message") or (node.text or "")
+            return " ".join(message.split())[:500]
+    return ""
+
+
+def _annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _read_cases(path: Path) -> list[dict[str, Any]]:
+    root = ET.parse(path).getroot()
+    cases: list[dict[str, Any]] = []
+    for case in root.iter("testcase"):
+        classname = case.attrib.get("classname", "")
+        name = case.attrib.get("name", "")
+        status = _case_status(case)
+        cases.append(
+            {
+                "classname": classname,
+                "name": name,
+                "status": status,
+                "time": float(case.attrib.get("time") or 0.0),
+                "message": _message(case),
+                "file": str(path),
+            }
+        )
+    return cases
+
+
+def _expand_patterns(patterns: list[str]) -> list[Path]:
+    paths: set[Path] = set()
+    for pattern in patterns:
+        for match in glob.glob(pattern, recursive=True):
+            path = Path(match)
+            if path.is_file():
+                paths.add(path)
+    return sorted(paths)
+
+
+def summarize(patterns: list[str]) -> dict[str, Any]:
+    files = _expand_patterns(patterns)
+    parse_errors: list[dict[str, str]] = []
+    cases: list[dict[str, Any]] = []
+
+    for path in files:
+        try:
+            cases.extend(_read_cases(path))
+        except ET.ParseError as exc:
+            parse_errors.append({"file": str(path), "error": str(exc)})
+
+    counts = {"passed": 0, "failed": 0, "error": 0, "skipped": 0}
+    by_key: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for case in cases:
+        status = case["status"]
+        counts[status] += 1
+        by_key[(case["classname"], case["name"])].add(status)
+
+    failed_cases = [case for case in cases if case["status"] in {"failed", "error"}]
+    flaky_candidates = [
+        {
+            "classname": classname,
+            "name": name,
+            "statuses": sorted(statuses),
+        }
+        for (classname, name), statuses in sorted(by_key.items())
+        if "passed" in statuses and ({"failed", "error"} & statuses)
+    ]
+
+    return {
+        "files": len(files),
+        "tests": len(cases),
+        "passed": counts["passed"],
+        "failures": counts["failed"],
+        "errors": counts["error"],
+        "skipped": counts["skipped"],
+        "failed_cases": failed_cases,
+        "flaky_candidates": flaky_candidates,
+        "parse_errors": parse_errors,
+        "status": "failed" if failed_cases or parse_errors else "passed",
+    }
+
+
+def write_markdown(summary: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# JUnit Summary",
+        "",
+        "| Metric | Count |",
+        "| --- | ---: |",
+        f"| XML files | {summary['files']} |",
+        f"| Tests | {summary['tests']} |",
+        f"| Passed | {summary['passed']} |",
+        f"| Failures | {summary['failures']} |",
+        f"| Errors | {summary['errors']} |",
+        f"| Skipped | {summary['skipped']} |",
+        f"| Flaky candidates | {len(summary['flaky_candidates'])} |",
+        "",
+    ]
+
+    if summary["failed_cases"]:
+        lines.extend(["## Failed Cases", ""])
+        for case in summary["failed_cases"]:
+            label = f"{case['classname']}.{case['name']}".strip(".")
+            message = f" - {case['message']}" if case.get("message") else ""
+            lines.append(f"- `{case['status']}` `{label}` in `{case['file']}`{message}")
+        lines.append("")
+
+    if summary["flaky_candidates"]:
+        lines.extend(["## Flaky Candidates", ""])
+        for case in summary["flaky_candidates"]:
+            label = f"{case['classname']}.{case['name']}".strip(".")
+            statuses = ", ".join(case["statuses"])
+            lines.append(f"- `{label}` had mixed statuses: `{statuses}`")
+        lines.append("")
+
+    if summary["parse_errors"]:
+        lines.extend(["## Parse Errors", ""])
+        for err in summary["parse_errors"]:
+            lines.append(f"- `{err['file']}`: {err['error']}")
+        lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def emit_annotations(summary: dict[str, Any]) -> None:
+    for case in summary["failed_cases"]:
+        label = f"{case['classname']}.{case['name']}".strip(".")
+        detail = case.get("message") or "JUnit reported a test failure."
+        print(f"::error title=JUnit {case['status']}::{_annotation_escape(label + ' - ' + detail)}")
+
+    for case in summary["flaky_candidates"]:
+        label = f"{case['classname']}.{case['name']}".strip(".")
+        statuses = ", ".join(case["statuses"])
+        print(f"::warning title=Flaky test candidate::{_annotation_escape(label + ' had mixed statuses: ' + statuses)}")
+
+    for err in summary["parse_errors"]:
+        print(f"::error title=JUnit parse error::{_annotation_escape(err['file'] + ': ' + err['error'])}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize JUnit XML into CI evidence artifacts.")
+    parser.add_argument("patterns", nargs="+", help="JUnit XML glob pattern(s).")
+    parser.add_argument("--json-out", required=True, help="Path to write summary JSON.")
+    parser.add_argument("--markdown-out", required=True, help="Path to write summary Markdown.")
+    parser.add_argument("--require-files", action="store_true", help="Fail if no XML files match.")
+    parser.add_argument("--github-annotations", action="store_true", help="Emit GitHub workflow annotations.")
+    args = parser.parse_args()
+
+    summary = summarize(args.patterns)
+    json_path = Path(args.json_out)
+    markdown_path = Path(args.markdown_out)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(summary, markdown_path)
+
+    if args.github_annotations:
+        emit_annotations(summary)
+
+    print(
+        "JUnit summary: "
+        f"files={summary['files']} tests={summary['tests']} failures={summary['failures']} "
+        f"errors={summary['errors']} skipped={summary['skipped']} "
+        f"flaky_candidates={len(summary['flaky_candidates'])}"
+    )
+
+    if args.require_files and summary["files"] == 0:
+        print("No JUnit XML files matched required patterns.", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_ci_junit_summary.py
+++ b/scripts/tests/test_ci_junit_summary.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.ci_junit_summary import summarize
+
+
+def _write_junit(path: Path, body: str) -> None:
+    path.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<testsuite tests="1">
+{body}
+</testsuite>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_summary_counts_failures_errors_skips_and_flake_candidates(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path / "TEST-first.xml",
+        """
+  <testcase classname="TimerTests" name="stablePass"/>
+  <testcase classname="TimerTests" name="stableFail"><failure message="boom"/></testcase>
+  <testcase classname="TimerTests" name="flaky"><failure message="first run"/></testcase>
+  <testcase classname="TimerTests" name="skipped"><skipped message="not relevant"/></testcase>
+""",
+    )
+    _write_junit(
+        tmp_path / "TEST-second.xml",
+        """
+  <testcase classname="TimerTests" name="flaky"/>
+  <testcase classname="TimerTests" name="errored"><error message="crash"/></testcase>
+""",
+    )
+
+    summary = summarize([str(tmp_path / "TEST-*.xml")])
+
+    assert summary["files"] == 2
+    assert summary["tests"] == 6
+    assert summary["passed"] == 2
+    assert summary["failures"] == 2
+    assert summary["errors"] == 1
+    assert summary["skipped"] == 1
+    assert summary["status"] == "failed"
+    assert summary["flaky_candidates"] == [
+        {"classname": "TimerTests", "name": "flaky", "statuses": ["failed", "passed"]}
+    ]
+
+
+def test_cli_writes_json_and_markdown(tmp_path: Path) -> None:
+    _write_junit(tmp_path / "TEST-one.xml", '<testcase classname="TimerTests" name="works"/>')
+    json_out = tmp_path / "summary.json"
+    markdown_out = tmp_path / "summary.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci_junit_summary.py",
+            str(tmp_path / "TEST-*.xml"),
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+            "--github-annotations",
+            "--require-files",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "JUnit summary: files=1 tests=1" in result.stdout
+    assert json.loads(json_out.read_text(encoding="utf-8"))["status"] == "passed"
+    assert "| Tests | 1 |" in markdown_out.read_text(encoding="utf-8")
+
+
+def test_require_files_returns_nonzero_when_missing(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci_junit_summary.py",
+            str(tmp_path / "missing-*.xml"),
+            "--json-out",
+            str(tmp_path / "summary.json"),
+            "--markdown-out",
+            str(tmp_path / "summary.md"),
+            "--require-files",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 2
+    assert "No JUnit XML files matched" in result.stderr


### PR DESCRIPTION
## Summary
- add repo-owned JUnit summarizer for JSON/Markdown CI evidence and GitHub annotations
- upload raw Android/Python JUnit evidence in CI
- add weekly/manual flaky test audit that runs Python and Android unit suites 3x and flags mixed pass/fail tests

## Verification
- pytest scripts/tests/test_ci_junit_summary.py scripts/tests/test_workflow_yaml_syntax.py scripts/tests/test_workflow_security_contracts.py -q
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'
- python3 -m py_compile scripts/ci_junit_summary.py