### PR TITLE
feat(timer): silence alarm on hardware volume keys

### DIFF
--- a/.maestro/regression-sound-arsenal-paywall-ios.yaml
+++ b/.maestro/regression-sound-arsenal-paywall-ios.yaml
@@ -11,7 +11,12 @@ appId: com.igorganapolsky.randomtimer
 - assertVisible: "Unlock Sound Arsenal"
 - tapOn: "Unlock Sound Arsenal"
 - extendedWaitUntil:
-    visible: "Restore purchase"
-    timeout: 10000
+    visible: "Not now"
+    timeout: 15000
+- scrollUntilVisible:
+    element: "Restore purchase"
+    direction: DOWN
+    timeout: 15000
+- assertVisible: "Restore purchase"
 - takeScreenshot: evidence/ios-sound-arsenal-paywall
 - stopApp

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/MainActivity.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -21,6 +22,7 @@ import com.iganapolsky.randomtimer.BuildConfig
 import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.notifications.MonthlyContentWorker
 import com.iganapolsky.randomtimer.notifications.ReengagementScheduler
+import com.iganapolsky.randomtimer.service.MediaButtonHandler
 import com.iganapolsky.randomtimer.service.TimerForegroundService
 import com.iganapolsky.randomtimer.ui.navigation.RandomTimerNavHost
 import com.iganapolsky.randomtimer.ui.theme.RandomTimerTheme
@@ -91,6 +93,23 @@ class MainActivity : ComponentActivity() {
         super.onPause()
         // Tell service app is in background - show notifications
         sendAppStateToService(isInForeground = false)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (MediaButtonHandler.isVolumeKey(event.keyCode) &&
+            MediaButtonHandler.shouldSilenceAlarm(event.keyCode, event.action)
+        ) {
+            silenceAlarmFromVolumeKey()
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    private fun silenceAlarmFromVolumeKey() {
+        val silenceIntent =
+            Intent(this, TimerForegroundService::class.java).apply {
+                action = TimerForegroundService.ACTION_SILENCE_ALARM
+            }
+        startService(silenceIntent)
     }
 
     private fun handleAlarmNotificationTap(intent: Intent?) {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/MediaButtonHandler.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/MediaButtonHandler.kt
@@ -24,9 +24,15 @@ object MediaButtonHandler {
             KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
             KeyEvent.KEYCODE_HEADSETHOOK,
             KeyEvent.KEYCODE_MEDIA_STOP,
+            KeyEvent.KEYCODE_VOLUME_UP,
+            KeyEvent.KEYCODE_VOLUME_DOWN,
             -> true
 
             else -> false
         }
     }
+
+    /** Volume keys should silence the alarm but still adjust system volume. */
+    fun isVolumeKey(keyCode: Int): Boolean =
+        keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/service/TimerForegroundService.kt
@@ -1158,7 +1158,8 @@ class TimerForegroundService : Service() {
                                 MediaButtonHandler.shouldSilenceAlarm(keyEvent.keyCode, keyEvent.action)
                             ) {
                                 silenceAlarm()
-                                return true
+                                // Let volume keys still adjust system volume.
+                                return !MediaButtonHandler.isVolumeKey(keyEvent.keyCode)
                             }
                             return super.onMediaButtonEvent(mediaButtonEvent)
                         }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/MediaButtonHandlerTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/service/MediaButtonHandlerTest.kt
@@ -25,11 +25,32 @@ class MediaButtonHandlerTest {
     }
 
     @Test
-    fun `non-media key is ignored`() {
-        val silence = MediaButtonHandler.shouldSilenceAlarm(
-            keyCode = KeyEvent.KEYCODE_VOLUME_UP,
-            action = KeyEvent.ACTION_DOWN
-        )
+    fun `ACTION_DOWN on volume up silences alarm`() {
+        val silence =
+            MediaButtonHandler.shouldSilenceAlarm(
+                keyCode = KeyEvent.KEYCODE_VOLUME_UP,
+                action = KeyEvent.ACTION_DOWN,
+            )
+        assertThat(silence).isTrue()
+    }
+
+    @Test
+    fun `ACTION_DOWN on volume down silences alarm`() {
+        val silence =
+            MediaButtonHandler.shouldSilenceAlarm(
+                keyCode = KeyEvent.KEYCODE_VOLUME_DOWN,
+                action = KeyEvent.ACTION_DOWN,
+            )
+        assertThat(silence).isTrue()
+    }
+
+    @Test
+    fun `unrelated key is ignored`() {
+        val silence =
+            MediaButtonHandler.shouldSilenceAlarm(
+                keyCode = KeyEvent.KEYCODE_HOME,
+                action = KeyEvent.ACTION_DOWN,
+            )
         assertThat(silence).isFalse()
     }
 
@@ -40,5 +61,12 @@ class MediaButtonHandlerTest {
             action = KeyEvent.ACTION_DOWN
         )
         assertThat(silence).isTrue()
+    }
+
+    @Test
+    fun `volume keys are identified`() {
+        assertThat(MediaButtonHandler.isVolumeKey(KeyEvent.KEYCODE_VOLUME_UP)).isTrue()
+        assertThat(MediaButtonHandler.isVolumeKey(KeyEvent.KEYCODE_VOLUME_DOWN)).isTrue()
+        assertThat(MediaButtonHandler.isVolumeKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)).isFalse()
     }
 }

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		DPCK00112233445566778804 /* DisciplinePackCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DPCK00112233445566778803 /* DisciplinePackCatalogTests.swift */; };
 		BC2E89FF69ECC3F835BB9D9D /* RandomTimerWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 05CD46A1911192043939F56F /* RandomTimerWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C1D2E3F4A5B60718C1D2E3F4 /* SilenceAndStopAlarmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F4A5B60718C1D2E3F5 /* SilenceAndStopAlarmTests.swift */; };
