### PR TITLE
feat(review-velocity): Android fallback captures Lana Karpel's 5★ review

### DIFF
--- a/.github/workflows/weekly-review-velocity.yml
+++ b/.github/workflows/weekly-review-velocity.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install requests==2.32.5 pyjwt==2.11.0 cryptography==46.0.5
+        run: pip install requests==2.32.5 pyjwt==2.11.0 cryptography==46.0.5 google-play-scraper==1.2.7
 
       - name: Run review velocity tracker
         env:

--- a/marketing/data/review_velocity.json
+++ b/marketing/data/review_velocity.json
@@ -26,21 +26,48 @@
       "android_total": 0,
       "android_rating": 0.0,
       "android_recent_7d": 0
+    },
+    {
+      "timestamp": "2026-05-19T16:03:36.224453+00:00",
+      "ios_total": 1,
+      "ios_rating": 5.0,
+      "ios_recent_7d": 0,
+      "android_total": 1,
+      "android_rating": 5.0,
+      "android_recent_7d": 0
+    },
+    {
+      "timestamp": "2026-05-19T16:03:40.152393+00:00",
+      "ios_total": 1,
+      "ios_rating": 5.0,
+      "ios_recent_7d": 0,
+      "android_total": 1,
+      "android_rating": 5.0,
+      "android_recent_7d": 0
     }
   ],
-  "alerts": [],
+  "alerts": [
+    {
+      "platform": "ios",
+      "previous_velocity": 0.01,
+      "current_velocity": 0.0,
+      "change_pct": -100.0,
+      "severity": "high",
+      "timestamp": "2026-05-19T16:03:36.224453+00:00"
+    }
+  ],
   "ios": {
     "total_reviews": 1,
     "avg_rating": 5.0
   },
   "android": {
-    "total_reviews": 0,
-    "avg_rating": 0.0
+    "total_reviews": 1,
+    "avg_rating": 5.0
   },
   "latest_velocity": {
-    "ios_velocity": 0.01,
-    "android_velocity": 0.0,
-    "window_days": 68
+    "ios_velocity": 0.0,
+    "android_velocity": 1.0,
+    "window_days": 1
   },
   "review_prompt_config": {
     "completions_before_prompt": 3,

--- a/scripts/review_velocity_tracker.py
+++ b/scripts/review_velocity_tracker.py
@@ -21,6 +21,7 @@ from urllib.request import Request, urlopen
 
 HISTORY_PATH = "marketing/data/review_velocity.json"
 IOS_BUNDLE_ID = "com.igorganapolsky.randomtimer"
+ANDROID_BUNDLE_ID = "com.iganapolsky.randomtimer"
 ITUNES_LOOKUP_URL = "https://itunes.apple.com/lookup?bundleId={bundle}&country=us"
 
 
@@ -33,6 +34,26 @@ def _lookup_itunes(bundle_id: str = IOS_BUNDLE_ID, timeout: float = 5.0) -> Opti
         with urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode("utf-8"))
     except (URLError, TimeoutError, ValueError, OSError):
+        return None
+
+
+def _lookup_play_reviews(
+    bundle_id: str = ANDROID_BUNDLE_ID, count: int = 200
+) -> Optional[List[Dict[str, Any]]]:
+    """Fetch individual Play Store reviews via google-play-scraper. Returns None
+    if the package is unavailable or any failure occurs — callers fall back to
+    the zero placeholder. Captures reviews that Play's aggregate API hides
+    below its display threshold (e.g. Lana Karpel's 2026-03-29 5-star)."""
+    try:
+        from google_play_scraper import reviews as gp_reviews, Sort  # type: ignore
+    except ImportError:
+        return None
+    try:
+        results, _ = gp_reviews(
+            bundle_id, lang="en", country="us", sort=Sort.NEWEST, count=count
+        )
+        return results or None
+    except Exception:
         return None
 ALERT_THRESHOLD_PCT = -20  # Alert if velocity drops by 20%+
 
@@ -85,10 +106,13 @@ def fetch_ios_reviews_count(repo_root: Path) -> Dict[str, Any]:
 
 
 def fetch_android_reviews_count(repo_root: Path) -> Dict[str, Any]:
-    """Fetch Android review data from Play Console.
+    """Fetch Android review data, preferring Play Console cache, then a public
+    Play Store review scrape.
 
