### PR TITLE
feat(landing): add MMA/BJJ/boxing/muay thai/HIIT keywords to product page meta + hero

### DIFF
--- a/marketing/product-pages/index.html
+++ b/marketing/product-pages/index.html
@@ -4,22 +4,22 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Random Tactical Timer | Train Reaction Under Stress</title>
-  <meta name="description" content="Train reaction under stress with random interval drills on iPhone and Android. Start the 7-day challenge: complete 3 drills this week." />
+  <meta name="description" content="Random timer for MMA, BJJ, boxing, muay thai &amp; HIIT — train reaction under stress with unpredictable interval drills on iPhone and Android." />
   <meta name="robots" content="index,follow,max-image-preview:large" />
   <link rel="canonical" href="https://igorganapolsky.github.io/Random-Timer" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Random Tactical Timer" />
   <meta property="og:title" content="Random Tactical Timer | Train Reaction Under Stress" />
-  <meta property="og:description" content="Train reaction under stress with random interval drills on iPhone and Android. Start the 7-day challenge: complete 3 drills this week." />
+  <meta property="og:description" content="Random timer for MMA, BJJ, boxing, muay thai &amp; HIIT — train reaction under stress with unpredictable interval drills on iPhone and Android." />
   <meta property="og:url" content="https://igorganapolsky.github.io/Random-Timer" />
   <meta property="og:image" content="https://igorganapolsky.github.io/Random-Timer/assets/social-preview.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Random Tactical Timer | Train Reaction Under Stress" />
-  <meta name="twitter:description" content="Train reaction under stress with random interval drills on iPhone and Android. Start the 7-day challenge: complete 3 drills this week." />
+  <meta name="twitter:description" content="Random timer for MMA, BJJ, boxing, muay thai &amp; HIIT — train reaction under stress with unpredictable interval drills on iPhone and Android." />
   <meta name="twitter:image" content="https://igorganapolsky.github.io/Random-Timer/assets/social-preview.png" />
   <link rel="stylesheet" href="styles.css" />
   <link rel="alternate" type="application/json" title="Agentic Merchant Protocol Data" href="https://igorganapolsky.github.io/Random-Timer/amp.json" />
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Random Tactical Timer","description":"Train reaction under stress with random interval drills on iPhone and Android. Start the 7-day challenge: complete 3 drills this week.","url":"https://igorganapolsky.github.io/Random-Timer","applicationCategory":"HealthAndFitnessApplication","operatingSystem":["iOS","Android"],"downloadUrl":"https://igorganapolsky.github.io/Random-Timer/download?utm_source=github_pages&utm_medium=organic&utm_campaign=site_7_day_challenge&utm_content=hero_primary","offers":{"@type":"Offer","price":"0.00","priceCurrency":"USD"},"potentialAction":{"@type":"DownloadAction","target":"https://igorganapolsky.github.io/Random-Timer/download?utm_source=github_pages&utm_medium=organic&utm_campaign=site_7_day_challenge&utm_content=hero_primary"}}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Random Tactical Timer","description":"Random timer for MMA, BJJ, boxing, muay thai &amp; HIIT — train reaction under stress with unpredictable interval drills on iPhone and Android.","url":"https://igorganapolsky.github.io/Random-Timer","applicationCategory":"HealthAndFitnessApplication","operatingSystem":["iOS","Android"],"downloadUrl":"https://igorganapolsky.github.io/Random-Timer/download?utm_source=github_pages&utm_medium=organic&utm_campaign=site_7_day_challenge&utm_content=hero_primary","offers":{"@type":"Offer","price":"0.00","priceCurrency":"USD"},"potentialAction":{"@type":"DownloadAction","target":"https://igorganapolsky.github.io/Random-Timer/download?utm_source=github_pages&utm_medium=organic&utm_campaign=site_7_day_challenge&utm_content=hero_primary"}}</script>
 
 </head>
 <body>
@@ -27,7 +27,7 @@
     <span class="eyebrow">7-day challenge • 3 drills • measurable stress training</span>
     <section class="hero">
       <div class="hero-copy">
-        <p class="meta">For combat sports, tactical drills, pad work, sparring, and reaction conditioning.</p>
+        <p class="meta">For MMA, BJJ, boxing, muay thai, HIIT, sparring, pad work, and tactical reaction conditioning.</p>
         <h1>Train reaction under stress.</h1>
         <p class="hero-lead">
           Random Tactical Timer fires at unpredictable moments so you cannot cheat the rep.


### PR DESCRIPTION
## What

The product landing at `marketing/product-pages/index.html` had **zero coverage** of high-volume sport keywords:

```
MMA          1   ← only one mention, deep in body
boxing       0
BJJ          0
muay thai    0
HIIT         0
CrossFit     0
sparring     1
```

Two surgical edits add the keyword set to the page's most-weighted zones:

### 1. Meta description (5 surfaces in one edit)

The `<meta name="description">`, OG description, Twitter description, and JSON-LD `description` all carried the same string — replaced atomically via `replace_all`. 134c → 141c, within Google's 155-char SERP-snippet limit.

```diff
- Train reaction under stress with random interval drills on iPhone and Android. Start the 7-day challenge: complete 3 drills this week.
+ Random timer for MMA, BJJ, boxing, muay thai & HIIT — train reaction under stress with unpredictable interval drills on iPhone and Android.
```

### 2. Hero meta line above H1

The first prose users see — was generic, now lists the sports explicitly.

```diff
- For combat sports, tactical drills, pad work, sparring, and reaction conditioning.
+ For MMA, BJJ, boxing, muay thai, HIIT, sparring, pad work, and tactical reaction conditioning.
```

## Why

- **SEO:** organic search for "MMA timer", "BJJ timer", "muay thai timer", "HIIT random interval" now match this page on the title-adjacent SEO surfaces, not just deep in the body.
- **Share previews:** when this page gets posted on Reddit / X / FB / iMessage, the OG/Twitter card now leads with the sport names instead of the brand-only line — higher click-through.
- **Conversion neutral:** hero CTA, H1, FAQ, and trust copy all unchanged. The added line is informational, not promotional.

## Context

Cycle 11 of the autonomous Ralph Loop. ASO/SEO ship tandem with the just-merged PRs #1538 (iOS keywords 99c), #1542 (iOS subtitle "training"), #1543 (Android short_description "muay thai") — same keyword set now hits the iOS App Store search, Play Store listing, AND the marketing landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)