### PR TITLE
fix(tests): document timer_extended as Android-only (analytics parity)

### DIFF
--- a/scripts/tests/test_mobile_analytics_parity.py
+++ b/scripts/tests/test_mobile_analytics_parity.py
@@ -60,7 +60,15 @@ class MobileAnalyticsParityTests(unittest.TestCase):
         # timer_backgrounded is iOS-only: iOS fires it when app backgrounds during
         # a running timer (informational). Android's foreground service doesn't need it.
         ios_only_events = {"timer_backgrounded"}
-        self.assertEqual(android_events, ios_events - ios_only_events)
+        # timer_extended is Android-only: Android's foreground-service notification
+        # exposes a "+5 min" extend-running-timer action (see
+        # TimerForegroundService.kt around line 430). iOS doesn't ship that
+        # affordance, so the event has no legitimate iOS emission point.
+        android_only_events = {"timer_extended"}
+        self.assertEqual(
+            android_events - android_only_events,
+            ios_events - ios_only_events,
+        )
 
     def test_screen_names_match_between_ios_and_android(self):
         android_source = ANDROID_ANALYTICS.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

Fix the second of the two `Python Script Tests` failures cascading on `develop` and every PR (run `26053808925` initial, also seen on PRs #1538 / #1539):

`scripts/tests/test_mobile_analytics_parity.py::test_event_names_match_between_ios_and_android` was asserting strict equality between Android's event-name set and iOS's (minus the documented iOS-only `timer_backgrounded`). It missed the symmetric case: Android also has a platform-specific event — `timer_extended` — emitted when a user taps the "+5 min" extend-running-timer action exposed by the Android foreground-service notification (`TimerForegroundService.kt:431`). iOS doesn't ship that affordance, so the event has no legitimate iOS emission point.

## Diff

Documented `timer_extended` as Android-only alongside the existing `timer_backgrounded` iOS-only exception. Same shape, same documentation pattern.

```python
ios_only_events = {"timer_backgrounded"}
android_only_events = {"timer_extended"}  # +5min notification action; iOS has no equivalent
self.assertEqual(
    android_events - android_only_events,
    ios_events - ios_only_events,
)
```

## Alternatives rejected

- **Add `timerExtended` to iOS** — would pass the test by lying. iOS would have the constant but no emission point; dead code.
- **Remove `TIMER_EXTENDED` from Android** — would silently delete a real emission point wired into the notification flow.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_mobile_analytics_parity.py -v` → 9 passed locally
- [ ] CI Python Script Tests goes green once this PR + parallel PR #1539 (gitignore `evidence/`) both land. Both Python failures will be resolved.

## Note

The `evidence/` gitignore test still fails on this branch because that fix is on parallel PR #1539 cut from the same `develop` SHA. Once both PRs merge, all Python script tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)