### PR TITLE
Release v1.3.34

### DIFF
--- a/release-notes/1.3.34.md
+++ b/release-notes/1.3.34.md
@@ -1,0 +1,14 @@
+# Release 1.3.34
+
+## Summary
+**1.3.34** is a revenue-protection release for Android and iOS. It hardens the mobile paywall against store product catalog mismatches and adds diagnostics that show when expected in-app purchase products are missing from Google Play Billing or StoreKit.
+
+## Technical Fixes
+- **Paywall catalog safety:** Android and iOS now report billing product catalog status after store product lookup, including available and missing product IDs.
+- **Unavailable plan handling:** Android hides unavailable known paywall plans after the billing catalog is verified, while preserving a safe fallback when the catalog is unknown.
+- **Conversion diagnostics:** The paywall conversion report now surfaces product catalog failures so revenue blockers are visible in operational reporting.
+- **Telemetry parity:** Store catalog diagnostics use shared analytics event and property names across Android and iOS.
+
+## Release Operations
+- Unified release candidate for Android and iOS.
+- Intended for immediate production submission after CI, internal distribution, and store read-back verification.


### PR DESCRIPTION
Release branch for Random Tactical Timer v1.3.34. Includes paywall product catalog diagnostics and release notes required by preflight.