### PR TITLE
fix: load escaped App Store env secrets

### DIFF
--- a/scripts/asc/asc_client.py
+++ b/scripts/asc/asc_client.py
@@ -17,7 +17,8 @@ if _SCRIPTS_ROOT not in sys.path:
 from pem_env import normalize_inline_pem
 from repo_dotenv import load_repo_dotenv
 
-load_repo_dotenv(Path(__file__).resolve().parent.parent)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+load_repo_dotenv(REPO_ROOT)
 
 APP_STORE_CONNECT_API = "https://api.appstoreconnect.apple.com/v1"
 

--- a/scripts/repo_dotenv.py
+++ b/scripts/repo_dotenv.py
@@ -11,6 +11,16 @@ import os
 from pathlib import Path
 
 
+def _strip_outer_quotes(value: str) -> str:
+    if len(value) >= 2 and value[:2] in ('\\"', "\\'") and value.endswith(value[:2]):
+        return value[2:-2]
+    if value.startswith('\\"') and value.endswith('\\"'):
+        return value[2:-2]
+    if value.startswith("\\'") and value.endswith("\\'"):
+        return value[2:-2]
+    return value.strip('"').strip("'")
+
+
 def load_repo_dotenv(repo_root: Path) -> None:
     env_path = repo_root / ".env"
     if not env_path.is_file():
@@ -28,22 +38,34 @@ def load_repo_dotenv(repo_root: Path) -> None:
             i += 1
             continue
         val = v.strip()
-        # Handle multiline quoted values (double or single quotes)
-        if val and val[0] in ('"', "'") and not val.endswith(val[0]):
+        # Handle multiline quoted values, including shell-escaped quotes copied
+        # from chat/tools into `.env` as \"...\".
+        quote = ""
+        quote_len = 0
+        if val.startswith('\\"'):
+            quote = '\\"'
+            quote_len = 2
+        elif val.startswith("\\'"):
+            quote = "\\'"
+            quote_len = 2
+        elif val and val[0] in ('"', "'"):
             quote = val[0]
-            parts = [val[1:]]  # strip opening quote
+            quote_len = 1
+
+        if quote and not val.endswith(quote):
+            parts = [val[quote_len:]]  # strip opening quote
             i += 1
             while i < len(lines):
                 line = lines[i]
                 if line.rstrip().endswith(quote):
-                    parts.append(line.rstrip()[:-1])  # strip closing quote
+                    parts.append(line.rstrip()[: -len(quote)])  # strip closing quote
                     i += 1
                     break
                 parts.append(line)
                 i += 1
             val = "\n".join(parts)
         else:
-            val = val.strip('"').strip("'")
+            val = _strip_outer_quotes(val)
             i += 1
         if key in os.environ and str(os.environ.get(key, "")).strip():
             continue

--- a/scripts/tests/test_asc_client.py
+++ b/scripts/tests/test_asc_client.py
@@ -29,6 +29,10 @@ def test_auth_from_env_requires_values(monkeypatch):
         ac.ASCAuth.from_env()
 
 
+def test_asc_client_loads_dotenv_from_repo_root():
+    assert ac.REPO_ROOT == ac.Path(__file__).resolve().parents[2]
+
+
 def test_request_raises_on_http_error(monkeypatch):
     auth = ac.ASCAuth(key_id="kid", issuer_id="iss", private_key="pk")
     client = ac.ASCClient(auth=auth)

--- a/scripts/tests/test_repo_dotenv.py
+++ b/scripts/tests/test_repo_dotenv.py
@@ -75,6 +75,33 @@ class RepoDotenvTests(unittest.TestCase):
                     else:
                         os.environ[k] = saved[k]
 
+    def test_multiline_value_with_escaped_quotes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            (tmp / ".env").write_text(
+                'APPSTORE_KEY_ID=\\"KEY123\\"\n'
+                'APPSTORE_PRIVATE_KEY=\\"-----BEGIN TEST BLOCK-----\n'  # gitleaks:allow
+                'AAAA\n'
+                'BBBB\n'
+                '-----END TEST BLOCK-----\\"\n',
+                encoding="utf-8",
+            )
+            env_keys = ("APPSTORE_KEY_ID", "APPSTORE_PRIVATE_KEY")
+            saved = {k: os.environ.pop(k, None) for k in env_keys}
+            try:
+                load_repo_dotenv(tmp)
+                self.assertEqual(os.environ.get("APPSTORE_KEY_ID"), "KEY123")
+                self.assertEqual(
+                    os.environ.get("APPSTORE_PRIVATE_KEY"),
+                    "-----BEGIN TEST BLOCK-----\nAAAA\nBBBB\n-----END TEST BLOCK-----",
+                )
+            finally:
+                for k in env_keys:
+                    if saved[k] is None:
+                        os.environ.pop(k, None)
+                    else:
+                        os.environ[k] = saved[k]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Load App Store Connect .env values from the repo root in ASC helpers.
- Parse shell-escaped quoted values such as APPSTORE_PRIVATE_KEY=\"...\".
- Add regression coverage for escaped multiline .env secrets.

## Verification
- python3 -m unittest scripts.tests.test_repo_dotenv
- python3 -m py_compile scripts/asc/asc_client.py scripts/repo_dotenv.py scripts/tests/test_asc_client.py
- Sanitized live parser check: escaped APPSTORE_* values load with BEGIN/END private-key markers and correct line count.

## Revenue impact
- Removes a release-automation blocker that forced manual App Store credential normalization during store submissions.