### PR TITLE
ci: avoid north star failures without active campaigns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
             --repo-root . \
             --lookback-days 30 \
             --wqtu-window-days 7 \
-            --require-posthog
+            --require-posthog-when-active
 
       - name: Warn if paid attribution guardrail is violated
         if: always()

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -352,6 +352,14 @@ def test_ci_workflow_has_dedicated_regression_guards_job():
     assert "AIVoiceCalloutManagerSelectionTest" in guard_job
 
 
+def test_ci_north_star_guardrail_only_requires_posthog_when_paid_campaigns_are_active():
+    source = CI_WORKFLOW.read_text(encoding="utf-8")
+    guard_job = source.split("north-star-guardrail:", 1)[1].split("\n  security:\n", 1)[0]
+
+    assert "--require-posthog-when-active" in guard_job
+    assert "--require-posthog\n" not in guard_job
+
+
 def test_north_star_guardrail_workflow_runs_daily_ops_pipeline():
     source = NORTH_STAR_GUARDRAIL_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- switch push CI North Star guardrail to require PostHog only when active paid campaigns exist
- keep strict failure for active paid-campaign attribution hygiene
- add workflow contract coverage so CI cannot regress to unconditional PostHog failure

## Verification
- pytest scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_north_star_guardrail.py scripts/tests/test_workflow_yaml_syntax.py -q
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml yaml ok"'