### PR TITLE
fix(audio): replace Angst SF male voice with Clyde drill instructor

### DIFF
--- a/.github/workflows/generate-base-voice-callouts.yml
+++ b/.github/workflows/generate-base-voice-callouts.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: eleven_multilingual_v2
         type: string
+      regenerate_all_male:
+        description: Regenerate every male bundled cue (not only missing files).
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -45,7 +50,12 @@ jobs:
           MALE_VOICE_ID: ${{ inputs.male_voice_id }}
           FEMALE_VOICE_ID: ${{ inputs.female_voice_id }}
           MODEL_ID: ${{ inputs.model_id }}
-        run: python scripts/generate_base_voice_callouts.py
+        run: |
+          args=()
+          if [ "${{ inputs.regenerate_all_male }}" = "true" ]; then
+            args+=(--regenerate-all-male)
+          fi
+          python scripts/generate_base_voice_callouts.py "${args[@]}"
 
       - name: Upload generated audio
         if: always()

--- a/.github/workflows/generate-base-voice-callouts.yml
+++ b/.github/workflows/generate-base-voice-callouts.yml
@@ -50,9 +50,10 @@ jobs:
           MALE_VOICE_ID: ${{ inputs.male_voice_id }}
           FEMALE_VOICE_ID: ${{ inputs.female_voice_id }}
           MODEL_ID: ${{ inputs.model_id }}
+          REGENERATE_ALL_MALE: ${{ inputs.regenerate_all_male }}
         run: |
           args=()
-          if [ "${{ inputs.regenerate_all_male }}" = "true" ]; then
+          if [ "$REGENERATE_ALL_MALE" = "true" ]; then
             args+=(--regenerate-all-male)
           fi
           python scripts/generate_base_voice_callouts.py "${args[@]}"

--- a/.github/workflows/generate-base-voice-callouts.yml
+++ b/.github/workflows/generate-base-voice-callouts.yml
@@ -10,7 +10,7 @@ on:
       male_voice_id:
         description: ElevenLabs male voice ID (drill sergeant default).
         required: false
-        default: DGzg6RaUqxGRTHSBjfgF
+        default: 2EiwWnXFnvU5JabPnv8n
         type: string
       female_voice_id:
         description: ElevenLabs female voice ID (empty skips female render).

--- a/.github/workflows/generate-ios-voice-callouts.yml
+++ b/.github/workflows/generate-ios-voice-callouts.yml
@@ -13,7 +13,7 @@ on:
       voice_id:
         description: Optional exact ElevenLabs voice ID.
         required: false
-        default: DGzg6RaUqxGRTHSBjfgF
+        default: 2EiwWnXFnvU5JabPnv8n
         type: string
       model_id:
         description: ElevenLabs model ID used for synthesis.
@@ -46,7 +46,7 @@ jobs:
       - name: Generate monthly Pro audio assets from ElevenLabs
         env:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-          DEFAULT_VOICE_ID: DGzg6RaUqxGRTHSBjfgF
+          DEFAULT_VOICE_ID: 2EiwWnXFnvU5JabPnv8n
           PACK_ID_INPUT: ${{ inputs.pack_id }}
           VOICE_ID_INPUT: ${{ inputs.voice_id }}
           MODEL_ID_INPUT: ${{ inputs.model_id }}

--- a/.github/workflows/monthly-pro-content-release.yml
+++ b/.github/workflows/monthly-pro-content-release.yml
@@ -101,7 +101,7 @@ jobs:
           args=(
             --manifest content/pro_audio/monthly_pro_audio_packs.json
             --release-month "${{ steps.meta.outputs.release_month }}"
-            --voice-id "${ELEVENLABS_VOICE_ID:-DGzg6RaUqxGRTHSBjfgF}"
+            --voice-id "${ELEVENLABS_VOICE_ID:-2EiwWnXFnvU5JabPnv8n}"
             --generate-sound-assets
             --sync-android-assets
           )

--- a/.maestro/regression-sound-arsenal-paywall-ios.yaml
+++ b/.maestro/regression-sound-arsenal-paywall-ios.yaml
@@ -11,7 +11,12 @@ appId: com.igorganapolsky.randomtimer
 - assertVisible: "Unlock Sound Arsenal"
 - tapOn: "Unlock Sound Arsenal"
 - extendedWaitUntil:
-    visible: "Restore purchase"
-    timeout: 10000
+    visible: "Not now"
+    timeout: 15000
+- scrollUntilVisible:
+    element: "Restore purchase"
+    direction: DOWN
+    timeout: 15000
+- assertVisible: "Restore purchase"
 - takeScreenshot: evidence/ios-sound-arsenal-paywall
 - stopApp

