### PR TITLE
feat(ios-aso): add 'sparring' + 'tabata' to App Store description TRAINING USES

### DIFF
--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -19,10 +19,10 @@ FEATURES
 
 TRAINING USES
 - Boxing pad rounds, bag work, and shadowboxing flurries
-- MMA, Muay Thai, and kickboxing reaction drills
+- MMA, Muay Thai, kickboxing, and sparring reaction drills
 - BJJ scrambles and positional transition drills
 - Military combatives and self-defense scenario training
-- HIIT and conditioning sessions that punish predictability
+- HIIT, tabata, and conditioning sessions that punish predictability
 
 Stop timing your drills. Start training your response.
 


### PR DESCRIPTION
## What

iOS `description.txt` was missing two high-volume keywords that ARE in every other surface — `sparring` (0 occurrences) and `tabata` (0 occurrences). Two single-line additive edits inside the `TRAINING USES` bullet list (not snapshot-pinned).

```diff
- - MMA, Muay Thai, and kickboxing reaction drills
+ - MMA, Muay Thai, kickboxing, and sparring reaction drills

- - HIIT and conditioning sessions that punish predictability
+ - HIIT, tabata, and conditioning sessions that punish predictability
```

## Why

Closes the "sparring" + "tabata" gap on the iOS App Store long-form description. Both keywords are present in:
- iOS App Store keywords field (PR #1538)
- Android short_description en-US (PR #1543) + multi-locale (PR #1549)
- Marketing landing page (PR #1544)
- AI-discovery agents.md + amp.json (PR #1545)
- Keyword engine strategy.json seeds (PR #1550)
- GitHub About (cycle 18 `gh api` patch)

…but the App Store full description silently omitted them — meaning iOS users searching App Store for "sparring drill" or "tabata timer" would NOT match this app's description, even though both belong in the catalog.

## Verification

- `pytest scripts/tests/test_store_metadata_copy.py -v` → 2 passed (pinned headline + lead paragraphs unaffected).
- Keyword coverage post-edit: sparring=1 (was 0), tabata=1 (was 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)