### PR TITLE
chore(android-changelog): add 1778679336.txt for next release's versionCode

### DIFF
--- a/native-android/fastlane/metadata/android/en-US/changelogs/1778679336.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1778679336.txt
@@ -1,0 +1,3 @@
+• Bluetooth headset & AirPods buttons can now stop the alarm
+• Tap the timer circle to dismiss when an alarm fires (ALARM or COMPLETE)
+• Competition Prep training presets organized into a collapsible section


### PR DESCRIPTION
## What

Add `native-android/fastlane/metadata/android/en-US/changelogs/1778679336.txt`.

## Why

Per CLAUDE.md mandate: "Update changelogs for every new version code".

- `build.gradle.kts` defaults `versionCode = ciVersionCode ?: 1778679336`.
- Latest changelog file pre-PR: `1774900017.txt` — strictly older.
- Without this file, the next Play Store release would ship with no "What's new" panel content for users.

## Content

```
• Bluetooth headset & AirPods buttons can now stop the alarm
• Tap the timer circle to dismiss when an alarm fires (ALARM or COMPLETE)
• Competition Prep training presets organized into a collapsible section
```

Three lines (under Play Store's 500-char limit), each maps to user-facing behavior shipped on `develop` in commit `284291be` ("bluetooth headset media-button stops alarm + tap-to-dismiss + competition-prep accordion"). Store-listing copy improvements (the cycle-1–12 ASO PRs) are intentionally excluded — those are metadata/SEO changes, not user-visible app behavior.

## Context

Cycle 13 of the autonomous Ralph Loop. Hygiene/release-readiness ship; closes a CLAUDE.md mandatory rule gap so the next release can publish cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)