### PR TITLE
fix: cap Actions storage growth on develop

### DIFF
--- a/.github/workflows/android17-canary.yml
+++ b/.github/workflows/android17-canary.yml
@@ -76,3 +76,4 @@ jobs:
             native-android/app/build/reports/tests/testDebugUnitTest
             native-android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,7 @@ jobs:
             /tmp/android-regression-junit-summary.json
             /tmp/android-regression-junit-summary.md
           if-no-files-found: warn
+          retention-days: 1
 
   android:
     name: Autonomous Android Tests
@@ -337,6 +338,7 @@ jobs:
         with:
           name: app-debug
           path: native-android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 1
 
       - name: Upload Android coverage report
         if: always()
@@ -351,6 +353,7 @@ jobs:
             /tmp/android-junit-summary.json
             /tmp/android-junit-summary.md
           if-no-files-found: warn
+          retention-days: 1
 
   ios:
     name: Autonomous iOS Build Check
@@ -491,6 +494,7 @@ jobs:
           name: ios-test-results-xcresult
           path: native-ios/build/TestResults.xcresult
           if-no-files-found: warn
+          retention-days: 1
 
   playwright-local:
     name: Playwright Local Checks
@@ -525,6 +529,7 @@ jobs:
           path: |
             tests/playwright/playwright-report
             tests/playwright/test-results
+          retention-days: 1
 
   python-scripts:
     name: Python Script Tests
@@ -566,6 +571,7 @@ jobs:
             /tmp/python-junit-summary.json
             /tmp/python-junit-summary.md
           if-no-files-found: warn
+          retention-days: 1
 
       - name: Upload Python coverage artifact
         if: always()
@@ -574,6 +580,7 @@ jobs:
           name: python-coverage-xml
           path: coverage-python.xml
           if-no-files-found: error
+          retention-days: 1
 
       - name: Upload Python coverage to Codecov
         if: always()
@@ -606,6 +613,7 @@ jobs:
             /tmp/release-context-ci.json
             /tmp/release-delegation-contract-ci.json
           if-no-files-found: warn
+          retention-days: 1
 
   north-star-guardrail:
     name: North Star Guardrail
@@ -663,7 +671,7 @@ jobs:
         with:
           name: north-star-guardrail
           path: marketing/data/north_star.json
-          retention-days: 7
+          retention-days: 1
 
   security:
     name: Autonomous Security

--- a/.github/workflows/daily-growth-publishing.yml
+++ b/.github/workflows/daily-growth-publishing.yml
@@ -133,6 +133,7 @@ jobs:
             marketing/data/publications.jsonl
             marketing/data/engagement.jsonl
             marketing/data/engagement-latest.md
+          retention-days: 1
             marketing/data/publish_ab_pilot_runs.jsonl
             marketing/data/publish_ab_pilot_summary.json
             marketing/data/publish_ab_pilot_report.md

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -86,15 +86,6 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: AVD cache
-        uses: actions/cache@v5.0.4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-api-30-${{ runner.os }}
-
       - name: Run Android UI smoke test on emulator
         uses: reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7 # v2
         with:
@@ -114,6 +105,7 @@ jobs:
           path: |
             native-android/app/build/reports/androidTests/connected
             native-android/app/build/outputs/androidTest-results/connected
+          retention-days: 1
 
   ios-device-tests:
     name: iOS Simulator + Maestro + Agent Device
@@ -221,3 +213,4 @@ jobs:
             native-ios/build/maestro
             native-ios/build/agent-device
           if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -387,6 +387,7 @@ jobs:
           name: ios-ipa-internal
           path: native-ios/RandomTimer.ipa
           if-no-files-found: warn
+          retention-days: 1
 
   android-play-internal:
     name: Android Google Play (Internal)
@@ -552,6 +553,7 @@ jobs:
           name: android-aab-internal
           path: native-android/app/build/outputs/bundle/release/app-release.aab
           if-no-files-found: warn
+          retention-days: 1
 
       - name: Cleanup secrets
         if: always()
