### PR TITLE
chore(release): add 1.3.39 release notes

### DIFF
--- a/release-notes/1.3.39.md
+++ b/release-notes/1.3.39.md
@@ -1,0 +1,12 @@
+# Release 1.3.39
+
+## Summary
+**1.3.39** improves billing diagnostics on Android Play installs and adds executive revenue-goal metrics so paywall purchase and catalog-miss signals are visible in PostHog-backed snapshots.
+
+## Product
+- **Android billing:** Emit `billing_product_not_found` once per SKU per session (thread-safe dedup) on Play Store installs when Billing is ready but a product ID is missing from the catalog.
+- **Analytics:** Executive metrics and paywall reports track `paywall_purchase_success` and Play-catalog `billing_product_not_found` counts for revenue-gap monitoring.
+
+## Release operations
+- Confirm Google Play IAP products remain active: `pro_base`, `elite_tactical`, `elite_tactical_monthly`.
+- iOS App Store version must be submitted from `PREPARE_FOR_SUBMISSION` after metadata and VALID build read-back.


### PR DESCRIPTION
## Summary
- Adds `release-notes/1.3.39.md` required by iOS submit preflight.

## Test plan
- [x] File matches MARKETING_VERSION 1.3.39

Made with [Cursor](https://cursor.com)