### PR TITLE
fix: restore Android FGS preflight checker

### DIFF
--- a/scripts/check_android_play_fgs_declaration.py
+++ b/scripts/check_android_play_fgs_declaration.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Guard Play foreground-service declaration acknowledgement before release."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+SPECIAL_USE_SERVICE_TYPE = re.compile(r'android:foregroundServiceType\s*=\s*"[^"]*\bspecialUse\b[^"]*"')
+
+
+def manifest_requires_special_use_declaration(manifest_path: Path) -> bool:
+    text = manifest_path.read_text(encoding="utf-8")
+    return "android.permission.FOREGROUND_SERVICE_SPECIAL_USE" in text or bool(SPECIAL_USE_SERVICE_TYPE.search(text))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--require-ack-env", default="PLAY_FGS_DECLARATION_ACK")
+    args = parser.parse_args()
+
+    if not args.manifest.is_file():
+        print(f"ERROR: manifest not found: {args.manifest}", file=sys.stderr)
+        return 2
+
+    if not manifest_requires_special_use_declaration(args.manifest):
+        print("OK: no Play foreground-service special-use declaration required.")
+        return 0
+
+    ack = os.environ.get(args.require_ack_env, "").strip()
+    if not ack:
+        print(
+            f"ERROR: manifest uses foregroundServiceType=specialUse; set {args.require_ack_env} "
+            "after confirming the matching Play Console foreground-service declaration.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: Play foreground-service special-use declaration acknowledged by {args.require_ack_env}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_android_play_fgs_declaration.py
+++ b/scripts/tests/test_check_android_play_fgs_declaration.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "check_android_play_fgs_declaration.py"
+SPEC = importlib.util.spec_from_file_location("check_android_play_fgs_declaration", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+
+def test_manifest_requires_special_use_declaration_from_permission() -> None:
+    assert mod.manifest_requires_special_use_declaration(ROOT / "native-android/app/src/main/AndroidManifest.xml")
+
+
+def test_manifest_without_special_use_does_not_require_ack(tmp_path: Path) -> None:
+    manifest = tmp_path / "AndroidManifest.xml"
+    manifest.write_text(
+        """<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+            <application>
+                <service android:name=".TimerService" android:foregroundServiceType="mediaPlayback" />
+            </application>
+        </manifest>""",
+        encoding="utf-8",
+    )
+
+    assert not mod.manifest_requires_special_use_declaration(manifest)


### PR DESCRIPTION
## Summary
- add the missing Android Play foreground-service declaration checker used by internal distribution
- add targeted tests for current manifest special-use detection and non-special-use manifests

## Proof
- uv run pytest -q scripts/tests/test_check_android_play_fgs_declaration.py scripts/tests/test_workflow_yaml_syntax.py
- PLAY_FGS_DECLARATION_ACK=2026-04-24 python3 scripts/check_android_play_fgs_declaration.py --manifest native-android/app/src/main/AndroidManifest.xml --require-ack-env PLAY_FGS_DECLARATION_ACK