+		VOLKEY00112233445566778802 /* AlarmVolumeKeyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = VOLKEY00112233445566778801 /* AlarmVolumeKeyPolicy.swift */; };
+		VOLKEY00112233445566778804 /* AlarmVolumeKeyPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VOLKEY00112233445566778803 /* AlarmVolumeKeyPolicyTests.swift */; };
 		D6D5DBA2177110DF7C339F94 /* ServiceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB219B60074D5E0130A3D15 /* ServiceProtocols.swift */; };
 		D8BFD3BC04A1001EE7329508 /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4045FE32D7D1E2F9D4C423C /* StorageService.swift */; };
 		D91C11A4CCFA99B1AF1AEA34 /* RandomTimerWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4F1687D48222CB0AD3509 /* RandomTimerWidgetBundle.swift */; };
@@ -205,6 +207,8 @@
 		B9A84792F8E1380EF1A87461 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		BDB556957D054D23B9D4D664 /* RandomTimerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RandomTimerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1D2E3F4A5B60718C1D2E3F5 /* SilenceAndStopAlarmTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SilenceAndStopAlarmTests.swift; sourceTree = "<group>"; };
+		VOLKEY00112233445566778801 /* AlarmVolumeKeyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmVolumeKeyPolicy.swift; sourceTree = "<group>"; };
+		VOLKEY00112233445566778803 /* AlarmVolumeKeyPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmVolumeKeyPolicyTests.swift; sourceTree = "<group>"; };
 		C2A2B6F508A20346A871C6F5 /* whistle.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = whistle.mp3; sourceTree = "<group>"; };
 		CCFBE5D59081407DA7F38ED6 /* RandomTimerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomTimerUITests.swift; sourceTree = "<group>"; };
 		CE62A2F6E881E0CCA7DF2361 /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
@@ -264,6 +268,7 @@
 				QTWP00112233445566778803 /* QualifiedTrainingPaywallPolicyTests.swift */,
 				RWAD00112233445566778803 /* RewardedAdSupportTests.swift */,
 				DPCK00112233445566778803 /* DisciplinePackCatalogTests.swift */,
+				VOLKEY00112233445566778803 /* AlarmVolumeKeyPolicyTests.swift */,
 				C1D2E3F4A5B60718C1D2E3F5 /* SilenceAndStopAlarmTests.swift */,
 				7B55AFED96FE157EA7D0BF85 /* TimerModelsTests.swift */,
 				PMONTHMSGT011223344556676 /* ProMonthlyContentMessagingTests.swift */,
@@ -305,6 +310,7 @@
 				A1B2C3D400000004DEADBEEF /* AnalyticsService.swift */,
 				CRSVC00112233445566778801 /* CrashReportingService.swift */,
 				A1B2C3D400000002DEADBEEF /* Logger.swift */,
