### PR TITLE
feat: add agent-friendly monetization deep links

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/MainActivity.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/MainActivity.kt
@@ -3,6 +3,7 @@ package com.iganapolsky.randomtimer
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -11,13 +12,16 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
+import com.iganapolsky.randomtimer.BuildConfig
 import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.notifications.ReengagementScheduler
 import com.iganapolsky.randomtimer.service.TimerForegroundService
 import com.iganapolsky.randomtimer.ui.navigation.RandomTimerNavHost
-import com.iganapolsky.randomtimer.BuildConfig
 import com.iganapolsky.randomtimer.ui.theme.RandomTimerTheme
 import com.iganapolsky.randomtimer.ui.theme.TimerColors
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,6 +30,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     @Inject lateinit var analyticsService: AnalyticsService
+    private var latestDeepLinkUri by mutableStateOf<Uri?>(null)
 
     private val notificationPermissionLauncher =
         registerForActivityResult(
@@ -46,7 +51,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         requestNotificationPermission()
         handleAlarmNotificationTap(intent)
-        handleDeepLink(intent)
+        latestDeepLinkUri = handleDeepLink(intent)
 
         // User is back — cancel any pending re-engagement reminders
         ReengagementScheduler.cancel(this)
@@ -57,7 +62,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = TimerColors.BackgroundDark,
                 ) {
-                    RandomTimerNavHost()
+                    RandomTimerNavHost(pendingDeepLinkUri = latestDeepLinkUri?.toString())
                 }
             }
         }
