### PR TITLE
fix: cap paid acquisition budget automation

### DIFF
--- a/scripts/paid_acquisition_seed.py
+++ b/scripts/paid_acquisition_seed.py
@@ -22,20 +22,27 @@ from growth_keyword_engine import load_blueprint, build_backlog
 
 CAMPAIGNS_PATH = "marketing/data/paid_campaigns.json"
 STRATEGY_PATH = "marketing/keywords/strategy.json"
+MONTHLY_EXTERNAL_SPEND_CAP_USD = 20.0
+MONTHLY_BUDGET_DAYS = 31
 
 # Default budget configuration
 DEFAULT_BUDGET = {
-    "daily_budget_usd": 10.0,
+    "daily_budget_usd": round(MONTHLY_EXTERNAL_SPEND_CAP_USD / MONTHLY_BUDGET_DAYS, 2),
     "launch_week_multiplier": 1.5,
     "max_cpt_usd": 1.50,  # max cost per tap (Apple) / click (Google)
     "target_cpa_usd": 3.00,  # target cost per acquisition
 }
 
 
+def _monthly_cap_daily_budget() -> float:
+    return round(MONTHLY_EXTERNAL_SPEND_CAP_USD / MONTHLY_BUDGET_DAYS, 2)
+
+
 def _safe_daily_budget_cap(previous_daily_budget: float) -> float:
+    monthly_cap = _monthly_cap_daily_budget()
     if previous_daily_budget <= 0:
-        return DEFAULT_BUDGET["daily_budget_usd"]
-    return round(min(previous_daily_budget * 1.25, previous_daily_budget + 5.0), 2)
+        return monthly_cap
+    return round(min(previous_daily_budget * 1.25, previous_daily_budget + 5.0, monthly_cap), 2)
 
 
 def _apply_budget_override_guardrails(
@@ -47,10 +54,8 @@ def _apply_budget_override_guardrails(
     budget_capped = False
     merged_budget = dict(current_budget)
 
-    if budget_override is None:
-        return merged_budget, requested_daily_budget, applied_daily_budget, budget_capped
-
-    merged_budget.update(budget_override)
+    if budget_override is not None:
+        merged_budget.update(budget_override)
     requested_daily_budget = float(merged_budget.get("daily_budget_usd", requested_daily_budget))
     previous_daily_budget = float(current_budget.get("daily_budget_usd", DEFAULT_BUDGET["daily_budget_usd"]))
     max_allowed_daily_budget = _safe_daily_budget_cap(previous_daily_budget)
@@ -269,6 +274,7 @@ def run_acquisition(repo_root: Path, budget_override: Optional[Dict] = None) -> 
         "google_themes": len(google_campaign["targeting"]["keyword_themes"]),
         "daily_budget_requested_usd": requested_daily_budget,
         "daily_budget_applied_usd": applied_daily_budget,
+        "monthly_budget_cap_usd": MONTHLY_EXTERNAL_SPEND_CAP_USD,
         "budget_capped": budget_capped,
     })
     campaigns_data["history"] = campaigns_data["history"][-50:]
@@ -283,6 +289,8 @@ def run_acquisition(repo_root: Path, budget_override: Optional[Dict] = None) -> 
         "apple_total_keywords": sum(len(ag["keywords"]) for ag in apple_campaign["ad_groups"]),
         "google_themes": len(google_campaign["targeting"]["keyword_themes"]),
         "google_headlines": len(google_campaign["ad_assets"]["headlines"]),
+        "monthly_budget_cap_usd": MONTHLY_EXTERNAL_SPEND_CAP_USD,
+        "budget_capped": budget_capped,
     }
 
 
@@ -294,6 +302,8 @@ def build_report(result: Dict[str, Any]) -> str:
         "",
         "## Budget",
         f"- Daily budget: **${result['budget']['daily_budget_usd']}**",
+        f"- Monthly external spend cap: **${result['monthly_budget_cap_usd']}**",
+        f"- Budget capped by guardrail: **{result['budget_capped']}**",
         f"- Target CPA: **${result['budget']['target_cpa_usd']}**",
         f"- Max CPT: **${result['budget']['max_cpt_usd']}**",
         "",

--- a/scripts/tests/test_paid_acquisition_seed.py
+++ b/scripts/tests/test_paid_acquisition_seed.py
@@ -59,7 +59,9 @@ def test_run_acquisition_preserves_unmanaged_campaigns_and_caps_budget(monkeypat
         tmp_path,
         budget_override={**pas.DEFAULT_BUDGET, "daily_budget_usd": 100.0},
     )
-    assert result["budget"]["daily_budget_usd"] == pytest.approx(35.0)
+    assert result["budget"]["daily_budget_usd"] == pytest.approx(0.65)
+    assert result["monthly_budget_cap_usd"] == pytest.approx(20.0)
+    assert result["budget_capped"] is True
 
     persisted = json.loads((tmp_path / "marketing" / "data" / "paid_campaigns.json").read_text(encoding="utf-8"))
     campaigns = {item["platform"]: item for item in persisted["campaigns"]}
@@ -72,5 +74,22 @@ def test_run_acquisition_preserves_unmanaged_campaigns_and_caps_budget(monkeypat
     history = persisted["history"][-1]
     assert history["action"] == "campaign_refresh"
     assert history["daily_budget_requested_usd"] == pytest.approx(100.0)
-    assert history["daily_budget_applied_usd"] == pytest.approx(35.0)
+    assert history["daily_budget_applied_usd"] == pytest.approx(0.65)
+    assert history["monthly_budget_cap_usd"] == pytest.approx(20.0)
     assert history["budget_capped"] is True
+
+
+def test_run_acquisition_caps_existing_budget_without_override(monkeypatch, tmp_path):
+    from scripts import paid_acquisition_seed as pas
+
+    _write_paid_campaigns(tmp_path / "marketing" / "data" / "paid_campaigns.json")
+    monkeypatch.setattr(pas, "load_blueprint", lambda _p: {})
+    monkeypatch.setattr(pas, "build_backlog", lambda _b: _sample_backlog())
+
+    result = pas.run_acquisition(tmp_path)
+
+    assert result["budget"]["daily_budget_usd"] == pytest.approx(0.65)
+    persisted = json.loads((tmp_path / "marketing" / "data" / "paid_campaigns.json").read_text(encoding="utf-8"))
+    assert persisted["budget_config"]["daily_budget_usd"] == pytest.approx(0.65)
+    assert persisted["history"][-1]["daily_budget_requested_usd"] == pytest.approx(30.0)
+    assert persisted["history"][-1]["budget_capped"] is True


### PR DESCRIPTION
## Summary
- Cap paid acquisition generated daily budgets to the $20/month operating budget.
- Apply the cap even when existing campaign config carries a higher legacy budget.
- Add report/read-back fields and regression coverage for capped overrides and legacy configs.

## Verification
- /tmp/random-timer-pytest-venv/bin/python -m pytest scripts/tests/test_paid_acquisition_seed.py -q
- git diff --check