+				VOLKEY00112233445566778801 /* AlarmVolumeKeyPolicy.swift */,
 				3BE6975376BF7C7C6B14F8BF /* NotificationService.swift */,
 				1F9A3C44B55D66E77F880010 /* ProSoundCatalog.swift */,
 				8EEB9F4FF4ED4C88A5232642 /* LiveActivityService.swift */,
@@ -656,6 +662,7 @@
 				0B6A472176A53D70127E8133 /* CircularTimerView.swift in Sources */,
 				4F4A683B236AE94216503707 /* Colors.swift in Sources */,
 				96771424C44C551B73F7732B /* GlassCard.swift in Sources */,
+				VOLKEY00112233445566778802 /* AlarmVolumeKeyPolicy.swift in Sources */,
 				1128B196E27E8531DC06D2FF /* NotificationService.swift in Sources */,
 				1F9A3C44B55D66E77F880011 /* ProSoundCatalog.swift in Sources */,
 				E1DD7FFA2F3044B7A5F461C1 /* LiveActivityService.swift in Sources */,
@@ -707,6 +714,7 @@
 				QTWP00112233445566778804 /* QualifiedTrainingPaywallPolicyTests.swift in Sources */,
 				RWAD00112233445566778804 /* RewardedAdSupportTests.swift in Sources */,
 				DPCK00112233445566778804 /* DisciplinePackCatalogTests.swift in Sources */,
+				VOLKEY00112233445566778804 /* AlarmVolumeKeyPolicyTests.swift in Sources */,
 				C1D2E3F4A5B60718C1D2E3F4 /* SilenceAndStopAlarmTests.swift in Sources */,
 				DB8217C38D6B214B931042F7 /* TimerModels.swift in Sources */,
 				840C3EEAD4E35D7D202C1C68 /* TimerModelsTests.swift in Sources */,

--- a/native-ios/RandomTimer/Sources/Services/AlarmVolumeKeyPolicy.swift
+++ b/native-ios/RandomTimer/Sources/Services/AlarmVolumeKeyPolicy.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Pure policy for hardware volume button behavior during alarm playback.
+enum AlarmVolumeKeyPolicy {
+    static func shouldSilenceOnVolumeChange(
+        status: TimerStatus?,
+        isAlarmSilenced: Bool,
+        previousVolume: Float,
+        newVolume: Float
+    ) -> Bool {
+        guard status == .alarm, !isAlarmSilenced else { return false }
+        return previousVolume != newVolume
+    }
+}

