### PR TITLE
fix(android): paywall catalog guard + analytics wiki refresh

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -53,6 +53,18 @@ jobs:
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
         run: python scripts/store_downloads_snapshot.py --repo-root . --days 30
 
+      - name: Build paywall conversion snapshot from PostHog
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: python scripts/paywall_conversion_report.py --repo-root . --days 30
+
+      - name: Build attribution and activation funnel snapshot from PostHog
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: python scripts/attribution_feedback.py --repo-root . --days 30
+
       - name: Build Apple Ads live metrics snapshot
         env:
           APPLE_ADS_CLIENT_ID: ${{ secrets.APPLE_ADS_CLIENT_ID }}
@@ -64,6 +76,25 @@ jobs:
 
       - name: Inject live data into dashboard
         run: python scripts/wiki_sync.py
+
+      - name: Commit refreshed marketing analytics snapshots
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add marketing/data/north_star.json \
+            marketing/data/store_downloads.json \
+            marketing/data/paywall_conversion_report.json \
+            marketing/data/paywall_conversion_report.md \
+            marketing/data/content_feedback.json \
+            marketing/data/attribution-report.md \
+            marketing/data/apple_ads_live_metrics.json
+          if git diff --staged --quiet; then
+            echo "No marketing snapshot changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(analytics): refresh marketing snapshots from wiki-sync"
+          git push
 
       - name: Publish wiki pages
         uses: Andrew-Chen-Wang/github-wiki-action@50650fccf3a10f741995523cf9708c53cec8912a # v4
@@ -80,5 +111,7 @@ jobs:
           path: |
             wiki/Daily-Metrics-Dashboard.md
             marketing/data/north_star.json
+            marketing/data/store_downloads.json
+            marketing/data/paywall_conversion_report.json
             marketing/data/apple_ads_live_metrics.json
           retention-days: 7

