### PR TITLE
docs: GSD 24/7 autonomous ops + Play IAP runbook

### DIFF
--- a/.claude/GSD.md
+++ b/.claude/GSD.md
@@ -1,0 +1,28 @@
+# GSD — Get Shit Done
+
+**Mode:** Ship concrete artifacts every cycle. No status without evidence.
+
+## Each cycle must produce one of
+
+- Merged PR (merge SHA)
+- Green workflow run URL
+- Updated `marketing/data/*.json` on `develop`
+- Published wiki / GitHub Release / store read-back log
+
+## Priority order
+
+1. Revenue blockers (IAP console, paywall catalog, publish)
+2. Distribution (internal signoff → Firebase / TestFlight)
+3. Store parity (release branch, read-back)
+4. Analytics freshness (wiki-sync, executive-metrics)
+5. Hygiene (green PRs, dependabot)
+
+## Automation vs CEO
+
+See **`docs/AUTONOMOUS_OPERATIONS.md`** and **`.claude/scheduled_tasks.json`**.
+
+## Code discipline
+
+- Worktree + PR off `develop` (`docs/workflow.md`)
+- Ralph Loop for multi-step fixes: `.claude/skills/ralph-mode.md`
+- TDD for product code: `AGENTS.md`

--- a/.claude/scheduled_tasks.json
+++ b/.claude/scheduled_tasks.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "description": "Documentation mirror of GitHub Actions cron schedules. Not an execution engine — workflows in .github/workflows/ are authoritative.",
+  "budget_cap_usd_monthly": 20,
+  "ceo_gates": [
+    "firebase-signoff",
+    "testflight-signoff",
+    "production-signoff",
+    "play_console_managed_publish",
+    "play_console_iap_products"
+  ],
+  "tasks": [
+    {
+      "id": "wiki-sync",
+      "workflow": ".github/workflows/wiki-sync.yml",
+      "cron": "*/15 * * * *",
+      "ceo_required": false,
+      "artifact": "marketing/data/*.json, GitHub Wiki"
+    },
+    {
+      "id": "executive-metrics",
+      "workflow": ".github/workflows/executive-metrics.yml",
+      "cron": "17 6 * * *",
+      "ceo_required": false,
+      "artifact": "executive-metrics artifact"
+    },
+    {
+      "id": "internal-distribution-push",
+      "workflow": ".github/workflows/internal-distribution.yml",
+      "trigger": "push develop|main",
+      "ceo_required": true,
+      "note": "Approves firebase-signoff and/or testflight-signoff before upload jobs run"
+    },
+    {
+      "id": "ci-pr",
+      "workflow": ".github/workflows/ci.yml",
+      "trigger": "pull_request|push develop|main",
+      "ceo_required": false,
+      "artifact": "app-debug APK"
+    },
+    {
+      "id": "device-tests-pr",
+      "workflow": ".github/workflows/device-tests.yml",
+      "trigger": "pull_request develop|main",
+      "ceo_required": false
+    },
+    {
+      "id": "store-release-watcher",
+      "workflow": ".github/workflows/store-release-watcher.yml",
+      "cron": "*/30 * * * *",
+      "ceo_required": false
+    },
+    {
+      "id": "daily-growth-publishing",
+      "workflow": ".github/workflows/daily-growth-publishing.yml",
+      "cron": "15 13 * * *",
+      "ceo_required": false
+    },
+    {
+      "id": "weekly-analytics",
+      "workflow": ".github/workflows/analytics.yml",
+      "cron": "0 0 * * 0",
+      "ceo_required": false,
+      "artifact": "weekly-paywall-conversion-report"
+    }
+  ]
+}