--- a/native-ios/RandomTimer/Sources/Services/NotificationService.swift
+++ b/native-ios/RandomTimer/Sources/Services/NotificationService.swift
@@ -25,7 +25,15 @@ final class NotificationService: NSObject, TimerNotificationHandling {
     /// Callback invoked when user taps "Silence" action on the notification
     var onNotificationSilence: (() -> Void)?
 
+    /// Supplies alarm state for hardware volume button handling.
+    var alarmVolumePolicyState: () -> (status: TimerStatus?, isAlarmSilenced: Bool) = { (nil, false) }
+
     // MARK: - Core Haptics
+
+    private var volumeObservation: NSKeyValueObservation?
+    private var observedOutputVolume: Float = 0
+    private var volumeSilenceObserverArmed = false
+    private var hiddenVolumeView: MPVolumeView?
 
     private var hapticEngine: CHHapticEngine?
     private var hapticPlayer: CHHapticPatternPlayer?
@@ -246,6 +254,7 @@ final class NotificationService: NSObject, TimerNotificationHandling {
 
         // Activate media session for Bluetooth/CarPlay dismiss
         activateMediaSession()
+        startVolumeButtonSilenceObserver()
 
         // Observe audio interruptions (phone calls, etc.)
         NotificationCenter.default.addObserver(
@@ -428,12 +437,79 @@ final class NotificationService: NSObject, TimerNotificationHandling {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     }
 
+    // MARK: - Hardware volume buttons
+
+    func startVolumeButtonSilenceObserver() {
+        stopVolumeButtonSilenceObserver()
+
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return
+        }
+
+        installHiddenVolumeViewIfNeeded()
+
+        let session = AVAudioSession.sharedInstance()
+        observedOutputVolume = session.outputVolume
+        volumeSilenceObserverArmed = false
+
+        volumeObservation = session.observe(\.outputVolume, options: [.new]) { [weak self] observedSession, _ in
+            Task { @MainActor in
+                self?.handleOutputVolumeChange(observedSession.outputVolume)
+            }
+        }
+    }
+
+    func stopVolumeButtonSilenceObserver() {
+        volumeObservation?.invalidate()
+        volumeObservation = nil
+        volumeSilenceObserverArmed = false
+        hiddenVolumeView?.removeFromSuperview()
+        hiddenVolumeView = nil
+    }
+
+    func handleOutputVolumeChange(_ newVolume: Float) {
+        if !volumeSilenceObserverArmed {
+            volumeSilenceObserverArmed = true
+            observedOutputVolume = newVolume
+            return
+        }
+
+        let (status, isAlarmSilenced) = alarmVolumePolicyState()
+        guard AlarmVolumeKeyPolicy.shouldSilenceOnVolumeChange(
+            status: status,
+            isAlarmSilenced: isAlarmSilenced,
+            previousVolume: observedOutputVolume,
+            newVolume: newVolume
+        ) else {
+            observedOutputVolume = newVolume
+            return
+        }
+
+        observedOutputVolume = newVolume
+        handleMediaButtonSilenceAction()
+    }
+
+    private func installHiddenVolumeViewIfNeeded() {
+        guard hiddenVolumeView == nil else { return }
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow) else { return }
+
+        let volumeView = MPVolumeView(frame: CGRect(x: -1000, y: -1000, width: 1, height: 1))
+        volumeView.isHidden = true
+        volumeView.alpha = 0.01
+        window.addSubview(volumeView)
+        hiddenVolumeView = volumeView
+    }
+
     func stopAlarmSound() {
         NotificationCenter.default.removeObserver(
             self,
             name: AVAudioSession.interruptionNotification,
             object: AVAudioSession.sharedInstance()
         )
+        stopVolumeButtonSilenceObserver()
         deactivateMediaSession()
         audioPlayer?.stop()
         audioPlayer = nil

--- a/native-ios/RandomTimer/Sources/Services/TimerManager.swift
+++ b/native-ios/RandomTimer/Sources/Services/TimerManager.swift
@@ -74,6 +74,10 @@ final class TimerManager: ObservableObject { // swiftlint:disable:this no_observ
                     self?.silenceAlarm()
                 }
             }
+            notificationService.alarmVolumePolicyState = { [weak self] in
+                guard let self else { return (nil, false) }
+                return (self.timerState?.status, self.isAlarmSilenced)
+            }
         }
 
         // Stop any alarm/vibration that might still be playing from a previous session

--- a/native-ios/RandomTimerTests/AlarmVolumeKeyPolicyTests.swift
+++ b/native-ios/RandomTimerTests/AlarmVolumeKeyPolicyTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import RandomTimer
+
+final class AlarmVolumeKeyPolicyTests: XCTestCase {
+
+    func testVolumeChangeDuringAlarmShouldSilence() {
+        XCTAssertTrue(
+            AlarmVolumeKeyPolicy.shouldSilenceOnVolumeChange(
+                status: .alarm,
+                isAlarmSilenced: false,
+                previousVolume: 0.5,
+                newVolume: 0.6
+            )
+        )
+    }
+
+    func testVolumeChangeWhenAlarmAlreadySilencedIsIgnored() {
+        XCTAssertFalse(
+            AlarmVolumeKeyPolicy.shouldSilenceOnVolumeChange(
+                status: .alarm,
+                isAlarmSilenced: true,
+                previousVolume: 0.5,
+                newVolume: 0.6
+            )
+        )
+    }
+
+    func testVolumeChangeWhileRunningIsIgnored() {
+        XCTAssertFalse(
+            AlarmVolumeKeyPolicy.shouldSilenceOnVolumeChange(
+                status: .running,
+                isAlarmSilenced: false,
+                previousVolume: 0.5,
+                newVolume: 0.6
+            )
+        )
+    }
+
+    func testUnchangedVolumeIsIgnored() {
+        XCTAssertFalse(
+            AlarmVolumeKeyPolicy.shouldSilenceOnVolumeChange(
+                status: .alarm,
+                isAlarmSilenced: false,
+                previousVolume: 0.5,
+                newVolume: 0.5
+            )
+        )
+    }
+}

