### PR TITLE
fix: install agent-browser playwright shell

### DIFF
--- a/.github/workflows/store-console-verification.yml
+++ b/.github/workflows/store-console-verification.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium chromium-headless-shell
 
+      - name: Install agent-browser Playwright shell
+        run: npx --yes playwright@1.57.0 install chromium-headless-shell
+
       - name: Prepare auth state files
         id: auth
         env:

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -97,6 +97,7 @@ def test_store_console_verification_targets_current_app_and_release_state() -> N
     readme = _read("tests/playwright/README.md")
 
     assert "chromium chromium-headless-shell" in workflow
+    assert "playwright@1.57.0 install chromium-headless-shell" in workflow
     for contents in (spec, agent):
         assert "play.google.com/console/u/1/developers/8239620436488925047/app/4976249162120849673/publishing" in contents
         assert "play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing" not in contents


### PR DESCRIPTION
## Summary
- install the Playwright 1.57 headless shell required by agent-browser@0.10.0
- pin a workflow contract assertion so Store Console Verification cannot regress to only installing the repo Playwright browser

## Verification
- git diff --check
- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_store_console_verification_targets_current_app_and_release_state -q