### PR TITLE
fix: tighten paywall analytics and voice variety

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -43,6 +43,7 @@ sealed class Screen(
 
 internal fun paywallEntryPointForFeature(feature: String): String =
     when (feature) {
+        "setup_upgrade_cta" -> "setup_upgrade_cta"
         "extended_range" -> "range_gate"
         "voice_callouts" -> "voice_gate"
         "repeat_loop" -> "repeat_gate"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -72,6 +72,11 @@ internal data class PaywallFeatureContext(
 
 internal fun paywallFeatureContext(entryPoint: String): PaywallFeatureContext =
     when (entryPoint) {
+        "setup_upgrade_cta" ->
+            PaywallFeatureContext(
+                eyebrow = "You tapped Unlock Pro",
+                valueCopy = "Pro turns the setup screen into a full training console: longer random windows, live callouts, round caps, and the full sound arsenal.",
+            )
         "range_gate" ->
             PaywallFeatureContext(
                 eyebrow = "You tapped 60-minute random windows",

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
@@ -10,6 +10,11 @@ class NavigationAnalyticsMappingTest {
     }
 
     @Test
+    fun setupUpgradeMapsToCanonicalSetupEntryPoint() {
+        assertThat(paywallEntryPointForFeature("setup_upgrade_cta")).isEqualTo("setup_upgrade_cta")
+    }
+
+    @Test
     fun upgradeSurfacesMapToDistinctIntentEntryPoints() {
         assertThat(paywallEntryPointForFeature("voice_callouts")).isEqualTo("voice_gate")
         assertThat(paywallEntryPointForFeature("pro_sounds")).isEqualTo("sound_arsenal_gate")

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -32,6 +32,9 @@ class PaywallSheetTest {
 
     @Test
     fun `paywall feature context explains selected gate value`() {
+        val setupContext = paywallFeatureContext("setup_upgrade_cta")
+        assertEquals("You tapped Unlock Pro", setupContext.eyebrow)
+
         val rangeContext = paywallFeatureContext("range_gate")
         assertEquals("You tapped 60-minute random windows", rangeContext.eyebrow)
         assertEquals(

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -375,7 +375,9 @@ final class AIVoiceCalloutService {
         audioPlayer = nil
         lastElapsedMilestone = 0
         nextCommandCueAt = 0
-        lastCommandCueFilename = nil
+        // Preserve the final command cue across sessions so a restarted timer
+        // cannot immediately repeat the last line the user just heard.
+        usedCommandCueFilenames.removeAll()
         lastPreviewCommandFilenameByGender.removeAll()
         usedPreviewCommandFilenamesByGender.removeAll()
         lastCueFiredAtElapsed = nil

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 enum PaywallEntryPoint: String {
+    case setupUpgradeCTA = "setup_upgrade_cta"
     case rangeGate = "range_gate"
     case voiceGate = "voice_gate"
     case repeatGate = "repeat_gate"
@@ -10,6 +11,7 @@ enum PaywallEntryPoint: String {
     /// Maps to the analytics feature name for feature_gate_hit events.
     var featureGateName: String {
         switch self {
+        case .setupUpgradeCTA: return "setup_upgrade_cta"
         case .rangeGate: return "extended_range"
         case .voiceGate: return "voice_callouts"
         case .repeatGate: return "repeat_loop"
@@ -26,6 +28,12 @@ struct PaywallFeatureContext: Equatable {
 
 func paywallFeatureContext(for entryPoint: PaywallEntryPoint) -> PaywallFeatureContext {
     switch entryPoint {
+    case .setupUpgradeCTA:
+        return PaywallFeatureContext(
+            eyebrow: "You tapped Unlock Pro",
+            valueCopy: "Pro turns the setup screen into a full training console: longer random windows, "
+                + "live callouts, round caps, and the full sound arsenal."
+        )
     case .rangeGate:
         return PaywallFeatureContext(
             eyebrow: "You tapped 60-minute random windows",

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -198,6 +198,22 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         sut.triggerCallout(elapsedSeconds: 60)
     }
 
+    func testResetSessionPreservesLastCommandCueToPreventImmediateSessionRepeat() {
+        let sut = makeVoiceCalloutService()
+
+        sut.beginSession(totalDurationSeconds: 300)
+        sut.triggerCallout(elapsedSeconds: 30)
+        let primed = sut._stateSnapshotForTesting()
+
+        sut.resetSession()
+        let reset = sut._stateSnapshotForTesting()
+
+        XCTAssertNotNil(primed.lastCommandCueFilename)
+        XCTAssertEqual(reset.lastCommandCueFilename, primed.lastCommandCueFilename)
+        XCTAssertEqual(reset.lastElapsedMilestone, 0)
+        XCTAssertEqual(reset.nextCommandCueAt, 0)
+    }
+
     func testCommandCueScheduleDoesNotCrashAcrossLongRun() {
         let sut = makeVoiceCalloutService()
         for elapsed in 1...180 {

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -44,6 +44,10 @@ final class TimerConfigProClampingTests: XCTestCase {
     }
 
     func testPaywallFeatureContextExplainsSelectedGateValue() {
+        let setupContext = paywallFeatureContext(for: .setupUpgradeCTA)
+        XCTAssertEqual(setupContext.eyebrow, "You tapped Unlock Pro")
+        XCTAssertEqual(.setupUpgradeCTA.featureGateName, "setup_upgrade_cta")
+
         let rangeContext = paywallFeatureContext(for: .rangeGate)
         XCTAssertEqual(rangeContext.eyebrow, "You tapped 60-minute random windows")
         XCTAssertEqual(

--- a/release-notes/1.3.29.md
+++ b/release-notes/1.3.29.md
@@ -1,0 +1,17 @@
+# Release 1.3.29
+
+## Summary
+**1.3.29** is the May 2026 stability, audio-variety, and store-readiness release for Random Tactical Timer.
+
+## Customer-visible changes
+- Improved voice callout variety so sessions avoid repeating the same command cue across resets.
+- Preserved the 30-second minimum spacing rule for voice callouts during active timers.
+- Kept elapsed-time callouts and screen-off training audio reliable for background sessions.
+- Included the May 2026 Pro combatives/corner audio pack and refreshed Sound Arsenal content.
+- Improved upgrade-path analytics so setup-screen Pro interest is tracked under the correct paywall entry point.
+
+## Release operations
+- Android `versionName` **1.3.29** and iOS `MARKETING_VERSION` **1.3.29** are aligned.
+- Google Play production publication is verified separately by public-store read-back.
+- iOS **1.3.29** remains dependent on App Store Review approval before public release.
+- This file satisfies internal distribution and production preflight release-note checks.


### PR DESCRIPTION
## Summary
- Preserve the last iOS command callout across timer resets so a new session cannot immediately repeat the final line from the previous session.
- Add canonical setup_upgrade_cta paywall entry-point mapping and contextual copy on iOS and Android.
- Add regression coverage for the new analytics mapping and iOS reset behavior.

## Verification
- PASS: /tmp/random-timer-pytest-venv/bin/python -m pytest scripts/tests/test_growth_workflow_contracts.py scripts/tests/test_workflow_security_contracts.py scripts/tests/test_workflow_yaml_syntax.py -q (PR #1303 support fix)
- PASS: ANDROID_HOME=/Users/igorganapolsky/Library/Android/sdk ANDROID_SDK_ROOT=/Users/igorganapolsky/Library/Android/sdk ./gradlew testDebugUnitTest --tests "com.iganapolsky.randomtimer.ui.navigation.NavigationAnalyticsMappingTest" --tests "com.iganapolsky.randomtimer.ui.screens.PaywallSheetTest"
- PASS: git diff --check
- PASS: pre-commit hook during commit
- INCONCLUSIVE: bounded local xcodebuild targeted test timed out after 180s during package/simulator setup without producing a test failure trace; CI must provide iOS read-back.