### PR TITLE
feat: add competition warmup preset

### DIFF
--- a/marketing/data/competition_warmup_experiment.md
+++ b/marketing/data/competition_warmup_experiment.md
@@ -1,0 +1,48 @@
+# Competition Warmup Experiment
+
+Date: 2026-05-12
+
+## Signal
+
+Local evidence source:
+
+```bash
+pdftotext -layout smoothcomp.pdf -
+```
+
+The Smoothcomp event-weekend email tells athletes to plan the day, control weight, warm up twice, and use small reactive movements to stay sharp before match time. This is a high-intent context for Random Tactical Timer because the athlete already needs unpredictable cues but Smoothcomp owns only event logistics.
+
+## Action
+
+Add a zero-spend Competition Warmup preset:
+
+- Range: 20-90 seconds
+- Alarm: 5 seconds
+- Repeat loop: on
+- Vibration: on
+- Sound: intense free-tier alarm
+
+Store metadata now names the preset for BJJ, judo, wrestling, and event-day prep.
+
+## Measurement
+
+Primary success signal remains Weekly Qualified Training Users:
+
+```sql
+SELECT count(*)
+FROM (
+  SELECT person_id
+  FROM events
+  WHERE event = 'timer_completed'
+    AND timestamp > now() - interval 7 day
+  GROUP BY person_id
+  HAVING count() >= 3
+)
+```
+
+Supporting signal:
+
+- `training_preset_applied` with `preset_id = 'competition_warmup'` on iOS and Android.
+- Settings-change events showing 20-90 second ranges as a fallback sanity check.
+
+Budget impact: `$0.00`.

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -327,6 +327,7 @@ object AnalyticsEvents {
     const val VOICE_GENDER_SELECTED = "voice_gender_selected"
     const val FEATURE_GATE_HIT = "feature_gate_hit"
     const val PAYWALL_GATE_FIRST_TIMER = "paywall_gate_first_timer"
+    const val TRAINING_PRESET_APPLIED = "training_preset_applied"
 
     // Attribution
     const val DEEP_LINK_OPENED = "deep_link_opened"
@@ -358,6 +359,7 @@ object AnalyticsProperties {
     const val RUNTIME_TARGET = "runtime_target"
     const val GENDER = "gender"
     const val FEATURE = "feature"
+    const val PRESET_ID = "preset_id"
     const val ALARM_RESPONSE_TIME = "alarm_response_time"
     const val ABANDON_REASON = "abandon_reason"
     const val SCREEN = "screen"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -217,6 +217,47 @@ fun activationPresetForFirstCompletionIfEligible(
     )
 }
 
+data class TrainingPreset(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val minSeconds: Int,
+    val maxSeconds: Int,
+    val alarmDuration: Int,
+    val repeatEnabled: Boolean,
+    val soundType: SoundType,
+    val vibrationEnabled: Boolean,
+) {
+    fun applyTo(config: TimerConfig): TimerConfig =
+        config.copy(
+            minSeconds = minSeconds,
+            maxSeconds = maxSeconds,
+            alarmDuration = alarmDuration,
+            hiddenMode = false,
+            repeatEnabled = repeatEnabled,
+            soundType = soundType,
+            vibrationEnabled = vibrationEnabled,
+            useExtendedRange = false,
+        )
+
+    companion object {
+        val CompetitionWarmup =
+            TrainingPreset(
+                id = "competition_warmup",
+                title = "Competition Warmup",
+                subtitle = "Reactive mat-ready cues for the 30 minutes before first call.",
+                minSeconds = 20,
+                maxSeconds = 90,
+                alarmDuration = 5,
+                repeatEnabled = true,
+                soundType = SoundType.INTENSE,
+                vibrationEnabled = true,
+            )
+
+        val ALL = listOf(CompetitionWarmup)
+    }
+}
+
 /**
  * Represents the current state of an active timer.
  */

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -153,6 +153,13 @@ fun RandomTimerNavHost(
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)
                 },
