### PR TITLE
fix(growth): source agents.md audience from strategy.json (kills daily regression)

### DIFF
--- a/scripts/growth_content_pipeline.py
+++ b/scripts/growth_content_pipeline.py
@@ -1045,6 +1045,17 @@ def build_site(output_root: Path) -> Dict[str, Any]:
         llms_lines.append(f"- {post['title']}: {base_url}/{post['markdown_url']}")
     (site_root / "llms.txt").write_text("\n".join(llms_lines) + "\n", encoding="utf-8")
 
+    audience_line = "athletes, trainers, coaches, and reaction-drill users"
+    strategy_path = output_root / "keywords" / "strategy.json"
+    if strategy_path.is_file():
+        try:
+            strategy_data = json.loads(strategy_path.read_text(encoding="utf-8"))
+            strategy_audience = str(strategy_data.get("audience") or "").strip()
+            if strategy_audience:
+                audience_line = strategy_audience
+        except (OSError, ValueError):
+            pass
+
     agent_lines = [
         "# Agent Index",
         "",
@@ -1052,7 +1063,7 @@ def build_site(output_root: Path) -> Dict[str, Any]:
         "",
         "## Intent",
         "- Product: Random Tactical Timer",
-        "- Audience: athletes, trainers, coaches, and reaction-drill users",
+        f"- Audience: {audience_line}",
         "- Outcomes: reaction readiness, unpredictability in interval training, repeatable setup",
         "",
         "## Latest posts",

--- a/scripts/tests/test_growth_content_pipeline.py
+++ b/scripts/tests/test_growth_content_pipeline.py
@@ -107,6 +107,42 @@ class GrowthContentPipelineTests(unittest.TestCase):
             self.assertTrue((root / "site" / "agents.md").is_file())
             self.assertTrue((root / "site" / "md" / "2026-02-19-sample.md").is_file())
 
+    def test_build_site_agents_md_audience_sources_from_strategy_json(self):
+        """agents.md must reflect keyword-rich audience from marketing/keywords/strategy.json,
+        not a hardcoded generic string. Otherwise the daily growth job overwrites the
+        keyword expansion shipped in PR #1545."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "posts").mkdir(parents=True, exist_ok=True)
+            (root / "diagrams").mkdir(parents=True, exist_ok=True)
+            (root / "keywords").mkdir(parents=True, exist_ok=True)
+            (root / "keywords" / "strategy.json").write_text(
+                '{"audience": "MMA fighters, BJJ practitioners, boxers, muay thai athletes",'
+                ' "seed_keywords": ["mma timer", "bjj rounds", "muay thai timer"]}',
+                encoding="utf-8",
+            )
+
+            pipeline.build_site(root)
+            agents_md = (root / "site" / "agents.md").read_text(encoding="utf-8")
+            self.assertIn("MMA fighters", agents_md)
+            self.assertIn("BJJ practitioners", agents_md)
+            self.assertNotIn(
+                "athletes, trainers, coaches, and reaction-drill users",
+                agents_md,
+                "generic placeholder leaked through despite strategy.json present",
+            )
+
+    def test_build_site_agents_md_falls_back_when_strategy_missing(self):
+        """Without strategy.json the build must still succeed with a non-empty audience line."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "posts").mkdir(parents=True, exist_ok=True)
+            (root / "diagrams").mkdir(parents=True, exist_ok=True)
+
+            pipeline.build_site(root)
+            agents_md = (root / "site" / "agents.md").read_text(encoding="utf-8")
+            self.assertIn("Audience:", agents_md)
+
     def test_build_site_renders_privacy_policy_page_and_legacy_alias(self):
         with tempfile.TemporaryDirectory() as td:
             repo = Path(td)


### PR DESCRIPTION
## Summary

The daily growth-publishing cron (\`scripts/growth_content_pipeline.py\` at 13:15 UTC, workflow \`.github/workflows/daily-growth-publishing.yml\`) regenerates \`marketing/site/agents.md\` from a **hardcoded** generic audience string (\`scripts/growth_content_pipeline.py:1055\` pre-fix).

This silently reverts keyword-rich expansions every day, producing churn auto-PRs (most recent: #1557) that revert PR #1545's AI-discovery audience block.

## Fix

\`build_site\` now reads \`audience\` from \`marketing/keywords/strategy.json\` (the existing single source of truth — already consumed by the keyword engine via \`ensure_keyword_backlog\`) with a graceful fallback when the file is absent. No new dependency.

## Tests

- \`test_build_site_agents_md_audience_sources_from_strategy_json\` — strategy.json present → keyword-rich audience flows to agents.md
- \`test_build_site_agents_md_falls_back_when_strategy_missing\` — strategy.json absent → still produces a non-empty \`Audience:\` line

Full \`test_growth_content_pipeline.py\` suite green (20/20).

## Downstream

After this lands, the next 13:15 UTC fire of the daily-growth pipeline will regenerate agents.md *with* the keyword-rich audience from \`strategy.json\`. PR #1557's regression in agents.md becomes obsolete on the next cron tick — close #1557 once this merges, or let tomorrow's auto-PR overwrite it.

## Test plan

- [ ] CI \`ci.yml\` green
- [ ] After merge: confirm next daily-growth-publishing run's agents.md contains the MMA / BJJ / muay thai / kickboxing terms