@@ -66,7 +71,8 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleAlarmNotificationTap(intent)
-        handleDeepLink(intent)
+        latestDeepLinkUri = null
+        latestDeepLinkUri = handleDeepLink(intent)
     }
 
     override fun onResume() {
@@ -113,9 +119,10 @@ class MainActivity : ComponentActivity() {
         startService(intent)
     }
 
-    private fun handleDeepLink(intent: Intent?) {
-        val uri = intent?.data ?: return
+    private fun handleDeepLink(intent: Intent?): Uri? {
+        val uri = intent?.data ?: return null
         analyticsService.trackDeepLink(uri)
+        return uri
     }
 
     private fun requestNotificationPermission() {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/DeepLinkTargets.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/DeepLinkTargets.kt
@@ -1,0 +1,77 @@
+package com.iganapolsky.randomtimer.ui.navigation
+
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+internal data class MonetizationDeepLink(
+    val entryPoint: String,
+    val feature: String,
+)
+
+internal fun monetizationDeepLinkFromUri(rawUri: String?): MonetizationDeepLink? {
+    if (rawUri.isNullOrBlank()) return null
+    val uri = runCatching { URI(rawUri) }.getOrNull() ?: return null
+    val params = parseQueryParams(uri.rawQuery)
+    val screen = params["screen"] ?: params["route"] ?: params["target"]
+    val path = uri.path.orEmpty().trim('/')
+    val isUpgradeIntent =
+        screen in setOf("upgrade", "paywall", "pro") ||
+            path.split('/').any { it in setOf("upgrade", "paywall", "pro") }
+
+    val isSupportedScheme =
+        (uri.scheme == "randomtimer" && uri.host == "open") ||
+            (
+                uri.scheme in setOf("http", "https") &&
+                    uri.host == "igorganapolsky.github.io" &&
+                    path.startsWith("Random-Timer")
+            )
+
+    if (!isSupportedScheme || !isUpgradeIntent) return null
+
+    val requested = params["entry_point"] ?: params["feature"] ?: "setup_upgrade_cta"
+    val entryPoint = normalizePaywallEntryPoint(requested)
+    return MonetizationDeepLink(
+        entryPoint = entryPoint,
+        feature = featureForPaywallEntryPoint(entryPoint),
+    )
+}
+
+internal fun normalizePaywallEntryPoint(value: String): String {
+    val trimmed = value.trim()
+    val knownEntryPoints =
+        setOf(
+            "setup_upgrade_cta",
+            "range_gate",
+            "voice_gate",
+            "repeat_gate",
+            "sound_arsenal_gate",
+        )
+    if (trimmed in knownEntryPoints) return trimmed
+    return paywallEntryPointForFeature(trimmed)
+        .takeUnless { it == "unknown" }
+        ?: "setup_upgrade_cta"
+}
+
+internal fun featureForPaywallEntryPoint(entryPoint: String): String =
+    when (entryPoint) {
+        "range_gate" -> "extended_range"
+        "voice_gate" -> "voice_callouts"
+        "repeat_gate" -> "repeat_loop"
+        "sound_arsenal_gate" -> "pro_sounds"
+        else -> "setup_upgrade_cta"
+    }
+
+private fun parseQueryParams(rawQuery: String?): Map<String, String> {
+    if (rawQuery.isNullOrBlank()) return emptyMap()
+    return rawQuery
+        .split('&')
+        .mapNotNull { part ->
+            val key = part.substringBefore('=', missingDelimiterValue = "").decodeQueryComponent()
+            if (key.isBlank()) return@mapNotNull null
+            val value = part.substringAfter('=', missingDelimiterValue = "").decodeQueryComponent()
+            key to value
+        }.toMap()
+}
+
+private fun String.decodeQueryComponent(): String = URLDecoder.decode(this, StandardCharsets.UTF_8.name())

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -55,6 +55,7 @@ internal fun paywallEntryPointForFeature(feature: String): String =
 fun RandomTimerNavHost(
     navController: NavHostController = rememberNavController(),
     viewModel: TimerViewModel = hiltViewModel(),
+    pendingDeepLinkUri: String? = null,
 ) {
     val config by viewModel.config.collectAsStateWithLifecycle()
     val timerState by viewModel.timerState.collectAsStateWithLifecycle()
@@ -77,6 +78,38 @@ fun RandomTimerNavHost(
     var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
     var paywallDefaultToAnnual by remember { mutableStateOf(false) }
     var paywallValueFramingVariant by remember { mutableStateOf(PaywallValueFraming.CONTROL) }
+
+    fun presentPaywallForFeature(feature: String) {
+        viewModel.trackFeatureGateHit(feature)
+        scope.launch {
+            proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
+            monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
+            lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
+            paywallEntryPoint = paywallEntryPointForFeature(feature)
+            paywallTrialEligibilityByProductId =
+                mapOf(
+                    ProManager.MONTHLY_PRODUCT_ID to
+                        viewModel.proManager.hasFreeTrialOffer(ProManager.MONTHLY_PRODUCT_ID),
+                    ProManager.ELITE_PRODUCT_ID to
+                        viewModel.proManager.hasFreeTrialOffer(ProManager.ELITE_PRODUCT_ID),
+                )
+            paywallDefaultToAnnual =
+                suspendCoroutine { cont ->
+                    viewModel.resolvePaywallDefaultAnnualExperiment { enabled ->
+                        cont.resume(enabled)
+                    }
+                }
+            paywallValueFramingVariant = viewModel.paywallValueFramingVariant()
+            showPaywall = true
+        }
+    }
+
+    LaunchedEffect(pendingDeepLinkUri, isPro) {
+        val monetizationTarget = monetizationDeepLinkFromUri(pendingDeepLinkUri)
+        if (monetizationTarget != null && !isPro) {
+            presentPaywallForFeature(monetizationTarget.feature)
+        }
+    }
 
     // Auto-navigate based on timer state
     LaunchedEffect(timerState, currentRoute) {
@@ -139,28 +172,7 @@ fun RandomTimerNavHost(
                 isPro = isPro,
                 isElite = isElite,
                 onUpgradeTap = { feature ->
-                    viewModel.trackFeatureGateHit(feature)
-                    scope.launch {
-                        proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
-                        monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
-                        lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
-                        paywallEntryPoint = paywallEntryPointForFeature(feature)
-                        paywallTrialEligibilityByProductId =
-                            mapOf(
-                                ProManager.MONTHLY_PRODUCT_ID to
-                                    viewModel.proManager.hasFreeTrialOffer(ProManager.MONTHLY_PRODUCT_ID),
-                                ProManager.ELITE_PRODUCT_ID to
-                                    viewModel.proManager.hasFreeTrialOffer(ProManager.ELITE_PRODUCT_ID),
-                            )
-                        paywallDefaultToAnnual =
-                            suspendCoroutine { cont ->
-                                viewModel.resolvePaywallDefaultAnnualExperiment { enabled ->
-                                    cont.resume(enabled)
-                                }
-                            }
-                        paywallValueFramingVariant = viewModel.paywallValueFramingVariant()
-                        showPaywall = true
-                    }
+                    presentPaywallForFeature(feature)
                 },
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/navigation/NavigationAnalyticsMappingTest.kt
@@ -25,4 +25,36 @@ class NavigationAnalyticsMappingTest {
     fun unknownUpgradeFallsBackToUnknownEntryPoint() {
         assertThat(paywallEntryPointForFeature("mystery_feature")).isEqualTo("unknown")
     }
+
+    @Test
+    fun monetizationDeepLinkRoutesCustomSchemeToRelevantPaywall() {
+        val target = monetizationDeepLinkFromUri("randomtimer://open/upgrade?feature=pro_sounds")
+
+        assertThat(target).isEqualTo(
+            MonetizationDeepLink(
+                entryPoint = "sound_arsenal_gate",
+                feature = "pro_sounds",
+            ),
+        )
+    }
+
+    @Test
+    fun monetizationDeepLinkRoutesWebUrlToRelevantPaywall() {
+        val target =
+            monetizationDeepLinkFromUri(
+                "https://igorganapolsky.github.io/Random-Timer/upgrade?entry_point=voice_gate",
+            )
+
+        assertThat(target).isEqualTo(
+            MonetizationDeepLink(
+                entryPoint = "voice_gate",
+                feature = "voice_callouts",
+            ),
+        )
+    }
+
+    @Test
+    fun monetizationDeepLinkIgnoresNonUpgradeDestinations() {
+        assertThat(monetizationDeepLinkFromUri("randomtimer://open/timer")).isNull()
+    }
 }

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		3FFD4482489894E382E7B6E8 /* klaxon.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 01D20814587EFDB22A275849 /* klaxon.mp3 */; };
 		49B707298D8B919D28D01A71 /* SharedTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD7E2987345EA2F0A52A882 /* SharedTypes.swift */; };
 		4C7AAC0D5B84BD7DFA0ACEAB /* TimerSetupScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA529E7A224C8E8728DAE7A /* TimerSetupScreen.swift */; };
+		DEE000000000000000000002 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE000000000000000000001 /* DeepLinkRouter.swift */; };
+		DEE000000000000000000004 /* DeepLinkRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE000000000000000000003 /* DeepLinkRouterTests.swift */; };
 		4E242D865279E0BFD5B9CF7B /* gentle-chime.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 91AD2CFB9AE9EF347F990B2F /* gentle-chime.mp3 */; };
 		4ED9D921707F80E1AC5501F3 /* RandomTimerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368C8F93B37D3B244F271919 /* RandomTimerApp.swift */; };
 		4F4A683B236AE94216503707 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A84792F8E1380EF1A87461 /* Colors.swift */; };
