### PR TITLE
fix: disable oversized Actions Gradle caches

### DIFF
--- a/.github/workflows/android17-canary.yml
+++ b/.github/workflows/android17-canary.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-          cache: gradle
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Grant Android execute permission
         run: chmod +x native-android/gradlew
@@ -301,7 +300,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Grant execute permission
         run: chmod +x gradlew

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Create dummy google-services.json for CI
         working-directory: native-android

--- a/.github/workflows/flaky-test-audit.yml
+++ b/.github/workflows/flaky-test-audit.yml
@@ -65,6 +65,7 @@ jobs:
             /tmp/python-flaky-summary.json
             /tmp/python-flaky-summary.md
           if-no-files-found: error
+          retention-days: 1
 
       - name: Fail on Python flaky audit failures
         if: steps.audit.outputs.failed != '0'
@@ -83,7 +84,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Grant execute permission
         run: chmod +x native-android/gradlew
@@ -138,6 +138,7 @@ jobs:
             /tmp/android-flaky-summary.json
             /tmp/android-flaky-summary.md
           if-no-files-found: error
+          retention-days: 1
 
       - name: Fail on Android flaky audit failures
         if: steps.audit.outputs.failed != '0'

--- a/scripts/tests/test_actions_storage_contracts.py
+++ b/scripts/tests/test_actions_storage_contracts.py
@@ -11,6 +11,7 @@ HIGH_VOLUME_WORKFLOWS = [
     ".github/workflows/native-release.yml",
     ".github/workflows/android17-canary.yml",
     ".github/workflows/daily-growth-publishing.yml",
+    ".github/workflows/flaky-test-audit.yml",
     ".github/workflows/store-console-verification.yml",
 ]
 
@@ -42,3 +43,14 @@ def test_device_tests_do_not_cache_android_emulator_images() -> None:
 
     assert "avd-api-30" not in text
     assert "~/.android/avd" not in text
+
+
+def test_high_volume_workflows_do_not_use_gradle_actions_cache() -> None:
+    offenders = [
+        workflow
+        for workflow in HIGH_VOLUME_WORKFLOWS
+        if "cache: 'gradle'" in (ROOT / workflow).read_text(encoding="utf-8")
+        or "cache: gradle" in (ROOT / workflow).read_text(encoding="utf-8")
+    ]
+
+    assert offenders == []


### PR DESCRIPTION
## Summary\n- remove setup-java Gradle cache usage from storage-heavy workflows\n- add 1-day retention to flaky-test audit artifacts\n- extend the Actions storage contract to reject Gradle cache reintroduction\n\n## Verification\n- uv run pytest -q scripts/tests/test_actions_storage_contracts.py scripts/tests/test_workflow_yaml_syntax.py\n- git diff --check\n- rg -n "cache:\s*'?gradle|avd-api-30|~/.android/avd" .github/workflows || true