### PR TITLE
chore(analytics): sync WQTU health and schedule Play IAP readback

### DIFF
--- a/.github/workflows/play-iap-product-readback.yml
+++ b/.github/workflows/play-iap-product-readback.yml
@@ -1,6 +1,8 @@
 name: Play IAP Product Readback
 
 on:
+  schedule:
+    - cron: "45 7 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -59,6 +59,13 @@ jobs:
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
         run: python scripts/paywall_conversion_report.py --repo-root . --days 30
 
+      - name: Build WQTU health snapshot from PostHog
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: python scripts/wqtu_dashboard.py --repo-root . --alert-threshold 1 || true
+
       - name: Build attribution and activation funnel snapshot from PostHog
         env:
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}

--- a/scripts/executive_metrics_snapshot.py
+++ b/scripts/executive_metrics_snapshot.py
@@ -466,6 +466,29 @@ def run(
         "crashlytics_bigquery": crashlytics,
     }
 
+    if (posthog or {}).get("status") == "ok":
+        payload["canonical_users"] = {
+            "metric_bundle_id": "executive_canonical_users_v1",
+            "window_days": (posthog or {}).get("window_days"),
+            "wqtu_7d": (posthog or {}).get("wqtu_7d_distinct_persons"),
+            "installs_30d": (posthog or {}).get("distinct_persons_application_installed"),
+            "timer_completed_persons_30d": (posthog or {}).get(
+                "distinct_persons_timer_completed"
+            ),
+            "paywall_purchase_success_persons_30d": (posthog or {}).get(
+                "distinct_persons_paywall_purchase_success"
+            ),
+            "paywall_purchase_success_events_30d": (posthog or {}).get(
+                "events_paywall_purchase_success"
+            ),
+        }
+    else:
+        payload["canonical_users"] = {
+            "metric_bundle_id": "executive_canonical_users_v1",
+            "status": "unavailable",
+            "reason": (posthog or {}).get("status"),
+        }
+
     ph_installed_ios = int(
         ((posthog or {}).get("distinct_persons_application_installed_ios") or 0)
         if (posthog or {}).get("status") == "ok"

--- a/scripts/tests/test_executive_metrics_snapshot.py
+++ b/scripts/tests/test_executive_metrics_snapshot.py
@@ -68,6 +68,32 @@ def test_posthog_section_includes_metric_field_ids_when_ok(monkeypatch: pytest.M
     assert out.get("distinct_persons_application_opened_android") == 0
 
 
+def test_run_payload_includes_canonical_users_when_posthog_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import executive_metrics_snapshot as ems
+
+    monkeypatch.setattr(ems, "_posthog_section", lambda *_a, **_k: {"status": "ok", "window_days": 30, "wqtu_7d_distinct_persons": 12, "distinct_persons_application_installed": 100, "distinct_persons_timer_completed": 40, "distinct_persons_paywall_purchase_success": 0, "events_paywall_purchase_success": 0})
+    monkeypatch.setattr(ems, "load_repo_dotenv", lambda *_a, **_k: None)
+
+    fake_store = types.SimpleNamespace(
+        _get_android_data=lambda _d: {"status": "skipped"},
+        _get_ios_data=lambda _d: {"status": "skipped"},
+    )
+    fake_crash = types.SimpleNamespace(
+        collect_crashlytics_snapshot=lambda **_k: {"status": "skipped"}
+    )
+    fake_refunds = types.SimpleNamespace(run=lambda **_k: {"status": "skipped"})
+    monkeypatch.setitem(sys.modules, "real_store_downloads", fake_store)
+    monkeypatch.setitem(sys.modules, "check_crashlytics", fake_crash)
+    monkeypatch.setitem(sys.modules, "check_refunds", fake_refunds)
+
+    payload = ems.run(Path("."), days=30, crashlytics_hours=168, load_dotenv=False)
+    canonical = payload.get("canonical_users") or {}
+    assert canonical.get("wqtu_7d") == 12
+    assert canonical.get("paywall_purchase_success_persons_30d") == 0
+
+
 def test_pragmatic_live_excludes_non_store_distribution_channels() -> None:
     from scripts import executive_metrics_snapshot as ems
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -19,6 +19,7 @@ WEEKLY_SHARED_WORKFLOW = ROOT / ".github/workflows/weekly-shared.yml"
 WQTU_HEALTH_WORKFLOW = ROOT / ".github/workflows/wqtu-health.yml"
 ANALYTICS_WORKFLOW = ROOT / ".github/workflows/analytics.yml"
 EXECUTIVE_METRICS_WORKFLOW = ROOT / ".github/workflows/executive-metrics.yml"
+PLAY_IAP_READBACK_WORKFLOW = ROOT / ".github/workflows/play-iap-product-readback.yml"
 WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
 WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
 STORE_RATINGS_SNAPSHOT_WORKFLOW = ROOT / ".github/workflows/store-ratings-snapshot.yml"
@@ -552,6 +553,22 @@ def test_analytics_workflow_publishes_weekly_paywall_conversion_report_artifact(
     assert "artifact_name: weekly-paywall-conversion-report" in source
     assert "marketing/data/paywall_conversion_report.md" in source
     assert "marketing/data/paywall_conversion_report.json" in source
+
+
+def test_play_iap_readback_workflow_scheduled_on_develop():
+    source = PLAY_IAP_READBACK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "schedule:" in source
+    assert 'cron: "45 7 * * *"' in source
+    assert "play_verify_iap_products.py" in source
+    assert "GOOGLE_PLAY_JSON_KEY" in source
+
+
+def test_wiki_sync_builds_wqtu_health_snapshot():
+    source = WIKI_SYNC_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "wqtu_dashboard.py" in source
+    assert "marketing/data" in source
 
 
 def test_executive_metrics_workflow_runs_daily_and_guards_ios_refund_signal():


### PR DESCRIPTION
## Summary
- Run `wqtu_dashboard.py` in wiki-sync so `marketing/data/wqtu_health.json` on develop stops staying stale (last commit was March).
- Schedule `play-iap-product-readback.yml` daily at 07:45 UTC (after executive metrics).
- Add `canonical_users` block to `executive_metrics.json` for one-line CEO scans (WQTU 7d, installs, paywall success).

## Test plan
- [x] `pytest scripts/tests/test_executive_metrics_snapshot.py::test_run_payload_includes_canonical_users_when_posthog_ok`
- [x] `pytest scripts/tests/test_growth_workflow_contracts.py::test_play_iap_readback_workflow_scheduled_on_develop`
- [x] `pytest scripts/tests/test_growth_workflow_contracts.py::test_wiki_sync_builds_wqtu_health_snapshot`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)