### PR TITLE
fix: block unmanaged paid campaign overspend

### DIFF
--- a/marketing/data/paid_campaigns.json
+++ b/marketing/data/paid_campaigns.json
@@ -4,14 +4,12 @@
       "platform": "apple_search_ads",
       "created": "2026-02-20T21:08:11Z",
       "status": "paused",
-      "campaign_id": 2143440089,
-      "launched_at": "2026-02-24T16:30:00Z",
-      "daily_budget_usd": 0.0,
+      "daily_budget_usd": 0.39,
       "ad_groups": [
         {
           "name": "Exact Match - High Intent",
           "match_type": "exact",
-          "max_cpt_usd": 1.5,
+          "max_cpt_usd": 1.75,
           "keywords": [
             {
               "text": "app sparring prep",
@@ -42,44 +40,56 @@
               "bid_score": 120
             },
             {
-              "text": "checker interval timer",
-              "bid_score": 115
+              "text": "app mental readiness",
+              "bid_score": 112
             },
             {
-              "text": "generator interval timer",
-              "bid_score": 115
+              "text": "app combat conditioning",
+              "bid_score": 112
             },
             {
-              "text": "checker reaction training",
-              "bid_score": 115
+              "text": "app interval timer",
+              "bid_score": 112
             },
             {
-              "text": "checker tactical timer",
-              "bid_score": 115
+              "text": "review interval timer",
+              "bid_score": 98
             },
             {
-              "text": "calculator mental readiness",
-              "bid_score": 115
+              "text": "review reaction training",
+              "bid_score": 98
             },
             {
-              "text": "generator sparring prep",
-              "bid_score": 115
+              "text": "review sparring prep",
+              "bid_score": 98
             },
             {
-              "text": "generator random timer",
-              "bid_score": 115
+              "text": "under 20 interval timer",
+              "bid_score": 98
             },
             {
-              "text": "generator tactical timer",
-              "bid_score": 115
+              "text": "vs sparring prep",
+              "bid_score": 98
             }
           ]
         },
         {
           "name": "Search Match - Discovery",
           "match_type": "search",
-          "max_cpt_usd": 1.05,
+          "max_cpt_usd": 1.2249999999999999,
           "keywords": [
+            {
+              "text": "no ads random timer",
+              "bid_score": 52
+            },
+            {
+              "text": "no ads boxing drills",
+              "bid_score": 52
+            },
+            {
+              "text": "free random timer",
+              "bid_score": 52
+            },
             {
               "text": "home workout timer",
               "bid_score": 52
@@ -93,11 +103,35 @@
               "bid_score": 52
             },
             {
+              "text": "free home workout timer",
+              "bid_score": 52
+            },
+            {
+              "text": "free combat conditioning",
+              "bid_score": 52
+            },
+            {
+              "text": "free focus drills",
+              "bid_score": 52
+            },
+            {
+              "text": "free mental readiness",
+              "bid_score": 52
+            },
+            {
+              "text": "no ads combat conditioning",
+              "bid_score": 52
+            },
+            {
               "text": "mental readiness",
               "bid_score": 44
             },
             {
               "text": "random timer for beginners",
+              "bid_score": 44
+            },
+            {
+              "text": "no ads mental readiness",
               "bid_score": 44
             },
             {
@@ -123,17 +157,13 @@
             {
               "text": "boxing drills for beginners",
               "bid_score": 44
-            },
-            {
-              "text": "boxing drills",
-              "bid_score": 44
             }
           ]
         },
         {
           "name": "Competitor - Brand",
           "match_type": "exact",
-          "max_cpt_usd": 1.8,
+          "max_cpt_usd": 2.1,
           "keywords": [
             {
               "text": "app sparring prep",
@@ -164,16 +194,16 @@
               "bid_score": 120
             },
             {
-              "text": "checker interval timer",
-              "bid_score": 115
+              "text": "app mental readiness",
+              "bid_score": 112
             },
             {
-              "text": "generator interval timer",
-              "bid_score": 115
+              "text": "app combat conditioning",
+              "bid_score": 112
             },
             {
-              "text": "checker reaction training",
-              "bid_score": 115
+              "text": "app interval timer",
+              "bid_score": 112
             }
           ]
         }
@@ -185,37 +215,34 @@
         "clock widget"
       ],
       "target_cpa_usd": 3.0,
-      "paused_at": "2026-03-03T00:08:07Z"
+      "campaign_id": 2143440089,
+      "launched_at": "2026-02-24T16:30:00Z"
     },
     {
       "platform": "google_uac",
       "created": "2026-02-20T21:08:11Z",
       "status": "ready_to_launch",
-      "daily_budget_usd": 10.0,
+      "daily_budget_usd": 0.26,
       "campaign_type": "installs",
-      "target_cpi_usd": 2.5,
       "target_cpa_usd": 3.0,
-      "campaign_name": "RandomTacticalTimer_UAC_Installs_v1",
-      "config_file": "marketing/google_uac_campaign.md",
       "ad_assets": {
         "headlines": [
           "Random Timer for HIIT & Drills",
-          "Tactical Timer - Train Smart",
           "Surprise Interval Timer App",
+          "Tactical Timer - Train Smarter",
           "Random Countdown Timer"
         ],
         "descriptions": [
           "Set a range, press start. You never know when it fires. Perfect for HIIT.",
           "Unpredictable timer for workouts, drills & party games. No ads, no tracking.",
-          "Keep sharp with random intervals. Used by athletes, coaches & gamers.",
-          "Train reaction, not rhythm. Fires at random within your time range. Free."
+          "Keep sharp with random intervals. Used by athletes, coaches & gamers."
         ]
       },
       "targeting": {
         "locations": [
           "US",
-          "CA",
           "GB",
+          "CA",
           "AU",
           "DE"
         ],
@@ -224,63 +251,41 @@
           "de"
         ],
         "keyword_themes": [
-          "reaction training",
-          "interval timer",
-          "tactical timer",
-          "random timer",
-          "focus drills",
-          "combat conditioning",
-          "boxing drills",
-          "home workout timer",
-          "sparring prep",
-          "HIIT timer app"
-        ],
-        "audience_signals": [
-          "In-Market: Sports & Fitness > Exercise & Fitness",
-          "In-Market: Sports & Fitness > Combat Sports",
-          "Affinity: Health & Fitness Buffs",
-          "Affinity: Sports Fans > Combat Sports Fans"
-        ],
-        "demographics": {
-          "ages": "18-54",
-          "genders": "all",
-          "devices": "mobile_only"
-        },
-        "exclude_existing_users": true
+          "app sparring prep",
+          "app boxing drills",
+          "app focus drills",
+          "app reaction training",
+          "app home workout timer",
+          "app tactical timer",
+          "app random timer",
+          "app mental readiness",
+          "app combat conditioning",
+          "app interval timer"
+        ]
       },
