### PR TITLE
feat(android-aso): short_description adds 'muay thai', drops redundant 'Random cues'

### DIFF
--- a/native-android/fastlane/metadata/android/en-US/short_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Random tactical timer: MMA, boxing, BJJ & HIIT. Random cues + AI coach voices.
+Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices.

--- a/scripts/tests/test_store_metadata_copy.py
+++ b/scripts/tests/test_store_metadata_copy.py
@@ -16,9 +16,14 @@ def test_android_store_copy_uses_reaction_positioning() -> None:
     assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in full_description
     assert "pattern-interrupt training built for combat sports, sparring, drills, and reaction work." in full_description
     assert "serious fighters and operators" not in full_description
+    # Short description pin (snapshot regression guard). Updated 2026-05-18:
+    # added "muay thai" as a new indexed term (high-volume combat-sport search),
+    # reordered to MMA → BJJ → boxing → muay thai → HIIT for natural reading,
+    # dropped redundant "Random cues" (Random already opens the string).
+    # 75/80 chars within Play Store's limit.
     assert (
         short_description.strip()
-        == "Random tactical timer: MMA, boxing, BJJ & HIIT. Random cues + AI coach voices."
+        == "Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices."
     )
 
 


### PR DESCRIPTION
## What

Play Store `short_description.txt` 78c → 75c. Swap user-visible + ASO-indexed copy on the listing card:

```
- Random tactical timer: MMA, boxing, BJJ & HIIT. Random cues + AI coach voices.
+ Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices.
```

Snapshot pin in `scripts/tests/test_store_metadata_copy.py` updated to match (regression guard stays active for future drift).

## Why

- **"muay thai" added** — high-volume combat-sport search term not currently indexed by the Play listing's title or short_description (full_description has it but Play's ranker weights short_description higher).
- **Sports reordered** — MMA → BJJ → boxing → muay thai → HIIT reads more naturally (grappling acronyms cluster, then explicit striking, then HIIT).
- **"Random cues" dropped** — redundant, "Random" already opens the string.
- **"AI coach voices" preserved** — Pro upsell anchor stays visible.

## Risk

Conversion-neutral — same brand opener, same call-to-action emphasis. ASO-positive: net new indexed term.

## Test plan

- [x] `pytest scripts/tests/test_store_metadata_copy.py -v` → 2 passed
- [x] 75/80 chars (5 byte headroom on Play Store's 80-char short_description limit)
- [ ] Ships next time Play Store metadata sync runs

## Context

Cycle 10 of the autonomous Ralph Loop. Parallel to PR #1542 (iOS ASO subtitle, just merged) — ships ASO on both stores in matched cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)