### PR TITLE
fix: allow 5s min/max timer range gap (Android UI)

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -27,7 +27,7 @@ class RangeSliderUiTest {
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Maximum: 1m").assertExists()
 
-        // Move min close to max; max should be pushed to keep a 30s gap.
+        // Move min close to max; max should be pushed to keep a 5s gap.
         composeRule
             .onNodeWithContentDescription("Minimum time slider")
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
@@ -35,7 +35,7 @@ class RangeSliderUiTest {
             }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Minimum: 50s").assertExists()
-        composeRule.onNodeWithText("Maximum: 1m 20s").assertExists()
+        composeRule.onNodeWithText("Maximum: 55s").assertExists()
     }
 
     @Test
@@ -49,7 +49,7 @@ class RangeSliderUiTest {
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Minimum: 2m 30s").assertExists()
 
-        // Move max below min + 30s; min should be pulled back.
+        // Move max below min + 5s; min should be pulled back.
         composeRule
             .onNodeWithContentDescription("Maximum time slider")
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
@@ -57,6 +57,6 @@ class RangeSliderUiTest {
             }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Maximum: 2m 40s").assertExists()
-        composeRule.onNodeWithText("Minimum: 2m 10s").assertExists()
+        composeRule.onNodeWithText("Minimum: 2m 35s").assertExists()
     }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -461,7 +461,6 @@ fun TimerSetupScreen(
                                 minValue = config.minSeconds,
                                 maxValue = config.maxSeconds,
                                 maxSliderRange = maxRange.toFloat(),
-                                minSliderMax = maxRange - 30f,
                                 compactMode = isCompactHeight,
                                 onMinChange = { newMin ->
                                     val (min, max) =
@@ -470,7 +469,6 @@ fun TimerSetupScreen(
                                             currentMaxSeconds = config.maxSeconds,
                                             newMinSeconds = newMin,
                                             maxSecondsLimit = maxRange,
-                                            minGapSeconds = 30,
                                         )
                                     updateConfig(minSeconds = min, maxSeconds = max)
                                 },
@@ -481,7 +479,6 @@ fun TimerSetupScreen(
                                             currentMaxSeconds = config.maxSeconds,
                                             newMaxSeconds = newMax,
                                             maxSecondsLimit = maxRange,
-                                            minGapSeconds = 30,
                                         )
                                     updateConfig(minSeconds = adjMin, maxSeconds = adjMax)
                                 },
@@ -1164,7 +1161,6 @@ private fun TimeRangeSliders(
     minValue: Int,
     maxValue: Int,
     maxSliderRange: Float = TimerConfig.MAX_SECONDS_FREE.toFloat(),
-    minSliderMax: Float = maxSliderRange - 30f,
     compactMode: Boolean = false,
     enabled: Boolean = true,
     onMinChange: (Int) -> Unit,
@@ -1176,7 +1172,6 @@ private fun TimeRangeSliders(
     val minFloorSeconds = TimeRangeAdjuster.DEFAULT_MIN_SECONDS
     val minGapSeconds = TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS
     val maxSliderRangeInt = maxSliderRange.toInt()
-    val minSliderMaxInt = minSliderMax.toInt()
     val sectionGap = if (compactMode) 8.dp else 12.dp
     val rowGap = 4.dp
     val nudgeSize = 32.dp

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -28,9 +28,6 @@ struct TimerSetupScreen: View {
     // Read directly from timerManager.config to avoid animation issues
     private var config: TimerConfig { timerManager.config }
 
-    private var maxSliderRange: Double { Double(proManager.maxSecondsLimit) }
-    private var minSliderMax: Double { maxSliderRange - 30 }
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {

--- a/scripts/tests/test_timer_defaults_parity.py
+++ b/scripts/tests/test_timer_defaults_parity.py
@@ -104,6 +104,19 @@ def test_timer_limits_and_gap_rules_match_across_mobile_platforms():
     assert "static let defaultMinGapSeconds = 5" in ios_models
 
 
+def test_timer_setup_screen_uses_five_second_range_gap_not_thirty():
+    """UI callbacks must use TimeRangeAdjuster gap (5s), not a legacy 30s floor."""
+    android_setup = ANDROID_SETUP_SCREEN.read_text(encoding="utf-8")
+    ios_setup = IOS_SETUP_SCREEN.read_text(encoding="utf-8")
+
+    assert "minGapSeconds = 30" not in android_setup
+    assert "maxRange - 30f" not in android_setup
+    assert "maxSliderRange - 30f" not in android_setup
+    assert "TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS" in android_setup
+    assert "defaultMinGapSeconds" in ios_setup
+    assert "maxSliderRange - 30" not in ios_setup
+
+
 def test_sound_catalog_matches_across_mobile_platforms():
     android_config = ANDROID_CONFIG.read_text(encoding="utf-8")
     ios_models = IOS_MODELS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- **Root cause:** `TimeRangeAdjuster` already enforces a **5s** gap, but Android `TimerSetupScreen` callbacks passed `minGapSeconds = 30`, forcing ~30s (often perceived as ~39s with 5s step snapping).
- **Fix:** Remove the 30s override; use default `TimeRangeAdjuster.DEFAULT_MIN_GAP_SECONDS` (5s). Drop unused `minSliderMax` offset and dead iOS `maxSliderRange - 30` property.
- **Tests:** New parity guard `test_timer_setup_screen_uses_five_second_range_gap_not_thirty`; updated `RangeSliderUiTest` expectations (50s min → 55s max).

## Platform parity
| Layer | Android | iOS |
|-------|---------|-----|
| Domain (`TimeRangeAdjuster`) | 5s | 5s (unchanged) |
| Setup UI gap | **30s → 5s** | 5s (unchanged) |

## Test plan
- [x] `pytest scripts/tests/test_timer_defaults_parity.py::test_timer_setup_screen_uses_five_second_range_gap_not_thirty`
- [ ] CI `testDebugUnitTest` + `app-debug` artifact
- [ ] Manual: drag min near max on Android; gap should be 5s (e.g. 50s / 55s)


Made with [Cursor](https://cursor.com)