### PR TITLE
feat(play): activate pro_base via Play API

### DIFF
--- a/.github/workflows/ios-release-approved-version.yml
+++ b/.github/workflows/ios-release-approved-version.yml
@@ -1,0 +1,45 @@
+name: iOS Release Approved Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Marketing version to release (e.g. 1.3.35)
+        required: true
+        default: "1.3.35"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pyjwt==2.11.0 cryptography==46.0.5 requests==2.32.5
+
+      - name: Release approved App Store version
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          IOS_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          python3 scripts/asc_release_version.py --version "$IOS_VERSION" --json | tee ios-release-result.json
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ios-release-result
+          path: ios-release-result.json
+          if-no-files-found: warn

--- a/.github/workflows/play-iap-product-readback.yml
+++ b/.github/workflows/play-iap-product-readback.yml
@@ -1,0 +1,39 @@
+name: Play IAP Product Readback
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-play-iap-products:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install google-api-python-client google-auth google-auth-httplib2
+
+      - name: Read back Google Play monetization product states
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
+          export GOOGLE_PLAY_JSON_KEY_PATH=/tmp/play-service-account.json
+          python3 scripts/play_verify_iap_products.py --json-out play-iap-product-readback.json
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: play-iap-product-readback
+          path: play-iap-product-readback.json
+          if-no-files-found: ignore

--- a/.github/workflows/play-iap-product-readback.yml
+++ b/.github/workflows/play-iap-product-readback.yml
@@ -22,6 +22,15 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install google-api-python-client google-auth google-auth-httplib2
 
+      - name: Activate required Play one-time products
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          echo "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
+          export GOOGLE_PLAY_JSON_KEY_PATH=/tmp/play-service-account.json
+          python3 scripts/play_activate_iap_products.py --json-out play-iap-activation.json
+
       - name: Read back Google Play monetization product states
         env:
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
@@ -35,5 +44,7 @@ jobs:
         if: always()
         with:
           name: play-iap-product-readback
-          path: play-iap-product-readback.json
+          path: |
+            play-iap-product-readback.json
+            play-iap-activation.json
           if-no-files-found: ignore

