### PR TITLE
chore(android-changelog): add 1778679337.txt to match PR #1537's versionCode bump target

### DIFF
--- a/native-android/fastlane/metadata/android/en-US/changelogs/1778679337.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1778679337.txt
@@ -1,0 +1,3 @@
+• Bluetooth headset & AirPods buttons can now stop the alarm
+• Tap the timer circle to dismiss when an alarm fires (ALARM or COMPLETE)
+• Competition Prep training presets organized into a collapsible section


### PR DESCRIPTION
## What

Add `native-android/fastlane/metadata/android/en-US/changelogs/1778679337.txt` ahead of the auto-bump in PR #1537.

## Why

PR #1537 will move `versionCode 1778679336 → 1778679337` and `versionName 1.3.34 → 1.3.35` in `native-android/app/build.gradle.kts`. Without a matching `1778679337.txt`, the next Play Store release would ship with an empty "What's new" panel — same regression class as the `1778679336.txt` gap that PR #1546 just fixed.

Content mirrors `1778679336.txt`: the versionCode increment is the routine post-release bump pattern, not a new feature drop, so the same three user-facing changes carry forward:

```
• Bluetooth headset & AirPods buttons can now stop the alarm
• Tap the timer circle to dismiss when an alarm fires (ALARM or COMPLETE)
• Competition Prep training presets organized into a collapsible section
```

## Sequencing

Land this first → then PR #1537 merges cleanly without orphaning its versionCode from a changelog file.

## Triage notes from cycle 15

Also closed in this cycle (not part of this PR):
- **#1527** (Release v1.3.33) — obsolete, v1.3.34 is already live per iTunes API verification. Was DIRTY with conflicts. Closed + branch deleted.
- **#1535** (older duplicate of #1537) — same title, identical purpose, newer wins. Closed + branch deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)