### PR TITLE
fix(android): monthly paywall uses elite_tactical P1M base plan

### DIFF
--- a/docs/PLAY_CONSOLE_IAP_RUNBOOK.md
+++ b/docs/PLAY_CONSOLE_IAP_RUNBOOK.md
@@ -7,7 +7,7 @@
 |------------|---------------------|
 | `pro_base` | One-time (INAPP) |
 | `elite_tactical` | Subscription (SUBS) |
-| `elite_tactical_monthly` | Subscription (SUBS), P1M |
+| `elite_tactical_monthly` | Logical paywall id only — **bill via `elite_tactical` P1M base plan** (Play has no active base plan on `elite_tactical_monthly`) |
 
 PostHog `billing_product_not_found` on Android means Play Billing returned none of these at runtime — fix in **Play Console**, not in app code alone.
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -370,8 +370,20 @@ class ProManager
         private suspend fun fetchAllProductDetails() {
             fetchProductDetails(BASE_PRODUCT_ID)
             fetchProductDetails(ELITE_PRODUCT_ID)
-            fetchProductDetails(MONTHLY_PRODUCT_ID)
+            syncMonthlyCatalogFromElite()
             trackProductCatalogStatus()
+        }
+
+        /** Play Console bills monthly via `elite_tactical` P1M base plan, not orphan `elite_tactical_monthly`. */
+        private fun syncMonthlyCatalogFromElite() {
+            val eliteDetails = cachedProductDetails[ELITE_PRODUCT_ID]
+            if (eliteDetails != null &&
+                monthlyOfferAvailableFromEliteOffers(eliteDetails.toSubscriptionOffers())
+            ) {
+                cachedProductDetails[MONTHLY_PRODUCT_ID] = eliteDetails
+            } else {
+                cachedProductDetails.remove(MONTHLY_PRODUCT_ID)
+            }
         }
 
         suspend fun availablePaywallProductIds(): Set<String> {
@@ -401,8 +413,9 @@ class ProManager
         }
 
         private suspend fun fetchProductDetails(productID: String): com.android.billingclient.api.ProductDetails? {
+            val billingProductId = playBillingProductId(productID)
             val productType =
-                if (productID == ELITE_PRODUCT_ID || productID == MONTHLY_PRODUCT_ID) {
+                if (billingProductId == ELITE_PRODUCT_ID) {
                     BillingClient.ProductType.SUBS
                 } else {
                     BillingClient.ProductType.INAPP
@@ -412,7 +425,7 @@ class ProManager
                 listOf(
                     QueryProductDetailsParams.Product
                         .newBuilder()
-                        .setProductId(productID)
+                        .setProductId(billingProductId)
                         .setProductType(productType)
                         .build(),
                 )
@@ -427,8 +440,14 @@ class ProManager
             val details = result.productDetailsList?.firstOrNull()
             if (details != null) {
                 cachedProductDetails[productID] = details
+                if (billingProductId != productID) {
+                    cachedProductDetails[billingProductId] = details
+                }
+                if (billingProductId == ELITE_PRODUCT_ID) {
+                    syncMonthlyCatalogFromElite()
+                }
             } else {
-                maybeReportBillingProductNotFound(productID, result.billingResult)
+                maybeReportBillingProductNotFound(billingProductId, result.billingResult)
             }
             return details
         }
@@ -818,6 +837,16 @@ internal data class SubscriptionOffer(
     val hasFreeTrial: Boolean
         get() = pricingPhases.any { it.isFree }
 }
+
+/** Maps paywall logical SKU to Play Billing product id (monthly → elite_tactical). */
+internal fun playBillingProductId(logicalProductId: String): String =
+    when (logicalProductId) {
+        ProManager.MONTHLY_PRODUCT_ID -> ProManager.ELITE_PRODUCT_ID
+        else -> logicalProductId
+    }
+
+internal fun monthlyOfferAvailableFromEliteOffers(offers: List<SubscriptionOffer>): Boolean =
+    selectSubscriptionOfferByPeriod(offers, "P1M") != null
 
 /** Selects the subscription offer that matches a specific ISO 8601 billing period (e.g. "P1Y", "P1M"). */
 internal fun selectSubscriptionOfferByPeriod(

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
@@ -1,0 +1,68 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ProManagerPlayBillingProductIdTest {
+    @Test
+    fun `playBillingProductId maps monthly logical id to elite_tactical`() {
+        assertThat(playBillingProductId(ProManager.MONTHLY_PRODUCT_ID))
+            .isEqualTo(ProManager.ELITE_PRODUCT_ID)
+    }
+
+    @Test
+    fun `playBillingProductId leaves other ids unchanged`() {
+        assertThat(playBillingProductId(ProManager.ELITE_PRODUCT_ID))
+            .isEqualTo(ProManager.ELITE_PRODUCT_ID)
+        assertThat(playBillingProductId(ProManager.BASE_PRODUCT_ID))
+            .isEqualTo(ProManager.BASE_PRODUCT_ID)
+    }
+
+    @Test
+    fun `monthlyOfferAvailableFromEliteDetails true when P1M offer exists`() {
+        val eliteOffers =
+            listOf(
+                SubscriptionOffer(
+                    offerToken = "annual",
+                    pricingPhases =
+                        listOf(
+                            SubscriptionPricingPhase(
+                                formattedPrice = "$29.99",
+                                billingPeriod = "P1Y",
+                            ),
+                        ),
+                ),
+                SubscriptionOffer(
+                    offerToken = "monthly",
+                    pricingPhases =
+                        listOf(
+                            SubscriptionPricingPhase(
+                                formattedPrice = "$3.99",
+                                billingPeriod = "P1M",
+                            ),
+                        ),
+                ),
+            )
+
+        assertThat(monthlyOfferAvailableFromEliteOffers(eliteOffers)).isTrue()
+    }
+
+    @Test
+    fun `monthlyOfferAvailableFromEliteDetails false without P1M`() {
+        val annualOnly =
+            listOf(
+                SubscriptionOffer(
+                    offerToken = "annual",
+                    pricingPhases =
+                        listOf(
+                            SubscriptionPricingPhase(
+                                formattedPrice = "$29.99",
+                                billingPeriod = "P1Y",
+                            ),
+                        ),
+                ),
+            )
+
+        assertThat(monthlyOfferAvailableFromEliteOffers(annualOnly)).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
- Bill monthly subscriptions through `elite_tactical` + P1M offer (Play Console truth).
- Expose `elite_tactical_monthly` in paywall catalog only when elite has a P1M offer.
- Document SKU mapping in Play IAP runbook.

## Evidence
Play IAP workflow run 26524132890: `elite_tactical` has base plans `annual` + `monthly` ACTIVE; `elite_tactical_monthly` has no base plans.

## Test plan
- [x] `ProManagerPlayBillingProductIdTest` (new)
- [ ] CI Android unit tests
- [ ] Ship 1.3.41+ to Play and verify paywall monthly purchase succeeds


Made with [Cursor](https://cursor.com)