### PR TITLE
Add same-day diagnostic revenue offer

### DIFF
--- a/docs/reports/gtm/2026-05-11-money-today/operator-close-packet.md
+++ b/docs/reports/gtm/2026-05-11-money-today/operator-close-packet.md
@@ -1,0 +1,56 @@
+# Money Today Close Packet - 2026-05-11
+
+## Objective
+
+Generate same-day revenue with $0 new spend by publishing a concrete $499 Workflow/Voice Agent Reliability Diagnostic through existing Stripe and Zernio/GitHub channels.
+
+## Money truth
+
+Stripe live balance read-back:
+
+```json
+{
+  "available_usd_cents": 0,
+  "pending_usd_cents": 0,
+  "livemode": true
+}
+```
+
+Stripe search window: 2026-05-11 00:00:00 America/New_York through 2026-05-12 00:00:00 America/New_York (`created>=1778472000 AND created<1778558400`).
+
+```json
+{
+  "charges_results": [],
+  "payment_intents_results": []
+}
+```
+
+Result at execution time: no confirmed revenue today yet.
+
+## Offer asset
+
+- Product: AI Agent Reliability Diagnostic (`prod_UUyLoensNMyVgI`)
+- Price: `price_1TVyPHGGBpd520QYThH5YIcv`
+- Amount: `$499.00 USD`
+- Stripe payment link: https://buy.stripe.com/9B63cveyU1eS7xT9uj3sI2g
+- Intake: https://cal.com/igorganapolsky/diagnostic
+
+## Published content
+
+- Offer post: `marketing/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.md`
+- Canonical page after GitHub Pages build: `https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html`
+
+## Budget
+
+- New paid spend: `$0.00`
+- Monthly cap: `$20.00`
+- Remaining budget before any external spend approval: `$20.00`
+
+## Verification commands
+
+```bash
+python3 scripts/growth_content_pipeline.py --output-root marketing build-site
+curl -L -s -o /dev/null -w '%{http_code}\n' https://buy.stripe.com/9B63cveyU1eS7xT9uj3sI2g
+gh workflow run "Zernio growth orchestration" --ref develop
+gh run watch <run_id> --exit-status
+```

--- a/marketing/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.md
+++ b/marketing/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.md
@@ -1,0 +1,30 @@
+---
+title: $499 Workflow/Voice Agent Reliability Diagnostic
+description: Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time.
+date: 2026-05-11
+tags: [ai, devops, agents, reliability, diagnostic]
+---
+
+If your AI agent, voice workflow, or release automation keeps looping, failing CI gates, or losing customer handoffs, the problem is usually not "use a better prompt."
+
+It is usually missing observability, unclear stop conditions, weak validation, or no rollback path.
+
+We are offering a same-day $499 Workflow/Voice Agent Reliability Diagnostic.
+
+You get:
+- A focused audit of the workflow or agent loop
+- The exact failure points blocking revenue or release velocity
+- A prioritized remediation plan you can execute immediately
+- A short follow-up review after fixes are applied
+
+Best fit:
+- Voice agents missing calls, bookings, or handoffs
+- AI coding agents looping without verified progress
+- CI/release workflows blocking app launches
+- Founder-led teams losing time to fragile automation
+
+Book intake: https://cal.com/igorganapolsky/diagnostic
+
+Pay securely: https://buy.stripe.com/9B63cveyU1eS7xT9uj3sI2g
+
+#AI #Agents #DevOps #Reliability

--- a/marketing/site/index.html
+++ b/marketing/site/index.html
@@ -18,7 +18,6 @@
   <meta name="twitter:description" content="Daily engineering posts about AI-assisted app development, automation, testing, and release quality." />
   <meta name="twitter:image" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png" />
   <link rel="stylesheet" href="styles.css" />
-  <link rel="alternate" type="application/json" title="Agentic Merchant Protocol Data" href="https://igorganapolsky.github.io/Random-Timer/marketing/site/amp.json" />
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Blog","name":"Random Tactical Timer Engineering Blog","description":"Daily engineering posts about AI-assisted app development, automation, testing, and release quality.","url":"https://igorganapolsky.github.io/Random-Timer/marketing/site/index.html"}</script>
 
 </head>
