### PR TITLE
fix: use available macOS runner for iOS releases

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -186,7 +186,7 @@ jobs:
     name: iOS TestFlight (Internal)
     needs: [gate, ios-testflight-signoff]
     if: needs.gate.outputs.should_run == 'true' && needs.ios-testflight-signoff.result == 'success' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
-    runs-on: macos-26
+    runs-on: macos-15
     outputs:
       uploaded: ${{ steps.ios_lineage.outputs.uploadable }}
     steps:

--- a/.github/workflows/ios-apple-id-release.yml
+++ b/.github/workflows/ios-apple-id-release.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   testflight-upload:
     name: iOS TestFlight (Apple-ID auth)
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/ios-cert-regen.yml
+++ b/.github/workflows/ios-cert-regen.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   regen:
     name: Nuke + regenerate Apple Distribution cert
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   sync-metadata:
-    runs-on: macos-26
+    runs-on: macos-15
     environment: production
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   submit:
-    runs-on: macos-26
+    runs-on: macos-15
     environment: production
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -138,7 +138,7 @@ jobs:
       needs.release-intent-gate.result == 'success' &&
       needs.internal-proof-or-waive.result == 'success' &&
       (needs.require-production-signoff.result == 'success' || needs.production-signoff-waive.result == 'success')
-    runs-on: macos-26
+    runs-on: macos-15
     environment: production
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary
- Switch iOS release/upload workflows from macos-26 to macos-15
- Keep signing/upload logic unchanged while avoiding queued jobs with no runner assigned

## Evidence
- Existing Internal Distribution iOS job 74655987397 is queued on macos-26 with no runner assigned
- CI Autonomous iOS Build Check completed successfully on the available macOS runner path
- Local verification: git diff --check