### PR TITLE
chore(gitignore): dedupe .claude/worktrees/ (was listed twice)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,6 @@ __pycache__/
 .claude/ralph/
 .claude/worktrees/
 .claude/scripts/feedback/
-.claude/worktrees/
 
 # CCPM local workspace (project management)
 .claude/epics/


### PR DESCRIPTION
## What

Remove the duplicate `.claude/worktrees/` entry from `.gitignore`. The line appeared on both line 89 and line 91 within the "Claude Code memory/cache" block.

```diff
 .claude/ralph/
 .claude/worktrees/
 .claude/scripts/feedback/
-.claude/worktrees/
```

## Why

Functionally a no-op (git treats both as the same rule), but the duplicate causes cognitive drag when reading the file. Cheapest possible monotonic-progress ship — the loop's keyword/ASO work has saturated across 11 surfaces and this cycle picked up a genuine micro-hygiene gap caught during routine audit.

## Verification

- `grep -n .claude/worktrees .gitignore` → exactly 1 match (was 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)