### PR TITLE
fix: target current store console states

### DIFF
--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -90,6 +90,21 @@ def test_public_store_version_readback_requires_public_evidence() -> None:
     assert "workflow_run.head_sha" not in contents
 
 
+def test_store_console_verification_targets_current_app_and_release_state() -> None:
+    spec = _read("tests/playwright/specs/store/store-console-readonly.spec.ts")
+    agent = _read("tests/playwright/scripts/verify-store-console-agent-browser.mjs")
+    readme = _read("tests/playwright/README.md")
+
+    for contents in (spec, agent):
+        assert "4976249162120849673/publishing" in contents
+        assert "4974974102541773558" not in contents
+
+    assert 'ASC_EXPECTED_STATE_TEXT || "Waiting for Review"' in agent
+    assert 'PLAY_EXPECTED_APP_NAME || "Random Tactical Timer"' in agent
+    assert "`ASC_EXPECTED_STATE_TEXT` (default: `Waiting for Review`)" in readme
+    assert "`PLAY_EXPECTED_APP_NAME` (default: `Random Tactical Timer`)" in readme
+
+
 def test_legacy_monthly_audio_pack_is_manual_only_and_fail_fast() -> None:
     contents = _read(".github/workflows/monthly-audio-pack.yml")
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -50,10 +50,10 @@ To wire scheduled CI checks without manual secret editing:
 Optional:
 
 - `ASC_VERSION_URL`
-- `ASC_EXPECTED_STATE_TEXT` (default: `Prepare for Submission`)
+- `ASC_EXPECTED_STATE_TEXT` (default: `Waiting for Review`)
 - `ASC_EXPECTED_APP_NAME` (default: `Random Tactical Timer`)
 - `PLAY_CONSOLE_URL`
-- `PLAY_EXPECTED_APP_NAME` (default: `Random Timer`)
+- `PLAY_EXPECTED_APP_NAME` (default: `Random Tactical Timer`)
 - `PLAY_EXPECTED_BANNER_TEXT`
 
 ## Strict Release-Readiness Gate

--- a/tests/playwright/scripts/verify-store-console-agent-browser.mjs
+++ b/tests/playwright/scripts/verify-store-console-agent-browser.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 const defaultAscUrl =
   "https://appstoreconnect.apple.com/apps/6758355312/distribution/ios/version/inflight";
 const defaultPlayUrl =
-  "https://play.google.com/console/u/0/developers/8239620436488925047/app/4974974102541773558/app-dashboard";
+  "https://play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing";
 const agentBrowserVersion = "0.10.0";
 
 function tryParseUrl(rawUrl) {
@@ -213,9 +213,9 @@ function main() {
   const ascUrl = process.env.ASC_VERSION_URL || defaultAscUrl;
   const playUrl = process.env.PLAY_CONSOLE_URL || defaultPlayUrl;
 
-  const ascExpectedState = process.env.ASC_EXPECTED_STATE_TEXT || "Prepare for Submission";
+  const ascExpectedState = process.env.ASC_EXPECTED_STATE_TEXT || "Waiting for Review";
   const ascExpectedAppName = process.env.ASC_EXPECTED_APP_NAME || "Random Tactical Timer";
-  const playExpectedAppName = process.env.PLAY_EXPECTED_APP_NAME || "Random Timer";
+  const playExpectedAppName = process.env.PLAY_EXPECTED_APP_NAME || "Random Tactical Timer";
   const playExpectedBannerText = process.env.PLAY_EXPECTED_BANNER_TEXT || "";
 
   const artifactsDir = path.resolve("test-results/agent-browser");

--- a/tests/playwright/specs/store/store-console-readonly.spec.ts
+++ b/tests/playwright/specs/store/store-console-readonly.spec.ts
@@ -3,7 +3,8 @@ import { expect, test } from "@playwright/test";
 
 const defaultAscUrl =
   "https://appstoreconnect.apple.com/apps/6758355312/distribution/ios/version/inflight";
-const defaultPlayUrl = "https://play.google.com/console";
+const defaultPlayUrl =
+  "https://play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing";
 
 function tryParseUrl(rawUrl: string): URL | null {
   try {


### PR DESCRIPTION
## Summary
- Point Play console verification at the current Random Tactical Timer app publishing overview
- Update agent-browser defaults to current ASC Waiting for Review state and correct Play app name
- Add a contract test so stale console app IDs/states do not regress

## Verification
- git diff --check
- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_store_console_verification_targets_current_app_and_release_state -q
- cd tests/playwright && npm run lint:generated