### PR TITLE
chore: technical debt audit 2026-05-26 (hygiene + PyYAML parity + report)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -10,7 +10,7 @@
       "command": "sh",
       "args": [
         "-lc",
-        "mkdir -p \"/Users/igorganapolsky/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"/Users/igorganapolsky/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"/Users/igorganapolsky/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""
+        "mkdir -p \"$HOME/.thumbgate/runtime\" && npm install --prefix \"$HOME/.thumbgate/runtime\" --no-save --omit=dev thumbgate@latest >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" serve"
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
       "command": "sh",
       "args": [
         "-lc",
-        "mkdir -p \"/Users/igorganapolsky/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"/Users/igorganapolsky/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"/Users/igorganapolsky/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""
+        "mkdir -p \"$HOME/.thumbgate/runtime\" && npm install --prefix \"$HOME/.thumbgate/runtime\" --no-save --omit=dev thumbgate@latest >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" serve"
       ]
     }
   }

--- a/docs/CLAUDE_CODE_API_KEY_HELPER.md
+++ b/docs/CLAUDE_CODE_API_KEY_HELPER.md
@@ -25,7 +25,7 @@ Official reference: [Claude Code settings — `apiKeyHelper`](https://code.claud
 
    ```json
    {
-     "apiKeyHelper": "/Users/YOU/.claude/get-anthropic-api-key.sh",
+     "apiKeyHelper": "$HOME/.claude/get-anthropic-api-key.sh",
      "env": {
        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3600000"
      }

--- a/docs/reports/technical-debt-audit-2026-05-26.md
+++ b/docs/reports/technical-debt-audit-2026-05-26.md
@@ -1,0 +1,112 @@
+# Technical Debt Audit — 2026-05-26
+
+## Honest scope
+
+This pass records **measured baselines**, **CI health**, **hygiene gate status**, and **Python automation coverage** with command evidence. It does **not** claim a literal line-by-line review of every file (1,550 tracked files; ~300k lines). Phased PRs remain the execution model. Prior audits: [2026-03-26](./technical-debt-audit-2026-03-26.md), [2026-04-03](./technical-debt-audit-2026-04-03.md).
+
+## Pre-audit protocol
+
+| Step | Result |
+|------|--------|
+| Read `CLAUDE.md`, `docs/GEMINI.md`, `AGENTS.md` | Reviewed (workspace rules + canonical Gemini path). |
+| Query RAG for cleanup lessons | **Not verified in this session.** No live RAG/MCP memory gateway was read or written. Local `.claude/memory/` is gitignored. |
+| Snapshot CI | `gh run list` / `gh run view` on `develop` (see below). |
+| Snapshot core systems | Marine voice pack verified in prior session; store-verify skill merged (#1614); orphan Angst MMA MP3s removed (#1616). |
+
+## Baseline metrics (tracked files)
+
+**Command:** `bash scripts/shell/metrics_repo.sh`  
+**Git SHA:** `2df334511930d80995fcd044cc19ca20bc95a413` (`develop` tip at audit start)
+
+| Metric | Before cleanup PR | After cleanup PR (expected) |
+|--------|---------------------|-----------------------------|
+| **Tracked files** | 1550 | 1552 (+`uv.lock` churn, +report) |
+| **Tracked lines** | 299,676 | ~300k (report + lockfile) |
+
+**Extension mix (top):** 337 mp3, 246 md, 227 py, 110 kt, 53 swift (audio + native + automation).
+
+## Hygiene gate
+
+**Command:** `bash scripts/shell/hygiene-check.sh`
+
+| Run | Errors | Warnings |
+|-----|--------|----------|
+| Before fixes | 3 (absolute paths in `.cursor/mcp.json`, `.mcp.json`, `docs/CLAUDE_CODE_API_KEY_HELPER.md`) | 0 |
+| After fixes | **0** | **0** |
+
+## Test coverage (Python `scripts/` only)
+
+**Command:** `uv run pytest scripts/tests/ --cov=scripts --cov-report=term -q`  
+**Date:** 2026-05-26
+
+| Metric | Value |
+|--------|-------|
+| Tests passed | **702** |
+| Aggregate `scripts/` coverage | **66%** |
+| `verify_elevenlabs_voices.py` | **94%** (duplicate dict key removed in this PR) |
+
+**Not measured here:** Android/iOS unit coverage, Codecov dashboard rollup, Maestro/device suites.
+
+**Local dev parity fix:** `PyYAML` added to `pyproject.toml` (CI already installed `PyYAML==6.0.2`; local `uv run pytest` failed without it).
+
+## CI health
+
+| Branch | Run | Conclusion | URL |
+|--------|-----|------------|-----|
+| `develop` | `26460600654` | **success** | https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26460600654 |
+
+Workflow: `ci.yml` on merge commit `2df33451` (includes #1614 + #1616).
+
+## Issues found and fixed (this PR)
+
+| Category | Finding | Action |
+|----------|---------|--------|
+| Hygiene | Machine-specific absolute paths in MCP config + API key helper doc | Use `$HOME` in `.cursor/mcp.json`, `.mcp.json`, `docs/CLAUDE_CODE_API_KEY_HELPER.md` |
+| Python | Duplicate `EXAVITQu4vr4xnSDxMaL` key in `SUPPORTED_VOICE_ENDPOINTS` | Remove duplicate entry |
+| Tooling | `PyYAML` missing from `pyproject.toml` / `uv.lock` | Add dependency for local=test parity with CI |
+| Voice (prior PR) | Orphan Angst MMA MP3s (not in catalog) | **Already merged** #1616 |
+| CI (prior PR) | Public store verify 30m timeouts | **Already merged** #1614 + `.claude/skills/store-verify-ci.md` |
+
+## Issues found — not fixed (phased backlog)
+
+| Category | Finding | Recommended phase |
+|----------|---------|-------------------|
+| Coverage | `zernio_orchestrate.py` ~57%, `verify_release.py` ~61% | Add integration mocks / CLI smoke tests |
+| Coverage | Native Android/iOS | JaCoCo / Xcode coverage gates (separate from `scripts/`) |
+| RAG | External memory gateway | Verify gateway in-session before prune/write |
+| Docs | 246 tracked `.md` files | Consolidate only with CEO-approved deletes |
+| TODO/FIXME | Sparse in py/kt/swift | Triage per file (not mass-deleted) |
+| Open PRs | #1612, #1598 | Hygiene merge or close |
+
+## RAG cleanup summary
+
+```
+RAG entries read: 0 (gateway not verified)
+RAG entries cleaned: 0
+RAG lessons logged: 0 (this report is the durable artifact)
+```
+
+## Protected components (post-change verification)
+
+| Component | Status |
+|-----------|--------|
+| CI pipeline (`develop`) | **success** at `26460600654` |
+| Hygiene pre-push gate | **pass** (0 errors) |
+| Python tests | **702 passed**, 66% `scripts/` coverage |
+| Marine voice pack | Unchanged (prior evidence; not re-audited in this PR) |
+| ElevenLabs voice contract | Clyde allowlist; Angst blocked in generator + verifier |
+
+## Deliverable summary
+
+```
+Files scanned: 1550 (git tracked enumeration)
+Issues found: 6 (hygiene paths, PyYAML parity, duplicate dict key, + backlog table)
+Issues fixed in PR: 4
+Files deleted: 0 (deletions in #1616 already on develop)
+Lines removed: ~1 (duplicate dict line)
+RAG entries cleaned: 0 (not verified)
+```
+
+## Accurate completion statement
+
+**Technical debt audit baseline complete for 2026-05-26. Core systems verified operational on `develop` CI (success). Hygiene gate passing. Python `scripts/` coverage 66% (702 tests). Full monorepo line-by-line cleanup and 100% coverage are phased work, not claimed in this session.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pytest-cov>=7,<9",
     "PyJWT>=2.10,<3",
     "requests>=2.32,<3",
+    "PyYAML>=6.0.2,<7",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/verify_elevenlabs_voices.py
+++ b/scripts/verify_elevenlabs_voices.py
@@ -28,7 +28,6 @@ SUPPORTED_VOICE_ENDPOINTS = {
     "AZnzlk1XvdvUeBnXmlld": f"{API_BASE_URL}/v1/text-to-speech/AZnzlk1XvdvUeBnXmlld?output_format={OUTPUT_FORMAT}",
     "EXAVITQu4vr4xnSDxMaL": f"{API_BASE_URL}/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL?output_format={OUTPUT_FORMAT}",
     "sS5fXGlqomdGXa7mxBcy": f"{API_BASE_URL}/v1/text-to-speech/sS5fXGlqomdGXa7mxBcy?output_format={OUTPUT_FORMAT}",
-    "EXAVITQu4vr4xnSDxMaL": f"{API_BASE_URL}/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL?output_format={OUTPUT_FORMAT}",
     "gE0owC0H9C8SzfDyIUtB": f"{API_BASE_URL}/v1/text-to-speech/gE0owC0H9C8SzfDyIUtB?output_format={OUTPUT_FORMAT}",
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -593,6 +593,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "random-timer-automation"
 version = "0.1.0"
 source = { virtual = "." }
@@ -604,6 +650,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "requests" },
 ]
 
@@ -616,6 +663,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.10,<3" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-cov", specifier = ">=7,<9" },
+    { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 


### PR DESCRIPTION
## Summary

- Baseline audit report: `docs/reports/technical-debt-audit-2026-05-26.md` (1,550 tracked files, ~300k lines, 702 Python tests, **66%** `scripts/` coverage)
- Hygiene gate: **0 errors** — `$HOME` instead of `/Users/...` in `.mcp.json` + API key helper doc
- Local/CI parity: `PyYAML` in `pyproject.toml` / `uv.lock`
- Remove duplicate `EXAVITQu4vr4xnSDxMaL` key in `verify_elevenlabs_voices.py`

## Not in scope (phased)

- Native Android/iOS coverage to 100%
- RAG gateway prune (not verified this session)
- Mass doc deletion

## Test plan

- [x] `bash scripts/shell/hygiene-check.sh` — pass
- [x] `uv run pytest scripts/tests/ --cov=scripts -q` — 702 passed, 66% coverage
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)