--- a/marketing/data/paywall_conversion_report.json
+++ b/marketing/data/paywall_conversion_report.json
@@ -1,35 +1,116 @@
 {
-  "generated_at": "2026-05-11T14:18:45+00:00",
+  "generated_at": "2026-05-19T16:26:51+00:00",
   "window_days": 30,
   "status": "ok",
   "reason": "",
   "funnel": {
-    "views": 333,
-    "offer_selects": 82,
-    "purchase_attempts": 12,
+    "views": 361,
+    "offer_selects": 112,
+    "purchase_attempts": 7,
     "purchase_successes": 0,
-    "view_to_select_rate": 0.2462,
-    "select_to_attempt_rate": 0.1463,
+    "view_to_select_rate": 0.3102,
+    "select_to_attempt_rate": 0.0625,
     "attempt_to_success_rate": 0.0
   },
   "top_failure_reasons": [
     {
       "reason": "user_cancelled",
-      "count": 10
+      "count": 7
+    }
+  ],
+  "failure_breakdown": [
+    {
+      "platform": "android",
+      "product_id": "unknown",
+      "reason": "user_cancelled",
+      "failures": 4,
+      "users": 1
+    },
+    {
+      "platform": "ios",
+      "product_id": "com.iganapolsky.randomtimer.pro",
+      "reason": "user_cancelled",
+      "failures": 3,
+      "users": 3
+    }
+  ],
+  "product_funnel": [
+    {
+      "platform": "ios",
+      "product_id": "com.iganapolsky.randomtimer.pro",
+      "offer_selects": 0,
+      "attempts": 3,
+      "successes": 0,
+      "select_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "platform": "ios",
+      "product_id": "com.iganapolsky.randomtimer.elite",
+      "offer_selects": 0,
+      "attempts": 2,
+      "successes": 0,
+      "select_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "platform": "android",
+      "product_id": "elite_tactical",
+      "offer_selects": 9,
+      "attempts": 1,
+      "successes": 0,
+      "select_to_attempt_rate": 0.1111,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "platform": "android",
+      "product_id": "pro_base",
+      "offer_selects": 7,
+      "attempts": 1,
+      "successes": 0,
+      "select_to_attempt_rate": 0.1429,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "platform": "android",
+      "product_id": "elite_tactical_monthly",
+      "offer_selects": 96,
+      "attempts": 0,
+      "successes": 0,
+      "select_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    }
+  ],
+  "product_catalog_failures": [
+    {
+      "platform": "android",
+      "product_id": "elite_tactical_monthly",
+      "failures": 500,
+      "users": 117
+    },
+    {
+      "platform": "android",
+      "product_id": "elite_tactical",
+      "failures": 337,
+      "users": 95
+    },
+    {
+      "platform": "android",
+      "product_id": "pro_base",
+      "failures": 103,
+      "users": 47
+    },
+    {
+      "platform": "android",
+      "product_id": "unknown",
+      "failures": 57,
+      "users": 32
     }
   ],
   "entry_points": [
     {
       "entry_point": "setup_upgrade_cta",
-      "views": 232,
-      "attempts": 0,
-      "successes": 0,
-      "view_to_attempt_rate": 0.0,
-      "attempt_to_success_rate": 0.0
-    },
-    {
-      "entry_point": "unknown",
-      "views": 49,
+      "views": 110,
       "attempts": 0,
       "successes": 0,
       "view_to_attempt_rate": 0.0,
@@ -37,33 +118,23 @@
     },
     {
       "entry_point": "range_gate",
-      "views": 41,
-      "attempts": 3,
-      "successes": 0,
-      "view_to_attempt_rate": 0.0732,
-      "attempt_to_success_rate": 0.0
-    },
-    {
-      "entry_point": "voice_gate",
-      "views": 6,
+      "views": 79,
       "attempts": 0,
       "successes": 0,
       "view_to_attempt_rate": 0.0,
       "attempt_to_success_rate": 0.0
     },
     {
-      "entry_point": "sound_gate",
-      "views": 5,
-      "attempts": 9,
+      "entry_point": "voice_gate",
+      "views": 60,
+      "attempts": 0,
       "successes": 0,
-      "view_to_attempt_rate": 1.8,
+      "view_to_attempt_rate": 0.0,
       "attempt_to_success_rate": 0.0
-    }
-  ],
-  "leaky_entry_points": [
+    },
     {
-      "entry_point": "setup_upgrade_cta",
-      "views": 232,
+      "entry_point": "repeat_gate",
+      "views": 50,
       "attempts": 0,
       "successes": 0,
       "view_to_attempt_rate": 0.0,
@@ -71,7 +142,65 @@
     },
     {
       "entry_point": "unknown",
-      "views": 49,
+      "views": 39,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "sound_arsenal_gate",
+      "views": 16,
+      "attempts": 2,
+      "successes": 0,
+      "view_to_attempt_rate": 0.125,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "sound_gate",
+      "views": 7,
+      "attempts": 5,
+      "successes": 0,
+      "view_to_attempt_rate": 0.7143,
+      "attempt_to_success_rate": 0.0
+    }
+  ],
+  "leaky_entry_points": [
+    {
+      "entry_point": "setup_upgrade_cta",
+      "views": 110,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "range_gate",
+      "views": 79,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "voice_gate",
+      "views": 60,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "repeat_gate",
+      "views": 50,
+      "attempts": 0,
+      "successes": 0,
+      "view_to_attempt_rate": 0.0,
+      "attempt_to_success_rate": 0.0
+    },
+    {
+      "entry_point": "unknown",
+      "views": 39,
       "attempts": 0,
       "successes": 0,
       "view_to_attempt_rate": 0.0,
@@ -81,68 +210,70 @@
   "settings_hotspots": [
     {
       "setting_name": "unknown",
-      "changes": 22802,
-      "users": 356
-    },
-    {
-      "setting_name": "sound_type",
-      "changes": 1030,
-      "users": 83
-    },
-    {
-      "setting_name": "alarm_duration",
-      "changes": 932,
-      "users": 80
+      "changes": 10085,
+      "users": 151
     },
     {
       "setting_name": "max_seconds",
-      "changes": 778,
-      "users": 90
+      "changes": 1900,
+      "users": 181
+    },
+    {
+      "setting_name": "alarm_duration",
+      "changes": 1582,
+      "users": 165
     },
     {
       "setting_name": "min_seconds",
-      "changes": 753,
-      "users": 82
+      "changes": 1484,
+      "users": 168
+    },
+    {
+      "setting_name": "sound_type",
+      "changes": 1373,
+      "users": 149
     },
     {
       "setting_name": "volume",
-      "changes": 520,
-      "users": 56
+      "changes": 1008,
+      "users": 110
     },
     {
       "setting_name": "repeat_enabled",
-      "changes": 261,
-      "users": 77
+      "changes": 649,
+      "users": 159
     },
     {
       "setting_name": "voice_callouts_enabled",
-      "changes": 257,
-      "users": 52
-    },
-    {
-      "setting_name": "voice_gender",
-      "changes": 107,
-      "users": 61
-    },
-    {
-      "setting_name": "repeat_rounds",
-      "changes": 100,
-      "users": 35
-    },
-    {
-      "setting_name": "use_extended_range",
-      "changes": 87,
-      "users": 42
+      "changes": 470,
+      "users": 99
     },
     {
       "setting_name": "vibration_enabled",
-      "changes": 60,
-      "users": 45
+      "changes": 287,
+      "users": 114
+    },
+    {
+      "setting_name": "repeat_rounds",
+      "changes": 225,
+      "users": 68
+    },
+    {
+      "setting_name": "voice_gender",
+      "changes": 221,
+      "users": 124
+    },
+    {
+      "setting_name": "use_extended_range",
+      "changes": 166,
+      "users": 90
     }
   ],
   "data_quality_warnings": [
     "unknown paywall entry_point is still receiving meaningful traffic",
-    "settings_changed is still dominated by unknown setting_name rows in live data"
+    "settings_changed is still dominated by unknown setting_name rows in live data",
+    "purchase failures are dominated by user_cancelled; prioritize pricing, plan default, and purchase-sheet value proof before assuming a store outage",
+    "product catalog lookup failures detected; verify App Store Connect and Google Play product IDs, approval state, and cleared-for-sale status"
   ],
   "query_errors": []
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -77,6 +77,7 @@ fun RandomTimerNavHost(
     var paywallEntryPoint by remember { mutableStateOf("unknown") }
     var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
     var paywallAvailableProductIds by remember { mutableStateOf(emptySet<String>()) }
+    var paywallBillingCatalogProbed by remember { mutableStateOf(false) }
     var paywallDefaultToAnnual by remember { mutableStateOf(false) }
     var paywallValueFramingVariant by remember { mutableStateOf(PaywallValueFraming.CONTROL) }
 
@@ -87,6 +88,7 @@ fun RandomTimerNavHost(
             monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
             lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
             paywallAvailableProductIds = viewModel.proManager.availablePaywallProductIds()
+            paywallBillingCatalogProbed = true
             paywallEntryPoint = paywallEntryPointForFeature(feature)
             paywallTrialEligibilityByProductId =
                 mapOf(
@@ -259,6 +261,7 @@ fun RandomTimerNavHost(
             valueFramingVariant = paywallValueFramingVariant,
             trialEligibilityByProductId = paywallTrialEligibilityByProductId,
             availableProductIds = paywallAvailableProductIds,
+            billingCatalogProbed = paywallBillingCatalogProbed,
             onPlanSelected = { plan, productId, selectionSource ->
                 viewModel.trackPaywallOfferSelected(
                     entryPoint = paywallEntryPoint,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -124,6 +124,7 @@ fun PaywallSheet(
     valueFramingVariant: String = PaywallValueFraming.CONTROL,
     trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
     availableProductIds: Set<String> = emptySet(),
+    billingCatalogProbed: Boolean = false,
     onPurchase: (String) -> Unit,
     onPlanSelected: (plan: String, productId: String, selectionSource: String) -> Unit = { _, _, _ -> },
     onRestore: () -> Unit,
@@ -131,13 +132,22 @@ fun PaywallSheet(
     onDebugUnlock: (() -> Unit)? = null,
 ) {
     val haptic = LocalHapticFeedback.current
-    val initialSelection = initialPlanSelection(entryPoint, defaultToAnnualPlan)
-    var selectedPlan by remember(entryPoint, defaultToAnnualPlan) { mutableStateOf(initialSelection) }
-    LaunchedEffect(availableProductIds, selectedPlan) {
-        if (!shouldShowPaywallPlan(selectedPlan, availableProductIds)) {
-            selectedPlan = fallbackPaywallPlan(availableProductIds)
+    val initialSelection =
+        initialPlanSelection(
+            entryPoint = entryPoint,
+            defaultToAnnualPlan = defaultToAnnualPlan,
+            availableProductIds = availableProductIds,
+            billingCatalogProbed = billingCatalogProbed,
+        )
+    var selectedPlan by remember(entryPoint, defaultToAnnualPlan, availableProductIds, billingCatalogProbed) {
+        mutableStateOf(initialSelection)
+    }
+    LaunchedEffect(availableProductIds, billingCatalogProbed, selectedPlan) {
+        if (!shouldShowPaywallPlan(selectedPlan, availableProductIds, billingCatalogProbed)) {
+            selectedPlan = fallbackPaywallPlan(availableProductIds, billingCatalogProbed)
         }
     }
+    val hasPurchasablePlan = hasPurchasablePaywallPlan(availableProductIds, billingCatalogProbed)
     val featureContext = paywallFeatureContext(entryPoint)
     val headline =
         if (valueFramingVariant == PaywallValueFraming.OUTCOMES_FIRST) {
@@ -182,9 +192,21 @@ fun PaywallSheet(
                 ) {
                     HorizontalDivider(color = TimerColors.TextSecondary.copy(alpha = 0.28f))
                     Spacer(modifier = Modifier.height(12.dp))
+                    if (billingCatalogProbed && !hasPurchasablePlan) {
+                        Text(
+                            text = "Purchases are temporarily unavailable. Please try again later.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TimerColors.TextSecondary,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(bottom = 12.dp),
+                        )
+                    }
                     PrimaryButton(
-                        text = ctaLabel,
+                        text = if (hasPurchasablePlan) ctaLabel else "Purchases unavailable",
                         onClick = {
+                            if (!hasPurchasablePlan) {
+                                return@PrimaryButton
+                            }
                             onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId, "primary_cta")
                             onPurchase(purchaseProductId)
                         },
@@ -351,7 +373,7 @@ fun PaywallSheet(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                if (shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, availableProductIds)) {
+                if (shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, availableProductIds, billingCatalogProbed)) {
                     PlanOptionCard(
                         title = "Lifetime",
                         priceLabel = stripPriceSuffix(lifetimePrice),
@@ -366,7 +388,7 @@ fun PaywallSheet(
                     Spacer(modifier = Modifier.height(8.dp))
                 }
 
-                if (shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, availableProductIds)) {
+                if (shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, availableProductIds, billingCatalogProbed)) {
                     PlanOptionCard(
                         title = "Monthly",
                         priceLabel = "${stripPriceSuffix(monthlyPrice)}/month",
@@ -381,7 +403,7 @@ fun PaywallSheet(
                     Spacer(modifier = Modifier.height(8.dp))
                 }
 
-                if (shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, availableProductIds)) {
+                if (shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, availableProductIds, billingCatalogProbed)) {
                     PlanOptionCard(
                         title = "Annual",
                         priceLabel = "${stripPriceSuffix(proPrice)}/year",
@@ -417,33 +439,62 @@ internal fun planNameForSelection(plan: SubscriptionPlanSelection): String =
 internal fun initialPlanSelection(
     entryPoint: String,
     defaultToAnnualPlan: Boolean,
-): SubscriptionPlanSelection =
-    when {
-        defaultToAnnualPlan -> SubscriptionPlanSelection.ANNUAL
-        entryPoint == "setup_upgrade_cta" -> SubscriptionPlanSelection.LIFETIME
-        else -> SubscriptionPlanSelection.MONTHLY
+    availableProductIds: Set<String> = emptySet(),
+    billingCatalogProbed: Boolean = false,
+): SubscriptionPlanSelection {
+    val preferred =
+        when {
+            defaultToAnnualPlan -> SubscriptionPlanSelection.ANNUAL
+            entryPoint == "setup_upgrade_cta" -> SubscriptionPlanSelection.LIFETIME
+            else -> SubscriptionPlanSelection.MONTHLY
+        }
+    if (!billingCatalogProbed || availableProductIds.isEmpty()) {
+        return preferred
     }
+    return if (shouldShowPaywallPlan(preferred, availableProductIds, billingCatalogProbed)) {
+        preferred
+    } else {
+        fallbackPaywallPlan(availableProductIds, billingCatalogProbed)
+    }
+}
 
 internal fun shouldShowPaywallPlan(
     plan: SubscriptionPlanSelection,
     availableProductIds: Set<String>,
+    billingCatalogProbed: Boolean = false,
 ): Boolean {
+    if (!billingCatalogProbed) {
+        return false
+    }
     if (availableProductIds.isEmpty()) {
-        return true
+        return false
     }
     val knownPaywallProductIds = SubscriptionPlanSelection.entries.map(::productIdForPlan).toSet()
     if (availableProductIds.intersect(knownPaywallProductIds).isEmpty()) {
-        return true
+        return false
     }
     return availableProductIds.contains(productIdForPlan(plan))
 }
 
-internal fun fallbackPaywallPlan(availableProductIds: Set<String>): SubscriptionPlanSelection =
+internal fun hasPurchasablePaywallPlan(
+    availableProductIds: Set<String>,
+    billingCatalogProbed: Boolean,
+): Boolean =
+    billingCatalogProbed &&
+        SubscriptionPlanSelection.entries.any {
+            shouldShowPaywallPlan(it, availableProductIds, billingCatalogProbed)
+        }
+
+internal fun fallbackPaywallPlan(
+    availableProductIds: Set<String>,
+    billingCatalogProbed: Boolean = false,
+): SubscriptionPlanSelection =
     listOf(
         SubscriptionPlanSelection.LIFETIME,
         SubscriptionPlanSelection.ANNUAL,
         SubscriptionPlanSelection.MONTHLY,
-    ).firstOrNull { shouldShowPaywallPlan(it, availableProductIds) } ?: SubscriptionPlanSelection.LIFETIME
+    ).firstOrNull { shouldShowPaywallPlan(it, availableProductIds, billingCatalogProbed) }
+        ?: SubscriptionPlanSelection.ANNUAL
 
 internal fun ctaLabelForPlan(
     selectedPlan: SubscriptionPlanSelection,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -140,15 +140,71 @@ class PaywallSheetTest {
                 ProManager.ELITE_PRODUCT_ID,
             )
 
-        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, availableProductIds))
-        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, availableProductIds))
-        assertEquals(false, shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, availableProductIds))
+        assertEquals(
+            true,
+            shouldShowPaywallPlan(
+                SubscriptionPlanSelection.LIFETIME,
+                availableProductIds,
+                billingCatalogProbed = true,
+            ),
+        )
+        assertEquals(
+            true,
+            shouldShowPaywallPlan(
+                SubscriptionPlanSelection.ANNUAL,
+                availableProductIds,
+                billingCatalogProbed = true,
+            ),
+        )
+        assertEquals(
+            false,
+            shouldShowPaywallPlan(
+                SubscriptionPlanSelection.MONTHLY,
+                availableProductIds,
+                billingCatalogProbed = true,
+            ),
+        )
     }
 
     @Test
-    fun `unknown billing catalog keeps paywall plans visible`() {
-        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, emptySet()))
-        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, emptySet()))
-        assertEquals(true, shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, emptySet()))
+    fun `unprobed billing catalog hides paywall plans`() {
+        assertEquals(
+            false,
+            shouldShowPaywallPlan(SubscriptionPlanSelection.LIFETIME, emptySet(), billingCatalogProbed = false),
+        )
+        assertEquals(
+            false,
+            shouldShowPaywallPlan(SubscriptionPlanSelection.ANNUAL, emptySet(), billingCatalogProbed = false),
+        )
+        assertEquals(
+            false,
+            shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, emptySet(), billingCatalogProbed = false),
+        )
+    }
+
+    @Test
+    fun `probed empty billing catalog hides paywall plans`() {
+        assertEquals(
+            false,
+            shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, emptySet(), billingCatalogProbed = true),
+        )
+        assertEquals(false, hasPurchasablePaywallPlan(emptySet(), billingCatalogProbed = true))
+    }
+
+    @Test
+    fun `initial plan selection prefers first purchasable plan when default is missing`() {
+        val available =
+            setOf(
+                ProManager.ELITE_PRODUCT_ID,
+            )
+        assertEquals(
+            SubscriptionPlanSelection.ANNUAL,
+            initialPlanSelection(
+                entryPoint = "range_gate",
+                defaultToAnnualPlan = false,
+                availableProductIds = available,
+                billingCatalogProbed = true,
+            ),
+        )
     }
 }

--- a/release-notes/1.3.35.md
+++ b/release-notes/1.3.35.md
@@ -1,0 +1,12 @@
+# Release 1.3.35
+
+## Summary
+**1.3.35** hardens Android paywall behavior when Google Play Billing products are missing from the store catalog, and upgrades the analytics pipeline so North Star (WQTU), paywall funnel, and activation metrics refresh automatically in-repo and on the wiki dashboard.
+
+## Product
+- **Android paywall:** Do not merchandise billing plans until the Play catalog probe completes; hide plans that are not returned by Billing; disable purchase CTA when no purchasable SKU is available (prevents dead-end monthly taps when `elite_tactical_monthly` is missing in Play Console).
+- **Analytics:** `wiki-sync.yml` now runs paywall conversion + attribution snapshots, commits refreshed `marketing/data/*.json` to `develop`, and injects a Paywall & Revenue section into the Daily Metrics Dashboard wiki.
+
+## Release operations
+- Requires **Google Play Console** IAP products active: `pro_base`, `elite_tactical`, `elite_tactical_monthly` (P0 revenue blocker if missing).
+- Ship Android to production after Firebase internal signoff on release SHA, then run `native-release` with public store read-back.

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -19,6 +19,8 @@ WEEKLY_SHARED_WORKFLOW = ROOT / ".github/workflows/weekly-shared.yml"
 WQTU_HEALTH_WORKFLOW = ROOT / ".github/workflows/wqtu-health.yml"
 ANALYTICS_WORKFLOW = ROOT / ".github/workflows/analytics.yml"
 EXECUTIVE_METRICS_WORKFLOW = ROOT / ".github/workflows/executive-metrics.yml"
+WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
+WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
 STORE_RATINGS_SNAPSHOT_WORKFLOW = ROOT / ".github/workflows/store-ratings-snapshot.yml"
 AGENTS_DOC = ROOT / "AGENTS.md"
 ANDROID_AGENT_WORKFLOW_DOC = ROOT / "docs/ANDROID_AGENT_WORKFLOW.md"
@@ -522,6 +524,18 @@ def test_analytics_deployment_report_reads_deployment_statuses():
     assert "/deployments/{deployment['id']}/statuses?per_page=1" in source
     assert 'latest_state = statuses[0]["state"] if statuses else "unknown"' in source
     assert '.state == "success"' not in source
+
+
+def test_wiki_sync_refreshes_posthog_snapshots_and_commits_marketing_data():
+    source = WIKI_SYNC_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python scripts/paywall_conversion_report.py --repo-root . --days 30" in source
+    assert "python scripts/attribution_feedback.py --repo-root . --days 30" in source
+    assert "python scripts/north_star_guardrail.py" in source
+    assert "python scripts/store_downloads_snapshot.py --repo-root . --days 30" in source
+    assert "Commit refreshed marketing analytics snapshots" in source
+    assert "marketing/data/paywall_conversion_report.json" in source
+    assert "marketing/data/north_star.json" in source
 
 
 def test_analytics_workflow_publishes_weekly_paywall_conversion_report_artifact():

--- a/scripts/tests/test_wiki_sync.py
+++ b/scripts/tests/test_wiki_sync.py
@@ -171,6 +171,42 @@ def test_inject_content(data_dir: Path, dashboard_template: str) -> None:
     assert "Total Posts Published | 1" in result
 
 
+def test_inject_paywall_funnel(data_dir: Path, dashboard_template: str) -> None:
+    (data_dir / "paywall_conversion_report.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-05-19T16:26:51+00:00",
+                "status": "ok",
+                "funnel": {
+                    "views": 361,
+                    "offer_selects": 112,
+                    "purchase_attempts": 7,
+                    "purchase_successes": 0,
+                    "attempt_to_success_rate": 0.0,
+                },
+                "top_failure_reasons": [{"reason": "user_cancelled", "count": 7}],
+                "product_catalog_failures": [
+                    {
+                        "platform": "android",
+                        "product_id": "elite_tactical_monthly",
+                        "failures": 500,
+                        "users": 117,
+                    }
+                ],
+            }
+        )
+    )
+    template = (
+        dashboard_template
+        + "\n<!-- PAYWALL_START -->\nplaceholder\n<!-- PAYWALL_END -->\n"
+    )
+    result = inject_dashboard_data(template, data_dir)
+    assert "Paywall Views | 361" in result
+    assert "Purchase Attempts | 7" in result
+    assert "user_cancelled (7)" in result
+    assert "elite_tactical_monthly (500)" in result
+
+
 def test_inject_referral(data_dir: Path, dashboard_template: str) -> None:
     result = inject_dashboard_data(dashboard_template, data_dir)
     assert "Reddit Posts | 2" in result

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -441,6 +441,51 @@ def inject_dashboard_data(dashboard: str, data_dir: Path) -> str:
             flags=re.DOTALL,
         )
 
+    # --- Paywall funnel ---
+    pw = load_json(data_dir / "paywall_conversion_report.json")
+    if pw:
+        funnel = pw.get("funnel", {})
+        quality_note = _data_quality_note(pw, fallback_source="paywall conversion snapshot degraded")
+        top_failures = pw.get("top_failure_reasons", [])
+        catalog_failures = pw.get("product_catalog_failures", [])
+        failure_summary = (
+            ", ".join(f"{row.get('reason', 'unknown')} ({row.get('count', 0)})" for row in top_failures[:5])
+            if top_failures
+            else "none"
+        )
+        android_catalog = [
+            row
+            for row in catalog_failures
+            if str(row.get("platform", "")).lower() == "android"
+        ]
+        catalog_summary = (
+            ", ".join(
+                f"{row.get('product_id', 'unknown')} ({row.get('failures', 0)})"
+                for row in android_catalog[:5]
+            )
+            if android_catalog
+            else "none"
+        )
+        paywall_block = (
+            "| Metric | Value |\n"
+            "|--------|-------|\n"
+            f"| Paywall Views | {_fmt_num_allow_zero(funnel.get('views'))} |\n"
+            f"| Offer Selects | {_fmt_num_allow_zero(funnel.get('offer_selects'))} |\n"
+            f"| Purchase Attempts | {_fmt_num_allow_zero(funnel.get('purchase_attempts'))} |\n"
+            f"| Purchase Successes | {_fmt_num_allow_zero(funnel.get('purchase_successes'))} |\n"
+            f"| Attempt → Success | {_fmt(funnel.get('attempt_to_success_rate'))} |\n\n"
+            f"**Top failure reasons:** {failure_summary}\n\n"
+            f"**Catalog failures (Android):** {catalog_summary}"
+        )
+        if quality_note:
+            paywall_block += f"\n\n{quality_note}"
+        dashboard = re.sub(
+            r"<!-- PAYWALL_START -->.*?<!-- PAYWALL_END -->",
+            f"<!-- PAYWALL_START -->\n{paywall_block}\n<!-- PAYWALL_END -->",
+            dashboard,
+            flags=re.DOTALL,
+        )
+
     # --- Review Velocity ---
     rv = load_json(data_dir / "review_velocity.json")
     if rv:

--- a/wiki/Daily-Metrics-Dashboard.md
+++ b/wiki/Daily-Metrics-Dashboard.md
@@ -55,6 +55,22 @@
 
 <!-- ATTRIBUTION_END -->
 
+## Paywall & Revenue Funnel (30-day)
+
+<!-- PAYWALL_START -->
+| Metric | Value |
+|--------|-------|
+| Paywall Views | — |
+| Offer Selects | — |
+| Purchase Attempts | — |
+| Purchase Successes | — |
+| Attempt → Success | — |
+
+**Top failure reasons:** —
+
+**Catalog failures (Android):** —
+<!-- PAYWALL_END -->
+
 ## Onboarding Funnel (30-day window)
 
 <!-- FUNNEL_START -->


### PR DESCRIPTION
## Summary
- Android paywall: probe billing catalog before merchandising plans; hide SKUs not returned by Play Billing; disable purchase CTA when nothing is purchasable (fixes dead-end taps on missing `elite_tactical_monthly`).
- Analytics: `wiki-sync` runs paywall + attribution snapshots, commits `marketing/data/*.json`, injects Paywall & Revenue into Daily Metrics Dashboard.

## Context
PostHog shows **997** `billing_product_not_found` failures on Android for `pro_base` / `elite_tactical` / `elite_tactical_monthly` — Play Console IAP activation still required (console-only P0).

## Test plan
- [x] `pytest scripts/tests/test_wiki_sync.py scripts/tests/test_growth_workflow_contracts.py::test_wiki_sync_refreshes_posthog_snapshots_and_commits_marketing_data`
- [ ] CI `ci.yml` android job + unit tests
- [ ] Manual: paywall with empty/missing catalog shows disabled CTA, not broken monthly default


Made with [Cursor](https://cursor.com)