### PR TITLE
feat(review-velocity): iTunes API fallback captures first iOS 5-star rating

### DIFF
--- a/marketing/data/review_velocity.json
+++ b/marketing/data/review_velocity.json
@@ -17,21 +17,30 @@
       "android_total": 0,
       "android_rating": 0.0,
       "android_recent_7d": 0
+    },
+    {
+      "timestamp": "2026-05-19T15:15:30.359107+00:00",
+      "ios_total": 1,
+      "ios_rating": 5.0,
+      "ios_recent_7d": 0,
+      "android_total": 0,
+      "android_rating": 0.0,
+      "android_recent_7d": 0
     }
   ],
   "alerts": [],
   "ios": {
-    "total_reviews": 0,
-    "avg_rating": 0.0
+    "total_reviews": 1,
+    "avg_rating": 5.0
   },
   "android": {
     "total_reviews": 0,
     "avg_rating": 0.0
   },
   "latest_velocity": {
-    "ios_velocity": 0.0,
+    "ios_velocity": 0.01,
     "android_velocity": 0.0,
-    "window_days": 19
+    "window_days": 68
   },
   "review_prompt_config": {
     "completions_before_prompt": 3,

--- a/scripts/review_velocity_tracker.py
+++ b/scripts/review_velocity_tracker.py
@@ -15,9 +15,25 @@ import json
 import datetime as dt
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 
 HISTORY_PATH = "marketing/data/review_velocity.json"
+IOS_BUNDLE_ID = "com.igorganapolsky.randomtimer"
+ITUNES_LOOKUP_URL = "https://itunes.apple.com/lookup?bundleId={bundle}&country=us"
+
+
+def _lookup_itunes(bundle_id: str = IOS_BUNDLE_ID, timeout: float = 5.0) -> Optional[Dict[str, Any]]:
+    """Public iTunes Search API lookup. Returns None on any network/decode failure
+    so callers can gracefully fall back to a zero placeholder."""
+    url = ITUNES_LOOKUP_URL.format(bundle=bundle_id)
+    try:
+        req = Request(url, headers={"User-Agent": "RandomTimer-review-velocity/1.0"})
+        with urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (URLError, TimeoutError, ValueError, OSError):
+        return None
 ALERT_THRESHOLD_PCT = -20  # Alert if velocity drops by 20%+
 
 
@@ -40,10 +56,12 @@ def save_velocity_history(repo_root: Path, history: Dict[str, Any]) -> None:
 
 
 def fetch_ios_reviews_count(repo_root: Path) -> Dict[str, Any]:
-    """Fetch iOS review data from ASC reviews history.
+    """Fetch iOS review data, preferring ASC cache, then iTunes Search API.
 
-    In production, call App Store Connect API directly.
-    Falls back to reading local history JSONL from ios-reviews-ops workflow.
+    Cache (populated by ASC integration) wins because it can include recent_7d
+    and per-review detail. Without it, the public iTunes Search API still
+    surfaces userRatingCount + averageUserRating so the tracker reports real
+    numbers instead of a silent zero placeholder.
     """
     history_path = repo_root / "marketing/data/asc_reviews_cache.json"
     if history_path.is_file():
@@ -53,7 +71,16 @@ def fetch_ios_reviews_count(repo_root: Path) -> Dict[str, Any]:
             "avg_rating": data.get("avg_rating", 0.0),
             "recent_count": data.get("recent_7d", 0),
         }
-    # Placeholder when no real data available
+
+    lookup = _lookup_itunes()
+    if lookup and lookup.get("resultCount", 0) >= 1:
+        result = lookup["results"][0]
+        return {
+            "total_reviews": int(result.get("userRatingCount", 0) or 0),
+            "avg_rating": float(result.get("averageUserRating", 0.0) or 0.0),
+            "recent_count": 0,
+        }
+
     return {"total_reviews": 0, "avg_rating": 0.0, "recent_count": 0}
 
 

--- a/scripts/tests/test_review_velocity_tracker.py
+++ b/scripts/tests/test_review_velocity_tracker.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.review_velocity_tracker as tracker
+
+
+class ReviewVelocityTrackerTests(unittest.TestCase):
+    def test_fetch_ios_reads_cache_when_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cache_dir = root / "marketing" / "data"
+            cache_dir.mkdir(parents=True)
+            (cache_dir / "asc_reviews_cache.json").write_text(
+                json.dumps({"total_count": 4, "avg_rating": 4.5, "recent_7d": 1}),
+                encoding="utf-8",
+            )
+            result = tracker.fetch_ios_reviews_count(root)
+            self.assertEqual(result, {"total_reviews": 4, "avg_rating": 4.5, "recent_count": 1})
+
+    def test_fetch_ios_falls_back_to_itunes_api_when_cache_missing(self):
+        """When no ASC cache exists, fall back to the public iTunes Search API
+        so the tracker reports real numbers instead of a silent zero placeholder."""
+        fake_response = {
+            "resultCount": 1,
+            "results": [{
+                "userRatingCount": 1,
+                "averageUserRating": 5.0,
+                "bundleId": "com.igorganapolsky.randomtimer",
+            }],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with patch.object(tracker, "_lookup_itunes", return_value=fake_response):
+                result = tracker.fetch_ios_reviews_count(root)
+
+        self.assertEqual(result["total_reviews"], 1)
+        self.assertEqual(result["avg_rating"], 5.0)
+        self.assertEqual(result["recent_count"], 0)
+
+    def test_fetch_ios_returns_zero_when_itunes_lookup_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with patch.object(tracker, "_lookup_itunes", return_value=None):
+                result = tracker.fetch_ios_reviews_count(root)
+            self.assertEqual(result, {"total_reviews": 0, "avg_rating": 0.0, "recent_count": 0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Before this PR: \`fetch_ios_reviews_count\` silently returned \`{total_reviews: 0, avg_rating: 0.0}\` when \`marketing/data/asc_reviews_cache.json\` was absent. That file is only populated by an ASC integration that doesn't exist yet, so weekly reports were uniformly zero.

After this PR: falls back to the public iTunes Search API (no auth, no new dependencies — stdlib \`urllib\`) when the cache is absent.

## Why now

Cycle 28 of the GSD loop pulled live iTunes data and found **\`userRatingCount: 1, averageUserRating: 5.0\`** on \`com.igorganapolsky.randomtimer\` v1.3.34 — the **first organic rating** across either platform since launch. After 22+ cycles of zero install delta this is the first conversion-funnel data point. Tracker should not keep reporting zero.

## Tests

- \`test_fetch_ios_reads_cache_when_present\` — ASC cache still wins when populated
- \`test_fetch_ios_falls_back_to_itunes_api_when_cache_missing\` — mocked iTunes response flows through (TDD red → green)
- \`test_fetch_ios_returns_zero_when_itunes_lookup_fails\` — network failure still returns zero placeholder (no crashes)

Live smoke-run of \`python3 scripts/review_velocity_tracker.py\` now reports:

\`\`\`
| iOS     | 1 | 5.0 | 0 |
| Android | 0 | 0.0 | 0 |
\`\`\`

A fresh snapshot is included in \`marketing/data/review_velocity.json\`.

## Test plan

- [ ] CI \`ci.yml\` green
- [ ] Next \`weekly-review-velocity.yml\` run produces non-zero iOS values