-      "negative_keywords": [
-        "free timer online",
-        "timer website",
-        "countdown website",
-        "clock widget",
-        "egg timer",
-        "pomodoro",
-        "meditation timer",
-        "sleep timer",
-        "cooking timer"
-      ],
-      "optimization_goal": "installs",
-      "app_store_urls": {
-        "android": "https://play.google.com/store/apps/details?id=com.iganapolsky.randomtimer",
-        "ios": "https://apps.apple.com/app/random-tactical-timer/id6758355312"
-      }
+      "optimization_goal": "installs"
     },
     {
       "platform": "reddit_ads",
       "created": "2026-02-23T13:34:00Z",
-      "status": "ready_to_launch",
-      "daily_budget_usd": 10.0,
+      "status": "blocked_budget_guardrail",
+      "daily_budget_usd": 0.0,
       "campaign_type": "app_installs",
       "target_cpi_usd": 2.5,
       "ad_groups": 4,
       "config_file": "marketing/data/reddit_ads_campaign.json",
       "subreddit_targets": 21,
       "keyword_targets": 15,
-      "creative_variants": 3
+      "creative_variants": 3,
+      "budget_guardrail_blocked": true,
+      "budget_guardrail_reason": "unmanaged_paid_channel_requires_explicit_budget_allocation_under_monthly_cap",
+      "daily_budget_requested_usd": 10.0,
+      "monthly_budget_cap_usd": 20.0,
+      "total_managed_daily_budget_usd": 0.65
     }
   ],
   "budget_config": {
-    "daily_budget_usd": 30.0,
+    "daily_budget_usd": 0.65,
     "launch_week_multiplier": 1.5,
     "max_cpt_usd": 1.75,
     "target_cpa_usd": 3.0
@@ -340,11 +345,20 @@
       "campaign_id": 2143440089,
       "reason": "post_merge_validation",
       "status": "PAUSED"
+    },
+    {
+      "timestamp": "2026-05-05T17:55:36.681578+00:00",
+      "action": "campaign_refresh",
+      "apple_keywords": 15,
+      "google_themes": 10,
+      "daily_budget_requested_usd": 30.0,
+      "daily_budget_applied_usd": 0.65,
+      "monthly_budget_cap_usd": 20.0,
+      "budget_capped": true
     }
   ],
   "budget_allocation": {
-    "apple_search_ads": 0.0,
-    "google_uac": 10.0,
-    "reddit_ads": 10.0
+    "apple_search_ads": 0.39,
+    "google_uac": 0.26
   }
 }