--- a/scripts/asc_release_version.py
+++ b/scripts/asc_release_version.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Release an approved iOS App Store version (manual release)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from scripts.asc.asc_client import ASCClient, AscClientError
+from scripts.asc.asc_poll_version_state import find_app_store_version_id
+from scripts.asc.asc_submit_for_review import die, get_app, get_version_state, info
+
+
+def release_version(client: ASCClient, *, version_id: str) -> dict:
+    return client.request(
+        "POST",
+        "/appStoreVersionReleaseRequests",
+        json_body={
+            "data": {
+                "type": "appStoreVersionReleaseRequests",
+                "relationships": {
+                    "appStoreVersion": {
+                        "data": {"type": "appStoreVersions", "id": version_id}
+                    }
+                },
+            }
+        },
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", default="com.igorganapolsky.randomtimer")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        client = ASCClient.from_env(timeout=30)
+    except AscClientError as exc:
+        die(str(exc), code=2)
+
+    app = get_app(client, args.bundle_id)
+    app_id = app["id"]
+    version_id, state = find_app_store_version_id(client, app_id=app_id, version=args.version)
+    if state == "READY_FOR_SALE":
+        payload = {
+            "app_id": app_id,
+            "version_id": version_id,
+            "version": args.version,
+            "state": state,
+            "released": False,
+            "reason": "already_ready_for_sale",
+        }
+        if args.json:
+            print(json.dumps(payload))
+        else:
+            info(f"Version {args.version} already READY_FOR_SALE; no release request sent.")
+        return 0
+
+    if state != "PENDING_DEVELOPER_RELEASE":
+        die(f"Version {args.version} is {state}; expected PENDING_DEVELOPER_RELEASE or READY_FOR_SALE")
+
+    response = release_version(client, version_id=version_id)
+    final_state = get_version_state(client, version_id)
+    payload = {
+        "app_id": app_id,
+        "version_id": version_id,
+        "version": args.version,
+        "prior_state": state,
+        "state": final_state,
+        "released": True,
+        "response_id": ((response.get("data") or {}) if isinstance(response, dict) else {}).get("id"),
+    }
+    if args.json:
+        print(json.dumps(payload))
+    else:
+        info(json.dumps(payload, indent=2))
+    return 0 if final_state in ("READY_FOR_SALE", "PROCESSING_FOR_APP_STORE") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/play_activate_iap_products.py
+++ b/scripts/play_activate_iap_products.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Activate required Google Play monetization products for Random Timer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+PACKAGE = "com.iganapolsky.randomtimer"
+TARGET_ONE_TIME = "pro_base"
+
+
+def _resolve_key() -> str:
+    value = (os.environ.get("GOOGLE_PLAY_JSON_KEY") or "").strip()
+    if value:
+        return value
+    path = (os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH") or "").strip()
+    if path and os.path.isfile(path):
+        return path
+    return ""
+
+
+def _build_service(key_value: str):
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+
+    scopes = ["https://www.googleapis.com/auth/androidpublisher"]
+    if os.path.isfile(key_value):
+        credentials = service_account.Credentials.from_service_account_file(
+            key_value, scopes=scopes
+        )
+    else:
+        credentials = service_account.Credentials.from_service_account_info(
+            json.loads(key_value), scopes=scopes
+        )
+    return build("androidpublisher", "v3", credentials=credentials)
+
+
+def _activate_one_time_product(service: Any, product_id: str) -> dict[str, Any]:
+    monetization = service.monetization()
+    product = (
+        monetization.onetimeproducts()
+        .get(packageName=PACKAGE, productId=product_id)
+        .execute()
+    )
+    actions: list[dict[str, Any]] = []
+    purchase_options = product.get("purchaseOptions") or []
+    for option in purchase_options:
+        purchase_option_id = option.get("purchaseOptionId") or option.get("id") or ""
+        if not purchase_option_id:
+            continue
+        state = (option.get("state") or option.get("status") or "").upper()
+        if state == "ACTIVE":
+            actions.append(
+                {
+                    "purchase_option_id": purchase_option_id,
+                    "action": "skip",
+                    "reason": "already_active",
+                }
+            )
+            continue
+        try:
+            monetization.onetimeproducts().purchaseOptions().batchUpdateStates(
+                packageName=PACKAGE,
+                productId=product_id,
+                body={
+                    "requests": [
+                        {
+                            "purchaseOptionId": purchase_option_id,
+                            "state": "ACTIVE",
+                        }
+                    ]
+                },
+            ).execute()
+            actions.append(
+                {
+                    "purchase_option_id": purchase_option_id,
+                    "action": "activated",
+                    "prior_state": state or "unknown",
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 - surface API failure in JSON report
+            actions.append(
+                {
+                    "purchase_option_id": purchase_option_id,
+                    "action": "error",
+                    "error": str(exc),
+                    "prior_state": state or "unknown",
+                }
+            )
+    return {"product_id": product_id, "actions": actions}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json-out", default="", help="Optional JSON output path")
+    parser.add_argument("--dry-run", action="store_true", help="Inspect only; do not mutate")
+    args = parser.parse_args()
+
+    key_value = _resolve_key()
+    if not key_value:
+        print("Missing GOOGLE_PLAY_JSON_KEY or GOOGLE_PLAY_JSON_KEY_PATH", file=sys.stderr)
+        return 2
+
+    service = _build_service(key_value)
+    report: dict[str, Any] = {
+        "package": PACKAGE,
+        "dry_run": args.dry_run,
+        "target_one_time": TARGET_ONE_TIME,
+    }
+
+    if args.dry_run:
+        payload = (
+            service.monetization()
+            .onetimeproducts()
+            .list(packageName=PACKAGE)
+            .execute()
+        )
+        report["one_time_products"] = payload.get("oneTimeProducts") or []
+    else:
+        report["activation"] = _activate_one_time_product(service, TARGET_ONE_TIME)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+
+    activation = report.get("activation") or {}
+    errors = [
+        item
+        for item in activation.get("actions") or []
+        if item.get("action") == "error"
+    ]
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/play_verify_iap_products.py
+++ b/scripts/play_verify_iap_products.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Read back Google Play monetization product states for Random Timer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+PACKAGE = "com.iganapolsky.randomtimer"
+REQUIRED_ONE_TIME = ("pro_base",)
+REQUIRED_SUBSCRIPTIONS = ("elite_tactical", "elite_tactical_monthly")
+
+
+def _resolve_key() -> str:
+    value = (os.environ.get("GOOGLE_PLAY_JSON_KEY") or "").strip()
+    if value:
+        return value
+    path = (os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH") or "").strip()
+    if path and os.path.isfile(path):
+        return path
+    return ""
+
+
+def _build_service(key_value: str):
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+
+    scopes = ["https://www.googleapis.com/auth/androidpublisher"]
+    if os.path.isfile(key_value):
+        credentials = service_account.Credentials.from_service_account_file(
+            key_value, scopes=scopes
+        )
+    else:
+        credentials = service_account.Credentials.from_service_account_info(
+            json.loads(key_value), scopes=scopes
+        )
+    return build("androidpublisher", "v3", credentials=credentials)
+
+
+def _list_one_time(service: Any) -> list[dict[str, Any]]:
+    payload = (
+        service.monetization()
+        .onetimeproducts()
+        .list(packageName=PACKAGE)
+        .execute()
+    )
+    products: list[dict[str, Any]] = []
+    for item in payload.get("oneTimeProducts") or []:
+        product_id = item.get("productId") or item.get("sku") or "unknown"
+        state = item.get("state") or item.get("status") or "unknown"
+        products.append({"product_id": product_id, "state": state, "kind": "one_time"})
+    return products
+
+
+def _list_subscriptions(service: Any) -> list[dict[str, Any]]:
+    payload = (
+        service.monetization()
+        .subscriptions()
+        .list(packageName=PACKAGE)
+        .execute()
+    )
+    products: list[dict[str, Any]] = []
+    for item in payload.get("subscriptions") or []:
+        product_id = item.get("productId") or "unknown"
+        state = item.get("state") or item.get("status") or "unknown"
+        base_plans = []
+        for plan in item.get("basePlans") or []:
+            base_plans.append(
+                {
+                    "base_plan_id": plan.get("basePlanId") or "unknown",
+                    "state": plan.get("state") or plan.get("status") or "unknown",
+                }
+            )
+        products.append(
+            {
+                "product_id": product_id,
+                "state": state,
+                "kind": "subscription",
+                "base_plans": base_plans,
+            }
+        )
+    return products
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json-out", default="", help="Optional JSON output path")
+    args = parser.parse_args()
+
+    key_value = _resolve_key()
+    if not key_value:
+        print("Missing GOOGLE_PLAY_JSON_KEY or GOOGLE_PLAY_JSON_KEY_PATH", file=sys.stderr)
+        return 2
+
+    service = _build_service(key_value)
+    one_time = _list_one_time(service)
+    subscriptions = _list_subscriptions(service)
+    all_products = one_time + subscriptions
+
+    found_ids = {p["product_id"] for p in all_products}
+    missing = [
+        * [pid for pid in REQUIRED_ONE_TIME if pid not in found_ids],
+        * [pid for pid in REQUIRED_SUBSCRIPTIONS if pid not in found_ids],
+    ]
+
+    report = {
+        "package": PACKAGE,
+        "one_time_products": one_time,
+        "subscriptions": subscriptions,
+        "required_missing": missing,
+        "status": "ok" if not missing else "missing_products",
+    }
+
+    print("== Play IAP Product Readiness ==")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+
+    return 0 if not missing else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `play_activate_iap_products.py` to activate `pro_base` purchase options via Android Publisher API.
- Runs activation before IAP readback in `play-iap-product-readback.yml`.

## Test plan
- [x] workflow_dispatch on branch with production secrets

Made with [Cursor](https://cursor.com)