### PR TITLE
fix: disable oversized Actions Gradle caches on release

### DIFF
--- a/.github/workflows/android17-canary.yml
+++ b/.github/workflows/android17-canary.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-          cache: gradle
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Grant Android execute permission
         run: chmod +x native-android/gradlew
@@ -274,7 +273,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Grant execute permission
         run: chmod +x gradlew

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Create dummy google-services.json for CI
         working-directory: native-android

--- a/scripts/tests/test_actions_storage_contracts.py
+++ b/scripts/tests/test_actions_storage_contracts.py
@@ -42,3 +42,13 @@ def test_device_tests_do_not_cache_android_emulator_images() -> None:
 
     assert "avd-api-30" not in text
     assert "~/.android/avd" not in text
+
+
+def test_high_volume_workflows_do_not_use_gradle_actions_cache() -> None:
+    offenders = []
+    for workflow in HIGH_VOLUME_WORKFLOWS:
+        text = (ROOT / workflow).read_text(encoding="utf-8")
+        if "cache: 'gradle'" in text or "cache: gradle" in text:
+            offenders.append(workflow)
+
+    assert offenders == []


### PR DESCRIPTION
## Summary\n- remove setup-java Gradle cache usage from storage-heavy release workflows\n- extend the Actions storage contract to reject Gradle cache reintroduction\n\n## Verification\n- uv run pytest -q scripts/tests/test_actions_storage_contracts.py scripts/tests/test_workflow_yaml_syntax.py\n- git diff --check\n- rg -n "cache:\s*'?gradle|avd-api-30|~/.android/avd" .github/workflows || true