### PR TITLE
fix: use media playback foreground service only

### DIFF
--- a/native-android/app/src/main/AndroidManifest.xml
+++ b/native-android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
 
     <!-- Foreground Service for active timer -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <!-- Keep screen on during alarm -->
@@ -80,16 +79,12 @@
             </intent-filter>
         </activity>
 
-        <!-- Timer Foreground Service. mediaPlayback FGS type is required so voice
-             callouts continue when screen is off; specialUse covers the timer semantics. -->
+        <!-- Timer Foreground Service. mediaPlayback keeps voice/sound callouts
+             reliable when the app is backgrounded or the screen is off. -->
         <service
             android:name=".service.TimerForegroundService"
             android:exported="false"
-            android:foregroundServiceType="specialUse|mediaPlayback">
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="timer" />
-        </service>
+            android:foregroundServiceType="mediaPlayback" />
 
         <!-- Alarm Receiver -->
         <receiver


### PR DESCRIPTION
## Summary
- Remove FOREGROUND_SERVICE_SPECIAL_USE from the Android manifest.
- Keep the timer service on mediaPlayback foreground service type only so Play does not require the special-use declaration path.

## Evidence
- bash scripts/shell/preflight-release.sh --platform android --layer 1: PREFLIGHT PASSED
- ANDROID_HOME=/Users/igorganapolsky/Library/Android/sdk ./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest --tests com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenBadgeTextTest compileDebugAndroidTestKotlin: BUILD SUCCESSFUL
- Manifest readback: android:foregroundServiceType="mediaPlayback" only

## Root Cause
Google Play Internal rejected the release upload with: You must let us know whether your app uses any Foreground Service permissions. The release manifest still declared specialUse, which triggers that declaration gate.