@@ -143,6 +145,7 @@
 		25FCEC0B24402A66BBCC142A /* RandomTimerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RandomTimerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3063864498ABB31478972EDD /* alarm.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = alarm.mp3; sourceTree = "<group>"; };
 		368C8F93B37D3B244F271919 /* RandomTimerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomTimerApp.swift; sourceTree = "<group>"; };
+		DEE000000000000000000001 /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
 		3BE6975376BF7C7C6B14F8BF /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		1F9A3C44B55D66E77F880010 /* ProSoundCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProSoundCatalog.swift; sourceTree = "<group>"; };
 		48232C2EAE9FAA775617C954 /* StoreReviewManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreReviewManager.swift; sourceTree = "<group>"; };
@@ -189,6 +192,7 @@
 		F5F3E399050BD30295736FEA /* drum_roll.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = drum_roll.mp3; sourceTree = "<group>"; };
 		PRIV001122334455AABB0001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = RandomTimer/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		PRVT001122334455AABB0001 /* ProValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProValidationTests.swift; sourceTree = "<group>"; };
+		DEE000000000000000000003 /* DeepLinkRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouterTests.swift; sourceTree = "<group>"; };
 		CRSVC00112233445566778801 /* CrashReportingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingService.swift; sourceTree = "<group>"; };
 		GSIPL00112233445566778801 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = RandomTimer/GoogleService-Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -220,6 +224,7 @@
 		3F3001C89372688DF388B3EA /* App */ = {
 			isa = PBXGroup;
 			children = (
+				DEE000000000000000000001 /* DeepLinkRouter.swift */,
 				368C8F93B37D3B244F271919 /* RandomTimerApp.swift */,
 			);
 			path = App;
@@ -232,6 +237,7 @@
 				DISTCH00112233445566778801 /* DistributionChannelResolverTests.swift */,
 				A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */,
 				A1B2C3D4E5F60718A1B2C3D5 /* CircularTimerViewTests.swift */,
+				DEE000000000000000000003 /* DeepLinkRouterTests.swift */,
 				PRVT001122334455AABB0001 /* ProValidationTests.swift */,
 				C1D2E3F4A5B60718C1D2E3F5 /* SilenceAndStopAlarmTests.swift */,
 				7B55AFED96FE157EA7D0BF85 /* TimerModelsTests.swift */,
@@ -628,6 +634,7 @@
 				1EF5792885AFE606EACC05F9 /* TimerManager.swift in Sources */,
 				17E69C010FAA04EFC0076358 /* TimerModels.swift in Sources */,
 				4C7AAC0D5B84BD7DFA0ACEAB /* TimerSetupScreen.swift in Sources */,
+				DEE000000000000000000002 /* DeepLinkRouter.swift in Sources */,
 				D6D5DBA2177110DF7C339F94 /* ServiceProtocols.swift in Sources */,
 				1BAE4130DA7DC5758A7F13FE /* StoreReviewManager.swift in Sources */,
 				B1C2D3E4F5A6071800STATS1 /* TrainingStatsService.swift in Sources */,
@@ -656,6 +663,7 @@
 				DISTCH00112233445566778802 /* DistributionChannelResolverTests.swift in Sources */,
 				A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */,
 				A1B2C3D4E5F60718A1B2C3D4 /* CircularTimerViewTests.swift in Sources */,
+				DEE000000000000000000004 /* DeepLinkRouterTests.swift in Sources */,
 				PRVT001122334455AABB0002 /* ProValidationTests.swift in Sources */,
 				C1D2E3F4A5B60718C1D2E3F4 /* SilenceAndStopAlarmTests.swift in Sources */,
 				DB8217C38D6B214B931042F7 /* TimerModels.swift in Sources */,

--- a/native-ios/RandomTimer/Sources/App/DeepLinkRouter.swift
+++ b/native-ios/RandomTimer/Sources/App/DeepLinkRouter.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Observation
+
+struct PaywallDeepLinkRequest: Equatable, Identifiable {
+    let id: UUID
+    let entryPoint: PaywallEntryPoint
+}
+
+@Observable
+@MainActor
+final class DeepLinkRouter {
+    private(set) var paywallRequest: PaywallDeepLinkRequest?
+
+    func handle(_ url: URL) {
+        guard let entryPoint = Self.paywallEntryPoint(from: url) else { return }
+        paywallRequest = PaywallDeepLinkRequest(id: UUID(), entryPoint: entryPoint)
+    }
+
+    nonisolated static func paywallEntryPoint(from url: URL) -> PaywallEntryPoint? {
+        guard isSupported(url: url), isUpgradeIntent(url: url) else { return nil }
+        let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .reduce(into: [String: String]()) { result, item in
+                result[item.name] = item.value
+            } ?? [:]
+        let requested = query["entry_point"] ?? query["feature"] ?? "setup_upgrade_cta"
+        return normalizedPaywallEntryPoint(requested)
+    }
+
+    nonisolated static func normalizedPaywallEntryPoint(_ value: String) -> PaywallEntryPoint {
+        if let entryPoint = PaywallEntryPoint(rawValue: value) {
+            return entryPoint == .unknown ? .setupUpgradeCTA : entryPoint
+        }
+        switch value {
+        case "extended_range": return .rangeGate
+        case "voice_callouts": return .voiceGate
+        case "repeat_loop": return .repeatGate
+        case "pro_sounds": return .soundArsenalGate
+        default: return .setupUpgradeCTA
+        }
+    }
+
+    private nonisolated static func isSupported(url: URL) -> Bool {
+        if url.scheme == "randomtimer", url.host == "open" {
+            return true
+        }
+        return (url.scheme == "https" || url.scheme == "http")
+            && url.host == "igorganapolsky.github.io"
+            && url.path.hasPrefix("/Random-Timer")
+    }
+
+    private nonisolated static func isUpgradeIntent(url: URL) -> Bool {
+        let pathParts = url.path
+            .split(separator: "/")
+            .map { String($0).lowercased() }
+        let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .reduce(into: [String: String]()) { result, item in
+                result[item.name] = item.value?.lowercased()
+            } ?? [:]
+        return pathParts.contains("upgrade")
+            || pathParts.contains("paywall")
+            || pathParts.contains("pro")
+            || ["upgrade", "paywall", "pro"].contains(query["screen"])
+            || ["upgrade", "paywall", "pro"].contains(query["route"])
+            || ["upgrade", "paywall", "pro"].contains(query["target"])
+    }
+}

--- a/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
+++ b/native-ios/RandomTimer/Sources/App/RandomTimerApp.swift
@@ -11,6 +11,7 @@ struct RandomTimerApp: App {
 
     // swiftlint:disable:next no_state_object
     @StateObject private var timerManager = TimerManager()
+    @State private var deepLinkRouter = DeepLinkRouter()
     @Environment(\.scenePhase) private var scenePhase
 
     /// GitHub Actions passes `OTHER_SWIFT_FLAGS=-D RT_SKIP_FIREBASE_FOR_CI` for `xcodebuild test`
@@ -45,9 +46,11 @@ struct RandomTimerApp: App {
             ContentView()
                 .environmentObject(timerManager)
                 .environmentObject(ProManager.shared)
+                .environment(deepLinkRouter)
                 .preferredColorScheme(.dark)
                 .onOpenURL { url in
                     AnalyticsService.shared.trackDeepLink(url)
+                    deepLinkRouter.handle(url)
                 }
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -68,6 +71,7 @@ struct RandomTimerApp: App {
 
 struct ContentView: View {
     @EnvironmentObject var timerManager: TimerManager
+    @Environment(DeepLinkRouter.self) private var deepLinkRouter
     @State private var didApplyUITestSeed: Bool = false
 
     var body: some View {
@@ -86,6 +90,7 @@ struct ContentView: View {
                 }
             }
         }
+        .environment(deepLinkRouter)
         .onAppear {
 #if DEBUG
             guard didApplyUITestSeed == false else { return }
@@ -158,4 +163,5 @@ struct ContentView: View {
     ContentView()
         .environmentObject(TimerManager())
         .environmentObject(ProManager.shared)
+        .environment(DeepLinkRouter())
 }

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -12,6 +12,7 @@ func primaryStartButtonCaption(hasFirstCompleted: Bool) -> String? {
 struct TimerSetupScreen: View {
     @EnvironmentObject var timerManager: TimerManager
     @EnvironmentObject var proManager: ProManager
+    @Environment(DeepLinkRouter.self) private var deepLinkRouter
     @State private var showPaywall = false
     @State private var paywallDefaultToAnnual = false
     @State private var paywallValueFramingVariant = PaywallValueFraming.control
@@ -566,6 +567,10 @@ struct TimerSetupScreen: View {
                 }
             }
         }
+        .onChange(of: deepLinkRouter.paywallRequest?.id) { _, _ in
+            guard !proManager.isPro, let request = deepLinkRouter.paywallRequest else { return }
+            presentPaywall(entryPoint: request.entryPoint)
+        }
     }
 
     // Helper to update config with specific field changes
@@ -1036,5 +1041,6 @@ private struct VolumeSliderView: View {
         TimerSetupScreen()
             .environmentObject(TimerManager())
             .environmentObject(ProManager.shared)
+            .environment(DeepLinkRouter())
     }
 }

--- a/native-ios/RandomTimerTests/DeepLinkRouterTests.swift
+++ b/native-ios/RandomTimerTests/DeepLinkRouterTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import RandomTimer
+
+final class DeepLinkRouterTests: XCTestCase {
+    func testCustomSchemeUpgradeRoutesToSoundArsenalPaywall() throws {
+        let url = try XCTUnwrap(URL(string: "randomtimer://open/upgrade?feature=pro_sounds"))
+
+        XCTAssertEqual(DeepLinkRouter.paywallEntryPoint(from: url), .soundArsenalGate)
+    }
+
+    func testWebUpgradeRoutesToVoicePaywall() throws {
+        let url = try XCTUnwrap(
+            URL(string: "https://igorganapolsky.github.io/Random-Timer/upgrade?entry_point=voice_gate")
+        )
+
+        XCTAssertEqual(DeepLinkRouter.paywallEntryPoint(from: url), .voiceGate)
+    }
+
+    func testNonUpgradeLinkDoesNotOpenPaywall() throws {
+        let url = try XCTUnwrap(URL(string: "randomtimer://open/timer"))
+
+        XCTAssertNil(DeepLinkRouter.paywallEntryPoint(from: url))
+    }
+}


### PR DESCRIPTION
## Summary
- Add stable Android and iOS upgrade deep links for agent/Gemini-friendly monetization flows
- Route custom scheme and web upgrade links into existing paywall entry points
- Cover deep-link parsing with focused Android and iOS tests

## Verification
- ANDROID_HOME=/Users/igorganapolsky/Library/Android/sdk ./gradlew testDebugUnitTest --tests '*NavigationAnalyticsMappingTest' --tests '*PaywallSheetTest'
- xcodebuild test -project native-ios/RandomTimer.xcodeproj -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:RandomTimerTests/DeepLinkRouterTests OTHER_SWIFT_FLAGS='-D RT_SKIP_FIREBASE_FOR_CI'
- git diff --check