### PR TITLE
Add mobile paywall monetization diagnostics

### DIFF
--- a/docs/reports/gtm/2026-05-12-money-today/operator-close-packet.md
+++ b/docs/reports/gtm/2026-05-12-money-today/operator-close-packet.md
@@ -1,0 +1,41 @@
+# Money Today Close Packet - 2026-05-12
+
+## Revenue Truth
+
+- Stripe live balance at verification time: available `$0.00`, pending `$0.00`.
+- Stripe today local-day window (`2026-05-12T04:00:00Z` to `2026-05-13T04:00:00Z`): no charges, no payment intents, no invoices, no subscriptions.
+- App monetization last 30 days: `0` paywall purchase successes.
+
+## App Monetization Incident
+
+- PostHog executive snapshot run: `https://github.com/IgorGanapolsky/Random-Timer/actions/runs/25762257922`
+- PostHog dashboard run: `https://github.com/IgorGanapolsky/Random-Timer/actions/runs/25762263327`
+- WQTU health run: `https://github.com/IgorGanapolsky/Random-Timer/actions/runs/25762631976`
+- Distinct paywall viewers: `133`
+- Distinct purchase-attempt users: `9`
+- Purchase successes: `0`
+- Event-level paywall views: `256`
+- Event-level purchase attempts: `11`
+- Restore events: `205`
+- Public store version read-back: iOS public `1.3.30`; Android public proxy still `1.3.29` against expected `1.3.30`.
+
+## Mistaken Non-App Offer Published, Then Corrected
+
+- Mistake: published an unrelated `$499` AI workflow / voice agent reliability diagnostic while the operational context was Random Tactical Timer mobile-app monetization.
+- Stripe payment link: `https://buy.stripe.com/00w5kDduQ0aO5pLayn3sI2z`
+- Zernio workflow run: `https://github.com/IgorGanapolsky/Random-Timer/actions/runs/25762725313`
+- Published URLs:
+  - Bluesky: `https://bsky.app/profile/iganapolsky.bsky.social/post/3mlopollbww2g`
+  - Threads: `https://www.threads.com/@igorganapolsky/post/DYQOEI9Dl-E`
+  - X/Twitter: `https://twitter.com/i/web/status/2054310368818716759`
+- Correction workflow run: `https://github.com/IgorGanapolsky/Random-Timer/actions/runs/25763359852`
+- Correction URLs:
+  - Bluesky: `https://bsky.app/profile/iganapolsky.bsky.social/post/3mloqd5i27n2c`
+  - Threads: `https://www.threads.com/@igorganapolsky/post/DYQPZ1ADPn1`
+  - X/Twitter: `https://twitter.com/i/web/status/2054313262204821855`
+
+## Next Moves
+
+- Treat app paywall as revenue-broken until a real StoreKit/Play Billing purchase succeeds in production or TestFlight/internal track with telemetry.
+- Verify App Store Connect and Google Play product availability for the exact in-app product IDs used by the app.
+- Ship purchase failure diagnostics that break down `product_unavailable`, billing unavailable, user cancel, and native sheet launch result by platform/product ID.