--- a/scripts/paid_acquisition_seed.py
+++ b/scripts/paid_acquisition_seed.py
@@ -80,6 +80,29 @@ def _merge_managed_campaign(
     return merged
 
 
+def _guard_unmanaged_campaign(
+    campaign: Dict[str, Any],
+    total_daily_budget: float,
+) -> Dict[str, Any]:
+    """Prevent stale unmanaged configs from bypassing the monthly budget cap."""
+    guarded = dict(campaign)
+    daily_budget = float(guarded.get("daily_budget_usd") or 0.0)
+    if daily_budget <= 0:
+        return guarded
+
+    guarded["budget_guardrail_blocked"] = True
+    guarded["budget_guardrail_reason"] = (
+        "unmanaged_paid_channel_requires_explicit_budget_allocation_under_monthly_cap"
+    )
+    guarded["daily_budget_requested_usd"] = daily_budget
+    guarded["daily_budget_usd"] = 0.0
+    if guarded.get("status") in {"draft", "ready_to_launch"}:
+        guarded["status"] = "blocked_budget_guardrail"
+    guarded["monthly_budget_cap_usd"] = MONTHLY_EXTERNAL_SPEND_CAP_USD
+    guarded["total_managed_daily_budget_usd"] = total_daily_budget
+    return guarded
+
+
 def load_campaigns(repo_root: Path) -> Dict[str, Any]:
     path = repo_root / CAMPAIGNS_PATH
     if path.is_file():
@@ -235,6 +258,8 @@ def run_acquisition(repo_root: Path, budget_override: Optional[Dict] = None) -> 
         [apple_campaign, google_campaign],
         budget["daily_budget_usd"],
     )
+    apple_campaign["daily_budget_usd"] = allocation["apple_search_ads"]
+    google_campaign["daily_budget_usd"] = allocation["google_uac"]
 
     # Update managed campaigns while preserving unrelated platforms.
     existing_campaigns = campaigns_data.get("campaigns", [])
@@ -259,7 +284,7 @@ def run_acquisition(repo_root: Path, budget_override: Optional[Dict] = None) -> 
             updated_campaigns.append(managed_updates[platform])
             managed_inserted.add(platform)
         else:
-            updated_campaigns.append(campaign)
+            updated_campaigns.append(_guard_unmanaged_campaign(campaign, budget["daily_budget_usd"]))
     for platform, campaign in managed_updates.items():
         if platform not in managed_inserted:
             updated_campaigns.append(campaign)
@@ -291,6 +316,15 @@ def run_acquisition(repo_root: Path, budget_override: Optional[Dict] = None) -> 
         "google_headlines": len(google_campaign["ad_assets"]["headlines"]),
         "monthly_budget_cap_usd": MONTHLY_EXTERNAL_SPEND_CAP_USD,
         "budget_capped": budget_capped,
+        "unmanaged_budget_guardrails": [
+            {
+                "platform": campaign.get("platform"),
+                "daily_budget_requested_usd": campaign.get("daily_budget_requested_usd"),
+                "status": campaign.get("status"),
+            }
+            for campaign in updated_campaigns
+            if campaign.get("budget_guardrail_blocked")
+        ],
     }
 
 
