### PR TITLE
chore(ci): throttle high-frequency Actions + smoke-tier iOS PR tests

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
   android-device-tests:
-    name: Android Emulator + Maestro Tests
+    name: Android Emulator + Compose + Maestro Smoke
     needs: changes
     if: needs.changes.outputs.android_device == 'true'
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Create dummy google-services.json for CI
         working-directory: native-android
@@ -201,6 +201,8 @@ jobs:
         env:
           SIMULATOR_UDID: ${{ steps.sim.outputs.sim_id }}
           MAESTRO_FLOW_TIMEOUT_SECONDS: "180"
+          # Smoke on PR saves macOS minutes; full paywall regressions via workflow_dispatch.
+          CI_IOS_DEVICE_TIER: ${{ github.event_name == 'workflow_dispatch' && 'full' || 'smoke' }}
         run: bash scripts/device-tests/ci-maestro-ios.sh
 
       - name: Upload iOS device test artifacts

--- a/.github/workflows/ios-internal-retry.yml
+++ b/.github/workflows/ios-internal-retry.yml
@@ -3,7 +3,7 @@ name: iOS Internal Retry
 
 "on":
   schedule:
-    - cron: "35 */3 * * *"
+    - cron: "35 */6 * * *" # Was */3 — Actions budget
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/resolve-bot-comments.yml
+++ b/.github/workflows/resolve-bot-comments.yml
@@ -1,8 +1,6 @@
 name: Resolve Bot Comments
 
 on:
-  schedule:
-    - cron: "*/30 * * * *" # Every 30 minutes
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/stackoverflow-hourly-digest.yml
+++ b/.github/workflows/stackoverflow-hourly-digest.yml
@@ -3,7 +3,7 @@ name: Stack Overflow hourly triage digest
 # Read-only: fetches public Atom tag feeds, uploads markdown + RSS subscription list. Does not post to SO.
 on:
   schedule:
-    - cron: '12 * * * *' # Every hour at :12 UTC
+    - cron: '12 14 * * *' # Daily 14:12 UTC (was hourly — Actions budget)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/store-release-watcher.yml
+++ b/.github/workflows/store-release-watcher.yml
@@ -2,7 +2,7 @@ name: Store Release Watcher
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 */6 * * *' # Was */30 — shared Actions budget
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -2,7 +2,7 @@ name: Wiki Sync
 
 on:
   schedule:
-    - cron: '*/15 * * * *' # Every 15 minutes for near-real-time paid + growth dashboard updates
+    - cron: '0 */6 * * *' # Every 6 hours (was */15 — Actions budget; push to develop still refreshes)
   workflow_dispatch:
   push:
     branches: [develop]

--- a/.maestro/ci-smoke-emulator.yaml
+++ b/.maestro/ci-smoke-emulator.yaml
@@ -1,0 +1,25 @@
+appId: com.iganapolsky.randomtimer
+---
+# CI emulator: no clearState — Maestro cannot relaunch after wipe on API 30 runners.
+# App data is reset by adb install -r in ci-maestro.sh before this flow runs.
+- launchApp
+- waitForAnimationToEnd
+
+- tapOn:
+    text: 'Allow'
+    optional: true
+- tapOn:
+    text: 'While using the app'
+    optional: true
+
+- extendedWaitUntil:
+    visible:
+      id: 'start_timer'
+    timeout: 120000
+
+- tapOn:
+    id: 'start_timer'
+
+- assertVisible:
+    text: 'Pause'
+    optional: true

--- a/docs/ACTIONS_BUDGET.md
+++ b/docs/ACTIONS_BUDGET.md
@@ -1,0 +1,32 @@
+# GitHub Actions budget policy
+
+Org-wide Actions spend is capped. **ThumbGate** and **openclaw-console** are the
+primary burn sources; this repo still must not waste minutes on schedules that do not
+directly earn revenue.
+
+## Tiers
+
+| Tier | Purpose | Trigger |
+|------|---------|---------|
+| **0** | Ship path | PR `ci.yml`, path-aware `device-tests.yml`, security scan |
+| **1** | Revenue ops | `daily-growth-publishing`, `native-release` (dispatch), store verify (dispatch) |
+| **2** | Dashboards / hygiene | Throttled `schedule` (6h or daily); `workflow_dispatch` always available |
+
+## Random-Timer schedule caps (2026-05-26)
+
+- `wiki-sync`: `*/15` → `0 */6 * * *` (push to `develop` on `marketing/data/**` still runs)
+- `store-release-watcher`: `*/30` → `0 */6 * * *`
+- `resolve-bot-comments`: schedule removed (PR `pull_request_target` only)
+- `stackoverflow-hourly-digest`: hourly → daily
+- `ios-internal-retry`: `*/3` → `*/6`
+- PR iOS device job: `CI_IOS_DEVICE_TIER=smoke` (Maestro smoke only; paywall regressions via dispatch)
+
+## Do not
+
+- Raise org Actions budget broadly before capping high-burn repos.
+- Add new `*/15` or `*/30` schedules without CEO approval and minute estimate.
+
+## Off-Actions alternatives
+
+Recurring agent loops → local cron, Railway, or a cheap self-hosted runner.
+Keep secrets and deploy gates on GitHub.