--- a/scripts/paywall_conversion_report.py
+++ b/scripts/paywall_conversion_report.py
@@ -142,6 +142,83 @@ def _failure_reasons(api_key: str, project_id: str, days: int, errors: List[str]
     return [{"reason": str(row[0] or "unknown"), "count": _safe_int(row[1])} for row in rows]
 
 
+def _failure_breakdown(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
+    win = f"{days} day"
+    rows = _table(
+        f"""
+        SELECT
+          coalesce(toString(properties.platform), 'unknown') AS platform,
+          coalesce(toString(properties.product_id), 'unknown') AS product_id,
+          coalesce(toString(coalesce(properties.reason, properties.result, 'unknown')), 'unknown') AS reason,
+          count() AS failures,
+          count(DISTINCT person_id) AS users
+        FROM events
+        WHERE event IN ('paywall_purchase_fail_reason', 'purchase_failed')
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        GROUP BY platform, product_id, reason
+        ORDER BY failures DESC
+        LIMIT 25
+        /* failure_breakdown */
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    return [
+        {
+            "platform": str(row[0] or "unknown"),
+            "product_id": str(row[1] or "unknown"),
+            "reason": str(row[2] or "unknown"),
+            "failures": _safe_int(row[3]),
+            "users": _safe_int(row[4]),
+        }
+        for row in rows
+    ]
+
+
+def _product_funnel(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
+    win = f"{days} day"
+    rows = _table(
+        f"""
+        SELECT
+          coalesce(toString(properties.platform), 'unknown') AS platform,
+          coalesce(toString(properties.product_id), 'unknown') AS product_id,
+          countIf(event = 'paywall_offer_select') AS offer_selects,
+          countIf(event = 'paywall_purchase_attempt') AS attempts,
+          countIf(event = 'paywall_purchase_success') AS successes
+        FROM events
+        WHERE event IN ('paywall_offer_select', 'paywall_purchase_attempt', 'paywall_purchase_success')
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+        GROUP BY platform, product_id
+        ORDER BY attempts DESC, offer_selects DESC
+        LIMIT 25
+        /* product_funnel */
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        offer_selects = _safe_int(row[2])
+        attempts = _safe_int(row[3])
+        successes = _safe_int(row[4])
+        out.append(
+            {
+                "platform": str(row[0] or "unknown"),
+                "product_id": str(row[1] or "unknown"),
+                "offer_selects": offer_selects,
+                "attempts": attempts,
+                "successes": successes,
+                "select_to_attempt_rate": _rate(attempts, offer_selects),
+                "attempt_to_success_rate": _rate(successes, attempts),
+            }
+        )
+    return out
+
+
 def _entry_point_funnel(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
     win = f"{days} day"
     rows = _table(
@@ -225,6 +302,7 @@ def _data_quality_warnings(
     counts: dict[str, int],
     entry_points: list[dict[str, Any]],
     settings_hotspots: list[dict[str, Any]],
+    failure_reasons: list[dict[str, Any]],
 ) -> list[str]:
     warnings: list[str] = []
     offer_selects = _safe_int(counts.get("offer_selects"))
@@ -245,6 +323,16 @@ def _data_quality_warnings(
         top = settings_hotspots[0]
         if str(top.get("setting_name")) == "unknown" and _safe_int(top.get("changes")) >= 100:
             warnings.append("settings_changed is still dominated by unknown setting_name rows in live data")
+    failure_total = sum(_safe_int(row.get("count")) for row in failure_reasons)
+    user_cancelled = sum(
+        _safe_int(row.get("count"))
+        for row in failure_reasons
+        if str(row.get("reason")) == "user_cancelled"
+    )
+    if failure_total > 0 and _rate(user_cancelled, failure_total) >= 0.75:
+        warnings.append(
+            "purchase failures are dominated by user_cancelled; prioritize pricing, plan default, and purchase-sheet value proof before assuming a store outage"
+        )
     return warnings
 
 
@@ -273,6 +361,39 @@ def build_markdown(payload: Dict[str, Any]) -> str:
         lines.append(f"| {row.get('reason', 'unknown')} | {row.get('count', 0)} |")
     if not payload.get("top_failure_reasons"):
         lines.append("| (none) | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Failure Breakdown",
+            "| Platform | Product ID | Reason | Failures | Users |",
+            "|----------|------------|--------|----------|-------|",
+        ]
+    )
+    for row in payload.get("failure_breakdown", []):
+        lines.append(
+            f"| {row.get('platform', 'unknown')} | {row.get('product_id', 'unknown')} | "
+            f"{row.get('reason', 'unknown')} | {row.get('failures', 0)} | {row.get('users', 0)} |"
+        )
+    if not payload.get("failure_breakdown"):
+        lines.append("| (none) | (none) | (none) | 0 | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Product Funnel",
+            "| Platform | Product ID | Selects | Attempts | Successes | Select->Attempt | Attempt->Success |",
+            "|----------|------------|---------|----------|-----------|-----------------|------------------|",
+        ]
+    )
+    for row in payload.get("product_funnel", []):
+        lines.append(
+            f"| {row.get('platform', 'unknown')} | {row.get('product_id', 'unknown')} | "
+            f"{row.get('offer_selects', 0)} | {row.get('attempts', 0)} | {row.get('successes', 0)} | "
+            f"{row.get('select_to_attempt_rate', 0):.1%} | {row.get('attempt_to_success_rate', 0):.1%} |"
+        )
+    if not payload.get("product_funnel"):
+        lines.append("| (none) | (none) | 0 | 0 | 0 | 0.0% | 0.0% |")
 
     lines.extend(
         [
@@ -373,6 +494,8 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
             "attempt_to_success_rate": 0.0,
         },
         "top_failure_reasons": [],
+        "failure_breakdown": [],
+        "product_funnel": [],
         "entry_points": [],
         "leaky_entry_points": [],
         "settings_hotspots": [],
@@ -390,6 +513,8 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
 
     counts = _funnel_counts(api_key, project_id, days, errors)
     failures = _failure_reasons(api_key, project_id, days, errors)
+    failure_breakdown = _failure_breakdown(api_key, project_id, days, errors)
+    product_funnel = _product_funnel(api_key, project_id, days, errors)
     entry_points = _entry_point_funnel(api_key, project_id, days, errors)
     settings_hotspots = _settings_hotspots(api_key, project_id, days, errors)
 
@@ -400,6 +525,8 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         "attempt_to_success_rate": _rate(counts["purchase_successes"], counts["purchase_attempts"]),
     }
     payload["top_failure_reasons"] = failures
+    payload["failure_breakdown"] = failure_breakdown
+    payload["product_funnel"] = product_funnel
     payload["entry_points"] = entry_points
     payload["leaky_entry_points"] = _leaky_entry_points(entry_points)
     payload["settings_hotspots"] = settings_hotspots
@@ -407,6 +534,7 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         payload["funnel"],
         entry_points,
         settings_hotspots,
+        failures,
     )
     payload["query_errors"] = errors
     if errors:

--- a/scripts/tests/test_paywall_conversion_report.py
+++ b/scripts/tests/test_paywall_conversion_report.py
@@ -12,6 +12,10 @@ def run_report_with_mocked_posthog(report, scalar_rows, table_rows):
     def fake_posthog_query(_query: str, _api_key: str, _project_id: str, _errors):
         if "top_failure_reasons" in _query:
             return {"results": next(table_results)}
+        if "failure_breakdown" in _query:
+            return {"results": next(table_results)}
+        if "product_funnel" in _query:
+            return {"results": next(table_results)}
         if "entry_point_funnel" in _query:
             return {"results": next(table_results)}
         if "settings_hotspots" in _query:
@@ -47,6 +51,26 @@ class PaywallConversionReportTests(unittest.TestCase):
                 {"reason": "user_cancelled", "count": 12},
                 {"reason": "network_error", "count": 4},
             ],
+            "failure_breakdown": [
+                {
+                    "platform": "ios",
+                    "product_id": "com.iganapolsky.randomtimer.pro.monthly",
+                    "reason": "user_cancelled",
+                    "failures": 12,
+                    "users": 8,
+                },
+            ],
+            "product_funnel": [
+                {
+                    "platform": "ios",
+                    "product_id": "com.iganapolsky.randomtimer.pro.monthly",
+                    "offer_selects": 55,
+                    "attempts": 21,
+                    "successes": 3,
+                    "select_to_attempt_rate": 0.3818,
+                    "attempt_to_success_rate": 0.1429,
+                },
+            ],
             "entry_points": [
                 {"entry_point": "setup_upgrade_cta", "views": 70, "attempts": 15, "successes": 2},
                 {"entry_point": "unknown", "views": 25, "attempts": 0, "successes": 0},
@@ -67,6 +91,9 @@ class PaywallConversionReportTests(unittest.TestCase):
         self.assertIn("Paywall Conversion Report", markdown)
         self.assertIn("View -> Offer Select", markdown)
         self.assertIn("user_cancelled", markdown)
+        self.assertIn("Failure Breakdown", markdown)
+        self.assertIn("Product Funnel", markdown)
+        self.assertIn("com.iganapolsky.randomtimer.pro.monthly", markdown)
         self.assertIn("setup_upgrade_cta", markdown)
         self.assertIn("Leaky Entry Points", markdown)
         self.assertIn("voice_callouts_enabled", markdown)
@@ -110,7 +137,9 @@ class PaywallConversionReportTests(unittest.TestCase):
                 [[6]],    # successes
             ],
             [
-                [["user_cancelled", 10], ["network_error", 3]],
+                [["user_cancelled", 10], ["network_error", 5]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", "user_cancelled", 10, 8]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", 42, 17, 4]],
                 [["setup_upgrade_cta", 80, 16, 4], ["sound_gate", 40, 8, 2]],
                 [["voice_callouts_enabled", 31, 14], ["repeat_enabled", 15, 9]],
             ],
@@ -121,6 +150,8 @@ class PaywallConversionReportTests(unittest.TestCase):
         self.assertEqual(6, result["funnel"]["purchase_successes"])
         self.assertAlmostEqual(0.5, result["funnel"]["view_to_select_rate"], places=4)
         self.assertEqual("user_cancelled", result["top_failure_reasons"][0]["reason"])
+        self.assertEqual("ios", result["failure_breakdown"][0]["platform"])
+        self.assertEqual(17, result["product_funnel"][0]["attempts"])
         self.assertEqual("voice_callouts_enabled", result["settings_hotspots"][0]["setting_name"])
         self.assertEqual([], result["leaky_entry_points"])
         self.assertEqual([], result["data_quality_warnings"])
@@ -138,6 +169,8 @@ class PaywallConversionReportTests(unittest.TestCase):
             ],
             [
                 [["user_cancelled", 10]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", "user_cancelled", 10, 8]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", 42, 17, 4]],
                 [["setup_upgrade_cta", 90, 0, 0], ["sound_gate", 40, 8, 2]],
                 [["voice_callouts_enabled", 31, 14]],
             ],
@@ -159,6 +192,8 @@ class PaywallConversionReportTests(unittest.TestCase):
             ],
             [
                 [["user_cancelled", 10]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", "user_cancelled", 10, 8]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", 42, 17, 0]],
                 [["unknown", 159, 0, 0], ["sound_gate", 68, 44, 1]],
                 [["unknown", 34847, 601]],
             ],
@@ -170,6 +205,9 @@ class PaywallConversionReportTests(unittest.TestCase):
         )
         self.assertTrue(
             any("settings_changed is still dominated by unknown" in warning for warning in result["data_quality_warnings"])
+        )
+        self.assertTrue(
+            any("purchase failures are dominated by user_cancelled" in warning for warning in result["data_quality_warnings"])
         )
 
 


### PR DESCRIPTION
## Summary
- expand paywall conversion reporting with platform/product failure breakdowns
- add product-level select/attempt/success funnel diagnostics
- record the 2026-05-12 mobile monetization incident and correction packet

## Evidence
- Production telemetry showed 373 paywall views, 87 offer selects, 11 purchase attempts, and 0 purchase successes in the 30d report from run 25762475279.
- Top known failure reason was user_cancelled.

## Verification
- python3 -m unittest scripts.tests.test_paywall_conversion_report