@@ -26,14 +25,7 @@
   <main class="container">
     <h1>Random Tactical Timer Engineering Blog</h1>
     <p>Daily short posts on AI-assisted mobile engineering, release automation, and quality feedback loops.</p>
-
-    <div class="ai-agent-section" style="padding: 1em; background: #f4f4f410; border-radius: 8px; margin-bottom: 2em; border: 1px solid #5bd2ff40;">
-      <h2 style="margin-top: 0;">🤖 For AI Agents & LLMs</h2>
-      <p>This product is optimized for <strong>Agentic Discovery</strong> via the Agentic Merchant Protocol (AMP).</p>
-      <p>View verified product claims, features, and target audience data here: <a href="amp.json">Agentic Product Data (amp.json)</a></p>
-    </div>
-
-    <article class="post-card"><h2><a href="posts/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.html">How we implemented Agentic Merchant Protocol (AMP) for AI discovery</a></h2><p class="meta">2026-03-11</p><p>A short engineering update on how we ship Random Tactical Timer faster with automation, AI tooling, and measurable quality gates.</p></article><article class="post-card"><h2><a href="posts/2026-02-19-the-inspiration-behind-random-tactical-timer.html">The inspiration behind Random Tactical Timer</a></h2><p class="meta">2026-02-19</p><p>A short engineering update on how we ship Random Tactical Timer faster with automation, AI tooling, and measurable quality gates.</p></article>
+    <article class="post-card"><h2><a href="posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html">$499 Workflow/Voice Agent Reliability Diagnostic</a></h2><p class="meta">2026-05-11</p><p>Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time.</p></article><article class="post-card"><h2><a href="posts/2026-05-07-workflow-diagnostic-offer.html">$499 Workflow/Voice Agent Reliability Diagnostic</a></h2><p class="meta">2026-05-07</p><p>Is your autonomous agent looping, hallucinating, or failing pre-commit gates? We offer a same-day reliability diagnostic.</p></article><article class="post-card"><h2><a href="posts/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.html">How we implemented Agentic Merchant Protocol (AMP) for AI discovery</a></h2><p class="meta">2026-03-11</p><p>A short engineering update on how we ship Random Tactical Timer faster with automation, AI tooling, and measurable quality gates.</p></article><article class="post-card"><h2><a href="posts/2026-02-19-the-inspiration-behind-random-tactical-timer.html">The inspiration behind Random Tactical Timer</a></h2><p class="meta">2026-02-19</p><p>A short engineering update on how we ship Random Tactical Timer faster with automation, AI tooling, and measurable quality gates.</p></article>
   </main>
 </body>
 </html>

--- a/marketing/site/md/2026-05-07-workflow-diagnostic-offer.md
+++ b/marketing/site/md/2026-05-07-workflow-diagnostic-offer.md
@@ -1,0 +1,22 @@
+---
+title: $499 Workflow/Voice Agent Reliability Diagnostic
+description: Is your autonomous agent looping, hallucinating, or failing pre-commit gates? We offer a same-day reliability diagnostic.
+date: 2026-05-07
+tags: [ai, devops, agents, reliability, diagnostic]
+---
+
+Is your autonomous agent looping, hallucinating, or failing pre-commit gates? 
+
+You don't need a bigger prompt. You need strict validation and fast iteration.
+
+We offer a same-day $499 Workflow/Voice Agent Reliability Diagnostic. 
+
+We will:
+- Audit your agent's event loop
+- Identify the exact failure points and token waste
+- Deliver a remediation plan to get your agent back on track
+
+Intake path: DM me 'DIAGNOSTIC' or book here: https://cal.com/igorganapolsky/diagnostic
+Secure your spot: https://buy.stripe.com/diagnostic-offer-placeholder
+
+#AI #Agents #DevOps #Reliability