--- a/scripts/device-tests/ci-maestro-ios.sh
+++ b/scripts/device-tests/ci-maestro-ios.sh
@@ -157,10 +157,17 @@ record_stage "pregrant notification permission"
 xcrun simctl privacy "$SIMULATOR_UDID" grant notifications "$BUNDLE_ID" 2>/dev/null || true
 
 run_maestro_flow "ios-smoke" "$PROJECT_ROOT/.maestro/ios-smoke-test.yaml"
-run_maestro_flow "pro-locks" "$PROJECT_ROOT/.maestro/regression-pro-locks-visible-ios.yaml"
-run_maestro_flow "free-sound-preview" "$PROJECT_ROOT/.maestro/regression-free-sound-preview-ios.yaml"
-run_maestro_flow "sound-arsenal-paywall" "$PROJECT_ROOT/.maestro/regression-sound-arsenal-paywall-ios.yaml"
-run_maestro_flow "paywall-sticky-cta" "$PROJECT_ROOT/.maestro/regression-paywall-sticky-cta-ios.yaml"
+
+# PR CI uses smoke tier (~10+ macOS min saved). Full paywall regressions: workflow_dispatch device-tests.
+CI_IOS_DEVICE_TIER="${CI_IOS_DEVICE_TIER:-full}"
+if [ "$CI_IOS_DEVICE_TIER" = "full" ]; then
+  run_maestro_flow "pro-locks" "$PROJECT_ROOT/.maestro/regression-pro-locks-visible-ios.yaml"
+  run_maestro_flow "free-sound-preview" "$PROJECT_ROOT/.maestro/regression-free-sound-preview-ios.yaml"
+  run_maestro_flow "sound-arsenal-paywall" "$PROJECT_ROOT/.maestro/regression-sound-arsenal-paywall-ios.yaml"
+  run_maestro_flow "paywall-sticky-cta" "$PROJECT_ROOT/.maestro/regression-paywall-sticky-cta-ios.yaml"
+else
+  echo "CI_IOS_DEVICE_TIER=smoke — skipping paywall Maestro regressions (use workflow_dispatch for full tier)."
+fi
 
 # Reset app state before Agent Device validates the home screen. Regression
 # flows may leave transient setup overlays or sheets visible.

--- a/scripts/device-tests/ci-maestro.sh
+++ b/scripts/device-tests/ci-maestro.sh
@@ -1,17 +1,39 @@
 #!/usr/bin/env sh
-# ci-maestro.sh — Run Android UI smoke verification on an emulator in CI.
+# ci-maestro.sh — Android device smoke on CI emulator.
+# 1) Compose instrumentation (stable on API 30 emulator)
+# 2) Maestro ci-smoke-emulator.yaml (parity with local Maestro flows)
 # Called by .github/workflows/device-tests.yml
 set -eu
 
-adb shell am force-stop com.iganapolsky.randomtimer 2>/dev/null || true
-adb shell pm clear com.iganapolsky.randomtimer 2>/dev/null || true
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)"
 
-cd native-android
+adb shell am force-stop com.iganapolsky.randomtimer 2>/dev/null || true
+
+cd "${REPO_ROOT}/native-android"
 chmod +x gradlew
 
-# Compose instrumentation is more reliable than Maestro for this setup screen on CI emulators.
+echo "== Android Compose smoke (TimerSetupSmokeTest) =="
 ./gradlew connectedDebugAndroidTest \
   --no-daemon \
   --stacktrace \
   -PenableFirebasePlugins=false \
   -Pandroid.testInstrumentationRunnerArguments.class=com.iganapolsky.randomtimer.ui.TimerSetupSmokeTest
