### PR TITLE
fix: align source versions with 1.3.29

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1774900011
-        versionName = "1.3.28"
+        versionCode = ciVersionCode ?: 1777931558
+        versionName = "1.3.29"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 451;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -716,7 +716,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.28;
+				MARKETING_VERSION = 1.3.29;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -729,7 +729,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 451;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -738,7 +738,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.28;
+				MARKETING_VERSION = 1.3.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -818,7 +818,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 451;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -826,7 +826,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.28;
+				MARKETING_VERSION = 1.3.29;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -839,7 +839,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 451;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RandomTimerWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -848,7 +848,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.28;
+				MARKETING_VERSION = 1.3.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Summary
- Align Android source metadata to production 1.3.29 / versionCode 1777931558.
- Align iOS source metadata to App Store Connect 1.3.29 / build 451.

## Evidence
- `python3 scripts/source_versions.py --repo-root . --format json` => Android 1.3.29 / 1777931558, iOS 1.3.29 / 451.
- `/tmp/random-timer-pytest-venv/bin/python -m pytest scripts/tests/test_source_versions.py scripts/tests/test_check_ios_version_lineage.py scripts/tests/test_compute_android_release_version_code.py -q` => 19 passed.
- `git diff --check` => passed.