--- a/content/pro_audio/voice_personas.json
+++ b/content/pro_audio/voice_personas.json
@@ -4,9 +4,9 @@
   "male": {
     "persona": "Marine Drill Instructor",
     "modelId": "eleven_multilingual_v2",
-    "voiceId": "DGzg6RaUqxGRTHSBjfgF",
-    "voiceName": "Configured drill instructor voice",
-    "voiceNamePattern": "marine|drill|instructor|sergeant",
+    "voiceId": "2EiwWnXFnvU5JabPnv8n",
+    "voiceName": "Clyde",
+    "voiceNamePattern": "marine|drill|instructor|sergeant|clyde",
     "probeText": "Stay sharp.",
     "runtimePackSource": "content/pro_audio/runtime/latest.json",
     "previewSamples": {

--- a/scripts/generate_base_voice_callouts.py
+++ b/scripts/generate_base_voice_callouts.py
@@ -45,6 +45,25 @@ DEFAULT_VOICE_SETTINGS = {
     "style": 0.3,
     "use_speaker_boost": True,
 }
+VOICE_PERSONAS_PATH = REPO_ROOT / "content/pro_audio/voice_personas.json"
+FORBIDDEN_MALE_VOICE_ID = "DGzg6RaUqxGRTHSBjfgF"  # ElevenLabs "Angst" (San Francisco accent)
+
+
+def _default_male_voice_id() -> str:
+    contract = json.loads(VOICE_PERSONAS_PATH.read_text(encoding="utf-8"))
+    voice_id = contract["male"]["voiceId"].strip()
+    if voice_id == FORBIDDEN_MALE_VOICE_ID:
+        raise SystemExit(f"Refusing forbidden male voice ID (Angst): {voice_id}")
+    return voice_id
+
+
+def _all_male_cue_lines(catalog: dict) -> list[tuple[str, str]]:
+    lines: list[tuple[str, str]] = [(catalog["previewElapsed"]["filename"], catalog["previewElapsed"]["text"])]
+    for cue in catalog["elapsedCues"]:
+        lines.append((cue["filename"], cue["text"]))
+    for cue in catalog["commandCues"]:
+        lines.append((cue["filename"], cue["text"]))
+    return lines
 
 
 def _existing_android_raw_stems() -> set[str]:
@@ -74,22 +93,35 @@ def _write_mirror(src_dir: Path, dst_dir: Path, stem: str, dst_prefix: str = "")
 
 
 def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--regenerate-all-male",
+        action="store_true",
+        help="Regenerate every male bundled cue (command, elapsed, preview), not only missing files.",
+    )
+    args = parser.parse_args()
+
     api_key = os.environ.get("ELEVENLABS_API_KEY", "").strip()
     if not api_key:
         print("ELEVENLABS_API_KEY not set", file=sys.stderr)
         return 2
 
-    male_voice_id = os.environ.get("MALE_VOICE_ID", "DGzg6RaUqxGRTHSBjfgF").strip()
+    male_voice_id = os.environ.get("MALE_VOICE_ID", _default_male_voice_id()).strip()
+    if male_voice_id == FORBIDDEN_MALE_VOICE_ID:
+        print(f"Refusing forbidden male voice ID (Angst): {male_voice_id}", file=sys.stderr)
+        return 2
     female_voice_id = os.environ.get("FEMALE_VOICE_ID", "").strip()
     model_id = os.environ.get("MODEL_ID", "eleven_multilingual_v2").strip()
 
     catalog = json.loads(ANDROID_VOICE_CATALOG_PATH.read_text(encoding="utf-8"))
-    missing = _missing_male_cues(catalog)
+    missing = _all_male_cue_lines(catalog) if args.regenerate_all_male else _missing_male_cues(catalog)
     if not missing:
         print("No missing cues. Nothing to generate.")
         return 0
 
-    print(f"Generating {len(missing)} missing cue(s):")
+    print(f"Generating {len(missing)} male cue(s):")
     for stem, text in missing:
         print(f"  - {stem}: {text!r}")
 

--- a/scripts/generate_monthly_audio_pack.py
+++ b/scripts/generate_monthly_audio_pack.py
@@ -195,8 +195,8 @@ def fetch_freesound_pack(token: str, dry_run: bool = False) -> list[Path]:
 
 ELEVENLABS_BASE = "https://api.elevenlabs.io"
 VOICE_MODEL = "eleven_turbo_v2_5"
-# Default: Ivanna — warrior drill instructor voice
-DEFAULT_VOICE_ID = "cgSgspJ2msm6clMCkdW9"
+# Default male drill instructor (Clyde) — must match content/pro_audio/voice_personas.json
+DEFAULT_VOICE_ID = "2EiwWnXFnvU5JabPnv8n"
 
 MONTHLY_CALLOUT_SCRIPTS: list[dict[str, str]] = [
     {"name": "cmd_go_monthly", "text": "Go! Push harder!"},

--- a/scripts/tests/test_generate_base_voice_callouts.py
+++ b/scripts/tests/test_generate_base_voice_callouts.py
@@ -1,0 +1,26 @@
+"""Tests for base voice callout generation helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import generate_base_voice_callouts as gbvc
+
+ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = ROOT / "native-android/app/src/main/assets/voice_callouts.json"
+
+
+def test_all_male_cue_lines_includes_preview_elapsed_and_commands() -> None:
+    catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    lines = gbvc._all_male_cue_lines(catalog)
+    filenames = {stem for stem, _ in lines}
+    assert "preview_elapsed" in filenames
+    assert "elapsed_60s" in filenames
+    assert "cmd_move_with_a_purpose" in filenames
+    assert len(lines) == 1 + len(catalog["elapsedCues"]) + len(catalog["commandCues"])
+
+
+def test_default_male_voice_id_matches_approved_clyde_contract() -> None:
+    assert gbvc._default_male_voice_id() == "2EiwWnXFnvU5JabPnv8n"
+    assert gbvc._default_male_voice_id() != gbvc.FORBIDDEN_MALE_VOICE_ID

--- a/scripts/tests/test_verify_elevenlabs_voices.py
+++ b/scripts/tests/test_verify_elevenlabs_voices.py
@@ -13,8 +13,9 @@ import pytest
 
 from scripts import verify_elevenlabs_voices as vev
 
-MALE_ALLOWED_ID = "DGzg6RaUqxGRTHSBjfgF"
+MALE_ALLOWED_ID = "2EiwWnXFnvU5JabPnv8n"
 FEMALE_ALLOWED_ID = "EXAVITQu4vr4xnSDxMaL"
+FORBIDDEN_ANGST_VOICE_ID = "DGzg6RaUqxGRTHSBjfgF"
 
 
 @pytest.mark.parametrize("voice_id", [MALE_ALLOWED_ID, FEMALE_ALLOWED_ID, "sS5fXGlqomdGXa7mxBcy"])
@@ -25,6 +26,11 @@ def test_supported_voice_id_accepts_allowlisted(voice_id: str) -> None:
 def test_supported_voice_id_rejects_unknown() -> None:
     with pytest.raises(RuntimeError, match="allowlist"):
         vev._supported_voice_id("not_in_list")
+
+
+def test_supported_voice_id_rejects_angst_san_francisco_voice() -> None:
+    with pytest.raises(RuntimeError, match="allowlist"):
+        vev._supported_voice_id(FORBIDDEN_ANGST_VOICE_ID)
 
 
 def test_text_to_speech_url() -> None:

--- a/scripts/tests/test_voice_regression_contracts.py
+++ b/scripts/tests/test_voice_regression_contracts.py
@@ -8,6 +8,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 VOICE_CONTRACT = ROOT / "content/pro_audio/voice_personas.json"
+FORBIDDEN_MALE_VOICE_ID = "DGzg6RaUqxGRTHSBjfgF"  # ElevenLabs "Angst" (San Francisco), not drill sergeant
+APPROVED_MALE_VOICE_ID = "2EiwWnXFnvU5JabPnv8n"  # ElevenLabs "Clyde"
 IOS_AUDIO_DIR = ROOT / "native-ios/RandomTimer/Resources/Audio"
 ANDROID_RAW_DIR = ROOT / "native-android/app/src/main/res/raw"
 IOS_SETUP = ROOT / "native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift"
@@ -54,7 +56,9 @@ def test_voice_contract_tracks_real_elevenlabs_personas() -> None:
     assert contract["schemaVersion"] == 1
     assert contract["provider"] == "elevenlabs"
     assert contract["male"]["modelId"] == "eleven_multilingual_v2"
-    assert contract["male"]["voiceId"] == "DGzg6RaUqxGRTHSBjfgF"
+    assert contract["male"]["voiceId"] == APPROVED_MALE_VOICE_ID
+    assert contract["male"]["voiceId"] != FORBIDDEN_MALE_VOICE_ID
+    assert contract["male"]["voiceName"] == "Clyde"
     assert contract["male"]["probeText"] == "Stay sharp."
     assert contract["female"]["modelId"] == "eleven_turbo_v2"
     assert contract["female"]["primaryVoice"]["voiceName"] == "Sarah"

--- a/scripts/verify_elevenlabs_voices.py
+++ b/scripts/verify_elevenlabs_voices.py
@@ -22,8 +22,9 @@ CONTROLLED_PROVIDER_MARKERS = (
     "no remaining credits",
     "failed or incomplete payment",
 )
+# ElevenLabs premade drill-sergeant male (Clyde). Do not allow DGzg6RaUqxGRTHSBjfgF (Angst, San Francisco).
 SUPPORTED_VOICE_ENDPOINTS = {
-    "DGzg6RaUqxGRTHSBjfgF": f"{API_BASE_URL}/v1/text-to-speech/DGzg6RaUqxGRTHSBjfgF?output_format={OUTPUT_FORMAT}",
+    "2EiwWnXFnvU5JabPnv8n": f"{API_BASE_URL}/v1/text-to-speech/2EiwWnXFnvU5JabPnv8n?output_format={OUTPUT_FORMAT}",
     "AZnzlk1XvdvUeBnXmlld": f"{API_BASE_URL}/v1/text-to-speech/AZnzlk1XvdvUeBnXmlld?output_format={OUTPUT_FORMAT}",
     "EXAVITQu4vr4xnSDxMaL": f"{API_BASE_URL}/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL?output_format={OUTPUT_FORMAT}",
     "sS5fXGlqomdGXa7mxBcy": f"{API_BASE_URL}/v1/text-to-speech/sS5fXGlqomdGXa7mxBcy?output_format={OUTPUT_FORMAT}",


### PR DESCRIPTION
## Root cause

Male Pro callouts are **pre-rendered MP3s**, not live ElevenLabs at runtime (preview and session both use `ProAudioPackStore` → bundled/runtime files; TTS is explicitly blocked by regression tests).

The male persona contract and CI defaults pointed at ElevenLabs voice ID **`DGzg6RaUqxGRTHSBjfgF`**, which is **Angst** (San Francisco accent), not a drill sergeant. That ID was introduced in `voice_personas.json` (v1.3.17) and wired through:

- `content/pro_audio/voice_personas.json`
- `.github/workflows/generate-base-voice-callouts.yml`
- `.github/workflows/generate-ios-voice-callouts.yml` / `monthly-pro-content-release.yml`
- `scripts/generate_base_voice_callouts.py` / `scripts/verify_elevenlabs_voices.py`

So every male `cmd_*`, `elapsed_*`, and `preview_elapsed` MP3 in iOS/Android bundles and the hosted runtime pack was synthesized with Angst.

## Fix

- Male persona → **Clyde** (`2EiwWnXFnvU5JabPnv8n`), aligned with the repo’s voice A/B test drill candidate.
- Block **`DGzg6RaUqxGRTHSBjfgF`** from CI allowlists and generator defaults.
- Add `--regenerate-all-male` to `generate_base_voice_callouts.py` + workflow input for one-shot rebake after billing is healthy.

## Asset regeneration (required for audible change)

Dispatch failed on this branch: ElevenLabs returned `payment_issue` (incomplete subscription payment). **Bundled audio will still sound like Angst until MP3s are regenerated.**

After payment is fixed, run:

1. **Generate Pro Audio Content** (`generate-ios-voice-callouts.yml`) on `develop` with `voice_id=2EiwWnXFnvU5JabPnv8n`, `generate_sound_assets=false`, **or**
2. **Generate Base Voice Callouts** with `male_voice_id=2EiwWnXFnvU5JabPnv8n` and `regenerate_all_male=true`

Then merge the audio commit into this PR (or re-run on this branch).

## Tests

- `scripts/tests/test_voice_regression_contracts.py`
- `scripts/tests/test_verify_elevenlabs_voices.py`
- `scripts/tests/test_generate_base_voice_callouts.py`

Made with [Cursor](https://cursor.com)

----
## Summary by Gitar

- **CI workflow:**
  - Added `REGENERATE_ALL_MALE` input to `generate-base-voice-callouts.yml` to support forced regeneration.
- **Test automation:**
  - Updated Maestro regression script to handle paywall scrolling and improved wait times for "Not now" visibility.

<sub>This will update automatically on new commits.</sub>