### PR TITLE
fix: provide token to public store readback

### DIFF
--- a/.github/workflows/public-store-version-readback.yml
+++ b/.github/workflows/public-store-version-readback.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Verify App Store and Play public versions
         env:
+          GH_TOKEN: ${{ github.token }}
           EXPECTED_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_version || '' }}
           TIMEOUT_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.timeout_seconds || '1800' }}
         run: |

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -84,6 +84,7 @@ def test_public_store_version_readback_requires_public_evidence() -> None:
     assert 'workflows: ["Native App Release"]' in contents
     assert 'cron: "0 */6 1-7 * *"' in contents
     assert "scripts/verify_public_store_versions.py" in contents
+    assert "GH_TOKEN: ${{ github.token }}" in contents
     assert "--json-out public-store-version-readback.json" in contents
     assert "Upload public store read-back evidence" in contents
     assert "workflow_run.head_sha" not in contents


### PR DESCRIPTION
## Summary\n- pass github.token as GH_TOKEN to public store version read-back so gh release view works in Actions\n- add a workflow contract assertion\n\n## Verification\n- git diff --check\n- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_public_store_version_readback_requires_public_evidence scripts/tests/test_verify_public_store_versions.py::test_read_github_latest_release_version_strips_v_prefix -q