### PR TITLE
docs(claude-code): apiKeyHelper setup for local Anthropic auth

### DIFF
--- a/.claude/scripts/get-anthropic-api-key.sh.example
+++ b/.claude/scripts/get-anthropic-api-key.sh.example
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# EXAMPLE ONLY — copy to ~/.claude/get-anthropic-api-key.sh and chmod +x.
+# Claude Code apiKeyHelper: print Anthropic API key to stdout (no trailing newline required).
+# Never commit the live script or real keys to the repo.
+#
+# Docs: docs/CLAUDE_CODE_API_KEY_HELPER.md
+# Unset ANTHROPIC_API_KEY in your shell when using apiKeyHelper (env wins over helper).
+
+set -euo pipefail
+
+# --- Level 1: gitignored env file on CEO machine ---
+ENV_FILE="${CLAUDE_ANTHROPIC_ENV_FILE:-${HOME}/.config/random-timer/anthropic.env}"
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+  set +a
+  if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    printf '%s' "${ANTHROPIC_API_KEY}"
+    exit 0
+  fi
+fi
+
+# --- Level 2: 1Password CLI (replace placeholder before use) ---
+ANTHROPIC_OP_REF="${ANTHROPIC_OP_REF:-op://REPLACE/Vault/Item/credential}"
+if command -v op >/dev/null 2>&1; then
+  if [[ "${ANTHROPIC_OP_REF}" != op://REPLACE/* ]]; then
+    op read "${ANTHROPIC_OP_REF}"
+    exit 0
+  fi
+fi
+
+echo "get-anthropic-api-key: configure Level 1 (${ENV_FILE}) or Level 2 (ANTHROPIC_OP_REF)" >&2
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ The user is the **CEO**. You are the **CTO** — a tool at the CEO's disposal. T
 - If a required action cannot be completed within the cap, pause and request explicit CEO approval with exact cost impact.
 - Include month-to-date spend and remaining budget in spend-related reports.
 
+## Claude Code (local API auth)
+
+Anthropic API keys for API-billed Claude Code: `apiKeyHelper` per `docs/CLAUDE_CODE_API_KEY_HELPER.md` (template `.claude/scripts/get-anthropic-api-key.sh.example`). Unset `ANTHROPIC_API_KEY` when the helper is active. GitHub stays on `gh auth`.
+
 ## Commands
 
 ```bash

--- a/docs/AUTONOMOUS_OPERATIONS.md
+++ b/docs/AUTONOMOUS_OPERATIONS.md
@@ -17,6 +17,8 @@ How Random Timer runs continuously without CEO action on every step, and where h
 
 Ralph state: `.claude/ralph/ATTEMPTS.md` (session-local; not committed).
 
+**Claude Code API auth (local):** `apiKeyHelper` + `docs/CLAUDE_CODE_API_KEY_HELPER.md` — unset `ANTHROPIC_API_KEY` when the helper is active; does not replace `gh auth`.
+
 ---
 
 ## What runs 24/7 automatically (no CEO click)
@@ -113,4 +115,5 @@ All status claims: command + path + sanitized output (`docs/OPERATIONAL_RELIABIL
 - `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` — Firebase project split, tester emails
 - `docs/PLAY_CONSOLE_IAP_RUNBOOK.md` — IAP SKU checklist (console-only P0)
 - `docs/workflow.md` — proof-of-work for agent PRs
+- `docs/CLAUDE_CODE_API_KEY_HELPER.md` — Claude Code `apiKeyHelper` (1Password / local env file)
 - `wiki/Growth-Systems-Overview.md` — weekly growth calendar

--- a/docs/CLAUDE_CODE_API_KEY_HELPER.md
+++ b/docs/CLAUDE_CODE_API_KEY_HELPER.md
@@ -1,0 +1,152 @@
+# Claude Code `apiKeyHelper` (Random Timer)
+
+How to supply an **Anthropic API key** to Claude Code on the CEO machine without storing secrets in this repo. For API-billed Claude Code sessions (Console / direct API), not Claude.ai subscription login.
+
+**Patterns:** Level 1 (local env file) and Level 2 (1Password `op read`), aligned with [Using 1Password to Manage Claude Code API Keys](https://blog.anchorline.io/p/using-1password-to-manage-claude) and [Claude Code authentication](https://code.claude.com/docs/en/authentication).
+
+**Repo template (example only):** `.claude/scripts/get-anthropic-api-key.sh.example`  
+**Live script (CEO machine, not committed):** `~/.claude/get-anthropic-api-key.sh`
+
+---
+
+## What this is / is not
+
+| In scope | Out of scope |
+|----------|----------------|
+| Anthropic API key for Claude Code CLI (`apiKeyHelper`) | GitHub — still **`gh auth login`** / keyring; CI uses Actions secrets |
+| Long local sessions (GSD, Ralph — `.claude/scripts/ralph-loop.sh`) | Storing keys in `settings.json`, `.env` in repo, or this doc |
+| Refresh via `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` | Replacing `ANTHROPIC_API_KEY` in GitHub Actions (`claude-review.yml`, etc.) |
+
+---
+
+## Credential priority (must unset env when using helper)
+
+Claude Code picks auth in a fixed order. Relevant entries:
+
+1. OAuth / subscription (if logged in)
+2. **`ANTHROPIC_API_KEY` environment variable** — wins over `apiKeyHelper` when set (after any one-time approval in interactive mode)
+3. **`apiKeyHelper` script stdout** — used when no env API key is active
+
+**Rule:** If `apiKeyHelper` should be the source of truth, **unset** `ANTHROPIC_API_KEY` (and `ANTHROPIC_AUTH_TOKEN` if set) in the shell profile, direnv, and IDE-integrated terminals before starting Claude Code.
+
+```bash
+unset ANTHROPIC_API_KEY
+unset ANTHROPIC_AUTH_TOKEN
+```
+
+Verify with **`/status`** inside Claude Code ([env var guidance](https://support.claude.com/en/articles/12304248-manage-api-key-environment-variables-in-claude-code)).
+
+---
+
+## Level 1 — Local env file (simple)
+
+1. Copy the template and install on the CEO machine:
+
+   ```bash
+   cp .claude/scripts/get-anthropic-api-key.sh.example ~/.claude/get-anthropic-api-key.sh
+   chmod +x ~/.claude/get-anthropic-api-key.sh
+   ```
+
+2. Create a **gitignored** env file (example path):
+
+   ```bash
+   mkdir -p ~/.config/random-timer
+   # ~/.config/random-timer/anthropic.env — mode 600, never commit
+   # ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+3. Point the script at that file (default in template: `CLAUDE_ANTHROPIC_ENV_FILE` or `~/.config/random-timer/anthropic.env`).
+
+4. Wire `apiKeyHelper` in user settings (see [CEO `settings.json` snippet](#ceo-settingsjson-snippet) below).
+
+---
+
+## Level 2 — 1Password CLI (`op read`)
+
+Requires [1Password CLI](https://developer.1password.com/docs/cli/) and `op signin` (or service account for automation).
+
+1. Store the Anthropic API key in 1Password (item + field names are yours; use a private vault).
+
+2. In `~/.claude/get-anthropic-api-key.sh`, set `ANTHROPIC_OP_REF` to your reference, e.g.:
+
+   ```bash
+   ANTHROPIC_OP_REF='op://Private/Anthropic API Key/credential'
+   ```
+
+   The template uses a **placeholder** `op://REPLACE/Vault/Item/credential` — replace before use.
+
+3. Ensure the script is executable and `apiKeyHelper` points at it.
+
+4. First Claude Code launch may prompt 1Password to unlock the vault (expected).
+
+**Note:** Native `op://` in `settings.json` `env` is a separate upstream feature ([anthropics/claude-code#23642](https://github.com/anthropics/claude-code/issues/23642)); this repo standardizes on **`apiKeyHelper` + shell script** for portability today.
+
+---
+
+## Long Ralph / GSD loops — refresh TTL
+
+By default, `apiKeyHelper` output is cached (~5 minutes) and refreshed on HTTP 401. For multi-hour Ralph loops (`.claude/scripts/ralph-loop.sh`, `.claude/skills/ralph-mode.md`), extend TTL in the **same shell** that launches Claude Code:
+
+```bash
+export CLAUDE_CODE_API_KEY_HELPER_TTL_MS=3600000   # 1 hour; adjust as needed
+```
+
+Optional: add to `~/.claude/settings.json` `env` block (no secret values):
+
+```json
+"env": {
+  "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3600000"
+}
+```
+
+---
+
+## CEO `settings.json` snippet
+
+Observed on CEO machine: `~/.claude/settings.json` exists (hooks, statusLine, theme). **Merge** `apiKeyHelper`; do not remove existing keys.
+
+Add (paths are examples — use your home directory):
+
+```json
+{
+  "apiKeyHelper": "/Users/igorganapolsky/.claude/get-anthropic-api-key.sh",
+  "env": {
+    "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3600000"
+  }
+}
+```
+
+If you already have `"env": { ... }`, merge keys into that object instead of duplicating `"env"`.
+
+Claude Code reloads `apiKeyHelper` when settings change; restart the CLI if `/status` still shows the wrong method.
+
+---
+
+## Activation checklist (paths only)
+
+| Step | Path / action |
+|------|----------------|
+| 1 | `cp` repo `.claude/scripts/get-anthropic-api-key.sh.example` → `~/.claude/get-anthropic-api-key.sh` |
+| 2 | `chmod +x ~/.claude/get-anthropic-api-key.sh` |
+| 3 | Configure Level 1 file **or** Level 2 `ANTHROPIC_OP_REF` inside that script |
+| 4 | `unset ANTHROPIC_API_KEY` (and `ANTHROPIC_AUTH_TOKEN`) in profile / terminal |
+| 5 | Add `"apiKeyHelper"` to `~/.claude/settings.json` (snippet above) |
+| 6 | Run `claude`, then `/status` — expect API key via helper, not stray env |
+| 7 | For Ralph: `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` + `.claude/scripts/ralph-loop.sh` as today |
+
+---
+
+## Complements GSD / Ralph / CI
+
+- **GSD / autonomous ops:** `docs/AUTONOMOUS_OPERATIONS.md` — scheduled work stays on GitHub Actions; local Claude Code uses this helper.
+- **Ralph:** `ralph-loop.sh` does not read the API key; it only runs tests/checks. Claude Code sessions **driving** Ralph should use the helper + TTL above.
+- **CI:** Workflows keep `secrets.ANTHROPIC_API_KEY`; no `apiKeyHelper` in CI.
+
+---
+
+## References
+
+- [Claude Code authentication](https://code.claude.com/docs/en/authentication) — `apiKeyHelper`, `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`
+- [Manage API key environment variables](https://support.claude.com/en/articles/12304248-manage-api-key-environment-variables-in-claude-code)
+- [1Password + Claude Code (Anchorline)](https://blog.anchorline.io/p/using-1password-to-manage-claude)
+- Repo: `.claude/scripts/ralph-loop.sh`, `.claude/GSD.md`, `CLAUDE.md` (Claude Code line)


### PR DESCRIPTION
## Summary
- Add `docs/CLAUDE_CODE_API_KEY_HELPER.md` (Level 1 env file + Level 2 1Password `op read`, priority order, Ralph TTL, CEO `settings.json` merge snippet).
- Add executable template `.claude/scripts/get-anthropic-api-key.sh.example` (no secrets in repo).
- One-line links in `CLAUDE.md` and `docs/AUTONOMOUS_OPERATIONS.md`.

## Test plan
- [ ] Copy example to `~/.claude/get-anthropic-api-key.sh`, configure Level 1 or 2 locally.
- [ ] `unset ANTHROPIC_API_KEY`; set `apiKeyHelper` in `~/.claude/settings.json`.
- [ ] `claude` → `/status` shows helper-based API auth.
- [ ] Ralph long session: `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` set as documented.


Made with [Cursor](https://cursor.com)