### PR TITLE
fix: harden paywall product catalog diagnostics

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -417,6 +417,7 @@ object AnalyticsEvents {
     const val PAYWALL_PURCHASE_SUCCESS = "paywall_purchase_success"
     const val PAYWALL_PURCHASE_RESULT = "paywall_purchase_result"
     const val PAYWALL_RESTORE_RESULT = "paywall_restore_result"
+    const val BILLING_PRODUCT_CATALOG_STATUS = "billing_product_catalog_status"
 
     // Loop
     const val LOOP_ROUND_COMPLETED = "loop_round_completed"
@@ -481,6 +482,10 @@ object AnalyticsProperties {
     const val PAYWALL_EXPERIMENT_VARIANT = "paywall_experiment_variant"
     const val PAYWALL_VALUE_FRAMING_VARIANT = "paywall_value_framing_variant"
     const val PAYWALL_SELECTION_SOURCE = "paywall_selection_source"
+    const val STATUS = "status"
+    const val AVAILABLE_PRODUCT_IDS = "available_product_ids"
+    const val MISSING_PRODUCT_IDS = "missing_product_ids"
+    const val PRODUCT_COUNT = "product_count"
 }
 
 object AnalyticsScreens {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -322,6 +322,33 @@ class ProManager
             fetchProductDetails(BASE_PRODUCT_ID)
             fetchProductDetails(ELITE_PRODUCT_ID)
             fetchProductDetails(MONTHLY_PRODUCT_ID)
+            trackProductCatalogStatus()
+        }
+
+        suspend fun availablePaywallProductIds(): Set<String> {
+            fetchAllProductDetails()
+            return cachedProductDetails.keys.toSet()
+        }
+
+        private fun trackProductCatalogStatus() {
+            val requiredProductIds = setOf(BASE_PRODUCT_ID, ELITE_PRODUCT_ID, MONTHLY_PRODUCT_ID)
+            val availableProductIds = cachedProductDetails.keys.sorted()
+            val missingProductIds = requiredProductIds.minus(availableProductIds.toSet()).sorted()
+            val status =
+                when {
+                    availableProductIds.isEmpty() -> "empty"
+                    missingProductIds.isNotEmpty() -> "missing_required_products"
+                    else -> "ok"
+                }
+            analyticsService.track(
+                AnalyticsEvents.BILLING_PRODUCT_CATALOG_STATUS,
+                mapOf(
+                    AnalyticsProperties.STATUS to status,
+                    AnalyticsProperties.AVAILABLE_PRODUCT_IDS to availableProductIds,
+                    AnalyticsProperties.MISSING_PRODUCT_IDS to missingProductIds,
+                    AnalyticsProperties.PRODUCT_COUNT to availableProductIds.size,
+                ),
+            )
         }
 
         private suspend fun fetchProductDetails(productID: String): com.android.billingclient.api.ProductDetails? {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -76,6 +76,7 @@ fun RandomTimerNavHost(
     var lifetimePrice by remember { mutableStateOf("$4.99") }
     var paywallEntryPoint by remember { mutableStateOf("unknown") }
     var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
+    var paywallAvailableProductIds by remember { mutableStateOf(emptySet<String>()) }
     var paywallDefaultToAnnual by remember { mutableStateOf(false) }
     var paywallValueFramingVariant by remember { mutableStateOf(PaywallValueFraming.CONTROL) }
 
@@ -85,6 +86,7 @@ fun RandomTimerNavHost(
             proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
             monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
             lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
+            paywallAvailableProductIds = viewModel.proManager.availablePaywallProductIds()
             paywallEntryPoint = paywallEntryPointForFeature(feature)
             paywallTrialEligibilityByProductId =
                 mapOf(
@@ -261,6 +263,7 @@ fun RandomTimerNavHost(
             defaultToAnnualPlan = paywallDefaultToAnnual,
             valueFramingVariant = paywallValueFramingVariant,
             trialEligibilityByProductId = paywallTrialEligibilityByProductId,
+            availableProductIds = paywallAvailableProductIds,
             onPlanSelected = { plan, productId, selectionSource ->
                 viewModel.trackPaywallOfferSelected(
                     entryPoint = paywallEntryPoint,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -121,6 +122,7 @@ fun PaywallSheet(
     defaultToAnnualPlan: Boolean = false,
     valueFramingVariant: String = PaywallValueFraming.CONTROL,
     trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
+    availableProductIds: Set<String> = emptySet(),
     onPurchase: (String) -> Unit,
     onPlanSelected: (plan: String, productId: String, selectionSource: String) -> Unit = { _, _, _ -> },
     onRestore: () -> Unit,
@@ -130,6 +132,11 @@ fun PaywallSheet(
     val haptic = LocalHapticFeedback.current
     val initialSelection = initialPlanSelection(entryPoint, defaultToAnnualPlan)
     var selectedPlan by remember(entryPoint, defaultToAnnualPlan) { mutableStateOf(initialSelection) }
+    LaunchedEffect(availableProductIds, selectedPlan) {
+        if (!shouldShowPaywallPlan(selectedPlan, availableProductIds)) {
+            selectedPlan = fallbackPaywallPlan(availableProductIds)
+        }
+    }
     val featureContext = paywallFeatureContext(entryPoint)
     val headline =
         if (valueFramingVariant == PaywallValueFraming.OUTCOMES_FIRST) {
@@ -343,42 +350,48 @@ fun PaywallSheet(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                PlanOptionCard(
-                    title = "Lifetime",
-                    priceLabel = stripPriceSuffix(lifetimePrice),
-                    badge = "One-time",
-                    isSelected = selectedPlan == SubscriptionPlanSelection.LIFETIME,
-                    onClick = {
-                        selectedPlan = SubscriptionPlanSelection.LIFETIME
-                        onPlanSelected("lifetime", ProManager.BASE_PRODUCT_ID, "plan_card")
-                    },
-                )
+                if (shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, availableProductIds)) {
+                    PlanOptionCard(
+                        title = "Lifetime",
+                        priceLabel = stripPriceSuffix(lifetimePrice),
+                        badge = "One-time",
+                        isSelected = selectedPlan == SubscriptionPlanSelection.LIFETIME,
+                        onClick = {
+                            selectedPlan = SubscriptionPlanSelection.LIFETIME
+                            onPlanSelected("lifetime", ProManager.BASE_PRODUCT_ID, "plan_card")
+                        },
+                    )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
 
-                PlanOptionCard(
-                    title = "Monthly",
-                    priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
-                    badge = null,
-                    isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
-                    onClick = {
-                        selectedPlan = SubscriptionPlanSelection.MONTHLY
-                        onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID, "plan_card")
-                    },
-                )
+                if (shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, availableProductIds)) {
+                    PlanOptionCard(
+                        title = "Monthly",
+                        priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
+                        badge = null,
+                        isSelected = selectedPlan == SubscriptionPlanSelection.MONTHLY,
+                        onClick = {
+                            selectedPlan = SubscriptionPlanSelection.MONTHLY
+                            onPlanSelected("monthly", ProManager.MONTHLY_PRODUCT_ID, "plan_card")
+                        },
+                    )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
 
-                PlanOptionCard(
-                    title = "Annual",
-                    priceLabel = "${stripPriceSuffix(proPrice)}/year",
-                    badge = "Best Value",
-                    isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
-                    onClick = {
-                        selectedPlan = SubscriptionPlanSelection.ANNUAL
-                        onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID, "plan_card")
-                    },
-                )
+                if (shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, availableProductIds)) {
+                    PlanOptionCard(
+                        title = "Annual",
+                        priceLabel = "${stripPriceSuffix(proPrice)}/year",
+                        badge = "Best Value",
+                        isSelected = selectedPlan == SubscriptionPlanSelection.ANNUAL,
+                        onClick = {
+                            selectedPlan = SubscriptionPlanSelection.ANNUAL
+                            onPlanSelected("annual", ProManager.ELITE_PRODUCT_ID, "plan_card")
+                        },
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(20.dp))
             }
@@ -409,6 +422,27 @@ internal fun initialPlanSelection(
         entryPoint == "setup_upgrade_cta" -> SubscriptionPlanSelection.LIFETIME
         else -> SubscriptionPlanSelection.MONTHLY
     }
+
+internal fun shouldShowPaywallPlan(
+    plan: SubscriptionPlanSelection,
+    availableProductIds: Set<String>,
+): Boolean {
+    if (availableProductIds.isEmpty()) {
+        return true
+    }
+    val knownPaywallProductIds = SubscriptionPlanSelection.entries.map(::productIdForPlan).toSet()
+    if (availableProductIds.intersect(knownPaywallProductIds).isEmpty()) {
+        return true
+    }
+    return availableProductIds.contains(productIdForPlan(plan))
+}
+
+internal fun fallbackPaywallPlan(availableProductIds: Set<String>): SubscriptionPlanSelection =
+    listOf(
+        SubscriptionPlanSelection.LIFETIME,
+        SubscriptionPlanSelection.ANNUAL,
+        SubscriptionPlanSelection.MONTHLY,
+    ).firstOrNull { shouldShowPaywallPlan(it, availableProductIds) } ?: SubscriptionPlanSelection.LIFETIME
 
 internal fun ctaLabelForPlan(
     selectedPlan: SubscriptionPlanSelection,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -130,4 +130,24 @@ class PaywallSheetTest {
             initialPlanSelection(entryPoint = "setup_upgrade_cta", defaultToAnnualPlan = true),
         )
     }
+
+    @Test
+    fun `known billing catalog hides unavailable paywall plans`() {
+        val availableProductIds =
+            setOf(
+                ProManager.BASE_PRODUCT_ID,
+                ProManager.ELITE_PRODUCT_ID,
+            )
+
+        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, availableProductIds))
+        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, availableProductIds))
+        assertEquals(false, shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, availableProductIds))
+    }
+
+    @Test
+    fun `unknown billing catalog keeps paywall plans visible`() {
+        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, emptySet()))
+        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, emptySet()))
+        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, emptySet()))
+    }
 }

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -542,6 +542,7 @@ enum AnalyticsEvents {
     static let paywallPurchaseSuccess = "paywall_purchase_success"
     static let paywallPurchaseResult = "paywall_purchase_result"
     static let paywallRestoreResult = "paywall_restore_result"
+    static let billingProductCatalogStatus = "billing_product_catalog_status"
 
     // Feature gates & voice
     static let voiceGenderSelected = "voice_gender_selected"
@@ -601,6 +602,10 @@ enum AnalyticsProperties {
     static let paywallExperimentVariant = "paywall_experiment_variant"
     static let paywallValueFramingVariant = "paywall_value_framing_variant"
     static let paywallSelectionSource = "paywall_selection_source"
+    static let status = "status"
+    static let availableProductIds = "available_product_ids"
+    static let missingProductIds = "missing_product_ids"
+    static let productCount = "product_count"
 }
 
 enum AnalyticsValues {

--- a/native-ios/RandomTimer/Sources/Services/ProManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProManager.swift
@@ -58,9 +58,34 @@ final class ProManager: ObservableObject { // swiftlint:disable:this no_observab
                 let ids = Self.productIDs
                 Self.log.error("ProManager: products EMPTY for IDs: \(ids). Check ASC config.")
             }
+            trackProductCatalogStatus()
         } catch {
             Self.log.error("ProManager: failed to fetch products: \(error)")
+            AnalyticsService.shared.track(AnalyticsEvents.billingProductCatalogStatus, properties: [
+                AnalyticsProperties.status: "fetch_failed",
+                AnalyticsProperties.reason: String(describing: error),
+                AnalyticsProperties.productCount: 0,
+            ])
         }
+    }
+
+    private func trackProductCatalogStatus() {
+        let availableProductIDs = Set(products.map(\.id))
+        let missingProductIDs = Self.productIDs.subtracting(availableProductIDs).sorted()
+        let status: String
+        if availableProductIDs.isEmpty {
+            status = "empty"
+        } else if missingProductIDs.isEmpty == false {
+            status = "missing_required_products"
+        } else {
+            status = "ok"
+        }
+        AnalyticsService.shared.track(AnalyticsEvents.billingProductCatalogStatus, properties: [
+            AnalyticsProperties.status: status,
+            AnalyticsProperties.availableProductIds: availableProductIDs.sorted(),
+            AnalyticsProperties.missingProductIds: missingProductIDs,
+            AnalyticsProperties.productCount: availableProductIDs.count,
+        ])
     }
 
     func formattedPrice(for productID: String) -> String {

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -65,6 +65,14 @@ final class TimerConfigProClampingTests: XCTestCase {
         XCTAssertEqual(ProManager.annualProductID, "com.iganapolsky.randomtimer.elite")
     }
 
+    func testBillingProductCatalogDiagnosticsUseSharedAnalyticsNames() {
+        XCTAssertEqual(AnalyticsEvents.billingProductCatalogStatus, "billing_product_catalog_status")
+        XCTAssertEqual(AnalyticsProperties.status, "status")
+        XCTAssertEqual(AnalyticsProperties.availableProductIds, "available_product_ids")
+        XCTAssertEqual(AnalyticsProperties.missingProductIds, "missing_product_ids")
+        XCTAssertEqual(AnalyticsProperties.productCount, "product_count")
+    }
+
     func testPaywallDoesNotShowMissingMonthlyProductWhenStoreKitDoesNotReturnIt() {
         XCTAssertTrue(shouldShowPaywallPlan(.lifetime, availableProductIDs: []))
         XCTAssertTrue(shouldShowPaywallPlan(.annual, availableProductIDs: []))

--- a/scripts/paywall_conversion_report.py
+++ b/scripts/paywall_conversion_report.py
@@ -219,6 +219,43 @@ def _product_funnel(api_key: str, project_id: str, days: int, errors: List[str])
     return out
 
 
+def _product_catalog_failures(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
+    win = f"{days} day"
+    rows = _table(
+        f"""
+        SELECT
+          coalesce(toString(properties.platform), 'unknown') AS platform,
+          coalesce(toString(properties.product_id), 'unknown') AS product_id,
+          count() AS failures,
+          count(DISTINCT person_id) AS users
+        FROM events
+        WHERE event IN ('billing_product_not_found', 'billing_product_catalog_status')
+          AND timestamp > now() - interval {win}
+          AND {LIVE_EVENTS_PREDICATE}
+          AND (
+            event = 'billing_product_not_found'
+            OR coalesce(toString(properties.status), '') IN ('empty', 'missing_required_products')
+          )
+        GROUP BY platform, product_id
+        ORDER BY failures DESC
+        LIMIT 25
+        /* product_catalog_failures */
+        """,
+        api_key,
+        project_id,
+        errors,
+    )
+    return [
+        {
+            "platform": str(row[0] or "unknown"),
+            "product_id": str(row[1] or "unknown"),
+            "failures": _safe_int(row[2]),
+            "users": _safe_int(row[3]),
+        }
+        for row in rows
+    ]
+
+
 def _entry_point_funnel(api_key: str, project_id: str, days: int, errors: List[str]) -> list[dict[str, Any]]:
     win = f"{days} day"
     rows = _table(
@@ -303,6 +340,7 @@ def _data_quality_warnings(
     entry_points: list[dict[str, Any]],
     settings_hotspots: list[dict[str, Any]],
     failure_reasons: list[dict[str, Any]],
+    product_catalog_failures: list[dict[str, Any]],
 ) -> list[str]:
     warnings: list[str] = []
     offer_selects = _safe_int(counts.get("offer_selects"))
@@ -332,6 +370,11 @@ def _data_quality_warnings(
     if failure_total > 0 and _rate(user_cancelled, failure_total) >= 0.75:
         warnings.append(
             "purchase failures are dominated by user_cancelled; prioritize pricing, plan default, and purchase-sheet value proof before assuming a store outage"
+        )
+    catalog_failure_total = sum(_safe_int(row.get("failures")) for row in product_catalog_failures)
+    if catalog_failure_total > 0:
+        warnings.append(
+            "product catalog lookup failures detected; verify App Store Connect and Google Play product IDs, approval state, and cleared-for-sale status"
         )
     return warnings
 
@@ -394,6 +437,22 @@ def build_markdown(payload: Dict[str, Any]) -> str:
         )
     if not payload.get("product_funnel"):
         lines.append("| (none) | (none) | 0 | 0 | 0 | 0.0% | 0.0% |")
+
+    lines.extend(
+        [
+            "",
+            "## Product Catalog Failures",
+            "| Platform | Product ID | Failures | Users |",
+            "|----------|------------|----------|-------|",
+        ]
+    )
+    for row in payload.get("product_catalog_failures", []):
+        lines.append(
+            f"| {row.get('platform', 'unknown')} | {row.get('product_id', 'unknown')} | "
+            f"{row.get('failures', 0)} | {row.get('users', 0)} |"
+        )
+    if not payload.get("product_catalog_failures"):
+        lines.append("| (none) | (none) | 0 | 0 |")
 
     lines.extend(
         [
@@ -496,6 +555,7 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         "top_failure_reasons": [],
         "failure_breakdown": [],
         "product_funnel": [],
+        "product_catalog_failures": [],
         "entry_points": [],
         "leaky_entry_points": [],
         "settings_hotspots": [],
@@ -515,6 +575,7 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
     failures = _failure_reasons(api_key, project_id, days, errors)
     failure_breakdown = _failure_breakdown(api_key, project_id, days, errors)
     product_funnel = _product_funnel(api_key, project_id, days, errors)
+    product_catalog_failures = _product_catalog_failures(api_key, project_id, days, errors)
     entry_points = _entry_point_funnel(api_key, project_id, days, errors)
     settings_hotspots = _settings_hotspots(api_key, project_id, days, errors)
 
@@ -527,6 +588,7 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
     payload["top_failure_reasons"] = failures
     payload["failure_breakdown"] = failure_breakdown
     payload["product_funnel"] = product_funnel
+    payload["product_catalog_failures"] = product_catalog_failures
     payload["entry_points"] = entry_points
     payload["leaky_entry_points"] = _leaky_entry_points(entry_points)
     payload["settings_hotspots"] = settings_hotspots
@@ -535,6 +597,7 @@ def run(repo_root: Path, days: int = 30) -> Dict[str, Any]:
         entry_points,
         settings_hotspots,
         failures,
+        product_catalog_failures,
     )
     payload["query_errors"] = errors
     if errors:

--- a/scripts/tests/test_paywall_conversion_report.py
+++ b/scripts/tests/test_paywall_conversion_report.py
@@ -16,6 +16,8 @@ def run_report_with_mocked_posthog(report, scalar_rows, table_rows):
             return {"results": next(table_results)}
         if "product_funnel" in _query:
             return {"results": next(table_results)}
+        if "product_catalog_failures" in _query:
+            return {"results": next(table_results)}
         if "entry_point_funnel" in _query:
             return {"results": next(table_results)}
         if "settings_hotspots" in _query:
@@ -71,6 +73,14 @@ class PaywallConversionReportTests(unittest.TestCase):
                     "attempt_to_success_rate": 0.1429,
                 },
             ],
+            "product_catalog_failures": [
+                {
+                    "platform": "ios",
+                    "product_id": "com.iganapolsky.randomtimer.pro.monthly",
+                    "failures": 5,
+                    "users": 3,
+                },
+            ],
             "entry_points": [
                 {"entry_point": "setup_upgrade_cta", "views": 70, "attempts": 15, "successes": 2},
                 {"entry_point": "unknown", "views": 25, "attempts": 0, "successes": 0},
@@ -93,6 +103,7 @@ class PaywallConversionReportTests(unittest.TestCase):
         self.assertIn("user_cancelled", markdown)
         self.assertIn("Failure Breakdown", markdown)
         self.assertIn("Product Funnel", markdown)
+        self.assertIn("Product Catalog Failures", markdown)
         self.assertIn("com.iganapolsky.randomtimer.pro.monthly", markdown)
         self.assertIn("setup_upgrade_cta", markdown)
         self.assertIn("Leaky Entry Points", markdown)
@@ -140,6 +151,7 @@ class PaywallConversionReportTests(unittest.TestCase):
                 [["user_cancelled", 10], ["network_error", 5]],
                 [["ios", "com.iganapolsky.randomtimer.pro.monthly", "user_cancelled", 10, 8]],
                 [["ios", "com.iganapolsky.randomtimer.pro.monthly", 42, 17, 4]],
+                [],
                 [["setup_upgrade_cta", 80, 16, 4], ["sound_gate", 40, 8, 2]],
                 [["voice_callouts_enabled", 31, 14], ["repeat_enabled", 15, 9]],
             ],
@@ -171,6 +183,7 @@ class PaywallConversionReportTests(unittest.TestCase):
                 [["user_cancelled", 10]],
                 [["ios", "com.iganapolsky.randomtimer.pro.monthly", "user_cancelled", 10, 8]],
                 [["ios", "com.iganapolsky.randomtimer.pro.monthly", 42, 17, 4]],
+                [],
                 [["setup_upgrade_cta", 90, 0, 0], ["sound_gate", 40, 8, 2]],
                 [["voice_callouts_enabled", 31, 14]],
             ],
@@ -194,6 +207,7 @@ class PaywallConversionReportTests(unittest.TestCase):
                 [["user_cancelled", 10]],
                 [["ios", "com.iganapolsky.randomtimer.pro.monthly", "user_cancelled", 10, 8]],
                 [["ios", "com.iganapolsky.randomtimer.pro.monthly", 42, 17, 0]],
+                [["ios", "com.iganapolsky.randomtimer.pro.monthly", 11, 7]],
                 [["unknown", 159, 0, 0], ["sound_gate", 68, 44, 1]],
                 [["unknown", 34847, 601]],
             ],
@@ -208,6 +222,9 @@ class PaywallConversionReportTests(unittest.TestCase):
         )
         self.assertTrue(
             any("purchase failures are dominated by user_cancelled" in warning for warning in result["data_quality_warnings"])
+        )
+        self.assertTrue(
+            any("product catalog lookup failures" in warning for warning in result["data_quality_warnings"])
         )
 
 


### PR DESCRIPTION
## Summary
- hide unavailable Android paywall plans once Google Billing returns the known product catalog
- track billing product catalog status on iOS and Android
- surface catalog lookup failures in the paywall conversion report

## Verification
- python3 -m unittest scripts.tests.test_paywall_conversion_report
- cd native-android && ./gradlew testDebugUnitTest --tests 'com.iganapolsky.randomtimer.ui.screens.PaywallSheetTest'
- cd native-ios && xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:RandomTimerTests/TimerConfigProClampingTests/testBillingProductCatalogDiagnosticsUseSharedAnalyticsNames test