### PR TITLE
fix: filter App Store auth state secret

### DIFF
--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -103,6 +103,9 @@ def test_store_console_verification_targets_current_app_and_release_state() -> N
     assert 'PLAY_EXPECTED_APP_NAME || "Random Tactical Timer"' in agent
     assert "`ASC_EXPECTED_STATE_TEXT` (default: `Waiting for Review`)" in readme
     assert "`PLAY_EXPECTED_APP_NAME` (default: `Random Tactical Timer`)" in readme
+    sync = _read("tests/playwright/scripts/sync-console-auth-secrets.mjs")
+    assert "function filterAscStorageState" in sync
+    assert "appstoreconnect\\.apple\\.com" in sync
 
 
 def test_legacy_monthly_audio_pack_is_manual_only_and_fail_fast() -> None:

--- a/tests/playwright/scripts/sync-console-auth-secrets.mjs
+++ b/tests/playwright/scripts/sync-console-auth-secrets.mjs
@@ -54,6 +54,17 @@ function filterPlayStorageState(rawJson) {
   return JSON.stringify({ cookies: filtered, origins: [] });
 }
 
+function filterAscStorageState(rawJson) {
+  const payload = JSON.parse(rawJson);
+  const cookies = Array.isArray(payload.cookies) ? payload.cookies : [];
+  const filtered = cookies.filter((cookie) =>
+    /(^|\.)apple\.com$|(^|\.)appstoreconnect\.apple\.com$|(^|\.)itunes\.apple\.com$/.test(
+      String(cookie.domain || ""),
+    ),
+  );
+  return JSON.stringify({ cookies: filtered, origins: [] });
+}
+
 function setSecret(repo, name, value) {
   execFileSync(
     ghPath,
@@ -71,7 +82,7 @@ const ascPath = path.join(root, ".auth", "appstore.json");
 const playPath = path.join(root, ".auth", "play.json");
 
 const repo = repoFromGitHubCli();
-const asc = readFileRequired(ascPath);
+const asc = filterAscStorageState(readFileRequired(ascPath));
 const play = filterPlayStorageState(readFileRequired(playPath));
 
 setSecret(repo, "ASC_STORAGE_STATE_JSON", asc);


### PR DESCRIPTION
## Summary
- Filter App Store Connect storage state to Apple/App Store domains before writing GitHub Actions secret
- Keep Play filtering intact
- Extend console-verification contract test so oversized stale ASC auth state cannot regress

## Verification
- git diff --check
- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_store_console_verification_targets_current_app_and_release_state -q
- cd tests/playwright && npm run lint:generated
- cd tests/playwright && npm run auth:sync-secrets