### PR TITLE
fix: require Xcode 26 for iOS distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -186,7 +186,7 @@ jobs:
     name: iOS TestFlight (Internal)
     needs: [gate, ios-testflight-signoff]
     if: needs.gate.outputs.should_run == 'true' && needs.ios-testflight-signoff.result == 'success' && (needs.gate.outputs.target == 'all_safe' || needs.gate.outputs.target == 'all' || needs.gate.outputs.target == 'ios')
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       uploaded: ${{ steps.ios_lineage.outputs.uploadable }}
     steps:

--- a/.github/workflows/ios-apple-id-release.yml
+++ b/.github/workflows/ios-apple-id-release.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   testflight-upload:
     name: iOS TestFlight (Apple-ID auth)
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/ios-cert-regen.yml
+++ b/.github/workflows/ios-cert-regen.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   regen:
     name: Nuke + regenerate Apple Distribution cert
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   sync-metadata:
-    runs-on: macos-15
+    runs-on: macos-26
     environment: production
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   submit:
-    runs-on: macos-15
+    runs-on: macos-26
     environment: production
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -138,7 +138,7 @@ jobs:
       needs.release-intent-gate.result == 'success' &&
       needs.internal-proof-or-waive.result == 'success' &&
       (needs.require-production-signoff.result == 'success' || needs.production-signoff-waive.result == 'success')
-    runs-on: macos-15
+    runs-on: macos-26
     environment: production
     steps:
       - uses: actions/checkout@v6.0.2

--- a/scripts/tests/test_ios_distribution_runner.py
+++ b/scripts/tests/test_ios_distribution_runner.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+IOS_DISTRIBUTION_WORKFLOWS = [
+    ".github/workflows/internal-distribution.yml",
+    ".github/workflows/native-release.yml",
+    ".github/workflows/ios-submit-review.yml",
+    ".github/workflows/ios-apple-id-release.yml",
+]
+
+
+def test_ios_distribution_uploads_use_xcode_26_runner() -> None:
+    for workflow in IOS_DISTRIBUTION_WORKFLOWS:
+        source = (ROOT / workflow).read_text(encoding="utf-8")
+        assert "runs-on: macos-26" in source, (
+            f"{workflow} must use macos-26 so App Store uploads are built "
+            "with the iOS 26 SDK required by App Store Connect."
+        )
+        assert "runs-on: macos-15" not in source, (
+            f"{workflow} must not use macos-15 for distribution uploads; "
+            "that runner builds with an SDK App Store Connect rejects."
+        )


### PR DESCRIPTION
## Summary
- Revert iOS distribution/upload workflows back to macos-26 because App Store Connect now rejects iOS 18.5 SDK uploads
- Add regression coverage so TestFlight/App Store upload workflows cannot be moved to macos-15 again

## Evidence
- Failed TestFlight upload run 25449488313: App Store Connect validation 409, built with iOS 18.5 SDK; requires iOS 26 SDK/Xcode 26+
- Local verification: git diff --check
- Local verification: uv run pytest scripts/tests/test_ios_distribution_runner.py -q