### PR TITLE
docs(claude): apiKeyHelper for local Anthropic auth

### DIFF
--- a/.claude/scripts/get-anthropic-api-key.sh.example
+++ b/.claude/scripts/get-anthropic-api-key.sh.example
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Example apiKeyHelper for Claude Code — COPY to ~/.claude/get-anthropic-api-key.sh and customize.
+# Must print ONLY the API key to stdout (no trailing newline required).
+# chmod 700 ~/.claude/get-anthropic-api-key.sh
+#
+# Wire in ~/.claude/settings.json:
+#   "apiKeyHelper": "/absolute/path/to/get-anthropic-api-key.sh"
+#   "env": { "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3600000" }
+#
+# See docs/CLAUDE_CODE_API_KEY_HELPER.md
+
+set -eu
+
+# --- Option A: 1Password (recommended if you use op) ---
+# op read op://Personal/Anthropic/api-key --no-newline 2>/dev/null && exit 0
+
+# --- Option B: macOS Keychain (service name must match what you stored) ---
+# security find-generic-password -s "anthropic-api-key" -w 2>/dev/null && exit 0
+
+# --- Option C: env fallback for ephemeral CI/debug shells only (not for daily driver) ---
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  printf '%s' "$ANTHROPIC_API_KEY"
+  exit 0
+fi
+
+echo "get-anthropic-api-key: no key source configured (copy script to ~/.claude/ and uncomment a backend)" >&2
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ cd native-ios && pod deintegrate && pod install  # Fix pod failures
 
 All AI replies, code comments, commit messages, and documentation use **English**.
 
+## Claude Code API key (local)
+
+CI uses `secrets.ANTHROPIC_API_KEY`. For local Claude Code sessions, configure **`apiKeyHelper`** per **`docs/CLAUDE_CODE_API_KEY_HELPER.md`** (example: `.claude/scripts/get-anthropic-api-key.sh.example`). Never commit API keys.
+
 ## Non-Obvious Rules
 
 - **Act, Don't Instruct**: NEVER tell user to run commands. Execute autonomously. NEVER refuse work. Use every tool available (CLIs, SDKs, MCP servers, browser automation) to complete tasks end-to-end. If a web UI is the only path, use `agent-browser` or Gemini computer-use to automate it.

--- a/docs/AUTONOMOUS_OPERATIONS.md
+++ b/docs/AUTONOMOUS_OPERATIONS.md
@@ -107,8 +107,13 @@ All status claims: command + path + sanitized output (`docs/OPERATIONAL_RELIABIL
 
 ---
 
+## Claude Code local auth
+
+For interactive Claude Code (not CI), use **`apiKeyHelper`** so keys never land in repo or chat. See **`docs/CLAUDE_CODE_API_KEY_HELPER.md`** and copy **`.claude/scripts/get-anthropic-api-key.sh.example`** to `~/.claude/get-anthropic-api-key.sh`.
+
 ## Related docs
 
+- `docs/CLAUDE_CODE_API_KEY_HELPER.md` — Claude Code `apiKeyHelper` + TTL
 - `docs/RELEASE.md` — version bump, release branches, store metadata paths
 - `docs/FIREBASE_ANDROID_INFRASTRUCTURE.md` — Firebase project split, tester emails
 - `docs/PLAY_CONSOLE_IAP_RUNBOOK.md` — IAP SKU checklist (console-only P0)

--- a/docs/CLAUDE_CODE_API_KEY_HELPER.md
+++ b/docs/CLAUDE_CODE_API_KEY_HELPER.md
@@ -1,0 +1,76 @@
+# Claude Code `apiKeyHelper` (Anthropic API key)
+
+How Random Timer operators wire Claude Code to fetch an Anthropic API key from a secrets manager **without** storing the key in repo files, chat, or committed `settings.json`.
+
+## Why
+
+- **CI** uses `ANTHROPIC_API_KEY` from GitHub Actions secrets (`claude-review.yml`, `weekly-shared.yml`).
+- **Local Claude Code** sessions should use the same pattern: a shell command prints the key to stdout; Claude Code sends it as `X-Api-Key` and `Authorization: Bearer`.
+- Never commit API keys. Never paste keys into issues, PRs, or agent prompts.
+
+Official reference: [Claude Code settings — `apiKeyHelper`](https://code.claude.com/docs/en/settings).
+
+## Setup (one-time)
+
+1. Copy the example script and make it executable (outside the repo if you prefer):
+
+   ```bash
+   cp .claude/scripts/get-anthropic-api-key.sh.example ~/.claude/get-anthropic-api-key.sh
+   chmod 700 ~/.claude/get-anthropic-api-key.sh
+   ```
+
+2. Edit `~/.claude/get-anthropic-api-key.sh` to use **your** secret backend (1Password `op`, macOS Keychain, `gh secret` is **not** for local Claude — use a personal vault).
+
+3. Add to **`~/.claude/settings.json`** (user scope — do not commit):
+
+   ```json
+   {
+     "apiKeyHelper": "/Users/YOU/.claude/get-anthropic-api-key.sh",
+     "env": {
+       "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3600000"
+     }
+   }
+   ```
+
+   Optional project-local override in `.claude/settings.json` (committed) may set only the **path** to a script name, never the key value:
+
+   ```json
+   {
+     "apiKeyHelper": ".claude/scripts/get-anthropic-api-key.sh.example"
+   }
+   ```
+
+   Prefer the user-scope path above so the real script stays in `~/.claude/`.
+
+4. Verify (sanitized — should print `sk-ant-…` length only):
+
+   ```bash
+   ~/.claude/get-anthropic-api-key.sh | wc -c
+   claude /status
+   ```
+
+## TTL and caching
+
+- `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` controls how long Claude Code caches the helper output (default ~5 minutes).
+- If TTL from `settings.json` is ignored on your Node/OS build, export the variable in the shell that launches `claude` (known upstream issue on some Node 24 / Windows builds).
+- For long sessions, implement **idempotent caching inside the helper script** (file or keychain with mtime check) so repeated helper invocations do not hammer 1Password/AWS.
+
+## Alternatives (no custom script)
+
+| Backend | `apiKeyHelper` value |
+|---------|----------------------|
+| 1Password CLI | `op read op://Vault/Anthropic/api-key --no-newline` |
+| AWS Secrets Manager | `aws secretsmanager get-secret-value --secret-id anthropic-api-key --query SecretString --output text` |
+
+## Security
+
+- Script must be mode `700` and owned by the CEO user.
+- Do not log stdout from the helper.
+- Rotate keys in the vault if a key ever appears in chat, CI logs, or a commit.
+- Agents: use GitHub Actions secrets for CI; use `apiKeyHelper` for local Claude Code only.
+
+## Related
+
+- `docs/AUTONOMOUS_OPERATIONS.md` — 24/7 automation and CEO gates
+- `CLAUDE.md` — CTO mandate and secret hygiene
+- `.github/workflows/claude-review.yml` — PR review uses `secrets.ANTHROPIC_API_KEY`


### PR DESCRIPTION
## Summary
- Add `docs/CLAUDE_CODE_API_KEY_HELPER.md` and `.claude/scripts/get-anthropic-api-key.sh.example` for Claude Code `apiKeyHelper` setup (secrets manager, TTL, security).
- Link from `CLAUDE.md` and `docs/AUTONOMOUS_OPERATIONS.md`.

## Test plan
- [x] `pytest scripts/tests/test_internal_signoff_gate.py` (9 passed)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)