### PR TITLE
fix: stabilize Play console verification

### DIFF
--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -96,7 +96,8 @@ def test_store_console_verification_targets_current_app_and_release_state() -> N
     readme = _read("tests/playwright/README.md")
 
     for contents in (spec, agent):
-        assert "4976249162120849673/publishing" in contents
+        assert "play.google.com/console/u/1/developers/8239620436488925047/app/4976249162120849673/publishing" in contents
+        assert "play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing" not in contents
         assert "4974974102541773558" not in contents
 
     assert 'ASC_EXPECTED_STATE_TEXT || "Waiting for Review"' in agent

--- a/tests/playwright/scripts/verify-store-console-agent-browser.mjs
+++ b/tests/playwright/scripts/verify-store-console-agent-browser.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 const defaultAscUrl =
   "https://appstoreconnect.apple.com/apps/6758355312/distribution/ios/version/inflight";
 const defaultPlayUrl =
-  "https://play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing";
+  "https://play.google.com/console/u/1/developers/8239620436488925047/app/4976249162120849673/publishing";
 const agentBrowserVersion = "0.10.0";
 
 function tryParseUrl(rawUrl) {

--- a/tests/playwright/specs/store/store-console-readonly.spec.ts
+++ b/tests/playwright/specs/store/store-console-readonly.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 const defaultAscUrl =
   "https://appstoreconnect.apple.com/apps/6758355312/distribution/ios/version/inflight";
 const defaultPlayUrl =
-  "https://play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing";
+  "https://play.google.com/console/u/1/developers/8239620436488925047/app/4976249162120849673/publishing";
 
 function tryParseUrl(rawUrl: string): URL | null {
   try {
@@ -65,8 +65,13 @@ async function selectPlayDeveloperAccount(page: any, expectedAccountName: string
 
 async function openPlayApp(page: any, expectedAppName: string): Promise<void> {
   const appHeading = page.getByText(new RegExp(expectedAppName, "i")).first();
-  if (isPlayAppDashboardUrl(page.url()) && (await appHeading.isVisible().catch(() => false))) {
-    return;
+  if (isPlayAppDashboardUrl(page.url())) {
+    try {
+      await expect(appHeading).toBeVisible({ timeout: 30_000 });
+      return;
+    } catch {
+      // Fall through to app-list selectors; Play can briefly show a global loading screen.
+    }
   }
 
   const appListEntry = page.getByRole("link", { name: new RegExp(expectedAppName, "i") }).first();


### PR DESCRIPTION
## Summary
- Target the authenticated Play Console u/1 URL for Random Tactical Timer
- Wait for direct app-page loading before falling back to app-list selectors
- Keep stale u/0 and wrong app IDs covered by the existing console verification contract

## Verification
- git diff --check
- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_store_console_verification_targets_current_app_and_release_state -q
- cd tests/playwright && npm run lint:generated
- cd tests/playwright && ASC_STORAGE_STATE_PATH=.auth/appstore.json PLAY_STORAGE_STATE_PATH=.auth/play.json npm run test:console