### PR TITLE
fix: use approved iOS paywall products

### DIFF
--- a/native-ios/RandomTimer/Sources/Services/ProManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProManager.swift
@@ -11,8 +11,8 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
     /// Monthly subscription — $3.99/month. Must be created in App Store Connect as an auto-renewable
     /// subscription before the paywall can complete a live purchase.
     static nonisolated let monthlyProductID = "com.iganapolsky.randomtimer.pro.monthly"
-    /// Annual subscription — $29.99/year. Maps to the existing elite SKU billing period.
-    static nonisolated let annualProductID = "com.iganapolsky.randomtimer.pro.annual"
+    /// Annual subscription — $29.99/year. App Store Connect currently exposes this as the elite SKU.
+    static nonisolated let annualProductID = eliteProductID
     /// In-app paywall default product — one-time non-consumable Pro Upgrade.
     static nonisolated let paywallProductID = baseProductID
     static nonisolated var productIDs: Set<String> {

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -84,6 +84,26 @@ func initialPaywallPlanSelection(
     return .monthly
 }
 
+func shouldShowPaywallPlan(
+    _ plan: PaywallPlanSelection,
+    availableProductIDs: Set<String>
+) -> Bool {
+    if availableProductIDs.isEmpty {
+        return plan != .monthly
+    }
+
+    let requiredProductID: String
+    switch plan {
+    case .monthly:
+        requiredProductID = ProManager.monthlyProductID
+    case .annual:
+        requiredProductID = ProManager.annualProductID
+    case .lifetime:
+        requiredProductID = ProManager.paywallProductID
+    }
+    return availableProductIDs.contains(requiredProductID)
+}
+
 struct PaywallSheet: View {
     static let hiddenUnlockHoldDuration: TimeInterval = 8.0
     static let headline = "Unlock Full Fight-Ready Training"
@@ -172,6 +192,10 @@ struct PaywallSheet: View {
         proManager.products.map(\.id).sorted().joined(separator: "|")
     }
 
+    private var availableProductIDs: Set<String> {
+        Set(proManager.products.map(\.id))
+    }
+
     private var ctaLabel: String {
         if introOfferEligibleProductIDs.contains(selectedProductID) {
             return "Start 7-Day Free Trial"
@@ -202,6 +226,14 @@ struct PaywallSheet: View {
                 .foregroundColor(.textSecondary)
 
                 Spacer()
+
+                Button("Restore purchase") {
+                    Task {
+                        await restorePurchaseFromPaywall()
+                    }
+                }
+                .font(.footnote.weight(.semibold))
+                .foregroundColor(.textSecondary)
 
                 Button {
                     trackDismiss(method: "close_button")
@@ -276,46 +308,64 @@ struct PaywallSheet: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)
 
-                PlanOptionRow(
-                    title: "Monthly",
-                    priceLabel: "\(monthlyPrice)/month",
-                    badge: nil,
-                    isSelected: selectedPlan == .monthly
-                ) {
-                    selectedPlan = .monthly
-                    trackOfferSelected(
-                        plan: "monthly",
-                        productID: ProManager.monthlyProductID,
-                        selectionSource: "plan_card"
-                    )
+                if shouldShowPaywallPlan(.lifetime, availableProductIDs: availableProductIDs) {
+                    PlanOptionRow(
+                        title: "Lifetime",
+                        priceLabel: lifetimePrice,
+                        badge: "One-time",
+                        isSelected: selectedPlan == .lifetime
+                    ) {
+                        selectedPlan = .lifetime
+                        trackOfferSelected(
+                            plan: "lifetime",
+                            productID: ProManager.paywallProductID,
+                            selectionSource: "plan_card"
+                        )
+                    }
                 }
 
-                PlanOptionRow(
-                    title: "Annual",
-                    priceLabel: "\(annualPrice)/year",
-                    badge: "Best Value",
-                    isSelected: selectedPlan == .annual
-                ) {
-                    selectedPlan = .annual
-                    trackOfferSelected(
-                        plan: "annual",
-                        productID: ProManager.annualProductID,
-                        selectionSource: "plan_card"
-                    )
+                if shouldShowPaywallPlan(.annual, availableProductIDs: availableProductIDs) {
+                    PlanOptionRow(
+                        title: "Annual",
+                        priceLabel: "\(annualPrice)/year",
+                        badge: "Best Value",
+                        isSelected: selectedPlan == .annual
+                    ) {
+                        selectedPlan = .annual
+                        trackOfferSelected(
+                            plan: "annual",
+                            productID: ProManager.annualProductID,
+                            selectionSource: "plan_card"
+                        )
+                    }
                 }
 
-                PlanOptionRow(
-                    title: "Lifetime",
-                    priceLabel: lifetimePrice,
-                    badge: "One-time",
-                    isSelected: selectedPlan == .lifetime
-                ) {
+                if shouldShowPaywallPlan(.monthly, availableProductIDs: availableProductIDs) {
+                    PlanOptionRow(
+                        title: "Monthly",
+                        priceLabel: "\(monthlyPrice)/month",
+                        badge: nil,
+                        isSelected: selectedPlan == .monthly
+                    ) {
+                        selectedPlan = .monthly
+                        trackOfferSelected(
+                            plan: "monthly",
+                            productID: ProManager.monthlyProductID,
+                            selectionSource: "plan_card"
+                        )
+                    }
+                }
+            }
+            .onChange(of: productsEligibilityKey) { _, _ in
+                if shouldShowPaywallPlan(selectedPlan, availableProductIDs: availableProductIDs) {
+                    return
+                }
+                if shouldShowPaywallPlan(.lifetime, availableProductIDs: availableProductIDs) {
                     selectedPlan = .lifetime
-                    trackOfferSelected(
-                        plan: "lifetime",
-                        productID: ProManager.paywallProductID,
-                        selectionSource: "plan_card"
-                    )
+                } else if shouldShowPaywallPlan(.annual, availableProductIDs: availableProductIDs) {
+                    selectedPlan = .annual
+                } else if shouldShowPaywallPlan(.monthly, availableProductIDs: availableProductIDs) {
+                    selectedPlan = .monthly
                 }
             }
         }
@@ -342,16 +392,7 @@ struct PaywallSheet: View {
 
             Button("Restore purchase") {
                 Task {
-                    let result = await proManager.restorePurchases()
-                    AnalyticsService.shared.track(AnalyticsEvents.paywallRestoreResult, properties: [
-                        AnalyticsProperties.entryPoint: entryPoint.rawValue,
-                        AnalyticsProperties.result: result.rawValue,
-                    ])
-
-                    if result == .restored || result == .alreadyUnlocked {
-                        hasTrackedDismiss = true
-                        dismiss()
-                    }
+                    await restorePurchaseFromPaywall()
                 }
             }
             .font(.footnote)
@@ -436,6 +477,20 @@ struct PaywallSheet: View {
             Button("OK") { purchaseError = nil }
         } message: {
             Text(purchaseError ?? "")
+        }
+    }
+
+    @MainActor
+    private func restorePurchaseFromPaywall() async {
+        let result = await proManager.restorePurchases()
+        AnalyticsService.shared.track(AnalyticsEvents.paywallRestoreResult, properties: [
+            AnalyticsProperties.entryPoint: entryPoint.rawValue,
+            AnalyticsProperties.result: result.rawValue,
+        ])
+
+        if result == .restored || result == .alreadyUnlocked {
+            hasTrackedDismiss = true
+            dismiss()
         }
     }
 

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -626,11 +626,11 @@ struct TimerSetupScreen: View {
             ]
         )
         paywallEntryPoint = entryPoint
+        showPaywall = true
         Task { @MainActor in
             await AnalyticsService.shared.reloadPaywallExperimentFlagsIfNeeded()
             paywallDefaultToAnnual = AnalyticsService.shared.paywallDefaultAnnualExperimentEnabled()
             paywallValueFramingVariant = AnalyticsService.shared.paywallValueFramingVariant()
-            showPaywall = true
         }
     }
 

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -61,6 +61,22 @@ final class TimerConfigProClampingTests: XCTestCase {
     func testPaywallUsesApprovedAppStoreConnectProductId() {
         XCTAssertEqual(ProManager.paywallProductID, ProManager.baseProductID)
         XCTAssertEqual(ProManager.paywallProductID, "com.iganapolsky.randomtimer.pro")
+        XCTAssertEqual(ProManager.annualProductID, ProManager.eliteProductID)
+        XCTAssertEqual(ProManager.annualProductID, "com.iganapolsky.randomtimer.elite")
+    }
+
+    func testPaywallDoesNotShowMissingMonthlyProductWhenStoreKitDoesNotReturnIt() {
+        XCTAssertTrue(shouldShowPaywallPlan(.lifetime, availableProductIDs: []))
+        XCTAssertTrue(shouldShowPaywallPlan(.annual, availableProductIDs: []))
+        XCTAssertFalse(shouldShowPaywallPlan(.monthly, availableProductIDs: []))
+
+        let approvedProductIDs: Set<String> = [
+            ProManager.baseProductID,
+            ProManager.eliteProductID,
+        ]
+        XCTAssertTrue(shouldShowPaywallPlan(.lifetime, availableProductIDs: approvedProductIDs))
+        XCTAssertTrue(shouldShowPaywallPlan(.annual, availableProductIDs: approvedProductIDs))
+        XCTAssertFalse(shouldShowPaywallPlan(.monthly, availableProductIDs: approvedProductIDs))
     }
 
     func testSetupUpgradeDefaultsToLifetimePlan() {

--- a/scripts/asc/asc_verify_iap_products.py
+++ b/scripts/asc/asc_verify_iap_products.py
@@ -23,8 +23,7 @@ else:
 DEFAULT_BUNDLE_ID = "com.igorganapolsky.randomtimer"
 DEFAULT_EXPECTED_PRODUCT_IDS = [
     "com.iganapolsky.randomtimer.pro",
-    "com.iganapolsky.randomtimer.pro.monthly",
-    "com.iganapolsky.randomtimer.pro.annual",
+    "com.iganapolsky.randomtimer.elite",
 ]
 DEFAULT_READY_STATES = {"APPROVED"}
 

--- a/scripts/tests/test_asc_verify_iap_products.py
+++ b/scripts/tests/test_asc_verify_iap_products.py
@@ -47,6 +47,15 @@ class _FakeClient:
 
 
 class AscVerifyIapProductsTests(unittest.TestCase):
+    def test_default_expected_products_match_live_ios_paywall_products(self):
+        self.assertEqual(
+            [
+                "com.iganapolsky.randomtimer.pro",
+                "com.iganapolsky.randomtimer.elite",
+            ],
+            verify.DEFAULT_EXPECTED_PRODUCT_IDS,
+        )
+
     def test_build_report_marks_expected_products_ready(self):
         report = verify.build_report(
             _FakeClient(),


### PR DESCRIPTION
## Summary
- Uses the ASC-approved Elite SKU for the iOS annual plan instead of the missing `com.iganapolsky.randomtimer.pro.annual` SKU.
- Hides the iOS monthly plan when StoreKit does not return `com.iganapolsky.randomtimer.pro.monthly`, preventing users from selecting a missing product.
- Updates the IAP product read-back default expected products to match the live approved iOS paywall products: lifetime Pro + Elite annual.

## Evidence
- Secret-backed IAP read-back run 25764898212 returned `status: blocked`, expected `1/3` ready, `2` missing.
- ASC products returned by run 25764898212: `com.iganapolsky.randomtimer.pro` APPROVED; `com.iganapolsky.randomtimer.elite` APPROVED.
- Local verifier tests pass: `PYTHONPATH=. python3 scripts/tests/test_asc_verify_iap_products.py` -> 3 tests OK.
- Local iOS build passes: `xcodebuild build -scheme RandomTimer -destination "platform=iOS Simulator,name=iPhone 16"` -> BUILD SUCCEEDED.
