### PR TITLE
Support Zernio underscore account IDs

### DIFF
--- a/scripts/tests/test_zernio_orchestrate.py
+++ b/scripts/tests/test_zernio_orchestrate.py
@@ -189,7 +189,7 @@ def test_parse_publish_accounts_platform_id_alias() -> None:
 
 def test_publish_accounts_from_current_accounts_filters_text_accounts() -> None:
     accounts = [
-        {"platform": "twitter", "id": "tw_1"},
+        {"platform": "twitter", "_id": "tw_1"},
         {"platform": "instagram", "id": "ig_1"},
         {"platformId": "threads", "accountId": "th_1"},
         {"platform": "youtube", "id": "yt_1"},

--- a/scripts/zernio_orchestrate.py
+++ b/scripts/zernio_orchestrate.py
@@ -132,7 +132,7 @@ def _parse_publish_accounts(raw: str) -> Tuple[Optional[List[Dict[str, str]]], O
 
 
 def _account_id(account: Dict[str, Any]) -> str:
-    return str(account.get("accountId") or account.get("account_id") or account.get("id") or "").strip()
+    return str(account.get("accountId") or account.get("account_id") or account.get("_id") or account.get("id") or "").strip()
 
 
 def _platform_id(account: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- support Zernio account  values from the live accounts API when building fallback publish targets
- update the focused Zernio test to cover 

## Verification
- uv run pytest scripts/tests/test_zernio_orchestrate.py
- python3 -m py_compile scripts/zernio_orchestrate.py scripts/tests/test_zernio_orchestrate.py