### PR TITLE
fix: surface lifetime paywall option

### DIFF
--- a/.github/workflows/ios-iap-product-readback.yml
+++ b/.github/workflows/ios-iap-product-readback.yml
@@ -1,0 +1,45 @@
+name: iOS IAP Product Readback
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/ios-iap-product-readback.yml"
+      - "scripts/asc/asc_verify_iap_products.py"
+      - "scripts/tests/test_asc_verify_iap_products.py"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-ios-iap-products:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+      APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+      APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install ASC client dependencies
+        run: python -m pip install --upgrade requests pyjwt cryptography
+
+      - name: Run unit tests
+        run: PYTHONPATH=. python scripts/tests/test_asc_verify_iap_products.py
+
+      - name: Read back App Store Connect product states
+        run: |
+          python scripts/asc/asc_verify_iap_products.py \
+            --json-out ios-iap-product-readback.json
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: ios-iap-product-readback
+          path: ios-iap-product-readback.json
+          if-no-files-found: ignore

--- a/.github/workflows/ios-iap-product-readback.yml
+++ b/.github/workflows/ios-iap-product-readback.yml
@@ -2,11 +2,6 @@ name: iOS IAP Product Readback
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/workflows/ios-iap-product-readback.yml"
-      - "scripts/asc/asc_verify_iap_products.py"
-      - "scripts/tests/test_asc_verify_iap_products.py"
 
 permissions:
   contents: read

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -72,6 +72,7 @@ fun RandomTimerNavHost(
     var showPaywall by remember { mutableStateOf(false) }
     var proPrice by remember { mutableStateOf("$29.99") }
     var monthlyPrice by remember { mutableStateOf("$3.99") }
+    var lifetimePrice by remember { mutableStateOf("$4.99") }
     var paywallEntryPoint by remember { mutableStateOf("unknown") }
     var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
     var paywallDefaultToAnnual by remember { mutableStateOf(false) }
@@ -142,6 +143,7 @@ fun RandomTimerNavHost(
                     scope.launch {
                         proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
                         monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
+                        lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
                         paywallEntryPoint = paywallEntryPointForFeature(feature)
                         paywallTrialEligibilityByProductId =
                             mapOf(
@@ -243,6 +245,7 @@ fun RandomTimerNavHost(
             entryPoint = paywallEntryPoint,
             proPrice = proPrice,
             monthlyPrice = monthlyPrice,
+            lifetimePrice = lifetimePrice,
             defaultToAnnualPlan = paywallDefaultToAnnual,
             valueFramingVariant = paywallValueFramingVariant,
             trialEligibilityByProductId = paywallTrialEligibilityByProductId,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -108,6 +108,7 @@ internal fun paywallFeatureContext(entryPoint: String): PaywallFeatureContext =
 internal enum class SubscriptionPlanSelection {
     MONTHLY,
     ANNUAL,
+    LIFETIME,
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -116,6 +117,7 @@ fun PaywallSheet(
     entryPoint: String = "unknown",
     proPrice: String,
     monthlyPrice: String = "$3.99",
+    lifetimePrice: String = "$4.99",
     defaultToAnnualPlan: Boolean = false,
     valueFramingVariant: String = PaywallValueFraming.CONTROL,
     trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
@@ -126,9 +128,8 @@ fun PaywallSheet(
     onDebugUnlock: (() -> Unit)? = null,
 ) {
     val haptic = LocalHapticFeedback.current
-    val initialSelection =
-        if (defaultToAnnualPlan) SubscriptionPlanSelection.ANNUAL else SubscriptionPlanSelection.MONTHLY
-    var selectedPlan by remember(defaultToAnnualPlan) { mutableStateOf(initialSelection) }
+    val initialSelection = initialPlanSelection(entryPoint, defaultToAnnualPlan)
+    var selectedPlan by remember(entryPoint, defaultToAnnualPlan) { mutableStateOf(initialSelection) }
     val featureContext = paywallFeatureContext(entryPoint)
     val headline =
         if (valueFramingVariant == PaywallValueFraming.OUTCOMES_FIRST) {
@@ -148,6 +149,7 @@ fun PaywallSheet(
             selectedPlan = selectedPlan,
             proPrice = proPrice,
             monthlyPrice = monthlyPrice,
+            lifetimePrice = lifetimePrice,
             trialEligibilityByProductId = trialEligibilityByProductId,
         )
 
@@ -342,6 +344,19 @@ fun PaywallSheet(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 PlanOptionCard(
+                    title = "Lifetime",
+                    priceLabel = stripPriceSuffix(lifetimePrice),
+                    badge = "One-time",
+                    isSelected = selectedPlan == SubscriptionPlanSelection.LIFETIME,
+                    onClick = {
+                        selectedPlan = SubscriptionPlanSelection.LIFETIME
+                        onPlanSelected("lifetime", ProManager.BASE_PRODUCT_ID, "plan_card")
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                PlanOptionCard(
                     title = "Monthly",
                     priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
                     badge = null,
@@ -375,18 +390,31 @@ internal fun productIdForPlan(plan: SubscriptionPlanSelection): String =
     when (plan) {
         SubscriptionPlanSelection.MONTHLY -> ProManager.MONTHLY_PRODUCT_ID
         SubscriptionPlanSelection.ANNUAL -> ProManager.ELITE_PRODUCT_ID
+        SubscriptionPlanSelection.LIFETIME -> ProManager.BASE_PRODUCT_ID
     }
 
 internal fun planNameForSelection(plan: SubscriptionPlanSelection): String =
     when (plan) {
         SubscriptionPlanSelection.MONTHLY -> "monthly"
         SubscriptionPlanSelection.ANNUAL -> "annual"
+        SubscriptionPlanSelection.LIFETIME -> "lifetime"
+    }
+
+internal fun initialPlanSelection(
+    entryPoint: String,
+    defaultToAnnualPlan: Boolean,
+): SubscriptionPlanSelection =
+    when {
+        defaultToAnnualPlan -> SubscriptionPlanSelection.ANNUAL
+        entryPoint == "setup_upgrade_cta" -> SubscriptionPlanSelection.LIFETIME
+        else -> SubscriptionPlanSelection.MONTHLY
     }
 
 internal fun ctaLabelForPlan(
     selectedPlan: SubscriptionPlanSelection,
     proPrice: String,
     monthlyPrice: String,
+    lifetimePrice: String,
     trialEligibilityByProductId: Map<String, Boolean>,
 ): String {
     val productId = productIdForPlan(selectedPlan)
@@ -396,6 +424,7 @@ internal fun ctaLabelForPlan(
     return when (selectedPlan) {
         SubscriptionPlanSelection.MONTHLY -> "Start Monthly \u2022 ${stripPriceSuffix(monthlyPrice)}/mo"
         SubscriptionPlanSelection.ANNUAL -> "Start Annual \u2022 ${stripPriceSuffix(proPrice)}/yr"
+        SubscriptionPlanSelection.LIFETIME -> "Unlock Lifetime \u2022 ${stripPriceSuffix(lifetimePrice)}"
     }
 }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -62,13 +62,17 @@ class PaywallSheetTest {
     }
 
     @Test
-    fun `subscription plan selection enum has monthly and annual variants`() {
+    fun `subscription plan selection enum has monthly annual and lifetime variants`() {
         val monthly = SubscriptionPlanSelection.MONTHLY
         val annual = SubscriptionPlanSelection.ANNUAL
+        val lifetime = SubscriptionPlanSelection.LIFETIME
         assertEquals(SubscriptionPlanSelection.MONTHLY, monthly)
         assertEquals(SubscriptionPlanSelection.ANNUAL, annual)
+        assertEquals(SubscriptionPlanSelection.LIFETIME, lifetime)
         assertEquals("monthly", planNameForSelection(monthly))
         assertEquals("annual", planNameForSelection(annual))
+        assertEquals("lifetime", planNameForSelection(lifetime))
+        assertEquals(ProManager.BASE_PRODUCT_ID, productIdForPlan(lifetime))
     }
 
     @Test
@@ -85,6 +89,7 @@ class PaywallSheetTest {
                 selectedPlan = SubscriptionPlanSelection.MONTHLY,
                 proPrice = "$29.99",
                 monthlyPrice = "$3.99",
+                lifetimePrice = "$4.99",
                 trialEligibilityByProductId = trialEligibility,
             ),
         )
@@ -94,8 +99,35 @@ class PaywallSheetTest {
                 selectedPlan = SubscriptionPlanSelection.ANNUAL,
                 proPrice = "$29.99",
                 monthlyPrice = "$3.99",
+                lifetimePrice = "$4.99",
                 trialEligibilityByProductId = trialEligibility,
             ),
+        )
+        assertEquals(
+            "Unlock Lifetime \u2022 $4.99",
+            ctaLabelForPlan(
+                selectedPlan = SubscriptionPlanSelection.LIFETIME,
+                proPrice = "$29.99",
+                monthlyPrice = "$3.99",
+                lifetimePrice = "$4.99",
+                trialEligibilityByProductId = trialEligibility,
+            ),
+        )
+    }
+
+    @Test
+    fun `setup upgrade defaults to lifetime while experiments can still force annual`() {
+        assertEquals(
+            SubscriptionPlanSelection.LIFETIME,
+            initialPlanSelection(entryPoint = "setup_upgrade_cta", defaultToAnnualPlan = false),
+        )
+        assertEquals(
+            SubscriptionPlanSelection.MONTHLY,
+            initialPlanSelection(entryPoint = "range_gate", defaultToAnnualPlan = false),
+        )
+        assertEquals(
+            SubscriptionPlanSelection.ANNUAL,
+            initialPlanSelection(entryPoint = "setup_upgrade_cta", defaultToAnnualPlan = true),
         )
     }
 }

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -71,6 +71,19 @@ enum PaywallPlanSelection {
     case lifetime
 }
 
+func initialPaywallPlanSelection(
+    entryPoint: PaywallEntryPoint,
+    defaultToAnnualExperiment: Bool
+) -> PaywallPlanSelection {
+    if defaultToAnnualExperiment {
+        return .annual
+    }
+    if entryPoint == .setupUpgradeCTA {
+        return .lifetime
+    }
+    return .monthly
+}
+
 struct PaywallSheet: View {
     static let hiddenUnlockHoldDuration: TimeInterval = 8.0
     static let headline = "Unlock Full Fight-Ready Training"
@@ -111,7 +124,10 @@ struct PaywallSheet: View {
         self.entryPoint = entryPoint
         self.defaultToAnnualExperiment = defaultToAnnualExperiment
         self.valueFramingVariant = valueFramingVariant
-        _selectedPlan = State(initialValue: defaultToAnnualExperiment ? .annual : .monthly)
+        _selectedPlan = State(initialValue: initialPaywallPlanSelection(
+            entryPoint: entryPoint,
+            defaultToAnnualExperiment: defaultToAnnualExperiment
+        ))
     }
 
     private var displayHeadline: String {

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -63,6 +63,21 @@ final class TimerConfigProClampingTests: XCTestCase {
         XCTAssertEqual(ProManager.paywallProductID, "com.iganapolsky.randomtimer.pro")
     }
 
+    func testSetupUpgradeDefaultsToLifetimePlan() {
+        XCTAssertEqual(
+            initialPaywallPlanSelection(entryPoint: .setupUpgradeCTA, defaultToAnnualExperiment: false),
+            .lifetime
+        )
+        XCTAssertEqual(
+            initialPaywallPlanSelection(entryPoint: .rangeGate, defaultToAnnualExperiment: false),
+            .monthly
+        )
+        XCTAssertEqual(
+            initialPaywallPlanSelection(entryPoint: .setupUpgradeCTA, defaultToAnnualExperiment: true),
+            .annual
+        )
+    }
+
     func testUiTestProLaunchArgumentOverridesEntitlementToBase() {
         XCTAssertEqual(
             ProManager.entitlementOverride(forLaunchArguments: ["-ui-test-pro", "true"]),

--- a/scripts/asc/asc_verify_iap_products.py
+++ b/scripts/asc/asc_verify_iap_products.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Read back App Store Connect IAP/subscription product states for Random Timer.
+
+This is a read-only monetization health check. App-version readiness can pass
+while paid products are missing, waiting for review, or unavailable to StoreKit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from asc.asc_client import ASCClient, AscClientError
+else:
+    from .asc_client import ASCClient, AscClientError
+
+DEFAULT_BUNDLE_ID = "com.igorganapolsky.randomtimer"
+DEFAULT_EXPECTED_PRODUCT_IDS = [
+    "com.iganapolsky.randomtimer.pro",
+    "com.iganapolsky.randomtimer.pro.monthly",
+    "com.iganapolsky.randomtimer.pro.annual",
+]
+DEFAULT_READY_STATES = {"APPROVED"}
+
+
+def _items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data")
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return [data]
+    return []
+
+
+def _attributes(resource: dict[str, Any]) -> dict[str, Any]:
+    attrs = resource.get("attributes")
+    return attrs if isinstance(attrs, dict) else {}
+
+
+def _find_app_id(client: Any, bundle_id: str) -> str:
+    payload = client.get(
+        "/apps",
+        params={
+            "filter[bundleId]": bundle_id,
+            "fields[apps]": "bundleId,name,sku",
+            "limit": 1,
+        },
+    )
+    for app in _items(payload):
+        if _attributes(app).get("bundleId") == bundle_id:
+            return str(app.get("id") or "")
+    raise AscClientError(f"No App Store Connect app found for bundleId={bundle_id}")
+
+
+def _summarize_iap(resource: dict[str, Any]) -> dict[str, Any]:
+    attrs = _attributes(resource)
+    return {
+        "kind": "in_app_purchase",
+        "id": resource.get("id"),
+        "product_id": attrs.get("productId"),
+        "name": attrs.get("name") or attrs.get("referenceName"),
+        "state": attrs.get("state"),
+        "type": attrs.get("inAppPurchaseType"),
+    }
+
+
+def _summarize_subscription(resource: dict[str, Any], group: dict[str, Any]) -> dict[str, Any]:
+    attrs = _attributes(resource)
+    group_attrs = _attributes(group)
+    return {
+        "kind": "subscription",
+        "id": resource.get("id"),
+        "product_id": attrs.get("productId"),
+        "name": attrs.get("name") or attrs.get("referenceName"),
+        "state": attrs.get("state"),
+        "subscription_period": attrs.get("subscriptionPeriod"),
+        "subscription_group_id": group.get("id"),
+        "subscription_group_name": group_attrs.get("referenceName"),
+    }
+
+
+def _list_in_app_purchases(client: Any, app_id: str) -> list[dict[str, Any]]:
+    payload = client.get(
+        f"/apps/{app_id}/inAppPurchasesV2",
+        params={
+            "fields[inAppPurchases]": "name,productId,inAppPurchaseType,state",
+            "limit": 200,
+        },
+    )
+    return [_summarize_iap(item) for item in _items(payload)]
+
+
+def _list_subscriptions(client: Any, app_id: str) -> list[dict[str, Any]]:
+    groups_payload = client.get(
+        f"/apps/{app_id}/subscriptionGroups",
+        params={"fields[subscriptionGroups]": "referenceName", "limit": 200},
+    )
+    subscriptions: list[dict[str, Any]] = []
+    for group in _items(groups_payload):
+        group_id = group.get("id")
+        if not group_id:
+            continue
+        subs_payload = client.get(
+            f"/subscriptionGroups/{group_id}/subscriptions",
+            params={
+                "fields[subscriptions]": "name,productId,state,subscriptionPeriod",
+                "limit": 200,
+            },
+        )
+        subscriptions.extend(
+            _summarize_subscription(subscription, group)
+            for subscription in _items(subs_payload)
+        )
+    return subscriptions
+
+
+def _normalize_states(states: Iterable[str]) -> set[str]:
+    return {state.strip().upper() for state in states if state.strip()}
+
+
+def build_report(
+    client: Any,
+    *,
+    bundle_id: str,
+    expected_product_ids: list[str],
+    ready_states: set[str] | None = None,
+) -> dict[str, Any]:
+    ready = ready_states or DEFAULT_READY_STATES
+    app_id = _find_app_id(client, bundle_id)
+    products = _list_in_app_purchases(client, app_id) + _list_subscriptions(client, app_id)
+    by_product_id = {
+        str(product.get("product_id")): product
+        for product in products
+        if product.get("product_id")
+    }
+
+    missing = [product_id for product_id in expected_product_ids if product_id not in by_product_id]
+    blocked: list[dict[str, Any]] = []
+    ready_expected_count = 0
+    for product_id in expected_product_ids:
+        product = by_product_id.get(product_id)
+        if not product:
+            continue
+        state = str(product.get("state") or "").upper()
+        if state in ready:
+            ready_expected_count += 1
+        else:
+            blocked.append(product)
+
+    status = "ready" if not missing and not blocked else "blocked"
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "bundle_id": bundle_id,
+        "app_id": app_id,
+        "status": status,
+        "ready_states": sorted(ready),
+        "expected_product_ids": expected_product_ids,
+        "products": products,
+        "summary": {
+            "expected_count": len(expected_product_ids),
+            "found_product_count": len(products),
+            "ready_expected_count": ready_expected_count,
+            "missing_expected_product_ids": missing,
+            "blocked_expected_products": blocked,
+        },
+    }
+
+
+def _print_report(report: dict[str, Any]) -> None:
+    summary = report["summary"]
+    print("== ASC IAP Product Readiness ==")
+    print(f"bundle_id: {report['bundle_id']}")
+    print(f"app_id: {report['app_id']}")
+    print(f"status: {report['status']}")
+    print(
+        "expected: "
+        f"{summary['ready_expected_count']}/{summary['expected_count']} ready; "
+        f"{len(summary['missing_expected_product_ids'])} missing; "
+        f"{len(summary['blocked_expected_products'])} blocked"
+    )
+    for product in report["products"]:
+        print(
+            "- "
+            f"{product.get('product_id')} [{product.get('kind')}] "
+            f"state={product.get('state')} name={product.get('name')}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", default=DEFAULT_BUNDLE_ID)
+    parser.add_argument(
+        "--expected-product-id",
+        action="append",
+        dest="expected_product_ids",
+        help="Expected paid product ID. Repeat to override defaults.",
+    )
+    parser.add_argument("--json-out", help="Write the full report to this path.")
+    parser.add_argument(
+        "--ready-state",
+        action="append",
+        dest="ready_states",
+        help="Accepted App Store Connect state. Repeat to override APPROVED.",
+    )
+    args = parser.parse_args(argv)
+
+    expected_product_ids = args.expected_product_ids or DEFAULT_EXPECTED_PRODUCT_IDS
+    ready_states = _normalize_states(args.ready_states or DEFAULT_READY_STATES)
+    report = build_report(
+        ASCClient.from_env(),
+        bundle_id=args.bundle_id,
+        expected_product_ids=expected_product_ids,
+        ready_states=ready_states,
+    )
+    if args.json_out:
+        out = Path(args.json_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _print_report(report)
+    return 0 if report["status"] == "ready" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_asc_verify_iap_products.py
+++ b/scripts/tests/test_asc_verify_iap_products.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.asc import asc_verify_iap_products as verify
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def get(self, path: str, params: dict | None = None):
+        self.calls.append(("GET", path, params))
+        if path == "/apps":
+            return {"data": [{"id": "app1", "attributes": {"bundleId": "com.example.app"}}]}
+        if path == "/apps/app1/inAppPurchasesV2":
+            return {
+                "data": [
+                    {
+                        "id": "iap1",
+                        "attributes": {
+                            "productId": "com.example.app.pro",
+                            "name": "Lifetime Pro",
+                            "inAppPurchaseType": "NON_CONSUMABLE",
+                            "state": "APPROVED",
+                        },
+                    }
+                ]
+            }
+        if path == "/apps/app1/subscriptionGroups":
+            return {"data": [{"id": "group1", "attributes": {"referenceName": "Pro"}}]}
+        if path == "/subscriptionGroups/group1/subscriptions":
+            return {
+                "data": [
+                    {
+                        "id": "sub1",
+                        "attributes": {
+                            "productId": "com.example.app.pro.monthly",
+                            "name": "Monthly Pro",
+                            "state": "APPROVED",
+                            "subscriptionPeriod": "ONE_MONTH",
+                        },
+                    }
+                ]
+            }
+        raise AssertionError(f"Unexpected call: {path}")
+
+
+class AscVerifyIapProductsTests(unittest.TestCase):
+    def test_build_report_marks_expected_products_ready(self):
+        report = verify.build_report(
+            _FakeClient(),
+            bundle_id="com.example.app",
+            expected_product_ids=[
+                "com.example.app.pro",
+                "com.example.app.pro.monthly",
+            ],
+        )
+
+        self.assertEqual("ready", report["status"])
+        self.assertEqual(2, report["summary"]["expected_count"])
+        self.assertEqual(2, report["summary"]["ready_expected_count"])
+        self.assertEqual([], report["summary"]["missing_expected_product_ids"])
+        self.assertEqual([], report["summary"]["blocked_expected_products"])
+
+    def test_build_report_flags_missing_and_blocked_products(self):
+        report = verify.build_report(
+            _FakeClient(),
+            bundle_id="com.example.app",
+            expected_product_ids=[
+                "com.example.app.pro",
+                "com.example.app.pro.monthly",
+                "com.example.app.pro.annual",
+            ],
+            ready_states={"APPROVED"},
+        )
+
+        self.assertEqual("blocked", report["status"])
+        self.assertEqual(3, report["summary"]["expected_count"])
+        self.assertEqual(2, report["summary"]["ready_expected_count"])
+        self.assertEqual(
+            ["com.example.app.pro.annual"],
+            report["summary"]["missing_expected_product_ids"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds the existing one-time Pro product to the Android paywall instead of hiding it behind billing support only.
- Defaults setup-upgrade paywall traffic to the lower-friction lifetime plan on iOS and Android unless the annual experiment explicitly overrides it.
- Adds a read-only App Store Connect IAP/subscription product-state verifier plus a CI workflow that can run with production secrets.

## Evidence
- PostHog evidence from run 25762475279 showed setup_upgrade_cta had 227 paywall views and 0 purchase attempts; purchase failures were dominated by user_cancelled.
- Android focused unit test passed locally with ANDROID_HOME set: `./gradlew testDebugUnitTest --tests com.iganapolsky.randomtimer.ui.screens.PaywallSheetTest`.
- iOS simulator build passed: `xcodebuild build -scheme RandomTimer -destination "platform=iOS Simulator,name=iPhone 16"`.
- ASC IAP verifier unit test passed: `PYTHONPATH=. python3 scripts/tests/test_asc_verify_iap_products.py`.
- Live local ASC read-back is blocked locally because this machine has no APPSTORE_* env values; GitHub secret names exist, and the new workflow uses those secrets.

## Notes
- iOS focused test build compiled, but simulator test launch failed with `Pseudo Terminal Setup Error` / `Device not configured`; the separate simulator build succeeded.
- Normal git push failed because local HTTPS credential prompting is broken; branch was pushed via gh-authenticated askpass without printing credentials.
