### PR TITLE
fix: tighten voice callout session UI

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
@@ -1,11 +1,10 @@
 package com.iganapolsky.randomtimer.ui.screens
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
@@ -132,8 +131,8 @@ class ActiveTimerScreenTapCircleTest {
             }
         }
 
-        composeRule.onNodeWithText("Voice Callouts On").assertDoesNotExist()
-        composeRule.onNodeWithText("Voice Callouts Locked").assertDoesNotExist()
+        assertTrue(composeRule.onAllNodesWithText("Voice Callouts On").fetchSemanticsNodes().isEmpty())
+        assertTrue(composeRule.onAllNodesWithText("Voice Callouts Locked").fetchSemanticsNodes().isEmpty())
     }
 
     @Test

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
@@ -2,8 +2,10 @@ package com.iganapolsky.randomtimer.ui.screens
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
@@ -101,6 +103,37 @@ class ActiveTimerScreenTapCircleTest {
             assertTrue(!silenced)
             assertTrue(!dismissed)
         }
+    }
+
+    @Test
+    fun freeRunningTimerDoesNotRenderVoiceCalloutBadge() {
+        val state =
+            TimerState(
+                config = TimerConfig.DEFAULT.copy(voiceEnabled = true),
+                targetDuration = 60.seconds,
+                remainingDuration = 30.seconds,
+                status = TimerStatus.RUNNING,
+            )
+
+        composeRule.setContent {
+            RandomTimerTheme {
+                ActiveTimerScreen(
+                    state = state,
+                    isPro = false,
+                    onStop = {},
+                    onDismissAlarm = {},
+                    onSilence = {},
+                    onPause = {},
+                    onResume = {},
+                    onReset = {},
+                    onLoopToggle = {},
+                    onVoiceToggle = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Voice Callouts On").assertDoesNotExist()
+        composeRule.onNodeWithText("Voice Callouts Locked").assertDoesNotExist()
     }
 
     @Test

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
@@ -1,8 +1,8 @@
 package com.iganapolsky.randomtimer.ui.screens
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.click
 import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -348,7 +348,9 @@ class AIVoiceCalloutManager
         fun resetSession() {
             stopPlayback()
             lastElapsedMilestone = 0
-            lastCommandCueFilename = null
+            // Preserve lastCommandCueFilename across sessions so a new session cannot
+            // immediately repeat the final command cue from the previous session.
+            usedCommandCueFilenames.clear()
             lastPreviewCommandFilenameByGender.clear()
             usedPreviewCommandFilenamesByGender.values.forEach { it.clear() }
             nextCommandCueAt = 0

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/CircularTimer.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/components/CircularTimer.kt
@@ -186,20 +186,14 @@ fun CircularTimer(
                 style = Stroke(width = strokePx, cap = StrokeCap.Round),
             )
 
-            // Orbiting shimmer dot (only when actively running, not paused/complete)
+            // One orbiting shimmer dot only. Extra glow rings look like additional
+            // progress indicators and undermine random-timer uncertainty.
             if (isActivelyRunning) {
                 val shimmerAngleRad = Math.toRadians((shimmerAngle - 90).toDouble())
                 val arcRadius = radius - strokePx / 2
                 val shimmerX = (radius + arcRadius * kotlin.math.cos(shimmerAngleRad)).toFloat()
                 val shimmerY = (radius + arcRadius * kotlin.math.sin(shimmerAngleRad)).toFloat()
 
-                // Outer glow (large, soft)
-                drawCircle(
-                    color = Color.White.copy(alpha = 0.15f),
-                    radius = strokePx * 2.5f,
-                    center = Offset(shimmerX, shimmerY),
-                )
-                // Inner bright spot
                 drawCircle(
                     color = Color.White.copy(alpha = 0.5f),
                     radius = strokePx,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreen.kt
@@ -272,11 +272,13 @@ fun ActiveTimerScreen(
                                 roundCount = state.roundCount,
                                 onClick = toggleLoop,
                             )
-                            VoiceBadge(
-                                enabled = voiceEnabled,
-                                isPro = isPro,
-                                onClick = toggleVoice,
-                            )
+                            if (shouldShowVoiceBadge(isPro)) {
+                                VoiceBadge(
+                                    enabled = voiceEnabled,
+                                    isPro = isPro,
+                                    onClick = toggleVoice,
+                                )
+                            }
                         }
                     }
                 }
@@ -463,6 +465,8 @@ internal fun voiceBadgeText(
         enabled -> "Voice Callouts On"
         else -> "Voice Callouts Off"
     }
+
+internal fun shouldShowVoiceBadge(isPro: Boolean): Boolean = isPro
 
 private fun formatDurationReadable(duration: kotlin.time.Duration): String {
     val totalSeconds = duration.inWholeSeconds.coerceAtLeast(0)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenBadgeTextTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenBadgeTextTest.kt
@@ -38,4 +38,10 @@ class ActiveTimerScreenBadgeTextTest {
     fun voiceBadgeShowsLockedStateForFreeUsersEvenWhenConfigIsStaleOn() {
         assertThat(voiceBadgeText(enabled = true, isPro = false)).isEqualTo("Voice Callouts Locked")
     }
+
+    @Test
+    fun voiceBadgeIsHiddenForFreeUsers() {
+        assertThat(shouldShowVoiceBadge(isPro = false)).isFalse()
+        assertThat(shouldShowVoiceBadge(isPro = true)).isTrue()
+    }
 }


### PR DESCRIPTION
## Summary
- Hide the voice callout badge for Free users so stale voice state cannot show on the active timer screen.
- Preserve the last command cue across session resets so the next session cannot immediately repeat the previous final callout.
- Remove the extra orbiting shimmer glow so the circular timer shows one indicator ball only.
- Add unit/instrumentation coverage for the Free badge behavior.

## Evidence
- ANDROID_HOME=/Users/igorganapolsky/Library/Android/sdk ./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest --tests com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenBadgeTextTest
- Result: BUILD SUCCESSFUL
- Push hook hygiene check: 0 errors, 0 warnings