+                onTrainingPresetApplied = { preset ->
+                    viewModel.trackTrainingPresetApplied(
+                        presetId = preset.id,
+                        minSeconds = preset.minSeconds,
+                        maxSeconds = preset.maxSeconds,
+                    )
+                },
                 onSecretUnlock = {
                     viewModel.proManager.forcePro()
                 },

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -85,6 +85,7 @@ import com.iganapolsky.randomtimer.domain.model.RangeToggleProfiles
 import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimeRangeAdjuster
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.TrainingPreset
 import com.iganapolsky.randomtimer.domain.model.VoiceGender
 import com.iganapolsky.randomtimer.domain.model.activationPresetForFirstCompletionIfEligible
 import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
@@ -149,6 +150,7 @@ fun TimerSetupScreen(
     isElite: Boolean = false,
     onUpgradeTap: (String) -> Unit = {},
     onVoiceGenderSelected: (VoiceGender) -> Unit = {},
+    onTrainingPresetApplied: (TrainingPreset) -> Unit = {},
     onSecretUnlock: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -308,6 +310,70 @@ fun TimerSetupScreen(
                                     style = MaterialTheme.typography.labelSmall,
                                     color = TimerColors.AccentPrimary,
                                 )
+                            }
+                        }
+                    }
+                }
+
+                item {
+                    GlassCard(modifier = Modifier.fillMaxWidth(), padding = spacing.cardContent) {
+                        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            Text(
+                                text = "Competition Prep",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = TimerColors.TextPrimary,
+                            )
+
+                            TrainingPreset.ALL.forEach { preset ->
+                                Surface(
+                                    onClick = {
+                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        updateConfig(
+                                            minSeconds = preset.minSeconds,
+                                            maxSeconds = preset.maxSeconds,
+                                            alarmDuration = preset.alarmDuration,
+                                            repeatEnabled = preset.repeatEnabled,
+                                            soundType = preset.soundType,
+                                            vibrationEnabled = preset.vibrationEnabled,
+                                            useExtendedRange = false,
+                                        )
+                                        onTrainingPresetApplied(preset)
+                                    },
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = TimerColors.GlassBackground,
+                                    border = BorderStroke(1.dp, TimerColors.GlassBorder),
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.weight(1f),
+                                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                                        ) {
+                                            Text(
+                                                text = preset.title,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                fontWeight = FontWeight.SemiBold,
+                                                color = TimerColors.TextPrimary,
+                                            )
+                                            Text(
+                                                text = preset.subtitle,
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = TimerColors.TextMuted,
+                                            )
+                                        }
+                                        Text(
+                                            text = "${formatTime(preset.minSeconds)}-${formatTime(preset.maxSeconds)}",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            fontWeight = FontWeight.Bold,
+                                            color = TimerColors.AccentPrimary,
+                                        )
+                                    }
+                                }
                             }
                         }
                     }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -295,6 +295,21 @@ class TimerViewModel
             )
         }
 
