### PR TITLE
chore(readme): resync store-line table + add sport keywords to intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 [![iOS](https://img.shields.io/badge/iOS-SwiftUI-blue?logo=apple)](native-ios/)
 [![Android](https://img.shields.io/badge/Android-Compose-3DDC84?logo=android)](native-android/)
 
-**Train reaction, not rhythm.** Native **iOS + Android** app: the buzzer fires at a **random** moment inside your range so you cannot anticipate it.
+**Train reaction, not rhythm.** Random interval timer for **MMA, BJJ, boxing, muay thai, kickboxing, HIIT, CrossFit, sparring, tabata, pad work, and tactical drills**. Native **iOS + Android** app: the buzzer fires at a **random** moment inside your range so you cannot anticipate it.
 
 *Store-facing line:* **TRAIN FOR CHAOS. NOT RHYTHM.** — same headline as [App Store description](native-ios/fastlane/metadata/en-US/description.txt) and [Play Store full description](native-android/fastlane/metadata/android/en-US/full_description.txt) (en-US).
 
 | Store | One-liner (en-US) |
 |--------|-------------------|
-| **App Store** subtitle | [Dry Fire, Boxing, BJJ, HIIT](native-ios/fastlane/metadata/en-US/subtitle.txt) |
-| **Play** short description | [Random timer with male & female AI coach voice for combat sports and HIIT.](native-android/fastlane/metadata/android/en-US/short_description.txt) |
+| **App Store** subtitle | [Random HIIT & combat training](native-ios/fastlane/metadata/en-US/subtitle.txt) |
+| **Play** short description | [Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices.](native-android/fastlane/metadata/android/en-US/short_description.txt) |
 
 ---
 


### PR DESCRIPTION
## What

Two surgical edits to `README.md`:

### 1. Resync the "Store-facing line" table

The table cited copy that **diverged from the metadata files it links to** after PRs #1542 + #1543 landed on develop:

```diff
- | **App Store** subtitle | [Dry Fire, Boxing, BJJ, HIIT](...) |
+ | **App Store** subtitle | [Random HIIT & combat training](...) |

- | **Play** short description | [Random timer with male & female AI coach voice for combat sports and HIIT.](...) |
+ | **Play** short description | [Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices.](...) |
```

Anyone reading the README saw stale copy that didn't match what's actually shipped.

### 2. Add sport keywords to intro

The README's lead paragraph was brand-only ("Train reaction, not rhythm. Native iOS + Android app…"). Added explicit sport keyword coverage so GitHub-indexed README + LLMs reading the repo surface the app for sport-specific queries.

```diff
- **Train reaction, not rhythm.** Native **iOS + Android** app: the buzzer fires at a **random** moment inside your range so you cannot anticipate it.
+ **Train reaction, not rhythm.** Random interval timer for **MMA, BJJ, boxing, muay thai, kickboxing, HIIT, CrossFit, sparring, tabata, pad work, and tactical drills**. Native **iOS + Android** app: the buzzer fires at a **random** moment inside your range so you cannot anticipate it.
```

## Why

Sixth discovery surface now coherent on the same keyword set. The five before:

| Surface | PR | Status |
|---|---|---|
| iOS App Store keywords | #1538 | Merged |
| iOS App Store subtitle | #1542 | Merged |
| Play Store short_description | #1543 | Merged |
| Marketing landing page | #1544 | Merged |
| AI-discovery (agents.md + amp.json ×2) | #1545 | Merged |
| **README.md (this PR)** | **#1547** | Open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)