### PR TITLE
feat(keywords): seed_keywords + audience adds combat-sport terms (engine source-of-truth)

### DIFF
--- a/marketing/keywords/strategy.json
+++ b/marketing/keywords/strategy.json
@@ -1,7 +1,7 @@
 {
   "niche": "mobile timer app for tactical and reaction training",
   "monetization": "app installs, retention, and app store reviews",
-  "audience": "athletes, tactical trainers, coaches, and users who need unpredictable interval drills",
+  "audience": "MMA fighters, BJJ practitioners, boxers, muay thai and kickboxing athletes, HIIT and CrossFit trainers, sparring and pad-work coaches, tactical and combatives instructors, and athletes who need unpredictable interval drills",
   "seed_keywords": [
     "reaction training",
     "interval timer",
@@ -12,7 +12,13 @@
     "boxing drills",
     "home workout timer",
     "sparring prep",
-    "mental readiness"
+    "mental readiness",
+    "mma timer",
+    "bjj rounds",
+    "muay thai timer",
+    "kickboxing rounds",
+    "hiit timer",
+    "crossfit timer"
   ],
   "modifiers": [
     "best",


### PR DESCRIPTION
## What

Update `marketing/keywords/strategy.json` — the seed file that `scripts/growth_keyword_engine.py` reads to generate the keyword backlog.

```diff
- "audience": "athletes, tactical trainers, coaches, and users who need unpredictable interval drills",
+ "audience": "MMA fighters, BJJ practitioners, boxers, muay thai and kickboxing athletes, HIIT and CrossFit trainers, sparring and pad-work coaches, tactical and combatives instructors, and athletes who need unpredictable interval drills",

  "seed_keywords": [
    "reaction training", "interval timer", "tactical timer", "random timer",
    "focus drills", "combat conditioning", "boxing drills", "home workout timer",
    "sparring prep", "mental readiness",
+   "mma timer",
+   "bjj rounds",
+   "muay thai timer",
+   "kickboxing rounds",
+   "hiit timer",
+   "crossfit timer"
  ],
```

## Why

The keyword engine generates `app <seed>`, `best <seed>`, `review <seed>`, `vs <seed>`, `under 20 <seed>`, `for beginners <seed>`, `free <seed>`, `no ads <seed>` per seed. **6 new seeds × 8 modifiers = 48 new search keywords** the engine will start scoring + targeting in `keyword_backlog.csv` / `.json` / `.md` outputs once the next pipeline run lands.

Previously the seed list named only generic terms ("reaction training", "interval timer", "tactical timer") — the combat-sport keyword set I've been propagating across every visible discovery surface was nowhere in the seed list, so the engine wasn't generating any sport-specific search candidates.

## Verification

- `python3 -c "import json; d=json.load(open('marketing/keywords/strategy.json')); print(len(d['seed_keywords']))"` → 16 (was 10).
- JSON validates.
- Engine reads this on next `growth_keyword_engine.py` run; output diff visible in `marketing/keywords/keyword_backlog.csv` after that run.

## Context

Final piece of the 9-surface keyword alignment from this loop:

| Surface | PR |
|---|---|
| iOS App Store keywords | #1538 |
| iOS App Store subtitle | #1542 |
| Play Store short_description (en-US) | #1543 |
| Marketing landing | #1544 |
| AI-discovery (agents.md + amp.json ×2) | #1545 |
| Android changelogs (1778679336/337) | #1546, #1548 |
| README | #1547 |
| Android short_description (de-DE/ja-JP/pt-BR) | #1549 |
| **Keyword engine seeds (this PR)** | **#1550** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)