--- a/docs/AUTONOMOUS_OPERATIONS.md
+++ b/docs/AUTONOMOUS_OPERATIONS.md
@@ -1,0 +1,116 @@
+# Autonomous Operations (24/7 + GSD)
+
+How Random Timer runs continuously without CEO action on every step, and where human gates remain.
+
+**Budget:** Hard cap **$20/month** external spend (`CLAUDE.md`). Scheduled jobs use GitHub Actions minutes, PostHog/ASC/Play APIs already in use — no new paid services without CEO approval.
+
+**GSD (Get Shit Done):** Each automation cycle must end with a concrete artifact: merge SHA, workflow run URL, committed JSON snapshot, or wiki update — not a plan.
+
+**Ralph Loop:** Multi-step implement → test → fix cycles for code tasks. See `.claude/skills/ralph-mode.md` and `.claude/scripts/ralph-loop.sh`.
+
+```bash
+.claude/scripts/ralph-loop.sh start "<task>" ISSUE-123
+.claude/scripts/ralph-loop.sh check    # pytest scripts/tests + Android unit tests
+.claude/scripts/ralph-loop.sh loop     # retry until green
+.claude/scripts/ralph-loop.sh stop
+```
+
+Ralph state: `.claude/ralph/ATTEMPTS.md` (session-local; not committed).
+
+---
+
+## What runs 24/7 automatically (no CEO click)
+
+| Schedule | Workflow | Purpose |
+|----------|----------|---------|
+| Every 15 min | `wiki-sync.yml` | PostHog → `marketing/data/*.json`, commit to `develop`, publish GitHub Wiki |
+| Daily 06:17 UTC | `executive-metrics.yml` | `executive_metrics.json` artifact (WQTU, paywall, stores) |
+| Daily 14:10 UTC | `north-star-guardrail.yml` | WQTU guardrail snapshot |
+| Daily 13:15 UTC | `daily-growth-publishing.yml` | Blog / Pages growth pipeline |
+| Every 6 h | `main.yml` | Legacy metrics cadence |
+| Every 6 h ( :25 ) | `zernio-growth-orchestration.yml` | Growth orchestration |
+| Every 30 min | `store-release-watcher.yml`, `resolve-bot-comments.yml` | Release + bot hygiene |
+| Weekly (calendar) | `analytics.yml`, `weekly-*`, `wqtu-health.yml` | ASO, CRO, referrals, attribution |
+| On push `develop`/`main` | `internal-distribution.yml` | **Starts** internal builds (see gates below) |
+| On PR/push | `ci.yml` | Unit tests, lint, **`app-debug` APK** artifact |
+
+Machine-readable registry: `.claude/scheduled_tasks.json` (documentation mirror of cron workflows).
+
+---
+
+## CEO gates (cannot be automated)
+
+| Gate | Environment / location | Unblocks |
+|------|-------------------------|----------|
+| Firebase internal APK | `firebase-signoff` | `android-firebase-internal` in `internal-distribution.yml` |
+| TestFlight internal | `testflight-signoff` | `ios-testflight-internal` |
+| Production store upload | `production-signoff` | `native-release.yml` upload jobs |
+| Play public version | Play Console → **Publish changes** | Managed publishing — approved builds stay staged until published |
+| Play IAP catalog | Play Console → Monetize → Products | `pro_base`, `elite_tactical`, `elite_tactical_monthly` must exist and be active |
+| App Store review | ASC | Optional `submit_review` on release workflow |
+
+Commit statuses required before production (`scripts/internal_signoff_gate.py`):
+
+- Android: `internal-signoff/firebase`
+- iOS: `internal-signoff/testflight`
+
+---
+
+## Standard operator flows (automate up to the gate)
+
+### Internal Android build (Firebase)
+
+```bash
+gh workflow run internal-distribution.yml --ref develop -f target=android_firebase
+```
+
+Then CEO: GitHub → Actions run → **Review deployments** → approve **`firebase-signoff`**.
+
+Evidence: job log `uploaded new release` / `distributed to testers/groups successfully`; console project **`random-timer-dist-new`** (`docs/FIREBASE_ANDROID_INFRASTRUCTURE.md`).
+
+### Internal full stack (TestFlight + Play internal + Firebase)
+
+```bash
+gh workflow run internal-distribution.yml --ref develop -f target=all
+```
+
+Approve **`testflight-signoff`** and **`firebase-signoff`** when prompted.
+
+### Production release (after internal signoffs on exact SHA)
+
+```bash
+gh workflow run native-release.yml --ref release/vX.Y.Z -f platform=both -f android_track=production
+```
+
+Approve **`production-signoff`**. Do **not** claim shipped until `public-store-version-readback.yml` passes.
+
+### Ralph / agent code change
+
+1. Worktree branch (`feat/*` / `fix/*` off `develop`) — `CLAUDE.md`
+2. Ralph loop or TDD per `AGENTS.md`
+3. PR → green `ci.yml` → merge
+4. `develop` CI produces `app-debug` artifact
+
+---
+
+## Push-triggered internal distribution
+
+On every push to `develop` or `main`, `internal-distribution.yml` runs with `target=all` but **waits** on signoff environments until CEO approves. Recent pushes may show `waiting` on `Android Firebase Signoff` — that is expected, not a failure.
+
+Use `target=all_safe` to skip Firebase when debugging Play internal only.
+
+---
+
+## Evidence protocol
+
+All status claims: command + path + sanitized output (`docs/OPERATIONAL_RELIABILITY.md`). Agents must not claim Firebase email, store version, or revenue without workflow log or API read-back.
+
+---
+
+## Related docs
+
+- `docs/RELEASE.md` — version bump, release branches, store metadata paths
+- `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` — Firebase project split, tester emails
+- `docs/PLAY_CONSOLE_IAP_RUNBOOK.md` — IAP SKU checklist (console-only P0)
+- `docs/workflow.md` — proof-of-work for agent PRs
+- `wiki/Growth-Systems-Overview.md` — weekly growth calendar

