### PR TITLE
fix: install agent-browser chromium shell revision

### DIFF
--- a/.github/workflows/store-console-verification.yml
+++ b/.github/workflows/store-console-verification.yml
@@ -35,7 +35,7 @@ jobs:
         run: npx playwright install --with-deps chromium chromium-headless-shell
 
       - name: Install agent-browser Playwright shell
-        run: npx --yes playwright@1.57.0 install chromium-headless-shell
+        run: npx --yes playwright@1.59.1 install chromium-headless-shell
 
       - name: Prepare auth state files
         id: auth

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -97,7 +97,7 @@ def test_store_console_verification_targets_current_app_and_release_state() -> N
     readme = _read("tests/playwright/README.md")
 
     assert "chromium chromium-headless-shell" in workflow
-    assert "playwright@1.57.0 install chromium-headless-shell" in workflow
+    assert "playwright@1.59.1 install chromium-headless-shell" in workflow
     for contents in (spec, agent):
         assert "play.google.com/console/u/1/developers/8239620436488925047/app/4976249162120849673/publishing" in contents
         assert "play.google.com/console/u/0/developers/8239620436488925047/app/4976249162120849673/publishing" not in contents


### PR DESCRIPTION
## Summary
- install Playwright 1.59.1 headless shell so agent-browser@0.10.0 gets chromium_headless_shell-1217
- update the workflow contract assertion to pin the required installer version

## Verification
- git diff --check
- uv run pytest scripts/tests/test_workflow_security_contracts.py::test_store_console_verification_targets_current_app_and_release_state -q