### PR TITLE
fix(android): remove Pro-only Training Presets section

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -61,7 +61,6 @@ internal val PAYWALL_FEATURE_ROWS =
     listOf(
         "60-minute random windows for full-length drills",
         "Combat and MMA voice callouts with live time checks",
-        "Expert training presets (Competition, Sparring, etc.)",
         "Round-capped loops for pad work, sparring, and circuits",
         "Full sound arsenal — bells, horns, sirens, and more",
         "Fresh pro audio drops when new packs land",

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -154,6 +154,10 @@ internal fun primaryStartButtonCaption(hasFirstCompleted: Boolean): String? =
         "Quick start: the default drill fires in 5-30 seconds."
     }
 
+internal fun competitionPrepSectionTitle(): String = "Competition Prep"
+
+internal fun isCompetitionPrepProGated(): Boolean = false
+
 internal fun readHasFirstCompleted(context: Context): Boolean =
     context
         .getSharedPreferences(AnalyticsService.PREFS_NAME, Context.MODE_PRIVATE)
@@ -183,7 +187,6 @@ fun TimerSetupScreen(
     var hasFirstCompleted by remember(context) { mutableStateOf(readHasFirstCompleted(context)) }
     val haptic = LocalHapticFeedback.current
     var showArsenal by remember { mutableStateOf(!isPro) }
-    var showCompetitionPrep by remember { mutableStateOf(false) }
     var storedFreeMinSeconds by rememberSaveable { mutableIntStateOf(TimerConfig.DEFAULT.minSeconds) }
     var storedFreeMaxSeconds by rememberSaveable { mutableIntStateOf(TimerConfig.DEFAULT.maxSeconds) }
     var storedExtendedMinSeconds by rememberSaveable { mutableIntStateOf(TimerConfig.DEFAULT.minSeconds) }
@@ -362,6 +365,72 @@ fun TimerSetupScreen(
                                 style = MaterialTheme.typography.labelSmall,
                                 color = TimerColors.AccentPrimary,
                             )
+                        }
+                    }
+                }
+
+                if (!isCompetitionPrepProGated()) {
+                    item {
+                        Text(
+                            text = "STANDARD OPS",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = TimerColors.TextMuted,
+                            modifier = Modifier.padding(start = 4.dp),
+                        )
+                    }
+                    item {
+                        GlassCard(modifier = Modifier.fillMaxWidth(), padding = spacing.cardContent) {
+                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                Text(
+                                    text = competitionPrepSectionTitle(),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = TimerColors.TextPrimary,
+                                )
+
+                                TrainingPreset.ALL.forEach { preset ->
+                                    Surface(
+                                        onClick = {
+                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                            onTrainingPresetApplied(preset)
+                                        },
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = TimerColors.GlassBackground,
+                                        border = BorderStroke(1.dp, TimerColors.GlassBorder),
+                                        modifier = Modifier.fillMaxWidth(),
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                        ) {
+                                            Column(
+                                                modifier = Modifier.weight(1f),
+                                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                                            ) {
+                                                Text(
+                                                    text = preset.title,
+                                                    style = MaterialTheme.typography.labelMedium,
+                                                    fontWeight = FontWeight.SemiBold,
+                                                    color = TimerColors.TextPrimary,
+                                                )
+                                                Text(
+                                                    text = preset.subtitle,
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = TimerColors.TextMuted,
+                                                )
+                                            }
+                                            Text(
+                                                text = "${formatTime(preset.minSeconds)}-${formatTime(preset.maxSeconds)}",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                fontWeight = FontWeight.Bold,
+                                                color = TimerColors.AccentPrimary,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -863,63 +932,6 @@ fun TimerSetupScreen(
                                                     color = TimerColors.AccentPrimary,
                                                 )
                                             }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (isPro) {
-                    item {
-                        GlassCard(modifier = Modifier.fillMaxWidth(), padding = spacing.cardContent) {
-                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                Text(
-                                    text = "Training Presets",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = TimerColors.TextPrimary,
-                                )
-
-                                TrainingPreset.ALL.forEach { preset ->
-                                    Surface(
-                                        onClick = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            onTrainingPresetApplied(preset)
-                                        },
-                                        shape = RoundedCornerShape(8.dp),
-                                        color = TimerColors.GlassBackground,
-                                        border = BorderStroke(1.dp, TimerColors.GlassBorder),
-                                        modifier = Modifier.fillMaxWidth(),
-                                    ) {
-                                        Row(
-                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            Column(
-                                                modifier = Modifier.weight(1f),
-                                                verticalArrangement = Arrangement.spacedBy(4.dp),
-                                            ) {
-                                                Text(
-                                                    text = preset.title,
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    fontWeight = FontWeight.SemiBold,
-                                                    color = TimerColors.TextPrimary,
-                                                )
-                                                Text(
-                                                    text = preset.subtitle,
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = TimerColors.TextMuted,
-                                                )
-                                            }
-                                            Text(
-                                                text = "${formatTime(preset.minSeconds)}-${formatTime(preset.maxSeconds)}",
-                                                style = MaterialTheme.typography.labelSmall,
-                                                fontWeight = FontWeight.Bold,
-                                                color = TimerColors.AccentPrimary,
-                                            )
                                         }
                                     }
                                 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -22,7 +22,6 @@ class PaywallSheetTest {
             listOf(
                 "60-minute random windows for full-length drills",
                 "Combat and MMA voice callouts with live time checks",
-                "Expert training presets (Competition, Sparring, etc.)",
                 "Round-capped loops for pad work, sparring, and circuits",
                 "Full sound arsenal — bells, horns, sirens, and more",
                 "Fresh pro audio drops when new packs land",

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
@@ -56,4 +56,14 @@ class TimerSetupScreenTextTest {
 
         assertThat(readHasFirstCompleted(context)).isTrue()
     }
+
+    @Test
+    fun competitionPrepSectionTitleMatchesIOS() {
+        assertThat(competitionPrepSectionTitle()).isEqualTo("Competition Prep")
+    }
+
+    @Test
+    fun competitionPrepIsAvailableWithoutPro() {
+        assertThat(isCompetitionPrepProGated()).isFalse()
+    }
 }


### PR DESCRIPTION
## Summary
- Moves **Competition Prep** preset card to the top of timer setup for **all users** (parity with iOS).
- Removes the Pro-gated **Training Presets** section that only appeared after subscribing.
- Drops misleading paywall bullet: "Expert training presets (Competition, Sparring, etc.)" — iOS paywall never listed this.

## Why
`marketing/data/competition_warmup_experiment.md` documents Competition Warmup as a **$0 growth** preset (event-day BJJ/judo/wrestling), not a monetization lever. Android had drifted: presets were Pro-only + paywall copy over-promised "Sparring" presets that do not exist (only `competition_warmup`).

## Test plan
- [ ] `./gradlew testDebugUnitTest --tests '*TimerSetupScreenTextTest' --tests '*PaywallSheetTest'`
- [ ] Free-tier Android: Competition Prep visible above Timer Range; tap applies 20–90s warmup
- [ ] Pro paywall: no "Expert training presets" row


Made with [Cursor](https://cursor.com)