### PR TITLE
fix: harden voice callout and free-mode badge behavior

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -232,6 +232,36 @@ internal fun nextCommandCue(
     return cues[(boundedIndex + 1) % cues.size]
 }
 
+internal fun normalizedVoiceCueText(text: String): String =
+    text
+        .trim()
+        .lowercase(Locale.US)
+        .replace(Regex("\\s+"), " ")
+
+internal fun commandCuePool(
+    baseline: List<VoiceCue>,
+    usedFilenames: Set<String>,
+    usedTexts: Set<String>,
+    lastFilename: String?,
+    lastText: String?,
+): List<VoiceCue> {
+    val fresh =
+        baseline.filter {
+            it.filename !in usedFilenames &&
+                normalizedVoiceCueText(it.text) !in usedTexts
+        }
+    if (fresh.isNotEmpty()) {
+        return fresh
+    }
+
+    val lastNormalizedText = lastText?.let(::normalizedVoiceCueText)
+    return baseline
+        .filter {
+            it.filename != lastFilename &&
+                normalizedVoiceCueText(it.text) != lastNormalizedText
+        }.ifEmpty { baseline }
+}
+
 internal fun nextPreviewCueFilename(
     filenames: List<String>,
     lastFilename: String?,
@@ -283,7 +313,9 @@ class AIVoiceCalloutManager
         private var mediaPlayer: MediaPlayer? = null
         private var currentVolume: Float = 1.0f
         private var lastCommandCueFilename: String? = null
+        private var lastCommandCueText: String? = null
         private val usedCommandCueFilenames = mutableSetOf<String>()
+        private val usedCommandCueTexts = mutableSetOf<String>()
         private val lastPreviewCommandFilenameByGender = mutableMapOf<VoiceGender, String?>()
         private val usedPreviewCommandFilenamesByGender =
             mutableMapOf(
@@ -351,6 +383,7 @@ class AIVoiceCalloutManager
             // Preserve lastCommandCueFilename across sessions so a new session cannot
             // immediately repeat the final command cue from the previous session.
             usedCommandCueFilenames.clear()
+            usedCommandCueTexts.clear()
             lastPreviewCommandFilenameByGender.clear()
             usedPreviewCommandFilenamesByGender.values.forEach { it.clear() }
             nextCommandCueAt = 0
@@ -534,6 +567,7 @@ class AIVoiceCalloutManager
                 val cue = randomCommandCue()
                 speak(cue)
                 lastCommandCueFilename = cue.filename
+                lastCommandCueText = cue.text
                 nextCommandCueAt = elapsedSeconds + 30
                 lastCueFiredAtElapsed = elapsedSeconds
             }
@@ -557,20 +591,32 @@ class AIVoiceCalloutManager
             // different cues were picked.
             val playable = catalog.commandCues.filter { cueHasAudio(it.filename) }
             val baseline = if (playable.isNotEmpty()) playable else catalog.commandCues
-            val available = baseline.filter { it.filename !in usedCommandCueFilenames }
             val pool =
-                available.ifEmpty {
+                commandCuePool(
+                    baseline = baseline,
+                    usedFilenames = usedCommandCueFilenames,
+                    usedTexts = usedCommandCueTexts,
+                    lastFilename = lastCommandCueFilename,
+                    lastText = lastCommandCueText,
+                ).ifEmpty {
                     usedCommandCueFilenames.clear()
-                    baseline
-                        .filter { it.filename != lastCommandCueFilename }
-                        .ifEmpty { baseline }
+                    usedCommandCueTexts.clear()
+                    commandCuePool(
+                        baseline = baseline,
+                        usedFilenames = emptySet(),
+                        usedTexts = emptySet(),
+                        lastFilename = lastCommandCueFilename,
+                        lastText = lastCommandCueText,
+                    )
                 }
             val cue =
                 nextCommandCue(pool, lastCommandCueFilename) { upperBound ->
                     Random.nextInt(upperBound)
                 }
             lastCommandCueFilename = cue.filename
+            lastCommandCueText = cue.text
             usedCommandCueFilenames.add(cue.filename)
+            usedCommandCueTexts.add(normalizedVoiceCueText(cue.text))
             return cue
         }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManagerSelectionTest.kt
@@ -110,6 +110,27 @@ class AIVoiceCalloutManagerSelectionTest {
     }
 
     @Test
+    fun commandCuePoolAvoidsRepeatedTextEvenWhenFilenameDiffers() {
+        val cues =
+            listOf(
+                VoiceCue(filename = "cue_a", text = "Move with a purpose."),
+                VoiceCue(filename = "cue_b", text = "  Move with a purpose.  "),
+                VoiceCue(filename = "cue_c", text = "Cut the angle and go."),
+            )
+
+        val pool =
+            commandCuePool(
+                baseline = cues,
+                usedFilenames = setOf("cue_a"),
+                usedTexts = setOf(normalizedVoiceCueText("Move with a purpose.")),
+                lastFilename = "cue_a",
+                lastText = "Move with a purpose.",
+            )
+
+        assertThat(pool.map { it.filename }).containsExactly("cue_c")
+    }
+
+    @Test
     fun nextPreviewCueFilenameAvoidsImmediateRepeatsAndCyclesUnusedSamples() {
         val used = linkedSetOf("cue_a")
 

--- a/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift
@@ -156,6 +156,36 @@ internal func nextCommandCue(
     return cues[nextIndex]
 }
 
+internal func normalizedVoiceCueText(_ text: String) -> String {
+    text
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+        .components(separatedBy: .whitespacesAndNewlines)
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+}
+
+internal func commandCuePool(
+    from baseline: [VoiceCueCatalog.Cue],
+    usedFilenames: Set<String>,
+    usedTexts: Set<String>,
+    lastFilename: String?,
+    lastText: String?
+) -> [VoiceCueCatalog.Cue] {
+    let fresh = baseline.filter {
+        !usedFilenames.contains($0.filename) && !usedTexts.contains(normalizedVoiceCueText($0.text))
+    }
+    if !fresh.isEmpty {
+        return fresh
+    }
+
+    let lastNormalizedText = lastText.map(normalizedVoiceCueText)
+    let nonRepeating = baseline.filter {
+        $0.filename != lastFilename && normalizedVoiceCueText($0.text) != lastNormalizedText
+    }
+    return nonRepeating.isEmpty ? baseline : nonRepeating
+}
+
 internal func nextPreviewFilename(
     from filenames: [String],
     lastFilename: String?,
@@ -332,7 +362,9 @@ final class AIVoiceCalloutService {
     private var lastElapsedMilestone = 0
     private var nextCommandCueAt = 0
     private var lastCommandCueFilename: String?
+    private var lastCommandCueText: String?
     private var usedCommandCueFilenames: Set<String> = []
+    private var usedCommandCueTexts: Set<String> = []
     private var lastCueFiredAtElapsed: Int?
     private var lastPreviewCommandFilenameByGender: [VoiceGender: String] = [:]
     private var usedPreviewCommandFilenamesByGender: [VoiceGender: Set<String>] = [:]
@@ -378,6 +410,7 @@ final class AIVoiceCalloutService {
         // Preserve the final command cue across sessions so a restarted timer
         // cannot immediately repeat the last line the user just heard.
         usedCommandCueFilenames.removeAll()
+        usedCommandCueTexts.removeAll()
         lastPreviewCommandFilenameByGender.removeAll()
         usedPreviewCommandFilenamesByGender.removeAll()
         lastCueFiredAtElapsed = nil
@@ -464,6 +497,7 @@ final class AIVoiceCalloutService {
             let cue = randomCommandCue()
             speak(cue)
             lastCommandCueFilename = cue.filename
+            lastCommandCueText = cue.text
             nextCommandCueAt = elapsedSeconds + 30
             lastCueFiredAtElapsed = elapsedSeconds
         }
@@ -495,17 +529,31 @@ final class AIVoiceCalloutService {
         // the same line on repeat while dedup thinks different cues were picked.
         let playable = catalog.commandCues.filter { cueHasAudio($0.filename) }
         let baseline = playable.isEmpty ? catalog.commandCues : playable
-        var pool = baseline.filter { !usedCommandCueFilenames.contains($0.filename) }
+        var pool = commandCuePool(
+            from: baseline,
+            usedFilenames: usedCommandCueFilenames,
+            usedTexts: usedCommandCueTexts,
+            lastFilename: lastCommandCueFilename,
+            lastText: lastCommandCueText
+        )
         if pool.isEmpty {
             usedCommandCueFilenames.removeAll()
-            pool = baseline.filter { $0.filename != lastCommandCueFilename }
-            if pool.isEmpty { pool = baseline }
+            usedCommandCueTexts.removeAll()
+            pool = commandCuePool(
+                from: baseline,
+                usedFilenames: [],
+                usedTexts: [],
+                lastFilename: lastCommandCueFilename,
+                lastText: lastCommandCueText
+            )
         }
         let cue = nextCommandCue(from: pool, lastFilename: lastCommandCueFilename) { upperBound in
             secureRandomInt(in: 0...(upperBound - 1))
         }
         lastCommandCueFilename = cue.filename
+        lastCommandCueText = cue.text
         usedCommandCueFilenames.insert(cue.filename)
+        usedCommandCueTexts.insert(normalizedVoiceCueText(cue.text))
         return cue
     }
 

--- a/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift
@@ -73,6 +73,10 @@ struct ActiveTimerScreen: View {
         return voiceBadgeText(enabled: enabled)
     }
 
+    static func shouldShowVoiceBadge(isPro: Bool) -> Bool {
+        isPro
+    }
+
     static func voiceBadgeAccessibilityLabel(enabled: Bool) -> String {
         enabled ? "Voice callouts enabled" : "Voice callouts disabled"
     }
@@ -321,7 +325,9 @@ struct ActiveTimerScreen: View {
         } else {
             HStack(spacing: 12) {
                 loopBadge
-                voiceBadge
+                if Self.shouldShowVoiceBadge(isPro: ProManager.shared.isPro) {
+                    voiceBadge
+                }
             }
         }
     }

--- a/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
+++ b/native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift
@@ -285,6 +285,24 @@ final class AIVoiceCalloutServiceTests: XCTestCase {
         XCTAssertEqual(selected.filename, "cue_b")
     }
 
+    func testCommandCuePoolAvoidsRepeatedTextEvenWhenFilenameDiffers() {
+        let cues = [
+            VoiceCueCatalog.Cue(filename: "cue_a", text: "Move with a purpose."),
+            VoiceCueCatalog.Cue(filename: "cue_b", text: "  Move with a purpose.  "),
+            VoiceCueCatalog.Cue(filename: "cue_c", text: "Cut the angle and go."),
+        ]
+
+        let pool = commandCuePool(
+            from: cues,
+            usedFilenames: ["cue_a"],
+            usedTexts: [normalizedVoiceCueText("Move with a purpose.")],
+            lastFilename: "cue_a",
+            lastText: "Move with a purpose."
+        )
+
+        XCTAssertEqual(pool.map(\.filename), ["cue_c"])
+    }
+
     func testNextPreviewFilenameAvoidsImmediateRepeatWhenPossible() {
         var usedFilenames: Set<String> = ["cue_a"]
 

--- a/native-ios/RandomTimerTests/CircularTimerViewTests.swift
+++ b/native-ios/RandomTimerTests/CircularTimerViewTests.swift
@@ -139,4 +139,9 @@ final class CircularTimerViewTests: XCTestCase {
     func testVoiceBadgeTextShowsLockedStateForFreeUsersEvenWhenConfigIsStaleOn() {
         XCTAssertEqual(ActiveTimerScreen.voiceBadgeText(enabled: true, isPro: false), "Voice Callouts Locked")
     }
+
+    func testVoiceBadgeIsHiddenForFreeUsers() {
+        XCTAssertFalse(ActiveTimerScreen.shouldShowVoiceBadge(isPro: false))
+        XCTAssertTrue(ActiveTimerScreen.shouldShowVoiceBadge(isPro: true))
+    }
 }

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -46,7 +46,7 @@ final class TimerConfigProClampingTests: XCTestCase {
     func testPaywallFeatureContextExplainsSelectedGateValue() {
         let setupContext = paywallFeatureContext(for: .setupUpgradeCTA)
         XCTAssertEqual(setupContext.eyebrow, "You tapped Unlock Pro")
-        XCTAssertEqual(.setupUpgradeCTA.featureGateName, "setup_upgrade_cta")
+        XCTAssertEqual(PaywallEntryPoint.setupUpgradeCTA.featureGateName, "setup_upgrade_cta")
 
         let rangeContext = paywallFeatureContext(for: .rangeGate)
         XCTAssertEqual(rangeContext.eyebrow, "You tapped 60-minute random windows")

--- a/scripts/attribution_feedback.py
+++ b/scripts/attribution_feedback.py
@@ -481,21 +481,23 @@ def run(
     content_existing = _load_json(content_existing_path)
 
     if not api_key or not project_id:
-        # Generate empty feedback files so downstream scripts don't break
+        # Generate current degraded feedback files so downstream scripts don't
+        # break, but never upload stale reports as if they were fresh evidence.
+        QUERY_ERRORS.append("missing_posthog_credentials")
         keyword_installs = aso_existing.get("keyword_installs", {}) if aso_existing else {}
         content_funnel = content_existing.get("onboarding_funnel", {"window_days": days}) if content_existing else {"window_days": days}
         campaigns = content_existing.get("top_campaigns_by_activation", []) if content_existing else []
         write_aso_feedback(repo_root, keyword_installs, preserved_from=aso_existing or None)
         write_content_feedback(repo_root, campaigns, content_funnel, preserved_from=content_existing or None)
-        if not report_path.exists():
-            report_path.write_text(
-                "# Attribution Feedback Report\n\nNo PostHog query data available: missing API key and/or project id.\n",
-                encoding="utf-8",
-            )
+        report_path.write_text(
+            build_report([], content_funnel, campaigns, keyword_installs),
+            encoding="utf-8",
+        )
         return {
-            "status": "skipped",
+            "status": "degraded",
             "reason": "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID",
             "report": str(report_path),
+            "preserved_previous_metrics": bool(aso_existing or content_existing),
         }
 
     attribution = fetch_utm_attribution(api_key, project_id, days)

--- a/scripts/tests/test_attribution_feedback.py
+++ b/scripts/tests/test_attribution_feedback.py
@@ -25,11 +25,14 @@ class AttributionFeedbackTests(unittest.TestCase):
         self.assertAlmostEqual(funnel["configured_to_completed_rate"], 32 / 60, places=4)
         self.assertAlmostEqual(funnel["open_to_completed_rate"], 32 / 129, places=4)
 
-    def test_run_missing_credentials_still_writes_report(self):
+    def test_run_missing_credentials_overwrites_stale_report_with_degraded_diagnostics(self):
         from scripts import attribution_feedback as af
 
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
+            report = root / "marketing" / "data" / "attribution-report.md"
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text("stale March report", encoding="utf-8")
             with mock.patch.dict(
                 "os.environ",
                 {
@@ -42,11 +45,13 @@ class AttributionFeedbackTests(unittest.TestCase):
             ):
                 result = af.run(root, days=30, dry_run=False)
 
-            self.assertEqual(result.get("status"), "skipped")
-            report = root / "marketing" / "data" / "attribution-report.md"
+            self.assertEqual(result.get("status"), "degraded")
             self.assertTrue(report.exists())
             text = report.read_text(encoding="utf-8")
-            self.assertIn("No PostHog query data available", text)
+            self.assertIn("# Attribution Feedback Report", text)
+            self.assertIn("Query Diagnostics", text)
+            self.assertIn("missing_posthog_credentials", text)
+            self.assertNotIn("stale March report", text)
 
     def test_run_preserves_previous_content_feedback_when_queries_degrade(self):
         from scripts import attribution_feedback as af


### PR DESCRIPTION
## Summary
- Hide the iOS voice callout active-timer badge for Free users, matching Android behavior so stale Free configs cannot show a voice control on the progress screen.
- Deduplicate runtime command cues by normalized text as well as filename on iOS and Android, preventing repeated lines from slipping through under different audio filenames.
- Add Android/iOS regression coverage for repeated cue text and Free-mode badge visibility.

## Evidence
- ANDROID_HOME=/Users/igorganapolsky/Library/Android/sdk ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.service.AIVoiceCalloutManagerSelectionTest' --tests 'com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenBadgeTextTest' -> BUILD SUCCESSFUL
- xcrun swiftc -parse native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift native-ios/RandomTimerTests/CircularTimerViewTests.swift native-ios/RandomTimerTests/AIVoiceCalloutServiceTests.swift -> exit 0
- python3 scripts/pro_audio_freshness.py -> activePackId 2026-05_combatives_corner, releaseMonth 2026-05, status fresh

## Note
- Local xcodebuild test hung during package resolution twice with no test output; CI remains the merge gate for full iOS test execution.