--- a/docs/PLAY_CONSOLE_IAP_RUNBOOK.md
+++ b/docs/PLAY_CONSOLE_IAP_RUNBOOK.md
@@ -1,0 +1,75 @@
+# Play Console IAP Runbook (P0 Revenue)
+
+**App:** Random Tactical Timer — `com.iganapolsky.randomtimer`  
+**Code product IDs** (`native-android/.../billing/ProManager.kt`):
+
+| Product ID | Billing type in app |
+|------------|---------------------|
+| `pro_base` | One-time (INAPP) |
+| `elite_tactical` | Subscription (SUBS) |
+| `elite_tactical_monthly` | Subscription (SUBS), P1M |
+
+PostHog `billing_product_not_found` on Android means Play Billing returned none of these at runtime — fix in **Play Console**, not in app code alone.
+
+**Console (App Distribution project is separate):** Monetize → Products in app `4976249162120849673`.
+
+---
+
+## Checklist (CEO / console)
+
+### 1. One-time product: `pro_base`
+
+1. Play Console → **Monetize with Play** → **Products** → **One-time products**
+2. Create or open product ID **`pro_base`**
+3. Set price, listing (en-US), **Activate**
+4. Confirm product is **Active** and available in target countries
+
+### 2. Subscriptions: `elite_tactical` (annual)
+
+1. **Subscriptions** → product **`elite_tactical`**
+2. Ensure at least one **base plan** (annual) is **Active**
+3. Price and eligibility set for production countries
+
+### 3. Subscription: `elite_tactical_monthly`
+
+1. **Subscriptions** → **Create subscription** ID **`elite_tactical_monthly`**
+2. Base plan: **Monthly (P1M)**, price **$3.99/month** (or intended price)
+3. **Activate** base plan and subscription
+
+### 4. Link to app
+
+- Products must be on the same app package as the release users install
+- After changes, allow **up to several hours** for Play Billing cache propagation
+
+### 5. Verify (no purchase required)
+
+- Install **production** build from Play (or latest Firebase after signoff)
+- Open paywall → PostHog should stop spiking `billing_product_not_found`
+- Optional: `billing_product_catalog_status` event should list IDs in `available_product_ids`
+
+---
+
+## Managed publishing (version parity)
+
+If production upload succeeded but Play Store still shows older **versionName** (e.g. 1.3.33):
+
+1. **Publishing overview** → **Publish N changes** (managed publishing ON)
+2. Staged items may include production rollout + listing assets
+
+Do not confuse **versionCode** in console (e.g. `1779125389`) with public **versionName** until publish completes.
+
+---
+
+## Evidence to capture
+
+- Screenshot: Subscriptions list showing all product IDs and Active state
+- Screenshot: One-time products showing `pro_base` Active
+- PostHog: paywall funnel / catalog failure counts declining after 24–48h
+
+---
+
+## Related
+
+- `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` — Firebase App Distribution (internal APK)
+- `docs/AUTONOMOUS_OPERATIONS.md` — CI gates and 24/7 automation
+- Merged paywall guard: PR #1562 — hides unbuyable SKUs until catalog probe completes

--- a/release-notes/1.3.35.md
+++ b/release-notes/1.3.35.md
@@ -5,8 +5,8 @@
 
 ## Product
 - **Android paywall:** Do not merchandise billing plans until the Play catalog probe completes; hide plans that are not returned by Billing; disable purchase CTA when no purchasable SKU is available (prevents dead-end monthly taps when `elite_tactical_monthly` is missing in Play Console).
-- **Analytics:** `wiki-sync.yml` now runs paywall conversion + attribution snapshots, commits refreshed `marketing/data/*.json` to `develop`, and injects a Paywall & Revenue section into the Daily Metrics Dashboard wiki.
+- **Analytics:** `wiki-sync.yml` runs paywall conversion + attribution snapshots, commits refreshed `marketing/data/*.json` to `develop`, and injects a Paywall & Revenue section into the Daily Metrics Dashboard wiki.
 
 ## Release operations
 - Requires **Google Play Console** IAP products active: `pro_base`, `elite_tactical`, `elite_tactical_monthly` (P0 revenue blocker if missing).
-- Ship Android to production after Firebase internal signoff on release SHA, then run `native-release` with public store read-back.
+- Ship Android to production only after internal signoff on release SHA and `public-store-version-readback` pass — see `docs/RELEASE.md`.


### PR DESCRIPTION
## Summary
- `docs/AUTONOMOUS_OPERATIONS.md` — what runs on cron vs CEO gates (firebase/testflight/production-signoff, Play publish/IAP)
- `.claude/scheduled_tasks.json` — machine-readable schedule registry (docs only)
- `.claude/GSD.md` — Get Shit Done mode: artifact-per-cycle rule
- `docs/PLAY_CONSOLE_IAP_RUNBOOK.md` — console steps for `pro_base`, `elite_tactical`, `elite_tactical_monthly`
- `release-notes/1.3.35.md` — release manifest on develop

## Test plan
- [x] Markdown only; no workflow behavior change


Made with [Cursor](https://cursor.com)