### PR TITLE
Fix iOS Firebase bootstrap crash fallback

### DIFF
--- a/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
+++ b/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
@@ -31,12 +31,9 @@ struct RandomTimerApp: App {
     init() {
         guard !Self.shouldSkipFirebaseForHostedTests else { return }
         guard Self.hasBundledFirebaseConfig else {
-            #if DEBUG
             Self.logger.warning("Skipping Firebase initialization because GoogleService-Info.plist is not bundled.")
+            AnalyticsService.shared.initialize()
             return
-            #else
-            preconditionFailure("Missing bundled GoogleService-Info.plist in release build.")
-            #endif
         }
         FirebaseApp.configure()
         CrashReportingService.shared.initialize()

--- a/scripts/regression_guards.py
+++ b/scripts/regression_guards.py
@@ -246,9 +246,15 @@ def check_ios_firebase_contract(repo_root: Path, errors: list[str]) -> None:
         errors=errors,
         label="RandomTimerApp.swift",
     )
-    _assert_contains(
+    _assert_not_contains(
         app_source,
         "Missing bundled GoogleService-Info.plist in release build.",
+        errors=errors,
+        label="RandomTimerApp.swift",
+    )
+    _assert_contains(
+        app_source,
+        "AnalyticsService.shared.initialize()",
         errors=errors,
         label="RandomTimerApp.swift",
     )


### PR DESCRIPTION
## Summary
- remove the release-build precondition crash when GoogleService-Info.plist is absent
- keep PostHog analytics initialization active even when Firebase config is unavailable
- update regression guards so this launch-crash path cannot return

## Verification
- uv run pytest scripts/tests/test_regression_guards.py scripts/tests/test_voice_regression_contracts.py scripts/tests/test_mobile_feature_parity.py scripts/tests/test_runtime_latest_manifest.py -q
- xcodebuild test -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 16' -skip-testing:RandomTimerUITests -quiet CODE_SIGNING_ALLOWED=NO 'OTHER_SWIFT_FLAGS= -D RT_SKIP_FIREBASE_FOR_CI'