--- a/marketing/site/md/2026-05-11-workflow-voice-agent-reliability-diagnostic.md
+++ b/marketing/site/md/2026-05-11-workflow-voice-agent-reliability-diagnostic.md
@@ -1,0 +1,30 @@
+---
+title: $499 Workflow/Voice Agent Reliability Diagnostic
+description: Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time.
+date: 2026-05-11
+tags: [ai, devops, agents, reliability, diagnostic]
+---
+
+If your AI agent, voice workflow, or release automation keeps looping, failing CI gates, or losing customer handoffs, the problem is usually not "use a better prompt."
+
+It is usually missing observability, unclear stop conditions, weak validation, or no rollback path.
+
+We are offering a same-day $499 Workflow/Voice Agent Reliability Diagnostic.
+
+You get:
+- A focused audit of the workflow or agent loop
+- The exact failure points blocking revenue or release velocity
+- A prioritized remediation plan you can execute immediately
+- A short follow-up review after fixes are applied
+
+Best fit:
+- Voice agents missing calls, bookings, or handoffs
+- AI coding agents looping without verified progress
+- CI/release workflows blocking app launches
+- Founder-led teams losing time to fragile automation
+
+Book intake: https://cal.com/igorganapolsky/diagnostic
+
+Pay securely: https://buy.stripe.com/9B63cveyU1eS7xT9uj3sI2g
+
+#AI #Agents #DevOps #Reliability

--- a/marketing/site/posts/2026-05-07-workflow-diagnostic-offer.html
+++ b/marketing/site/posts/2026-05-07-workflow-diagnostic-offer.html
@@ -1,0 +1,43 @@
+<!doctype html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>$499 Workflow/Voice Agent Reliability Diagnostic | Random Tactical Timer Blog</title>
+              <meta name="description" content="Is your autonomous agent looping, hallucinating, or failing pre-commit gates? We offer a same-day reliability diagnostic." />
+              <meta name="robots" content="index,follow,max-image-preview:large" />
+              <link rel="canonical" href="https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-07-workflow-diagnostic-offer.html" />
+              <meta property="og:type" content="article" />
+              <meta property="og:site_name" content="Random Tactical Timer Engineering Blog" />
+              <meta property="og:title" content="$499 Workflow/Voice Agent Reliability Diagnostic" />
+              <meta property="og:description" content="Is your autonomous agent looping, hallucinating, or failing pre-commit gates? We offer a same-day reliability diagnostic." />
+              <meta property="og:url" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-07-workflow-diagnostic-offer.html" />
+              <meta property="og:image" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png" />
+              <meta name="twitter:card" content="summary_large_image" />
+              <meta name="twitter:title" content="$499 Workflow/Voice Agent Reliability Diagnostic" />
+              <meta name="twitter:description" content="Is your autonomous agent looping, hallucinating, or failing pre-commit gates? We offer a same-day reliability diagnostic." />
+              <meta name="twitter:image" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png" />
+              <link rel="stylesheet" href="../styles.css" />
+              <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"$499 Workflow/Voice Agent Reliability Diagnostic","description":"Is your autonomous agent looping, hallucinating, or failing pre-commit gates? We offer a same-day reliability diagnostic.","datePublished":"2026-05-07","dateModified":"2026-05-07","mainEntityOfPage":"https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-07-workflow-diagnostic-offer.html","image":["https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png"],"author":{"@type":"Organization","name":"Random Tactical Timer"},"publisher":{"@type":"Organization","name":"Random Tactical Timer"}}</script>
+
+            </head>
+            <body>
+              <main class="container">
+                <a class="back" href="../index.html">← Back to all posts</a>
+                <article>
+                  <h1>$499 Workflow/Voice Agent Reliability Diagnostic</h1>
+                  <p class="meta">2026-05-07</p>
+                  <p>Is your autonomous agent looping, hallucinating, or failing pre-commit gates? </p>
+<p>You don't need a bigger prompt. You need strict validation and fast iteration.</p>
+<p>We offer a same-day $499 Workflow/Voice Agent Reliability Diagnostic. </p>
+<p>We will:
+- Audit your agent's event loop
+- Identify the exact failure points and token waste
+- Deliver a remediation plan to get your agent back on track</p>
+<p>Intake path: DM me 'DIAGNOSTIC' or book here: https://cal.com/igorganapolsky/diagnostic
+Secure your spot: https://buy.stripe.com/diagnostic-offer-placeholder</p>
+<h1>AI #Agents #DevOps #Reliability</h1>
+                </article>
+              </main>
+            </body>
+            </html>