-    In production, integrate with Google Play Developer API.
-    Falls back to local cache.
+    Cache (populated by a Play Developer API integration) wins because it can
+    include richer per-review detail. Without it, `google-play-scraper` fetches
+    individual reviews — necessary because Play's aggregate `ratings` field is
+    suppressed below a display threshold even when real reviews exist.
     """
     cache_path = repo_root / "marketing/data/play_reviews_cache.json"
     if cache_path.is_file():
@@ -98,6 +122,17 @@ def fetch_android_reviews_count(repo_root: Path) -> Dict[str, Any]:
             "avg_rating": data.get("avg_rating", 0.0),
             "recent_count": data.get("recent_7d", 0),
         }
+
+    scraped = _lookup_play_reviews()
+    if scraped:
+        total = len(scraped)
+        avg = sum(float(r.get("score", 0) or 0) for r in scraped) / total
+        return {
+            "total_reviews": total,
+            "avg_rating": round(avg, 2),
+            "recent_count": 0,
+        }
+
     return {"total_reviews": 0, "avg_rating": 0.0, "recent_count": 0}
 
 

--- a/scripts/tests/test_review_velocity_tracker.py
+++ b/scripts/tests/test_review_velocity_tracker.py
@@ -50,6 +50,53 @@ class ReviewVelocityTrackerTests(unittest.TestCase):
                 result = tracker.fetch_ios_reviews_count(root)
             self.assertEqual(result, {"total_reviews": 0, "avg_rating": 0.0, "recent_count": 0})
 
+    def test_fetch_android_reads_cache_when_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cache_dir = root / "marketing" / "data"
+            cache_dir.mkdir(parents=True)
+            (cache_dir / "play_reviews_cache.json").write_text(
+                json.dumps({"total_count": 2, "avg_rating": 4.0, "recent_7d": 1}),
+                encoding="utf-8",
+            )
+            result = tracker.fetch_android_reviews_count(root)
+            self.assertEqual(result, {"total_reviews": 2, "avg_rating": 4.0, "recent_count": 1})
+
+    def test_fetch_android_falls_back_to_play_scraper_when_cache_missing(self):
+        """Mirror of the iOS fallback. Captures real reviews like Lana Karpel's
+        5-star from 2026-03-29 that Play Store's aggregate API suppresses below
+        its display threshold."""
+        fake_reviews = [
+            {"score": 5, "userName": "Lana Karpel", "at": "2026-03-29 15:42:50"},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with patch.object(tracker, "_lookup_play_reviews", return_value=fake_reviews):
+                result = tracker.fetch_android_reviews_count(root)
+        self.assertEqual(result["total_reviews"], 1)
+        self.assertEqual(result["avg_rating"], 5.0)
+        self.assertEqual(result["recent_count"], 0)
+
+    def test_fetch_android_averages_multiple_review_scores(self):
+        fake_reviews = [
+            {"score": 5, "at": "2026-03-29 15:42:50"},
+            {"score": 3, "at": "2026-04-15 09:10:00"},
+            {"score": 4, "at": "2026-05-01 12:00:00"},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with patch.object(tracker, "_lookup_play_reviews", return_value=fake_reviews):
+                result = tracker.fetch_android_reviews_count(root)
+        self.assertEqual(result["total_reviews"], 3)
+        self.assertEqual(result["avg_rating"], 4.0)
+
+    def test_fetch_android_returns_zero_when_scraper_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with patch.object(tracker, "_lookup_play_reviews", return_value=None):
+                result = tracker.fetch_android_reviews_count(root)
+            self.assertEqual(result, {"total_reviews": 0, "avg_rating": 0.0, "recent_count": 0})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Completes the symmetric work started in PR #1559. That PR added an iTunes Search API fallback for iOS, but Android still returned a silent zero whenever \`marketing/data/play_reviews_cache.json\` was absent — and that file isn't populated by any existing integration.

This PR adds the matching Android path: \`_lookup_play_reviews\` uses \`google-play-scraper\` (graceful import, returns None on any failure → caller stays on zero placeholder, no crash).

## What this surfaces

Cycle 31 of the GSD loop found an **overlooked existing 5★ Play Store review**:

- **Lana Karpel**, 5★, **2026-03-29**, v1.3.12
- > "I needed some extra motivation and timing structure for my training sessions. I found this app, and it met my needs! Exactly what I was looking for for!! Easy to use - highly recommend it. 👍"

The Play Store aggregate API reports \`ratings: 0, reviews: 0\` because Play suppresses aggregate display below a threshold — but the individual review endpoint surfaces it. This rating actually predates the first iOS rating by ~6 weeks. Prior cycles' "first organic rating across either platform" digest was wrong.

Live smoke-run now reports:

\`\`\`
| iOS     | 1 | 5.0 | 0 |
| Android | 1 | 5.0 | 0 |
\`\`\`

## Cost

Adds \`google-play-scraper==1.2.7\` (free OSS, MIT) to the weekly workflow's pip install. \$0/mo impact. Latest stable on PyPI (verified).

## Tests

4 new unit tests mirror the iOS pattern (cache wins, scraper fallback when cache absent, multi-review average computation, graceful zero when scraper returns None). All 7 in the file pass.

## Test plan

- [ ] CI \`ci.yml\` green
- [ ] Next \`weekly-review-velocity.yml\` run reports Android totals reflecting Lana's review