### PR TITLE
fix(ci): PYTHONPATH for Play IAP readback workflow

### DIFF
--- a/.github/workflows/play-iap-product-readback.yml
+++ b/.github/workflows/play-iap-product-readback.yml
@@ -12,6 +12,8 @@ jobs:
   verify-play-iap-products:
     runs-on: ubuntu-latest
     environment: production
+    env:
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -561,6 +561,8 @@ def test_play_iap_readback_workflow_scheduled_on_develop():
     assert "schedule:" in source
     assert 'cron: "45 7 * * *"' in source
     assert "play_verify_iap_products.py" in source
+    assert "play_activate_iap_products.py" in source
+    assert 'PYTHONPATH: ${{ github.workspace }}' in source
     assert "GOOGLE_PLAY_JSON_KEY" in source
 
 


### PR DESCRIPTION
## Summary
- Set job-level `PYTHONPATH` so `from scripts.play_monetization_client` resolves in CI.
- Extend workflow contract test to assert activate script + PYTHONPATH.

## Test plan
- [x] `pytest scripts/tests/test_growth_workflow_contracts.py::test_play_iap_readback_workflow_scheduled_on_develop`
- [ ] Merge and re-dispatch `play-iap-product-readback.yml`

Made with [Cursor](https://cursor.com)