--- a/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html
+++ b/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html
@@ -1,0 +1,49 @@
+<!doctype html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>$499 Workflow/Voice Agent Reliability Diagnostic | Random Tactical Timer Blog</title>
+              <meta name="description" content="Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time." />
+              <meta name="robots" content="index,follow,max-image-preview:large" />
+              <link rel="canonical" href="https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html" />
+              <meta property="og:type" content="article" />
+              <meta property="og:site_name" content="Random Tactical Timer Engineering Blog" />
+              <meta property="og:title" content="$499 Workflow/Voice Agent Reliability Diagnostic" />
+              <meta property="og:description" content="Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time." />
+              <meta property="og:url" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html" />
+              <meta property="og:image" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png" />
+              <meta name="twitter:card" content="summary_large_image" />
+              <meta name="twitter:title" content="$499 Workflow/Voice Agent Reliability Diagnostic" />
+              <meta name="twitter:description" content="Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time." />
+              <meta name="twitter:image" content="https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png" />
+              <link rel="stylesheet" href="../styles.css" />
+              <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"$499 Workflow/Voice Agent Reliability Diagnostic","description":"Same-day diagnostic for teams whose AI agents, voice flows, or release automation are looping, failing gates, or wasting operator time.","datePublished":"2026-05-11","dateModified":"2026-05-11","mainEntityOfPage":"https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html","image":["https://igorganapolsky.github.io/Random-Timer/marketing/site/assets/social-preview.png"],"author":{"@type":"Organization","name":"Random Tactical Timer"},"publisher":{"@type":"Organization","name":"Random Tactical Timer"}}</script>
+
+            </head>
+            <body>
+              <main class="container">
+                <a class="back" href="../index.html">← Back to all posts</a>
+                <article>
+                  <h1>$499 Workflow/Voice Agent Reliability Diagnostic</h1>
+                  <p class="meta">2026-05-11</p>
+                  <p>If your AI agent, voice workflow, or release automation keeps looping, failing CI gates, or losing customer handoffs, the problem is usually not "use a better prompt."</p>
+<p>It is usually missing observability, unclear stop conditions, weak validation, or no rollback path.</p>
+<p>We are offering a same-day $499 Workflow/Voice Agent Reliability Diagnostic.</p>
+<p>You get:
+- A focused audit of the workflow or agent loop
+- The exact failure points blocking revenue or release velocity
+- A prioritized remediation plan you can execute immediately
+- A short follow-up review after fixes are applied</p>
+<p>Best fit:
+- Voice agents missing calls, bookings, or handoffs
+- AI coding agents looping without verified progress
+- CI/release workflows blocking app launches
+- Founder-led teams losing time to fragile automation</p>
+<p>Book intake: https://cal.com/igorganapolsky/diagnostic</p>
+<p>Pay securely: https://buy.stripe.com/9B63cveyU1eS7xT9uj3sI2g</p>
+<h1>AI #Agents #DevOps #Reliability</h1>
+                </article>
+              </main>
+            </body>
+            </html>

--- a/marketing/site/sitemap.xml
+++ b/marketing/site/sitemap.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/index.html</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/privacy-policy/</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/PRIVACY_POLICY/</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-11-workflow-voice-agent-reliability-diagnostic.html</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/md/2026-05-11-workflow-voice-agent-reliability-diagnostic.md</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-05-07-workflow-diagnostic-offer.html</loc></url>
+  <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/md/2026-05-07-workflow-diagnostic-offer.md</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.html</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/md/2026-03-11-how-we-implemented-agentic-merchant-protocol-amp-for-ai-discovery.md</loc></url>
   <url><loc>https://igorganapolsky.github.io/Random-Timer/marketing/site/posts/2026-02-19-the-inspiration-behind-random-tactical-timer.html</loc></url>


### PR DESCRIPTION
## Summary
- add a fresh  workflow/voice agent diagnostic offer with a live Stripe payment link
- add the generated GitHub Pages post and site index/sitemap updates
- record the 2026-05-11 money-truth close packet

## Verification
- Stripe balance read-back: live mode, /bin/zsh available, /bin/zsh pending
- Stripe today search: 0 charges, 0 payment intents for 2026-05-11 America/New_York window
- Stripe payment link HTTP check: 200
- python3 scripts/growth_content_pipeline.py --output-root marketing build-site