### PR TITLE
fix: wait for Android billing reconnect

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -204,8 +204,7 @@ class ProManager
         ): Boolean {
             pendingPurchaseEntryPoint = entryPoint
             clearPendingTrialOffer()
-            if (!billingClient.isReady) {
-                connectAndRestore()
+            if (!ensureBillingReadyForPurchase()) {
                 trackPurchaseResult(
                     success = false,
                     source = MonetizationSources.PAYWALL,
@@ -303,6 +302,20 @@ class ProManager
                 return false
             }
             return true
+        }
+
+        private suspend fun ensureBillingReadyForPurchase(): Boolean {
+            if (billingClient.isReady) {
+                return true
+            }
+            connectAndRestore()
+            repeat(6) {
+                delay(500)
+                if (billingClient.isReady) {
+                    return true
+                }
+            }
+            return billingClient.isReady
         }
 
         private suspend fun fetchAllProductDetails() {

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -255,6 +255,25 @@ def test_sound_arsenal_copy_and_purchase_path_are_normalized_for_pro():
     assert "launchPurchase(it, productID, paywallEntryPoint)" in android_nav
 
 
+def test_android_purchase_waits_for_billing_reconnect_before_failing():
+    android_pro_manager = _read(ANDROID_PRO_MANAGER)
+    launch_purchase = android_pro_manager.split("suspend fun launchPurchase(", 1)[1].split(
+        "private suspend fun fetchAllProductDetails",
+        1,
+    )[0]
+
+    assert "ensureBillingReadyForPurchase()" in launch_purchase
+    assert "private suspend fun ensureBillingReadyForPurchase()" in android_pro_manager
+    assert "connectAndRestore()" in android_pro_manager
+    assert "delay(500)" in android_pro_manager
+    assert launch_purchase.index("ensureBillingReadyForPurchase()") < launch_purchase.index(
+        'debugMessage = "billing_not_ready"'
+    )
+    assert launch_purchase.index("ensureBillingReadyForPurchase()") < launch_purchase.index(
+        "fetchProductDetails(productID)"
+    )
+
+
 def test_free_sound_arsenal_taps_preview_without_forcing_ios_paywall():
     ios_setup = _read(IOS_SETUP)
     assert "timerManager.previewSound(type: sound)" in ios_setup


### PR DESCRIPTION
## Summary
- Wait briefly for BillingClient reconnect before failing Android paywall purchases as billing_not_ready
- Keep purchase flow on the normal product-details and Billing launch path when reconnect succeeds
- Add regression coverage for the Android billing reconnect guard

## PostHog evidence
- Linked DAU insight 5FFqr2z5 shows traffic, not revenue.
- 30d paywall funnel: 585 views, 82 offer selects, 42 purchase attempts, 0 successes.
- Android purchase_result failures: 125 events / 97 users with debug_message=billing_not_ready.
- iOS purchase_result: 42 user_cancelled events / 22 users.

## Verification
- uv run pytest scripts/tests/test_mobile_feature_parity.py -q
- Android Gradle unit test attempted but local SDK is not configured: missing ANDROID_HOME/local.properties; CI should run Gradle.
