### PR TITLE
fix: repair revenue workflow dispatches

### DIFF
--- a/.github/workflows/weekly-attribution-feedback.yml
+++ b/.github/workflows/weekly-attribution-feedback.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/weekly-north-star-experiment.yml
+++ b/.github/workflows/weekly-north-star-experiment.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Compute and enforce north star guardrail
         env:
+          PYTHONPATH: .
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
         run: |
@@ -41,6 +42,7 @@ jobs:
 
       - name: Refresh attribution funnel snapshot
         env:
+          PYTHONPATH: .
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
         run: |
@@ -49,10 +51,14 @@ jobs:
             --days 30
 
       - name: Build daily North Star ops input
+        env:
+          PYTHONPATH: .
         run: |
           python scripts/north_star_ops.py --repo-root .
 
       - name: Build weekly experiment brief
+        env:
+          PYTHONPATH: .
         run: |
           python scripts/north_star_experiment.py --repo-root .
 


### PR DESCRIPTION
Fixes two revenue automation dispatch failures observed on May 5, 2026.

Evidence from failed runs:
- Weekly Attribution Feedback Loop run 25392821728 failed in create-pull-request because checkout persisted an Authorization header and create-pull-request added another, producing GitHub HTTP 400 Duplicate header: Authorization.
- Weekly North Star Experiment run 25392821724 failed in north_star_experiment.py with ModuleNotFoundError: No module named 'scripts'.

Changes:
- Disable persisted checkout credentials before peter-evans/create-pull-request owns Git auth.
- Set PYTHONPATH=. for North Star workflow script steps.

Local verification:
- PYTHONPATH=. python3 scripts/north_star_experiment.py --repo-root .
- PYTHONPATH=. python3 -m py_compile scripts/north_star_experiment.py scripts/north_star_ops.py scripts/attribution_feedback.py
- git diff --check