+        fun trackTrainingPresetApplied(
+            presetId: String,
+            minSeconds: Int,
+            maxSeconds: Int,
+        ) {
+            analyticsService.track(
+                AnalyticsEvents.TRAINING_PRESET_APPLIED,
+                mapOf(
+                    AnalyticsProperties.PRESET_ID to presetId,
+                    "min_duration" to minSeconds,
+                    "max_duration" to maxSeconds,
+                ),
+            )
+        }
+
         fun trackFeatureGateHit(feature: String) {
             analyticsService.track(
                 AnalyticsEvents.FEATURE_GATE_HIT,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
@@ -325,4 +325,17 @@ class TimerConfigTest {
         assertThat(result.profiles.freeMinSeconds).isEqualTo(45)
         assertThat(result.profiles.freeMaxSeconds).isEqualTo(180)
     }
+
+    @Test
+    fun `competition warmup preset applies event day settings`() {
+        val config = TrainingPreset.CompetitionWarmup.applyTo(TimerConfig.DEFAULT)
+
+        assertThat(config.minSeconds).isEqualTo(20)
+        assertThat(config.maxSeconds).isEqualTo(90)
+        assertThat(config.alarmDuration).isEqualTo(5)
+        assertThat(config.repeatEnabled).isTrue()
+        assertThat(config.vibrationEnabled).isTrue()
+        assertThat(config.soundType).isEqualTo(SoundType.INTENSE)
+        assertThat(config.useExtendedRange).isFalse()
+    }
 }

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1774900017.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1774900017.txt
@@ -1,3 +1,4 @@
+• New Competition Warmup preset for BJJ, judo, wrestling, and event-day prep
 • Quick-start defaults: one tap to start your first timer
 • First-run guide explains randomized training in 3 steps
 • "Why random?" explainer builds confidence before purchase

--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -20,6 +20,7 @@ WHY IT WORKS:
 
 KEY FEATURES:
 - True random trigger within your selected min/max range
+- Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
 - Hidden countdown mode — no timer watching allowed
 - Loop mode for continuous random chaos rounds
 - High-intensity alarm + haptic vibration + volume precision

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -447,6 +447,7 @@ enum AnalyticsEvents {
     static let voiceGenderSelected = "voice_gender_selected"
     static let featureGateHit = "feature_gate_hit"
     static let paywallGateFirstTimer = "paywall_gate_first_timer"
+    static let trainingPresetApplied = "training_preset_applied"
 
     // Attribution
     static let deepLinkOpened = "deep_link_opened"
@@ -481,6 +482,7 @@ enum AnalyticsProperties {
     static let trialVerified = "trial_verified"
     static let gender = "gender"
     static let feature = "feature"
+    static let presetId = "preset_id"
     static let alarmResponseTime = "alarm_response_time"
     static let environment = "environment"
     static let buildAudience = "build_audience"

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -34,6 +34,52 @@ struct TimerSetupScreen: View {
                     .padding(.top, 16)
                     .padding(.leading, 4)
 
+                // Event-weekend preset for combat-sports competitors.
+                GlassCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Competition Prep", systemImage: "figure.martial.arts")
+                            .font(.headline)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.textPrimary)
+
+                        ForEach(TrainingPreset.all) { preset in
+                            Button {
+                                applyTrainingPreset(preset)
+                            } label: {
+                                HStack(alignment: .center, spacing: 12) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(preset.title)
+                                            .font(.subheadline.weight(.semibold))
+                                            .foregroundColor(.textPrimary)
+
+                                        Text(preset.subtitle)
+                                            .font(.caption2)
+                                            .foregroundColor(.textMuted)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+
+                                    Spacer()
+
+                                    let minLabel = TimeInterval(preset.minSeconds).formattedDuration
+                                    let maxLabel = TimeInterval(preset.maxSeconds).formattedDuration
+                                    Text("\(minLabel)-\(maxLabel)")
+                                        .font(.caption.weight(.bold))
+                                        .foregroundColor(.accentPrimary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 10)
+                                .background(Color.glassBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.glassBorder, lineWidth: 1)
+                                )
+                                .cornerRadius(8)
+                            }
+                            .accessibilityLabel("Apply \(preset.title) preset")
+                        }
+                    }
+                }
+
                 // 1. Timer Range Card
                 GlassCard {
                     VStack(alignment: .leading) {
@@ -595,6 +641,24 @@ struct TimerSetupScreen: View {
         )
         paywallEntryPoint = entryPoint
         showPaywall = true
+    }
+
+    private func applyTrainingPreset(_ preset: TrainingPreset) {
+        let presetConfig = preset.applying(to: config)
+        persistActiveRangeProfile(
+            minSeconds: presetConfig.minSeconds,
+            maxSeconds: presetConfig.maxSeconds,
+            useExtendedRange: presetConfig.useExtendedRange
+        )
+        timerManager.updateConfig(presetConfig.clamped(isPro: proManager.isPro))
+        AnalyticsService.shared.track(
+            AnalyticsEvents.trainingPresetApplied,
+            properties: [
+                AnalyticsProperties.presetId: preset.id,
+                "min_duration": preset.minSeconds,
+                "max_duration": preset.maxSeconds,
+            ]
+        )
     }
 
     private var currentRangeProfiles: RangeToggleProfiles {

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -65,6 +65,19 @@ final class TimerConfigTests: XCTestCase {
         XCTAssertTrue(config.vibrationEnabled)
     }
 
+    func testCompetitionWarmupPresetAppliesEventDaySettings() {
+        let base = TimerConfig.default
+        let config = TrainingPreset.competitionWarmup.applying(to: base)
+
+        XCTAssertEqual(config.minSeconds, 20)
+        XCTAssertEqual(config.maxSeconds, 90)
+        XCTAssertEqual(config.alarmDuration, 5)
+        XCTAssertTrue(config.repeatEnabled)
+        XCTAssertTrue(config.vibrationEnabled)
+        XCTAssertEqual(config.soundType, .intense)
+        XCTAssertFalse(config.useExtendedRange)
+    }
+
     func testConfigDecodingFromLooseJSON() throws {
         // Test that our custom decoder handles various formats (strings, numbers, etc)
         let payload = Data("""

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -382,6 +382,53 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     }
 }
 
+// MARK: - Training Presets
+
+public struct TrainingPreset: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let subtitle: String
+    public let minSeconds: Int
+    public let maxSeconds: Int
+    public let alarmDuration: Int
+    public let repeatEnabled: Bool
+    public let soundType: SoundType
+    public let vibrationEnabled: Bool
+
+    public func applying(to config: TimerConfig) -> TimerConfig {
+        TimerConfig(
+            minSeconds: minSeconds,
+            maxSeconds: maxSeconds,
+            alarmDuration: alarmDuration,
+            hiddenMode: false,
+            repeatEnabled: repeatEnabled,
+            soundType: soundType,
+            volume: config.volume,
+            vibrationEnabled: vibrationEnabled,
+            useExtendedRange: false,
+            voiceEnabled: config.voiceEnabled,
+            voiceGender: config.voiceGender,
+            repeatRounds: config.repeatRounds
+        )
+    }
+
+    public static let competitionWarmup = TrainingPreset(
+        id: "competition_warmup",
+        title: "Competition Warmup",
+        subtitle: "Reactive mat-ready cues for the 30 minutes before first call.",
+        minSeconds: 20,
+        maxSeconds: 90,
+        alarmDuration: 5,
+        repeatEnabled: true,
+        soundType: .intense,
+        vibrationEnabled: true
+    )
+
+    public static let all: [TrainingPreset] = [
+        .competitionWarmup,
+    ]
+}
+
 // MARK: - Range Adjustment
 
 /// Shared business rules for the "Goes Off In This Range" sliders.

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -10,6 +10,7 @@ Built for combat sports, HIIT, CrossFit, and reaction training.
 
 FEATURES
 - Random trigger timing inside your selected range
+- Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
 - Hidden countdown mode to stop timer watching
 - Male or female AI coach voice callouts (Pro)
 - Loop mode with optional round limits

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,3 +1,4 @@
+• New Competition Warmup preset for BJJ, judo, wrestling, and event-day prep
 • Monthly Pro subscription support
 • Clearer Pro paywall focused on training outcomes
 • Paywall timing moved after the first completed timer session


### PR DESCRIPTION
## Summary\n- Adds a Competition Warmup preset for combat-sports event-day prep on iOS and Android.\n- Tracks preset usage with training_preset_applied / preset_id=competition_warmup on both platforms.\n- Updates App Store / Play metadata and records the Smoothcomp-derived zero-spend experiment.\n\n## Verification\n- cd native-android && ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.domain.model.TimerConfigTest'\n- cd native-ios && xcodebuild test -scheme RandomTimer -only-testing:RandomTimerTests/TimerConfigTests -destination 'platform=iOS Simulator,name=iPhone 16 Pro'\n\nBudget impact: /bin/zsh.00 external spend.