### PR TITLE
fix: run iOS review submission on Linux

### DIFF
--- a/.github/workflows/ios-submit-review.yml
+++ b/.github/workflows/ios-submit-review.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   submit:
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     environment: production
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/scripts/tests/test_ios_distribution_runner.py
+++ b/scripts/tests/test_ios_distribution_runner.py
@@ -6,7 +6,6 @@ ROOT = Path(__file__).resolve().parents[2]
 IOS_DISTRIBUTION_WORKFLOWS = [
     ".github/workflows/internal-distribution.yml",
     ".github/workflows/native-release.yml",
-    ".github/workflows/ios-submit-review.yml",
     ".github/workflows/ios-apple-id-release.yml",
 ]
 
@@ -22,3 +21,12 @@ def test_ios_distribution_uploads_use_xcode_26_runner() -> None:
             f"{workflow} must not use macos-15 for distribution uploads; "
             "that runner builds with an SDK App Store Connect rejects."
         )
+
+
+def test_ios_submit_review_uses_linux_runner_because_it_does_not_build_binary() -> None:
+    source = (ROOT / ".github/workflows/ios-submit-review.yml").read_text(encoding="utf-8")
+
+    assert "runs-on: ubuntu-latest" in source
+    assert "runs-on: macos-26" not in source
+    assert "build_app" not in source
+    assert "upload_to_testflight" not in source


### PR DESCRIPTION
## Summary\n- move iOS submit-for-review workflow from macos-26 to ubuntu-latest because it does not build or upload an IPA\n- keep Xcode 26 runner guard scoped to binary distribution workflows\n- add a regression guard that submit-for-review stays off scarce macOS runners\n\n## Verification\n- git diff --check\n- uv run pytest scripts/tests/test_ios_distribution_runner.py scripts/tests/test_growth_workflow_contracts.py::test_ios_submit_review_workflow_guards_ios_version_lineage -q