@@ -741,6 +743,7 @@ jobs:
           name: android-apk-firebase-internal
           path: native-android/app/build/outputs/apk/release/app-release.apk
           if-no-files-found: warn
+          retention-days: 1
 
       - name: Cleanup secrets
         if: always()

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -265,6 +265,7 @@ jobs:
         with:
           name: ios-ipa
           path: native-ios/RandomTimer.ipa
+          retention-days: 1
 
   android-release:
     needs:
@@ -459,6 +460,7 @@ jobs:
           name: play-upload-result
           path: /tmp/play-upload-result.json
           if-no-files-found: ignore
+          retention-days: 1
 
       - name: Upload Play upload error (if any)
         uses: actions/upload-artifact@v7.0.0
@@ -467,6 +469,7 @@ jobs:
           name: play-upload-error
           path: /tmp/play-upload-error.json
           if-no-files-found: ignore
+          retention-days: 1
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v7.0.0
@@ -474,6 +477,7 @@ jobs:
         with:
           name: android-aab
           path: native-android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 1
 
       - name: Cleanup secrets
         if: always()
@@ -638,6 +642,7 @@ jobs:
           name: play-public-listing-report
           path: /tmp/play-public-listing.txt
           if-no-files-found: ignore
+          retention-days: 1
 
       - name: Cleanup secrets
         if: always()
@@ -844,6 +849,7 @@ jobs:
           path: |
             /tmp/asc_ready.json
             /tmp/delegation_contract.json
+          retention-days: 1
           if-no-files-found: ignore
 
       - name: Submit for App Review (App Store)
@@ -879,6 +885,7 @@ jobs:
         with:
           name: asc-version-resolution
           path: /tmp/asc_version.json
+          retention-days: 1
 
       - name: Cleanup secrets
         if: always()

--- a/.github/workflows/store-console-verification.yml
+++ b/.github/workflows/store-console-verification.yml
@@ -91,3 +91,4 @@ jobs:
           path: |
             tests/playwright/playwright-report
             tests/playwright/test-results
+          retention-days: 1

--- a/scripts/tests/test_actions_storage_contracts.py
+++ b/scripts/tests/test_actions_storage_contracts.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+HIGH_VOLUME_WORKFLOWS = [
+    ".github/workflows/ci.yml",
+    ".github/workflows/device-tests.yml",
+    ".github/workflows/internal-distribution.yml",
+    ".github/workflows/native-release.yml",
+    ".github/workflows/android17-canary.yml",
+    ".github/workflows/daily-growth-publishing.yml",
+    ".github/workflows/store-console-verification.yml",
+]
+
+
+def _upload_artifact_blocks(text: str) -> list[str]:
+    marker = "uses: actions/upload-artifact@"
+    blocks: list[str] = []
+    parts = text.split(marker)
+    for part in parts[1:]:
+        next_step = part.find("\n      - name:")
+        blocks.append(part if next_step == -1 else part[:next_step])
+    return blocks
+
+
+def test_high_volume_upload_artifacts_use_short_retention() -> None:
+    offenders: list[str] = []
+    for workflow in HIGH_VOLUME_WORKFLOWS:
+        text = (ROOT / workflow).read_text(encoding="utf-8")
+        for block in _upload_artifact_blocks(text):
+            if "retention-days: 1" not in block:
+                offenders.append(workflow)
+                break
+
+    assert offenders == []
+
+
+def test_device_tests_do_not_cache_android_emulator_images() -> None:
+    text = (ROOT / ".github/workflows/device-tests.yml").read_text(encoding="utf-8")
+
+    assert "avd-api-30" not in text
+    assert "~/.android/avd" not in text


### PR DESCRIPTION
## Summary\n- cap high-volume GitHub Actions artifacts at 1 day on develop workflows\n- remove reusable AVD emulator cache from device tests\n- add a regression guard for storage-heavy workflow artifacts\n\n## Verification\n- uv run pytest -q scripts/tests/test_actions_storage_contracts.py scripts/tests/test_workflow_yaml_syntax.py\n- git diff --check