### PR TITLE
fix(ci): wiki-sync commit wiki pages before rebase

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -88,7 +88,9 @@ jobs:
             marketing/data/paywall_conversion_report.md \
             marketing/data/content_feedback.json \
             marketing/data/attribution-report.md \
-            marketing/data/apple_ads_live_metrics.json
+            marketing/data/apple_ads_live_metrics.json \
+            wiki/Daily-Metrics-Dashboard.md \
+            wiki/Paid-Acquisition.md
           if git diff --staged --quiet; then
             echo "No marketing snapshot changes to commit."
             exit 0

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -536,6 +536,9 @@ def test_wiki_sync_refreshes_posthog_snapshots_and_commits_marketing_data():
     assert "Commit refreshed marketing analytics snapshots" in source
     assert "marketing/data/paywall_conversion_report.json" in source
     assert "marketing/data/north_star.json" in source
+    assert "wiki/Daily-Metrics-Dashboard.md" in source
+    assert "wiki/Paid-Acquisition.md" in source
+    assert "git pull --rebase origin develop" in source
 
 
 def test_analytics_workflow_publishes_weekly_paywall_conversion_report_artifact():


### PR DESCRIPTION
## Summary
- Stage `wiki/Daily-Metrics-Dashboard.md` and `wiki/Paid-Acquisition.md` in the wiki-sync commit step so `git pull --rebase` is not blocked by unstaged wiki edits from `wiki_sync.py`.
- Use `fetch-depth: 0` for reliable rebase on push to `develop`.

## Evidence
Run 26113594241 failed: `cannot pull with rebase: You have unstaged changes` after committing marketing snapshots only.

## Test plan
- [x] `pytest scripts/tests/test_growth_workflow_contracts.py::test_wiki_sync_refreshes_posthog_snapshots_and_commits_marketing_data`

Made with [Cursor](https://cursor.com)