### PR TITLE
fix: tighten paywall funnel signal

### DIFF
--- a/docs/POSTHOG_ANALYTICS.md
+++ b/docs/POSTHOG_ANALYTICS.md
@@ -43,6 +43,7 @@ Dashboards (`scripts/wqtu_dashboard.py`, `scripts/engagement_dashboard.py`, `scr
 | Step | Event | Meaning |
 | --- | --- | --- |
 | **Impression** | `paywall_viewed` (and legacy `paywall_view`) | User saw the paywall surface. |
+| **Plan selection** | `paywall_offer_select` | User selected a plan card or tapped the primary paywall CTA. It includes `paywall_selection_source` (`plan_card` \| `primary_cta`). Automatic default-plan impressions must not emit this event. |
 | **Attempt** | **`paywall_purchase_attempt`** | The app **started the platform purchase path** for a selected product: **iOS** — tracked at the beginning of `PaywallSheet`’s `purchase(productID:)` **immediately before** `proManager.purchase` (StoreKit). **Android** — tracked in `ProManager` **immediately before** `billingClient.launchBillingFlow` (Play Billing). |
 
 So **“attempt” is not a generic CTA tap** elsewhere in the app; it is **“we are invoking / about to invoke native purchase for this product from the paywall.”** It is also **not** proof the Google / Apple sheet was seen (e.g. `launchBillingFlow` can return non-OK right after; StoreKit can fail early)—only that the **instrumented** start of that path ran.
@@ -66,8 +67,8 @@ Screens emitted on both platforms:
 - `alarm_triggered`: `target_duration` (seconds)
 - `timer_completed`: see [timer_completed emission paths](#timer_completed-emission-paths) below (iOS and Android differ in **number of code paths** and optional `source` / `entitlement_level`)
 - `paywall_view` / `paywall_viewed`: `entry_point`, **`paywall_experiment_variant`** (`monthly_default` \| `annual_default`) — reflects the in-app default plan arm driven by PostHog flag **`paywall_default_plan_annual`** (see `docs/OBSERVABILITY.md`). Also **`paywall_value_framing_variant`** (`control` \| `outcomes_first`) from multivariate flag **`paywall_value_framing`** (copy experiment; default `control` until you add the flag in PostHog).
-- `subscription_funnel_step`: `funnel_step`, plus `entry_point`, `paywall_experiment_variant`, `paywall_value_framing_variant`, and step-specific keys (e.g. `product_id`, `plan`).
-- `paywall_offer_select`: `entry_point`, `product_id`, `plan`
+- `subscription_funnel_step`: `funnel_step`, plus `entry_point`, `paywall_experiment_variant`, `paywall_value_framing_variant`, and step-specific keys (e.g. `product_id`, `plan`, `paywall_selection_source`).
+- `paywall_offer_select`: `entry_point`, `product_id`, `plan`, `paywall_selection_source`
 - `paywall_*` (other): `entry_point` where applicable; purchase/result events also include `result` (iOS) or `success` / `response_code` (Android) as implemented per platform
 - common context on all events: `platform`, `app_version`, `environment`, `build_audience`, `build_type`, `runtime_target`
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -454,6 +454,7 @@ object AnalyticsProperties {
     const val REVENUE = "revenue"
     const val PAYWALL_EXPERIMENT_VARIANT = "paywall_experiment_variant"
     const val PAYWALL_VALUE_FRAMING_VARIANT = "paywall_value_framing_variant"
+    const val PAYWALL_SELECTION_SOURCE = "paywall_selection_source"
 }
 
 object AnalyticsScreens {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -226,16 +226,18 @@ fun RandomTimerNavHost(
 
     if (showPaywall) {
         PaywallSheet(
+            entryPoint = paywallEntryPoint,
             proPrice = proPrice,
             monthlyPrice = monthlyPrice,
             defaultToAnnualPlan = paywallDefaultToAnnual,
             valueFramingVariant = paywallValueFramingVariant,
             trialEligibilityByProductId = paywallTrialEligibilityByProductId,
-            onPlanSelected = { plan, productId ->
+            onPlanSelected = { plan, productId, selectionSource ->
                 viewModel.trackPaywallOfferSelected(
                     entryPoint = paywallEntryPoint,
                     productId = productId,
                     plan = plan,
+                    selectionSource = selectionSource,
                 )
             },
             onPurchase = { productID ->

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -66,6 +65,40 @@ internal val PAYWALL_FEATURE_ROWS =
         "Fresh pro audio drops when new packs land",
     )
 
+internal data class PaywallFeatureContext(
+    val eyebrow: String,
+    val valueCopy: String,
+)
+
+internal fun paywallFeatureContext(entryPoint: String): PaywallFeatureContext =
+    when (entryPoint) {
+        "range_gate" ->
+            PaywallFeatureContext(
+                eyebrow = "You tapped 60-minute random windows",
+                valueCopy = "Pro removes the 5-minute cap so long rounds, circuits, and stress drills can run on your timing.",
+            )
+        "voice_gate" ->
+            PaywallFeatureContext(
+                eyebrow = "You tapped voice callouts",
+                valueCopy = "Pro adds time checks plus combat, MMA, and conditioning cues without revealing the random timer.",
+            )
+        "repeat_gate" ->
+            PaywallFeatureContext(
+                eyebrow = "You tapped round control",
+                valueCopy = "Pro lets you cap loops from 1-100 rounds instead of guessing when a training block should end.",
+            )
+        "sound_arsenal_gate" ->
+            PaywallFeatureContext(
+                eyebrow = "You tapped the sound arsenal",
+                valueCopy = "Pro lets you equip the full alarm arsenal instead of only previewing locked sounds.",
+            )
+        else ->
+            PaywallFeatureContext(
+                eyebrow = "Pro Tactical",
+                valueCopy = "Unlock longer random windows, combat callouts, round caps, and the full sound arsenal.",
+            )
+    }
+
 /** Identifies which subscription plan the user has selected on the paywall. */
 internal enum class SubscriptionPlanSelection {
     MONTHLY,
@@ -75,13 +108,14 @@ internal enum class SubscriptionPlanSelection {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PaywallSheet(
+    entryPoint: String = "unknown",
     proPrice: String,
     monthlyPrice: String = "$3.99",
     defaultToAnnualPlan: Boolean = false,
     valueFramingVariant: String = PaywallValueFraming.CONTROL,
     trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
     onPurchase: (String) -> Unit,
-    onPlanSelected: (plan: String, productId: String) -> Unit = { _, _ -> },
+    onPlanSelected: (plan: String, productId: String, selectionSource: String) -> Unit = { _, _, _ -> },
     onRestore: () -> Unit,
     onDismiss: () -> Unit,
     onDebugUnlock: (() -> Unit)? = null,
@@ -90,6 +124,7 @@ fun PaywallSheet(
     val initialSelection =
         if (defaultToAnnualPlan) SubscriptionPlanSelection.ANNUAL else SubscriptionPlanSelection.MONTHLY
     var selectedPlan by remember(defaultToAnnualPlan) { mutableStateOf(initialSelection) }
+    val featureContext = paywallFeatureContext(entryPoint)
     val headline =
         if (valueFramingVariant == PaywallValueFraming.OUTCOMES_FIRST) {
             PAYWALL_HEADLINE_OUTCOMES_FIRST
@@ -102,14 +137,6 @@ fun PaywallSheet(
         } else {
             PAYWALL_SUBHEADLINE
         }
-    LaunchedEffect(defaultToAnnualPlan) {
-        if (defaultToAnnualPlan) {
-            onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID)
-        } else {
-            onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID)
-        }
-    }
-
     val purchaseProductId = productIdForPlan(selectedPlan)
     val ctaLabel =
         ctaLabelForPlan(
@@ -143,7 +170,7 @@ fun PaywallSheet(
                     PrimaryButton(
                         text = ctaLabel,
                         onClick = {
-                            onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId)
+                            onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId, "primary_cta")
                             onPurchase(purchaseProductId)
                         },
                         modifier =
@@ -248,6 +275,32 @@ fun PaywallSheet(
                     color = TimerColors.TextSecondary,
                     textAlign = TextAlign.Center,
                 )
+                Spacer(modifier = Modifier.height(12.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(14.dp),
+                    colors =
+                        CardDefaults.cardColors(
+                            containerColor = TimerColors.AccentPrimary.copy(alpha = 0.08f),
+                        ),
+                    border = BorderStroke(1.dp, TimerColors.AccentPrimary.copy(alpha = 0.25f)),
+                ) {
+                    Column(modifier = Modifier.padding(14.dp)) {
+                        Text(
+                            text = featureContext.eyebrow,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = TimerColors.AccentPrimary,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = featureContext.valueCopy,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TimerColors.TextPrimary,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = PAYWALL_PRICING_FOOTER,
                     style = MaterialTheme.typography.bodySmall,
@@ -290,7 +343,7 @@ fun PaywallSheet(
                     isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
                     onClick = {
                         selectedPlan = SubscriptionPlanSelection.MONTHLY
-                        onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID)
+                        onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID, "plan_card")
                     },
                 )
 
@@ -303,7 +356,7 @@ fun PaywallSheet(
                     isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
                     onClick = {
                         selectedPlan = SubscriptionPlanSelection.ANNUAL
-                        onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID)
+                        onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID, "plan_card")
                     },
                 )
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -315,6 +315,7 @@ class TimerViewModel
             entryPoint: String,
             productId: String,
             plan: String,
+            selectionSource: String,
         ) {
             val framing = analyticsService.paywallValueFramingVariant()
             analyticsService.track(
@@ -323,6 +324,7 @@ class TimerViewModel
                     AnalyticsProperties.ENTRY_POINT to entryPoint,
                     AnalyticsProperties.PRODUCT_ID to productId,
                     "plan" to plan,
+                    AnalyticsProperties.PAYWALL_SELECTION_SOURCE to selectionSource,
                     AnalyticsProperties.PAYWALL_VALUE_FRAMING_VARIANT to framing,
                 ),
             )
@@ -331,6 +333,7 @@ class TimerViewModel
                 mapOf(
                     AnalyticsProperties.PRODUCT_ID to productId,
                     "plan" to plan,
+                    AnalyticsProperties.PAYWALL_SELECTION_SOURCE to selectionSource,
                 ),
             )
         }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -31,6 +31,19 @@ class PaywallSheetTest {
     }
 
     @Test
+    fun `paywall feature context explains selected gate value`() {
+        val rangeContext = paywallFeatureContext("range_gate")
+        assertEquals("You tapped 60-minute random windows", rangeContext.eyebrow)
+        assertEquals(
+            "Pro removes the 5-minute cap so long rounds, circuits, and stress drills can run on your timing.",
+            rangeContext.valueCopy,
+        )
+
+        val unknownContext = paywallFeatureContext("unknown")
+        assertEquals("Pro Tactical", unknownContext.eyebrow)
+    }
+
+    @Test
     fun `price label normalizes to yearly pricing`() {
         assertEquals("$29.99/year", normalizedPriceLabel("$29.99"))
         assertEquals("$29.99/yr", normalizedPriceLabel("$29.99/yr"))

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
@@ -186,6 +186,39 @@ class TimerViewModelAnalyticsTest {
     }
 
     @Test
+    fun `trackPaywallOfferSelected includes selection source`() {
+        viewModel.trackPaywallOfferSelected(
+            entryPoint = "range_gate",
+            productId = ProManager.ELITE_PRODUCT_ID,
+            plan = "annual",
+            selectionSource = "primary_cta",
+        )
+
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.PAYWALL_OFFER_SELECT,
+                match {
+                    it["entry_point"] == "range_gate" &&
+                        it["product_id"] == ProManager.ELITE_PRODUCT_ID &&
+                        it["plan"] == "annual" &&
+                        it["paywall_selection_source"] == "primary_cta" &&
+                        it["paywall_value_framing_variant"] == "control"
+                },
+            )
+        }
+        verify {
+            analyticsService.trackSubscriptionFunnelStep(
+                SubscriptionFunnelSteps.PAYWALL_PLAN_SELECTED,
+                match {
+                    it["product_id"] == ProManager.ELITE_PRODUCT_ID &&
+                        it["plan"] == "annual" &&
+                        it["paywall_selection_source"] == "primary_cta"
+                },
+            )
+        }
+    }
+
+    @Test
     fun `updateConfig emits per-setting analytics with setting_name`() {
         val updated = TimerConfig.DEFAULT.copy(minSeconds = 10, maxSeconds = 45, voiceEnabled = true)
 

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -586,6 +586,7 @@ enum AnalyticsProperties {
     static let revenue = "revenue"
     static let paywallExperimentVariant = "paywall_experiment_variant"
     static let paywallValueFramingVariant = "paywall_value_framing_variant"
+    static let paywallSelectionSource = "paywall_selection_source"
 }
 
 enum AnalyticsValues {

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -19,6 +19,43 @@ enum PaywallEntryPoint: String {
     }
 }
 
+struct PaywallFeatureContext: Equatable {
+    let eyebrow: String
+    let valueCopy: String
+}
+
+func paywallFeatureContext(for entryPoint: PaywallEntryPoint) -> PaywallFeatureContext {
+    switch entryPoint {
+    case .rangeGate:
+        return PaywallFeatureContext(
+            eyebrow: "You tapped 60-minute random windows",
+            valueCopy: "Pro removes the 5-minute cap so long rounds, circuits, "
+                + "and stress drills can run on your timing."
+        )
+    case .voiceGate:
+        return PaywallFeatureContext(
+            eyebrow: "You tapped voice callouts",
+            valueCopy: "Pro adds time checks plus combat, MMA, and conditioning cues "
+                + "without revealing the random timer."
+        )
+    case .repeatGate:
+        return PaywallFeatureContext(
+            eyebrow: "You tapped round control",
+            valueCopy: "Pro lets you cap loops from 1-100 rounds instead of guessing when a training block should end."
+        )
+    case .soundArsenalGate:
+        return PaywallFeatureContext(
+            eyebrow: "You tapped the sound arsenal",
+            valueCopy: "Pro lets you equip the full alarm arsenal instead of only previewing locked sounds."
+        )
+    case .unknown:
+        return PaywallFeatureContext(
+            eyebrow: "Pro Tactical",
+            valueCopy: "Unlock longer random windows, combat callouts, round caps, and the full sound arsenal."
+        )
+    }
+}
+
 /// Which plan option is highlighted on the paywall.
 enum PaywallPlanSelection {
     case monthly
@@ -79,6 +116,10 @@ struct PaywallSheet: View {
         valueFramingVariant == PaywallValueFraming.outcomesFirst
             ? Self.subheadlineOutcomesFirst
             : Self.subheadline
+    }
+
+    private var featureContext: PaywallFeatureContext {
+        paywallFeatureContext(for: entryPoint)
     }
 
     // MARK: - Derived helpers
@@ -173,6 +214,25 @@ struct PaywallSheet: View {
                     }
             )
 
+            VStack(alignment: .leading, spacing: 4) {
+                Text(featureContext.eyebrow)
+                    .font(.caption.bold())
+                    .foregroundColor(.accentPrimary)
+                Text(featureContext.valueCopy)
+                    .font(.caption)
+                    .foregroundColor(.textPrimary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.accentPrimary.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.accentPrimary.opacity(0.25), lineWidth: 1)
+            )
+
             VStack(alignment: .leading, spacing: 16) {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(Self.featureTitle)
@@ -199,7 +259,11 @@ struct PaywallSheet: View {
                     isSelected: selectedPlan == .monthly
                 ) {
                     selectedPlan = .monthly
-                    trackOfferSelected(plan: "monthly", productID: ProManager.monthlyProductID)
+                    trackOfferSelected(
+                        plan: "monthly",
+                        productID: ProManager.monthlyProductID,
+                        selectionSource: "plan_card"
+                    )
                 }
 
                 PlanOptionRow(
@@ -209,7 +273,11 @@ struct PaywallSheet: View {
                     isSelected: selectedPlan == .annual
                 ) {
                     selectedPlan = .annual
-                    trackOfferSelected(plan: "annual", productID: ProManager.annualProductID)
+                    trackOfferSelected(
+                        plan: "annual",
+                        productID: ProManager.annualProductID,
+                        selectionSource: "plan_card"
+                    )
                 }
 
                 PlanOptionRow(
@@ -219,7 +287,11 @@ struct PaywallSheet: View {
                     isSelected: selectedPlan == .lifetime
                 ) {
                     selectedPlan = .lifetime
-                    trackOfferSelected(plan: "lifetime", productID: ProManager.paywallProductID)
+                    trackOfferSelected(
+                        plan: "lifetime",
+                        productID: ProManager.paywallProductID,
+                        selectionSource: "plan_card"
+                    )
                 }
             }
         }
@@ -231,7 +303,11 @@ struct PaywallSheet: View {
         VStack(spacing: 12) {
             PrimaryButton(title: ctaButtonTitle) {
                 Task {
-                    trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)
+                    trackOfferSelected(
+                        plan: planName(for: selectedPlan),
+                        productID: selectedProductID,
+                        selectionSource: "primary_cta"
+                    )
                     await purchase(productID: selectedProductID)
                 }
             }
@@ -313,7 +389,6 @@ struct PaywallSheet: View {
                 entryPoint: entryPoint.rawValue,
                 experimentVariant: variant
             )
-            trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)
             let framing = AnalyticsService.shared.paywallValueFramingVariant()
             AnalyticsService.shared.track(AnalyticsEvents.paywallView, properties: [
                 AnalyticsProperties.entryPoint: entryPoint.rawValue,
@@ -467,13 +542,14 @@ struct PaywallSheet: View {
         ])
     }
 
-    private func trackOfferSelected(plan: String, productID: String) {
+    private func trackOfferSelected(plan: String, productID: String, selectionSource: String) {
         let experimentVariant = PaywallExperimentVariants.label(defaultAnnual: defaultToAnnualExperiment)
         let framing = AnalyticsService.shared.paywallValueFramingVariant()
         AnalyticsService.shared.track(AnalyticsEvents.paywallOfferSelect, properties: [
             AnalyticsProperties.entryPoint: entryPoint.rawValue,
             AnalyticsProperties.productId: productID,
             "plan": plan,
+            AnalyticsProperties.paywallSelectionSource: selectionSource,
             AnalyticsProperties.paywallExperimentVariant: experimentVariant,
             AnalyticsProperties.paywallValueFramingVariant: framing,
         ])
@@ -482,6 +558,7 @@ struct PaywallSheet: View {
             properties: [
                 AnalyticsProperties.productId: productID,
                 "plan": plan,
+                AnalyticsProperties.paywallSelectionSource: selectionSource,
             ]
         )
     }

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -43,6 +43,17 @@ final class TimerConfigProClampingTests: XCTestCase {
         XCTAssertEqual(PaywallSheet.headlineOutcomesFirst, "Finish Strong With Full Random Pressure")
     }
 
+    func testPaywallFeatureContextExplainsSelectedGateValue() {
+        let rangeContext = paywallFeatureContext(for: .rangeGate)
+        XCTAssertEqual(rangeContext.eyebrow, "You tapped 60-minute random windows")
+        XCTAssertEqual(
+            rangeContext.valueCopy,
+            "Pro removes the 5-minute cap so long rounds, circuits, and stress drills can run on your timing."
+        )
+
+        XCTAssertEqual(paywallFeatureContext(for: .unknown).eyebrow, "Pro Tactical")
+    }
+
     func testPaywallUsesApprovedAppStoreConnectProductId() {
         XCTAssertEqual(ProManager.paywallProductID, ProManager.baseProductID)
         XCTAssertEqual(ProManager.paywallProductID, "com.iganapolsky.randomtimer.pro")

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -93,15 +93,18 @@ def test_paywall_purchase_cta_reemits_current_plan_selection_before_purchase():
     android_paywall = _read(ANDROID_PAYWALL)
     ios_paywall = _read(IOS_PAYWALL)
 
-    assert "onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId)" in android_paywall
+    android_selection = 'onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId, "primary_cta")'
+    assert android_selection in android_paywall
     assert "onPurchase(purchaseProductId)" in android_paywall
-    assert android_paywall.index("onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId)") < android_paywall.index(
+    assert android_paywall.index(android_selection) < android_paywall.index(
         "onPurchase(purchaseProductId)"
     )
 
-    assert "trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)" in ios_paywall
+    ios_selection = 'selectionSource: "primary_cta"'
+    assert "trackOfferSelected(" in ios_paywall
+    assert ios_selection in ios_paywall
     assert "await purchase(productID: selectedProductID)" in ios_paywall
-    assert ios_paywall.index("trackOfferSelected(plan: planName(for: selectedPlan), productID: selectedProductID)") < ios_paywall.index(
+    assert ios_paywall.index(ios_selection) < ios_paywall.index(
         "await purchase(productID: selectedProductID)"
     )
 


### PR DESCRIPTION
## Summary
- Add feature-specific paywall context for each Pro gate so users see exactly what they tapped to unlock.
- Stop emitting `paywall_offer_select` on automatic default-plan presentation; only user plan-card taps and primary CTA taps emit it.
- Add `paywall_selection_source` to paywall and subscription funnel analytics on iOS/Android, plus docs/tests.

## Verification
- `cd native-android && ./gradlew testDebugUnitTest --tests "*PaywallSheetTest" --tests "*TimerViewModelAnalyticsTest"`
- `python3 -m unittest scripts.tests.test_mobile_analytics_parity -v`
- `python3 -m py_compile scripts/paywall_conversion_report.py scripts/engagement_dashboard.py scripts/executive_metrics_snapshot.py`
- `swiftc -parse native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift native-ios/RandomTimerTests/ProValidationTests.swift`
- `git diff --check`

## Note
Full iOS `xcodebuild test` did not reach compilation because SwiftPM hung cloning protocolbuffers/abseil submodules under Xcode DerivedData. The touched Swift files pass parser validation.