### PR TITLE
fix(gitignore): ignore evidence/ to satisfy repo-hygiene contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ native-android/gradle/gradle-daemon-jvm.properties
 
 # RLHF runtime artifacts (per-checkout local audit / feedback / memory state)
 .rlhf/
+
+# Local-only evidence artifacts (per-checkout screenshots, manual capture)
+evidence/


### PR DESCRIPTION
## What

Add `evidence/` to `.gitignore` to satisfy `scripts/tests/test_repo_hygiene_contracts.py::test_gitignore_covers_known_local_artifact_buckets`, which is currently failing on `develop` (CI run `26053808925`) and on PR #1538.

## Why

The test pins `.gitignore` against an expected list of local-only artifact buckets. `evidence/` was missing — broken on develop and cascading to every PR cut from it.

## Risk

- Two PNGs already tracked under `evidence/` stay tracked (git ignores rules don't untrack already-committed files).
- Future per-checkout artifacts (screenshots, manual captures) stop drifting into commits.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_repo_hygiene_contracts.py::test_gitignore_covers_known_local_artifact_buckets -v` → PASSED locally
- [ ] CI Python Script Tests goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)