### PR TITLE
feat: add competition warmup preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Autonomous PR/branch hygiene and **never committing PATs** are defined in `CLAUD
 
 **CTO session start (PR hygiene):** follow `CLAUDE.md` → *PR Management & System Hygiene* → *CTO session start protocol* (`gh auth status`, `git fetch --prune`, open PR audit, orphan branch map, merge only on green required checks, post-merge CI on `develop`/`main`). Say **"Done merging PRs"** only with merge SHAs and verified CI — never after a PAT appears in chat (rotate the token first; do not record it in docs).
 
+**Completion phrase:** use **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."** only after all open PRs are reviewed/merged or blocked with evidence, orphan branches/worktrees are addressed with before/after counts, stale files/logs are cleaned with counts, `develop` and `main` CI are verified by link, an operational dry run completes, and RAG/lesson logging status is read back. Never include secrets or PAT values in these docs or status reports.
+
 **Stack Overflow:** Draft answers as Markdown under `marketing/referral_content/stackoverflow_answers/` (see `docs/STACK_OVERFLOW_PLAYBOOK.md`); include `develop` permalinks to this repo where we actually use the pattern, plus disclosure when linking our code.
 
 ## Agent-Model Matching Standard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,4 @@ PRDs live in `.claude/prds/`, epics in `.claude/epics/`. Navigate with `ls`, `ca
 - Say **"Done merging PRs"** only after: open PRs audited (`gh pr list`, `gh pr checks`), merges evidenced with **merge commit SHA** + required checks green (or documented waiver), orphan branches triaged, and **CI verified** on the post-merge `develop` / `main` tip.
 - Prefer **`gh` CLI** and Actions secrets over raw PATs in chat or tracked files. **Rotate** any token that appears in a prompt or log.
 - **RAG / external memory**: read or write only when that gateway is verified in the active session; otherwise state “not verified” instead of claiming persistence.
+- Final confirmation must use **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."** only after merge SHAs, branch count before/after, stale cleanup counts, CI links, dry-run evidence, and RAG/lesson logging status have all been read back.

--- a/docs/GEMINI.md
+++ b/docs/GEMINI.md
@@ -94,3 +94,4 @@ cd native-ios && xcodebuild -scheme RandomTimer test
 
 ### CTO session start protocol (PR hygiene)
 - Same numbered protocol as `CLAUDE.md` → *PR Management & System Hygiene* → *CTO session start protocol*: auth without pasting PATs, prune + open PR list + checks, orphan branch triage, merge only when required checks are green, verify `develop`/`main` CI, RAG only if verified in-session.
+- Use **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."** only after merge SHAs, branch count before/after, stale cleanup counts, CI links, dry-run evidence, and RAG/lesson logging status have all been verified and reported without secrets.

