### PR TITLE
chore(cro): weekly conversion optimization + localization sync — mixed-baseline audit attached

### DIFF
--- a/marketing/data/cro_experiments.json
+++ b/marketing/data/cro_experiments.json
@@ -183,6 +183,98 @@
       ],
       "metric": "conversion_rate",
       "duration_days": 21
+    },
+    {
+      "id": "7394ca3f",
+      "type": "title_ab_test",
+      "platform": "android",
+      "created": "2026-05-19T12:01:32.970332+00:00",
+      "status": "proposed",
+      "variants": [
+        {
+          "id": "control",
+          "title": "Random Tactical Timer"
+        },
+        {
+          "id": "variant_a",
+          "title": "Random Timer - HIIT & Drills"
+        },
+        {
+          "id": "variant_b",
+          "title": "Tactical Timer - Random Intervals"
+        },
+        {
+          "id": "variant_c",
+          "title": "Random Workout Timer"
+        }
+      ],
+      "metric": "conversion_rate",
+      "duration_days": 14,
+      "notes": "Test title variants focusing on different keyword strategies"
+    },
+    {
+      "id": "3852040a",
+      "type": "short_description_ab_test",
+      "platform": "android",
+      "created": "2026-05-19T12:01:32.970353+00:00",
+      "status": "proposed",
+      "variants": [
+        {
+          "id": "control",
+          "text": "Random timer for HIIT, drills & party games. Set a range \u2014 boom."
+        },
+        {
+          "id": "variant_a",
+          "text": "Surprise timer for workouts, games & drills. Never know when it fires!"
+        },
+        {
+          "id": "variant_b",
+          "text": "Unpredictable interval timer for HIIT, boxing & reaction training."
+        }
+      ],
+      "metric": "conversion_rate",
+      "duration_days": 14
+    },
+    {
+      "id": "d29cb215",
+      "type": "screenshot_ab_test",
+      "platform": "both",
+      "created": "2026-05-19T12:01:32.970362+00:00",
+      "status": "proposed",
+      "variants": [
+        {
+          "id": "control",
+          "order": [
+            "hero_timer",
+            "alarm_screen",
+            "settings",
+            "loop_mode"
+          ],
+          "description": "Current order: timer > alarm > settings > loop"
+        },
+        {
+          "id": "variant_a",
+          "order": [
+            "hero_alarm",
+            "loop_mode",
+            "hero_timer",
+            "settings"
+          ],
+          "description": "Lead with alarm impact > loop > timer > settings"
+        },
+        {
+          "id": "variant_b",
+          "order": [
+            "use_case_hiit",
+            "hero_timer",
+            "alarm_screen",
+            "loop_mode"
+          ],
+          "description": "Lead with use case > timer > alarm > loop"
+        }
+      ],
+      "metric": "conversion_rate",
+      "duration_days": 21
     }
   ],
   "active_variants": {}

--- a/marketing/data/cro_report.md
+++ b/marketing/data/cro_report.md
@@ -1,0 +1,24 @@
+# CRO Optimization Report
+
+**Date:** 2026-05-19T12:01:32.970762+00:00
+
+## Localization Status (Top 5 Markets)
+| Locale | Language | Android | iOS |
+|--------|----------|---------|-----|
+| en-US | English (US) | OK | OK |
+| ja | Japanese | OK | OK |
+| de-DE | German | OK | OK |
+| ko | Korean | OK | OK |
+| pt-BR | Portuguese (Brazil) | OK | OK |
+
+## Experiments
+- New experiments proposed: 3
+- Total experiments: 9
+- Active: 0
+- Proposed: 9
+
+## Next Steps
+1. Review proposed experiments in `marketing/data/cro_experiments.json`
+2. Activate experiments via Google Play Console Experiments
+3. Monitor conversion rates for 14-21 days
+4. Apply winning variants to metadata


### PR DESCRIPTION
## Auto-generated branch

This branch was produced by the weekly CRO optimization automation (scripts/cro_*). It proposes 3 new A/B test entries in `marketing/data/cro_experiments.json` + adds a row to `cro_report.md`.

## Cycle-25 audit of the proposed experiments

### ✅ #7394ca3f — `title_ab_test`

Control: `"Random Tactical Timer"` — **matches the live Android title.txt**. Variants are plausible keyword-strategy alternatives:
- `Random Timer - HIIT & Drills`
- `Tactical Timer - Random Intervals`
- `Random Workout Timer`

Risk: low. The variants don't include MMA/BJJ/muay thai — narrower than current title's brand voice, but valid candidate diversity.

### ⚠️ #3852040a — `short_description_ab_test`

Control: `"Random timer for HIIT, drills & party games. Set a range — boom."` — **does NOT match the live short_description** which is now `"Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices."` (merged via PR #1543).

This control appears to be either a historical baseline from before #1543 or pulled from a different locale (the `ja`/`ko` Android locales use a "HIIT, drills, party games" phrasing). Either way the auto-pipeline operated on stale en-US data — running this test as-is would compare candidate variants against the wrong baseline.

**Recommended action:** drop this proposal from the experiment plan (let the next auto-run refresh against current copy), OR have the operator edit the control text to match the current en-US short_description before activating.

### ✅ #d29cb215 — `screenshot_ab_test`

Control: `["hero_timer", "alarm_screen", "settings", "loop_mode"]` — plausible against the current `1_setup`/`2_active`/`3_voice`/`4_loop` file lineup. Variants reorder screenshots for different funnel emphases. Standard screenshot CRO — no copy concerns.

## Triage from cycle 25 of the autonomous Ralph Loop

Loop has been saturated for ~6 cycles (keyword work landed across 11 surfaces); this is the first genuinely new branch the loop has surfaced from upstream automation. Not auto-merging because of proposal #2's stale-baseline issue; opening as a PR for human review since the value/risk mix is non-uniform across the three proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)