@@ -318,6 +352,21 @@ def build_report(result: Dict[str, Any]) -> str:
         "## Google UAC",
         f"- Keyword themes: {result['google_themes']}",
         f"- Headlines: {result['google_headlines']}",
+        "",
+        "## Unmanaged Paid Channel Guardrails",
+        *(
+            [
+                "- none",
+            ]
+            if not result.get("unmanaged_budget_guardrails")
+            else [
+                (
+                    f"- {item['platform']}: blocked at $0/day "
+                    f"(requested ${item['daily_budget_requested_usd']}/day, status {item['status']})"
+                )
+                for item in result["unmanaged_budget_guardrails"]
+            ]
+        ),
         "",
         "## Next Steps",
         "1. Review campaign configs in `marketing/data/paid_campaigns.json`",

--- a/scripts/tests/test_paid_acquisition_seed.py
+++ b/scripts/tests/test_paid_acquisition_seed.py
@@ -69,7 +69,19 @@ def test_run_acquisition_preserves_unmanaged_campaigns_and_caps_budget(monkeypat
     assert campaigns["apple_search_ads"]["status"] == "active"
     assert campaigns["apple_search_ads"]["campaign_id"] == 12345
     assert campaigns["apple_search_ads"]["launched_at"] == "2026-02-24T16:30:00Z"
-    assert campaigns["reddit_ads"]["status"] == "ready_to_launch"
+    assert campaigns["apple_search_ads"]["daily_budget_usd"] == pytest.approx(0.39)
+    assert campaigns["google_uac"]["daily_budget_usd"] == pytest.approx(0.26)
+    assert campaigns["reddit_ads"]["status"] == "blocked_budget_guardrail"
+    assert campaigns["reddit_ads"]["daily_budget_usd"] == pytest.approx(0.0)
+    assert campaigns["reddit_ads"]["daily_budget_requested_usd"] == pytest.approx(10.0)
+    assert campaigns["reddit_ads"]["budget_guardrail_blocked"] is True
+    assert result["unmanaged_budget_guardrails"] == [
+        {
+            "platform": "reddit_ads",
+            "daily_budget_requested_usd": 10.0,
+            "status": "blocked_budget_guardrail",
+        }
+    ]
 
     history = persisted["history"][-1]
     assert history["action"] == "campaign_refresh"
@@ -91,5 +103,10 @@ def test_run_acquisition_caps_existing_budget_without_override(monkeypatch, tmp_
     assert result["budget"]["daily_budget_usd"] == pytest.approx(0.65)
     persisted = json.loads((tmp_path / "marketing" / "data" / "paid_campaigns.json").read_text(encoding="utf-8"))
     assert persisted["budget_config"]["daily_budget_usd"] == pytest.approx(0.65)
+    campaigns = {item["platform"]: item for item in persisted["campaigns"]}
+    assert campaigns["apple_search_ads"]["daily_budget_usd"] == pytest.approx(0.39)
+    assert campaigns["google_uac"]["daily_budget_usd"] == pytest.approx(0.26)
+    assert campaigns["reddit_ads"]["daily_budget_usd"] == pytest.approx(0.0)
+    assert campaigns["reddit_ads"]["status"] == "blocked_budget_guardrail"
     assert persisted["history"][-1]["daily_budget_requested_usd"] == pytest.approx(30.0)
     assert persisted["history"][-1]["budget_capped"] is True


### PR DESCRIPTION
The May 5 paid-acquisition run proved Apple/Google were capped, but the generated paid_campaigns.json still left reddit_ads ready_to_launch at $10/day.

Changes:
- Treat budget_config.daily_budget_usd as total managed daily budget.
- Split managed budget across Apple Search Ads ($0.39/day) and Google UAC ($0.26/day).
- Block unmanaged paid channels at $0/day unless explicitly allocated under the monthly cap.
- Update generated paid_campaigns.json so reddit_ads is no longer ready_to_launch at $10/day.

Verification:
- /tmp/random-timer-pytest-venv/bin/python -m pytest scripts/tests/test_paid_acquisition_seed.py -q -> 2 passed
- python3 scripts/paid_acquisition_seed.py --repo-root . --report-out /tmp/paid-acquisition-local-report.md -> report shows reddit_ads blocked at $0/day

Spend status: no paid spend started; month-to-date external spend remains $0, remaining budget $20.