### PR TITLE
fix(release): add 1.3.36/1.3.37 release notes for preflight

### DIFF
--- a/release-notes/1.3.36.md
+++ b/release-notes/1.3.36.md
@@ -1,0 +1,12 @@
+# Release 1.3.36
+
+## Summary
+**1.3.36** production release: Android and iOS store publish via `native-release` on `main`, including Play IAP catalog alignment and iOS analytics compile fixes from the release branch.
+
+## Product
+- Shipped production builds for Random Tactical Timer on Google Play and App Store Connect.
+- Play subscription `elite_tactical_monthly` base plan active in Play Console monetization catalog.
+
+## Release operations
+- Tagged `v1.3.36` on `main` after green `native-release` run.
+- Store readback may lag on public Play HTML (`1.3.35` proxy) while production track shows `1.3.36` uploaded.

--- a/release-notes/1.3.37.md
+++ b/release-notes/1.3.37.md
@@ -1,0 +1,11 @@
+# Release 1.3.37
+
+## Summary
+**1.3.37** is the post-release develop integration bump after **1.3.36** shipped to production (Android Play + iOS App Store pipeline). No user-facing product changes beyond version alignment on `develop`.
+
+## Product
+- Version bump only on `develop` after `release/v1.3.36` merged to `main`.
+
+## Release operations
+- Internal distribution (TestFlight + Firebase) uses this file for preflight release notes on `develop`.
+- Public production remains **1.3.36** until the next `release/v*` cut from `develop`.


### PR DESCRIPTION
## Summary
- Adds `release-notes/1.3.37.md` required by internal-distribution preflight on `develop`.
- Adds `release-notes/1.3.36.md` for release traceability after production ship.

## Test plan
- [ ] CI green
- [ ] Merge and re-run Internal Distribution on `develop`

Made with [Cursor](https://cursor.com)