+
+echo "== Android Maestro smoke (ci-smoke-emulator.yaml) =="
+APK="${REPO_ROOT}/native-android/app/build/outputs/apk/debug/app-debug.apk"
+if [ ! -f "${APK}" ]; then
+  echo "Debug APK missing; assembling..."
+  ./gradlew assembleDebug --no-daemon -q -PenableFirebasePlugins=false
+fi
+adb install -r -d "${APK}" || adb install -r "${APK}"
+
+if ! command -v maestro >/dev/null 2>&1; then
+  curl -Ls "https://get.maestro.mobile.dev" | bash
+fi
+export PATH="${HOME}/.maestro/bin:${PATH}"
+export MAESTRO_DRIVER_STARTUP_TIMEOUT="${MAESTRO_DRIVER_STARTUP_TIMEOUT:-180000}"
+export MAESTRO_DISABLE_ANALYTICS=true
+
+cd "${REPO_ROOT}"
+maestro test .maestro/ci-smoke-emulator.yaml

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -21,7 +21,7 @@ ANALYTICS_WORKFLOW = ROOT / ".github/workflows/analytics.yml"
 EXECUTIVE_METRICS_WORKFLOW = ROOT / ".github/workflows/executive-metrics.yml"
 PLAY_IAP_READBACK_WORKFLOW = ROOT / ".github/workflows/play-iap-product-readback.yml"
 WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
-WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
+ACTIONS_BUDGET_DOC = ROOT / "docs/ACTIONS_BUDGET.md"
 STORE_RATINGS_SNAPSHOT_WORKFLOW = ROOT / ".github/workflows/store-ratings-snapshot.yml"
 AGENTS_DOC = ROOT / "AGENTS.md"
 ANDROID_AGENT_WORKFLOW_DOC = ROOT / "docs/ANDROID_AGENT_WORKFLOW.md"
@@ -423,6 +423,9 @@ def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
     assert "native-ios/build/device-tests-ios" not in source
     assert "regression-free-sound-preview-ios.yaml" in ios_script
     assert "regression-sound-arsenal-paywall-ios.yaml" in ios_script
+    assert "CI_IOS_DEVICE_TIER" in ios_script
+    assert "CI_IOS_DEVICE_TIER:" in source
+    assert "workflow_dispatch' && 'full' || 'smoke'" in source
     assert "retry_agent_device_capture" in ios_script
     assert "AGENT_DEVICE_SESSION" in ios_script
     assert "MAESTRO_DRIVER_STARTUP_TIMEOUT=300000" in ios_script
@@ -609,3 +612,15 @@ def test_ci_crashlytics_job_uses_dedicated_runtime_secret_and_is_not_best_effort
     assert "google-auth==" in crashlytics_section
     assert "Missing CRASHLYTICS_SERVICE_ACCOUNT_JSON secret" in crashlytics_section
     assert "continue-on-error: true" not in crashlytics_section
+
+
+def test_actions_budget_throttles_high_frequency_schedules():
+    wiki = WIKI_SYNC_WORKFLOW.read_text(encoding="utf-8")
+    watcher = (ROOT / ".github/workflows/store-release-watcher.yml").read_text(encoding="utf-8")
+    resolve = (ROOT / ".github/workflows/resolve-bot-comments.yml").read_text(encoding="utf-8")
+
+    assert "cron: '0 */6 * * *'" in wiki
+    assert "cron: '0 */6 * * *'" in watcher
+    assert "schedule:" not in resolve.split("workflow_dispatch:", 1)[0]
+    assert ACTIONS_BUDGET_DOC.exists()
+    assert "CI_IOS_DEVICE_TIER" in ACTIONS_BUDGET_DOC.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- throttle high-frequency scheduled workflows to reduce shared Actions spend (`wiki-sync`, `store-release-watcher`, `stackoverflow-hourly-digest`, `ios-internal-retry`, and remove schedule from `resolve-bot-comments`)
- keep PR signal while reducing macOS burn by running iOS smoke tier on PRs and reserving full regression flows for `workflow_dispatch`
- restore Android CI Maestro reliability with explicit APK install and `.maestro/ci-smoke-emulator.yaml`
- add `docs/ACTIONS_BUDGET.md` policy and contract coverage in `scripts/tests/test_growth_workflow_contracts.py`

## Test plan
- [x] `uv run pytest scripts/tests/test_growth_workflow_contracts.py -q`
- [ ] GitHub Actions on this PR

Made with [Cursor](https://cursor.com)