--- a/native-ios/RandomTimerTests/NotificationServiceMediaSessionTests.swift
+++ b/native-ios/RandomTimerTests/NotificationServiceMediaSessionTests.swift
@@ -78,4 +78,30 @@ final class NotificationServiceMediaSessionTests: XCTestCase {
 
         XCTAssertTrue(didSilence)
     }
+
+    func testHandleOutputVolumeChangeSilencesDuringAlarm() {
+        let service = NotificationService()
+        var didSilence = false
+
+        service.alarmVolumePolicyState = { (.alarm, false) }
+        service.onMediaButtonSilence = { didSilence = true }
+
+        service.handleOutputVolumeChange(0.5)
+        service.handleOutputVolumeChange(0.6)
+
+        XCTAssertTrue(didSilence)
+    }
+
+    func testHandleOutputVolumeChangeIgnoredWhenAlreadySilenced() {
+        let service = NotificationService()
+        var didSilence = false
+
+        service.alarmVolumePolicyState = { (.alarm, true) }
+        service.onMediaButtonSilence = { didSilence = true }
+
+        service.handleOutputVolumeChange(0.5)
+        service.handleOutputVolumeChange(0.6)
+
+        XCTAssertFalse(didSilence)
+    }
 }

--- a/scripts/device-tests/adb/test-media-buttons.sh
+++ b/scripts/device-tests/adb/test-media-buttons.sh
@@ -75,20 +75,19 @@ else
 fi
 cleanup
 
-# ── Test 3: VOLUME_UP does NOT dismiss alarm (negative test) ──
-begin_test "volume_key_does_not_dismiss_alarm"
+# ── Test 3: VOLUME_UP silences alarm (sound stops, timer UI remains) ──
+begin_test "volume_key_silences_alarm"
 if wait_for_active_alarm; then
   dump_notifications
   if grep -q "Time's Up" "$NOTIF_DUMP"; then
-    adb shell input keyevent 24  # KEYCODE_VOLUME_UP — should NOT dismiss
+    adb shell input keyevent 24  # KEYCODE_VOLUME_UP — should silence alarm audio
     sleep 2
 
-    # Alarm should still be present
     dump_notifications
-    if grep -q "Time's Up" "$NOTIF_DUMP" || has_package_notification; then
-      assert_eq "still_active" "still_active" "Alarm NOT dismissed by VOLUME_UP"
+    if grep -q "Alarm Silenced" "$NOTIF_DUMP" || grep -q "Time's Up" "$NOTIF_DUMP"; then
+      assert_eq "silenced" "silenced" "Alarm silenced by VOLUME_UP"
     else
-      assert_eq "dismissed" "still_active" "Alarm should NOT be dismissed by VOLUME_UP"
+      assert_eq "missing_notification" "silenced" "Alarm should be silenced by VOLUME_UP"
     fi
   else
     assert_eq "completed" "completed" "Alarm already completed"


### PR DESCRIPTION
## Summary
- **Android:** `MediaButtonHandler` treats `KEYCODE_VOLUME_UP` / `KEYCODE_VOLUME_DOWN` as silence triggers; `MainActivity.dispatchKeyEvent` forwards volume keys to `ACTION_SILENCE_ALARM`; MediaSession does not consume volume keys so system volume still adjusts.
- **iOS:** `AlarmVolumeKeyPolicy` + `NotificationService` output-volume observer (with hidden `MPVolumeView`) call the same silence path as Bluetooth/media buttons during `ALARM`.
- **Device test:** `test-media-buttons.sh` updated — volume up now expects silenced alarm, not dismiss.

## Reset-on-volume setting
No `reset timer on volume` (or equivalent) preference exists in repo today. Volume keys only **silence** alarm audio and keep alarm UI/state (parity with iOS circle tap / media silence). Reset still requires explicit Reset UI.

## Test plan
- [x] `MediaButtonHandlerTest` — volume up/down silence; volume key identification
- [x] `AlarmVolumeKeyPolicyTests` — policy matrix
- [x] `NotificationServiceMediaSessionTests` — `handleOutputVolumeChange` callbacks
- [ ] CI `ci.yml` green on PR
- [ ] Optional: `scripts/device-tests/adb/test-media-buttons.sh` on device


Made with [Cursor](https://cursor.com)

----
## Summary by Gitar

- **CI/CD:**
  - Stabilized `regression-sound-arsenal-paywall-ios.yaml` by updating Maestro tap targets and adding scroll-to-visibility logic.

<sub>This will update automatically on new commits.</sub>