### PR TITLE
fix: install agent-browser headless shell

### DIFF
--- a/.github/workflows/store-console-verification.yml
+++ b/.github/workflows/store-console-verification.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium chromium-headless-shell
 
       - name: Prepare auth state files
         id: auth

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -91,10 +91,12 @@ def test_public_store_version_readback_requires_public_evidence() -> None:
 
 
 def test_store_console_verification_targets_current_app_and_release_state() -> None:
+    workflow = _read(".github/workflows/store-console-verification.yml")
     spec = _read("tests/playwright/specs/store/store-console-readonly.spec.ts")
     agent = _read("tests/playwright/scripts/verify-store-console-agent-browser.mjs")
     readme = _read("tests/playwright/README.md")
 
+    assert "chromium chromium-headless-shell" in workflow
     for contents in (spec, agent):
         assert "play.google.com/console/u/1/developers/8239620436488925047/app/4976249162120849673/publishing" in contents
         assert "play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing" not in contents


### PR DESCRIPTION
## Summary
- Install `chromium-headless-shell` for Store Console Verification so `agent-browser` can launch in CI
- Add a workflow contract assertion for the browser dependency

## Verification
- git diff --check
- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_store_console_verification_targets_current_app_and_release_state -q