--- a/marketing/data/competition_warmup_experiment.md
+++ b/marketing/data/competition_warmup_experiment.md
@@ -1,0 +1,48 @@
+# Competition Warmup Experiment
+
+Date: 2026-05-12
+
+## Signal
+
+Local evidence source:
+
+```bash
+pdftotext -layout smoothcomp.pdf -
+```
+
+The Smoothcomp event-weekend email tells athletes to plan the day, control weight, warm up twice, and use small reactive movements to stay sharp before match time. This is a high-intent context for Random Tactical Timer because the athlete already needs unpredictable cues but Smoothcomp owns only event logistics.
+
+## Action
+
+Add a zero-spend Competition Warmup preset:
+
+- Range: 20-90 seconds
+- Alarm: 5 seconds
+- Repeat loop: on
+- Vibration: on
+- Sound: intense free-tier alarm
+
+Store metadata now names the preset for BJJ, judo, wrestling, and event-day prep.
+
+## Measurement
+
+Primary success signal remains Weekly Qualified Training Users:
+
+```sql
+SELECT count(*)
+FROM (
+  SELECT person_id
+  FROM events
+  WHERE event = 'timer_completed'
+    AND timestamp > now() - interval 7 day
+  GROUP BY person_id
+  HAVING count() >= 3
+)
+```
+
+Supporting signal:
+
+- `training_preset_applied` with `preset_id = 'competition_warmup'` on iOS and Android.
+- Settings-change events showing 20-90 second ranges as a fallback sanity check.
+
+Budget impact: `$0.00`.

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -436,6 +436,8 @@ object AnalyticsEvents {
     // Feature engagement
     const val VOICE_GENDER_SELECTED = "voice_gender_selected"
     const val FEATURE_GATE_HIT = "feature_gate_hit"
+    const val PAYWALL_GATE_FIRST_TIMER = "paywall_gate_first_timer"
+    const val TRAINING_PRESET_APPLIED = "training_preset_applied"
 
     // Attribution
     const val DEEP_LINK_OPENED = "deep_link_opened"
@@ -470,6 +472,7 @@ object AnalyticsProperties {
     const val RUNTIME_TARGET = "runtime_target"
     const val GENDER = "gender"
     const val FEATURE = "feature"
+    const val PRESET_ID = "preset_id"
     const val ALARM_RESPONSE_TIME = "alarm_response_time"
     const val ABANDON_REASON = "abandon_reason"
     const val SCREEN = "screen"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -213,6 +213,47 @@ fun activationLegacyRangePresetIfEligible(current: TimerConfig): TimerConfig? {
     )
 }
 
+data class TrainingPreset(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val minSeconds: Int,
+    val maxSeconds: Int,
+    val alarmDuration: Int,
+    val repeatEnabled: Boolean,
+    val soundType: SoundType,
+    val vibrationEnabled: Boolean,
+) {
+    fun applyTo(config: TimerConfig): TimerConfig =
+        config.copy(
+            minSeconds = minSeconds,
+            maxSeconds = maxSeconds,
+            alarmDuration = alarmDuration,
+            hiddenMode = false,
+            repeatEnabled = repeatEnabled,
+            soundType = soundType,
+            vibrationEnabled = vibrationEnabled,
+            useExtendedRange = false,
+        )
+
+    companion object {
+        val CompetitionWarmup =
+            TrainingPreset(
+                id = "competition_warmup",
+                title = "Competition Warmup",
+                subtitle = "Reactive mat-ready cues for the 30 minutes before first call.",
+                minSeconds = 20,
+                maxSeconds = 90,
+                alarmDuration = 5,
+                repeatEnabled = true,
+                soundType = SoundType.INTENSE,
+                vibrationEnabled = true,
+            )
+
+        val ALL = listOf(CompetitionWarmup)
+    }
+}
+
 /**
  * Represents the current state of an active timer.
  */

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -285,10 +285,12 @@ internal fun runtimeVoiceCueForElapsedSecond(
     elapsedSeconds: Int,
     lastElapsedMilestone: Int,
     catalog: VoiceCueCatalog,
-): VoiceCue? {
-    if (elapsedSeconds == lastElapsedMilestone) return null
-    return catalog.elapsedCueBySecond[elapsedSeconds]?.let { VoiceCue(filename = it.filename, text = it.text) }
-}
+): VoiceCue? =
+    catalog.elapsedCues
+        .asSequence()
+        .filter { it.second > lastElapsedMilestone && it.second <= elapsedSeconds }
+        .maxByOrNull { it.second }
+        ?.let { VoiceCue(filename = it.filename, text = it.text) }
 
 /**
  * Returns a bundled "time elapsed" announcement only on full-minute marks (60, 120, …).
@@ -302,14 +304,16 @@ internal fun runtimeVoiceCueForElapsedMark(
     if (elapsedSeconds <= 0) {
         return null
     }
-    if (elapsedSeconds % 60 != 0) {
-        return null
-    }
     return runtimeVoiceCueForElapsedSecond(
         elapsedSeconds = elapsedSeconds,
         lastElapsedMilestone = lastElapsedMilestone,
         catalog = catalog,
-    )
+    )?.takeIf { cue ->
+        catalog.elapsedCues
+            .firstOrNull { it.filename == cue.filename }
+            ?.second
+            ?.rem(60) == 0
+    }
 }
 
 internal fun nextCommandCue(

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt
@@ -332,6 +332,36 @@ internal fun nextCommandCue(
     return cues[(boundedIndex + 1) % cues.size]
 }
 
+internal fun normalizedVoiceCueText(text: String): String =
+    text
+        .trim()
+        .lowercase(Locale.US)
+        .replace(Regex("\\s+"), " ")
+
+internal fun commandCuePool(
+    baseline: List<VoiceCue>,
+    usedFilenames: Set<String>,
+    usedTexts: Set<String>,
+    lastFilename: String?,
+    lastText: String?,
+): List<VoiceCue> {
+    val fresh =
+        baseline.filter {
+            it.filename !in usedFilenames &&
+                normalizedVoiceCueText(it.text) !in usedTexts
+        }
+    if (fresh.isNotEmpty()) {
+        return fresh
+    }
+
+    val lastNormalizedText = lastText?.let(::normalizedVoiceCueText)
+    return baseline
+        .filter {
+            it.filename != lastFilename &&
+                normalizedVoiceCueText(it.text) != lastNormalizedText
+        }.ifEmpty { baseline }
+}
+
 internal fun nextPreviewCueFilename(
     filenames: List<String>,
     lastFilename: String?,
@@ -383,7 +413,9 @@ class AIVoiceCalloutManager
         private var mediaPlayer: MediaPlayer? = null
         private var currentVolume: Float = 1.0f
         private var lastCommandCueFilename: String? = null
+        private var lastCommandCueText: String? = null
         private val usedCommandCueFilenames = mutableSetOf<String>()
+        private val usedCommandCueTexts = mutableSetOf<String>()
         private val lastPreviewCommandFilenameByGender = mutableMapOf<VoiceGender, String?>()
         private val usedPreviewCommandFilenamesByGender =
             mutableMapOf(
@@ -438,7 +470,9 @@ class AIVoiceCalloutManager
             stopPlayback()
             lastElapsedMilestone = 0
             lastCommandCueFilename = null
+            lastCommandCueText = null
             usedCommandCueFilenames.clear()
+            usedCommandCueTexts.clear()
             lastPreviewCommandFilenameByGender.clear()
             usedPreviewCommandFilenamesByGender.values.forEach { it.clear() }
             nextCommandCueAt = 0
@@ -617,6 +651,7 @@ class AIVoiceCalloutManager
                 val cue = randomCommandCue()
                 speak(cue.text)
                 lastCommandCueFilename = cue.filename
+                lastCommandCueText = cue.text
                 nextCommandCueAt = elapsedSeconds + 30
                 lastCueFiredAtElapsed = elapsedSeconds
             }
@@ -640,20 +675,34 @@ class AIVoiceCalloutManager
             // different cues were picked.
             val playable = catalog.commandCues.filter { cueHasAudio(it.filename) }
             val baseline = if (playable.isNotEmpty()) playable else catalog.commandCues
-            val available = baseline.filter { it.filename !in usedCommandCueFilenames }
-            val pool =
-                available.ifEmpty {
-                    usedCommandCueFilenames.clear()
-                    baseline
-                        .filter { it.filename != lastCommandCueFilename }
-                        .ifEmpty { baseline }
-                }
+            var pool =
+                commandCuePool(
+                    baseline = baseline,
+                    usedFilenames = usedCommandCueFilenames,
+                    usedTexts = usedCommandCueTexts,
+                    lastFilename = lastCommandCueFilename,
+                    lastText = lastCommandCueText,
+                )
+            if (pool.size == baseline.size && usedCommandCueFilenames.isNotEmpty()) {
+                usedCommandCueFilenames.clear()
+                usedCommandCueTexts.clear()
+                pool =
+                    commandCuePool(
+                        baseline = baseline,
+                        usedFilenames = usedCommandCueFilenames,
+                        usedTexts = usedCommandCueTexts,
+                        lastFilename = lastCommandCueFilename,
+                        lastText = lastCommandCueText,
+                    )
+            }
             val cue =
                 nextCommandCue(pool, lastCommandCueFilename) { upperBound ->
                     Random.nextInt(upperBound)
                 }
             lastCommandCueFilename = cue.filename
+            lastCommandCueText = cue.text
             usedCommandCueFilenames.add(cue.filename)
+            usedCommandCueTexts.add(normalizedVoiceCueText(cue.text))
             return cue
         }
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -163,6 +163,13 @@ fun RandomTimerNavHost(
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)
                 },
+                onTrainingPresetApplied = { preset ->
+                    viewModel.trackTrainingPresetApplied(
+                        presetId = preset.id,
+                        minSeconds = preset.minSeconds,
+                        maxSeconds = preset.maxSeconds,
+                    )
+                },
                 onSecretUnlock = {
                     viewModel.proManager.forcePro()
                 },

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -91,6 +91,7 @@ import com.iganapolsky.randomtimer.domain.model.RangeToggleProfiles
 import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimeRangeAdjuster
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
+import com.iganapolsky.randomtimer.domain.model.TrainingPreset
 import com.iganapolsky.randomtimer.domain.model.VoiceGender
 import com.iganapolsky.randomtimer.domain.model.activationLegacyRangePresetIfEligible
 import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
@@ -173,6 +174,7 @@ fun TimerSetupScreen(
     isElite: Boolean = false,
     onUpgradeTap: (String) -> Unit = {},
     onVoiceGenderSelected: (VoiceGender) -> Unit = {},
+    onTrainingPresetApplied: (TrainingPreset) -> Unit = {},
     onSecretUnlock: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -359,6 +361,70 @@ fun TimerSetupScreen(
                                 style = MaterialTheme.typography.labelSmall,
                                 color = TimerColors.AccentPrimary,
                             )
+                        }
+                    }
+                }
+
+                item {
+                    GlassCard(modifier = Modifier.fillMaxWidth(), padding = spacing.cardContent) {
+                        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            Text(
+                                text = "Competition Prep",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = TimerColors.TextPrimary,
+                            )
+
+                            TrainingPreset.ALL.forEach { preset ->
+                                Surface(
+                                    onClick = {
+                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        updateConfig(
+                                            minSeconds = preset.minSeconds,
+                                            maxSeconds = preset.maxSeconds,
+                                            alarmDuration = preset.alarmDuration,
+                                            repeatEnabled = preset.repeatEnabled,
+                                            soundType = preset.soundType,
+                                            vibrationEnabled = preset.vibrationEnabled,
+                                            useExtendedRange = false,
+                                        )
+                                        onTrainingPresetApplied(preset)
+                                    },
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = TimerColors.GlassBackground,
+                                    border = BorderStroke(1.dp, TimerColors.GlassBorder),
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.weight(1f),
+                                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                                        ) {
+                                            Text(
+                                                text = preset.title,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                fontWeight = FontWeight.SemiBold,
+                                                color = TimerColors.TextPrimary,
+                                            )
+                                            Text(
+                                                text = preset.subtitle,
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = TimerColors.TextMuted,
+                                            )
+                                        }
+                                        Text(
+                                            text = "${formatTime(preset.minSeconds)}-${formatTime(preset.maxSeconds)}",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            fontWeight = FontWeight.Bold,
+                                            color = TimerColors.AccentPrimary,
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -345,6 +345,21 @@ class TimerViewModel
             )
         }
 
+        fun trackTrainingPresetApplied(
+            presetId: String,
+            minSeconds: Int,
+            maxSeconds: Int,
+        ) {
+            analyticsService.track(
+                AnalyticsEvents.TRAINING_PRESET_APPLIED,
+                mapOf(
+                    AnalyticsProperties.PRESET_ID to presetId,
+                    "min_duration" to minSeconds,
+                    "max_duration" to maxSeconds,
+                ),
+            )
+        }
+
         fun trackFeatureGateHit(feature: String) {
             analyticsService.track(
                 AnalyticsEvents.FEATURE_GATE_HIT,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
@@ -288,4 +288,17 @@ class TimerConfigTest {
         assertThat(result.profiles.freeMinSeconds).isEqualTo(45)
         assertThat(result.profiles.freeMaxSeconds).isEqualTo(180)
     }
+
+    @Test
+    fun `competition warmup preset applies event day settings`() {
+        val config = TrainingPreset.CompetitionWarmup.applyTo(TimerConfig.DEFAULT)
+
+        assertThat(config.minSeconds).isEqualTo(20)
+        assertThat(config.maxSeconds).isEqualTo(90)
+        assertThat(config.alarmDuration).isEqualTo(5)
+        assertThat(config.repeatEnabled).isTrue()
+        assertThat(config.vibrationEnabled).isTrue()
+        assertThat(config.soundType).isEqualTo(SoundType.INTENSE)
+        assertThat(config.useExtendedRange).isFalse()
+    }
 }

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1774900017.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1774900017.txt
@@ -1,3 +1,4 @@
+• New Competition Warmup preset for BJJ, judo, wrestling, and event-day prep
 • Quick-start defaults: one tap to start your first timer
 • First-run guide explains randomized training in 3 steps
 • "Why random?" explainer builds confidence before purchase

--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -20,6 +20,7 @@ WHY IT WORKS:
 
 KEY FEATURES:
 - True random trigger within your selected min/max range
+- Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
 - Hidden countdown mode — no timer watching allowed
 - Loop mode for continuous random chaos rounds
 - High-intensity alarm + haptic vibration + volume precision

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -546,6 +546,9 @@ enum AnalyticsEvents {
     // Feature gates & voice
     static let voiceGenderSelected = "voice_gender_selected"
     static let featureGateHit = "feature_gate_hit"
+    static let paywallGateFirstTimer = "paywall_gate_first_timer"
+    static let trainingPresetApplied = "training_preset_applied"
+
     // Attribution
     static let deepLinkOpened = "deep_link_opened"
     static let appleAdsAttribution = "apple_ads_attribution"
@@ -583,6 +586,7 @@ enum AnalyticsProperties {
     static let trialVerified = "trial_verified"
     static let gender = "gender"
     static let feature = "feature"
+    static let presetId = "preset_id"
     static let alarmResponseTime = "alarm_response_time"
     static let environment = "environment"
     static let buildAudience = "build_audience"

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -42,6 +42,52 @@ struct TimerSetupScreen: View {
                     .padding(.top, 16)
                     .padding(.leading, 4)
 
+                // Event-weekend preset for combat-sports competitors.
+                GlassCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Competition Prep", systemImage: "figure.martial.arts")
+                            .font(.headline)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.textPrimary)
+
+                        ForEach(TrainingPreset.all) { preset in
+                            Button {
+                                applyTrainingPreset(preset)
+                            } label: {
+                                HStack(alignment: .center, spacing: 12) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(preset.title)
+                                            .font(.subheadline.weight(.semibold))
+                                            .foregroundColor(.textPrimary)
+
+                                        Text(preset.subtitle)
+                                            .font(.caption2)
+                                            .foregroundColor(.textMuted)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+
+                                    Spacer()
+
+                                    let minLabel = TimeInterval(preset.minSeconds).formattedDuration
+                                    let maxLabel = TimeInterval(preset.maxSeconds).formattedDuration
+                                    Text("\(minLabel)-\(maxLabel)")
+                                        .font(.caption.weight(.bold))
+                                        .foregroundColor(.accentPrimary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 10)
+                                .background(Color.glassBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.glassBorder, lineWidth: 1)
+                                )
+                                .cornerRadius(8)
+                            }
+                            .accessibilityLabel("Apply \(preset.title) preset")
+                        }
+                    }
+                }
+
                 // 1. Timer Range Card
                 GlassCard {
                     VStack(alignment: .leading) {
@@ -586,6 +632,24 @@ struct TimerSetupScreen: View {
             paywallValueFramingVariant = AnalyticsService.shared.paywallValueFramingVariant()
             showPaywall = true
         }
+    }
+
+    private func applyTrainingPreset(_ preset: TrainingPreset) {
+        let presetConfig = preset.applying(to: config)
+        persistActiveRangeProfile(
+            minSeconds: presetConfig.minSeconds,
+            maxSeconds: presetConfig.maxSeconds,
+            useExtendedRange: presetConfig.useExtendedRange
+        )
+        timerManager.updateConfig(presetConfig.clamped(isPro: proManager.isPro))
+        AnalyticsService.shared.track(
+            AnalyticsEvents.trainingPresetApplied,
+            properties: [
+                AnalyticsProperties.presetId: preset.id,
+                "min_duration": preset.minSeconds,
+                "max_duration": preset.maxSeconds,
+            ]
+        )
     }
 
     private var currentRangeProfiles: RangeToggleProfiles {

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -64,6 +64,19 @@ final class TimerConfigTests: XCTestCase {
         XCTAssertTrue(config.vibrationEnabled)
     }
 
+    func testCompetitionWarmupPresetAppliesEventDaySettings() {
+        let base = TimerConfig.default
+        let config = TrainingPreset.competitionWarmup.applying(to: base)
+
+        XCTAssertEqual(config.minSeconds, 20)
+        XCTAssertEqual(config.maxSeconds, 90)
+        XCTAssertEqual(config.alarmDuration, 5)
+        XCTAssertTrue(config.repeatEnabled)
+        XCTAssertTrue(config.vibrationEnabled)
+        XCTAssertEqual(config.soundType, .intense)
+        XCTAssertFalse(config.useExtendedRange)
+    }
+
     func testConfigDecodingFromLooseJSON() throws {
         // Test that our custom decoder handles various formats (strings, numbers, etc)
         let payload = Data("""

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -381,6 +381,53 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     }
 }
 
+// MARK: - Training Presets
+
+public struct TrainingPreset: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let subtitle: String
+    public let minSeconds: Int
+    public let maxSeconds: Int
+    public let alarmDuration: Int
+    public let repeatEnabled: Bool
+    public let soundType: SoundType
+    public let vibrationEnabled: Bool
+
+    public func applying(to config: TimerConfig) -> TimerConfig {
+        TimerConfig(
+            minSeconds: minSeconds,
+            maxSeconds: maxSeconds,
+            alarmDuration: alarmDuration,
+            hiddenMode: false,
+            repeatEnabled: repeatEnabled,
+            soundType: soundType,
+            volume: config.volume,
+            vibrationEnabled: vibrationEnabled,
+            useExtendedRange: false,
+            voiceEnabled: config.voiceEnabled,
+            voiceGender: config.voiceGender,
+            repeatRounds: config.repeatRounds
+        )
+    }
+
+    public static let competitionWarmup = TrainingPreset(
+        id: "competition_warmup",
+        title: "Competition Warmup",
+        subtitle: "Reactive mat-ready cues for the 30 minutes before first call.",
+        minSeconds: 20,
+        maxSeconds: 90,
+        alarmDuration: 5,
+        repeatEnabled: true,
+        soundType: .intense,
+        vibrationEnabled: true
+    )
+
+    public static let all: [TrainingPreset] = [
+        .competitionWarmup,
+    ]
+}
+
 // MARK: - Range Adjustment
 
 /// Shared business rules for the "Goes Off In This Range" sliders.

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -10,6 +10,7 @@ Built for combat sports, HIIT, CrossFit, and reaction training.
 
 FEATURES
 - Random trigger timing inside your selected range
+- Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
 - Hidden countdown mode to stop timer watching
 - Male or female AI coach voice callouts (Pro)
 - Loop mode with optional round limits (Pro)

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,2 @@
+• New Competition Warmup preset for BJJ, judo, wrestling, and event-day prep
 Monthly Pro content update — May 2026

--- a/scripts/tests/test_audio_asset_regressions.py
+++ b/scripts/tests/test_audio_asset_regressions.py
@@ -9,11 +9,15 @@ ROOT = Path(__file__).resolve().parents[2]
 ANDROID_RAW_DIR = ROOT / "native-android/app/src/main/res/raw"
 IOS_SOUND_DIR = ROOT / "native-ios/RandomTimer/Resources/Sounds"
 RUNTIME_LATEST = ROOT / "content/pro_audio/runtime/latest.json"
-RUNTIME_SOUND_DIR = ROOT / "content/pro_audio/runtime/packs/2026-03_marine_foundations/sounds"
 IOS_SETUP = ROOT / "native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift"
 ANDROID_SETUP = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt"
 IOS_VOICE_SERVICE = ROOT / "native-ios/RandomTimer/Sources/Services/AIVoiceCalloutService.swift"
 ANDROID_VOICE_MANAGER = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/service/AIVoiceCalloutManager.kt"
+
+
+def _runtime_sound_dir() -> Path:
+    latest = json.loads(RUNTIME_LATEST.read_text(encoding="utf-8"))
+    return ROOT / "content/pro_audio/runtime/packs" / latest["packId"] / "sounds"
 
 
 def _read(path: Path) -> str:
@@ -36,20 +40,22 @@ SOUND_ARSENAL_FILES = {
 }
 
 def test_sound_arsenal_files_exist_across_ios_android_and_runtime_pack() -> None:
+    runtime_sound_dir = _runtime_sound_dir()
     for runtime_name, (ios_filename, android_filename) in SOUND_ARSENAL_FILES.items():
         ios_path = IOS_SOUND_DIR / ios_filename
         android_path = ANDROID_RAW_DIR / android_filename
-        runtime_path = RUNTIME_SOUND_DIR / f"{runtime_name}.mp3"
+        runtime_path = runtime_sound_dir / f"{runtime_name}.mp3"
         for path in (ios_path, android_path, runtime_path):
             assert path.exists(), f"Missing Sound Arsenal asset: {path}"
             assert path.stat().st_size > 5000, f"{path.name} too small ({path.stat().st_size}B)"
 
 
 def test_sound_arsenal_checksums_match_across_ios_android_and_runtime_pack() -> None:
+    runtime_sound_dir = _runtime_sound_dir()
     for runtime_name, (ios_filename, android_filename) in SOUND_ARSENAL_FILES.items():
         ios_path = IOS_SOUND_DIR / ios_filename
         android_path = ANDROID_RAW_DIR / android_filename
-        runtime_path = RUNTIME_SOUND_DIR / f"{runtime_name}.mp3"
+        runtime_path = runtime_sound_dir / f"{runtime_name}.mp3"
         ios_hash = _sha256(ios_path)
         android_hash = _sha256(android_path)
         runtime_hash = _sha256(runtime_path)

--- a/wiki/PR-Hygiene-Lessons.md
+++ b/wiki/PR-Hygiene-Lessons.md
@@ -1,0 +1,9 @@
+# PR Hygiene Lessons
+
+## 2026-05-12
+
+- If a feature PR targets `main` from a branch that is not based on `develop`, close it and rebuild a replacement branch from `origin/develop`; do not retarget a divergent branch and create a noisy PR.
+- Treat any PAT exposed in chat or logs as compromised. Do not reuse it, do not store it in repo docs, and use existing `gh` authentication plus per-command Git auth headers instead of token-bearing remotes.
+- CI failures can reveal base-branch regressions. Fix the root failing contract in the replacement branch, then rerun the same local and GitHub checks before merge.
+- Runtime audio regression tests should read the active pack from `content/pro_audio/runtime/latest.json` rather than hard-coding retired pack IDs.
+- External RAG and ML-pipeline logging were not verified in this session; only this repo `wiki/` file was updated.


### PR DESCRIPTION
## Summary
- Add Competition Warmup tactical training preset for event-day prep
- Add Android/iOS preset model, UI, analytics, and tests
- Restore Android voice cue text dedupe helpers so debug unit tests compile and enforce non-repeating cue text

## Local verification
- iOS: xcodebuild test -scheme RandomTimer -only-testing:RandomTimerTests/TimerConfigTests -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -> 18 tests, 0 failures
- Android: cd native-android && ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.domain.model.TimerConfigTest' -> BUILD SUCCESSFUL

## Replacement note
Replaces #1499, which was blocked because it targeted main from a branch not based on develop.