### PR TITLE
ci: make push gates path aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
+            python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output
+          elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
+            git diff --name-only "$BEFORE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
             python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output
           else
             python3 scripts/ci_changed_components.py --all --github-output

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -31,11 +31,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
+            python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output
+          elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
+            git diff --name-only "$BEFORE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
             python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output
           else
             python3 scripts/ci_changed_components.py --all --github-output

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -126,6 +126,10 @@ def test_pr_ci_uses_path_aware_heavy_job_gates() -> None:
     assert device_tests.count("permissions:\n      contents: read") >= 3
     assert "Path-Aware CI Gate" in ci
     assert "Path-Aware Device Gate" in device_tests
+    assert "BEFORE_SHA: ${{ github.event.before || '' }}" in ci
+    assert "BEFORE_SHA: ${{ github.event.before || '' }}" in device_tests
+    assert 'elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then' in ci
+    assert 'elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then' in device_tests
     assert "python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output" in ci
     assert "python3 scripts/ci_changed_components.py --files /tmp/changed-files.txt --github-output" in device_tests
     assert "if: needs.changes.outputs.android == 'true'" in ci


### PR DESCRIPTION
## Summary
- use push before..head diffs for CI path-aware gates instead of forcing all native jobs
- keep PR behavior unchanged and keep workflow_dispatch/unknown events conservative
- extend workflow contract tests for push gating

## Verification
- pytest scripts/tests/test_workflow_security_contracts.py scripts/tests/test_ci_changed_components.py scripts/tests/test_workflow_yaml_syntax.py -q
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/device-tests.yml"); puts "workflow yaml ok"'