### PR TITLE
chore(repo-profile): expand suggested About description + sync-list (matches live update)

### DIFF
--- a/docs/REPO_PROFILE.md
+++ b/docs/REPO_PROFILE.md
@@ -4,11 +4,19 @@ Keep the **GitHub repo About** field aligned with **store listings** (canonical 
 
 ## Suggested short description (≤350 characters)
 
-> Random Tactical Timer — random-interval training for combat sports & HIIT. iOS & Android. Same story as App Store / Play (en-US).
+> Random Tactical Timer — random-interval training for MMA, BJJ, boxing, muay thai, kickboxing, HIIT, CrossFit, sparring, and tactical drills. iOS & Android. Same story as App Store / Play (en-US).
 
 Tighter option:
 
-> Train reaction, not rhythm. Native iOS + Android random timer for combat sports, BJJ, boxing, and HIIT.
+> Train reaction, not rhythm. Random interval timer for MMA, BJJ, boxing, muay thai, kickboxing, HIIT, CrossFit, sparring, and tactical drills. Native iOS + Android.
+
+**Keep this in sync with:**
+- `native-ios/fastlane/metadata/en-US/subtitle.txt` (App Store subtitle)
+- `native-android/fastlane/metadata/android/en-US/short_description.txt` (Play short description)
+- `README.md` intro paragraph
+- `marketing/keywords/strategy.json` `audience` field
+- `marketing/site/agents.md` Intent.Audience
+- `marketing/site/amp.json` + `marketing/product-pages/amp.json` `description` + `agentic_merchant_protocol.target_audiences`
 
 ## Website
 


### PR DESCRIPTION
## What

Two changes:

1. **`docs/REPO_PROFILE.md`** — the canonical doc for the GitHub About field. The "Suggested short description" examples now match the keyword set across all 9 surfaces aligned earlier in the loop. Added an explicit sync-list so future readers know where the description's contract lives.

2. **Live GitHub About field** — already updated via `gh api -X PATCH repos/IgorGanapolsky/Random-Timer` in this same cycle. New description (163c, within the 350c limit):

   > Train reaction, not rhythm. Random interval timer for MMA, BJJ, boxing, muay thai, kickboxing, HIIT, CrossFit, sparring, and tactical drills. Native iOS + Android.

   Verified live via `gh api repos/IgorGanapolsky/Random-Timer --jq '.description'`.

## Why

The repo About field is the **first thing GitHub-search and OG-share previews show** when the repo is linked. Pre-fix it said "combat sports, BJJ, boxing, and HIIT" — missing MMA, muay thai, kickboxing, CrossFit, sparring, and tactical drills. Same gap pattern as the other 9 surfaces fixed earlier in this loop.

## NOT in scope

- **Topics** — capped at 20 and currently full of technical tags (glassmorphism, mvvm, foreground-service, hilt, …). Swapping some for sport-specific topics (mma, bjj, muay-thai, …) is a real ASO/discovery improvement, but it's a deliberate trade-off (lose engineering-search signal, gain consumer-search signal) — left for a separate review rather than this additive doc PR.

## Verification

- `gh api repos/IgorGanapolsky/Random-Timer --jq '.description'` returns the new copy.
- `grep "muay thai" docs/REPO_PROFILE.md` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)