### PR TITLE
fix(ci): wiki-sync stage all snapshot outputs

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -82,13 +82,8 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add marketing/data/north_star.json \
-            marketing/data/store_downloads.json \
-            marketing/data/paywall_conversion_report.json \
-            marketing/data/paywall_conversion_report.md \
-            marketing/data/content_feedback.json \
-            marketing/data/attribution-report.md \
-            marketing/data/apple_ads_live_metrics.json \
+          git add marketing/data \
+            marketing/keywords/posthog_feedback.json \
             wiki/Daily-Metrics-Dashboard.md \
             wiki/Paid-Acquisition.md
           if git diff --staged --quiet; then

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -538,6 +538,8 @@ def test_wiki_sync_refreshes_posthog_snapshots_and_commits_marketing_data():
     assert "marketing/data/north_star.json" in source
     assert "wiki/Daily-Metrics-Dashboard.md" in source
     assert "wiki/Paid-Acquisition.md" in source
+    assert "marketing/keywords/posthog_feedback.json" in source
+    assert "git add marketing/data" in source
     assert "git pull --rebase origin develop" in source
 
 


### PR DESCRIPTION
## Summary
Stage entire `marketing/data/` plus `marketing/keywords/posthog_feedback.json` before rebase/push. Fixes unstaged `paid_campaigns.json` and keyword feedback files left by north_star_guardrail and attribution_feedback.

## Evidence
Runs 26114514960 / 26113594241: `cannot pull with rebase: You have unstaged changes` after partial `git add`.

## Test plan
- [x] `test_wiki_sync_refreshes_posthog_snapshots_and_commits_marketing_data`

Made with [Cursor](https://cursor.com)