### PR TITLE
feat(ops): operational verification bundle (full session proof)

### DIFF
--- a/.github/workflows/operational-verification-bundle.yml
+++ b/.github/workflows/operational-verification-bundle.yml
@@ -43,8 +43,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
-            printf '%s' "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
-            echo "GOOGLE_PLAY_JSON_KEY_PATH=/tmp/play-service-account.json" >> "$GITHUB_ENV"
+            KEY_FILE="${RUNNER_TEMP}/play-service-account.json"
+            umask 077
+            printf '%s' "$GOOGLE_PLAY_JSON_KEY" > "$KEY_FILE"
+            chmod 600 "$KEY_FILE"
+            echo "GOOGLE_PLAY_JSON_KEY_PATH=$KEY_FILE" >> "$GITHUB_ENV"
           fi
 
       - name: Write ASC API key (if secrets present)
@@ -55,11 +58,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${APPSTORE_PRIVATE_KEY:-}" ] && [ -n "${APPSTORE_KEY_ID:-}" ]; then
-            printf '%s' "$APPSTORE_PRIVATE_KEY" > /tmp/asc_key.p8
-            echo "APPSTORE_PRIVATE_KEY_PATH=/tmp/asc_key.p8" >> "$GITHUB_ENV"
+            KEY_FILE="${RUNNER_TEMP}/asc_key.p8"
+            umask 077
+            printf '%s' "$APPSTORE_PRIVATE_KEY" > "$KEY_FILE"
+            chmod 600 "$KEY_FILE"
+            echo "APPSTORE_PRIVATE_KEY_PATH=$KEY_FILE" >> "$GITHUB_ENV"
           fi
 
       - name: Run operational verification bundle
+        id: bundle
         env:
           GH_TOKEN: ${{ github.token }}
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
@@ -73,13 +80,10 @@ jobs:
           if [ -n "$EXPECTED_VERSION" ]; then
             CMD+=(--expected-version "$EXPECTED_VERSION")
           fi
-          "${CMD[@]}" || EC=$?
-          EC=${EC:-0}
-          echo "bundle_exit_code=$EC" >> "$GITHUB_OUTPUT"
-          # Tier-2 and revenue may fail while tier0 passed — upload evidence regardless.
-          exit 0
+          "${CMD[@]}"
 
       - name: Upload bundle artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: operational-verification-bundle
@@ -87,9 +91,11 @@ jobs:
           if-no-files-found: error
 
       - name: Summary
+        if: always()
         run: |
           python3 - <<'PY'
           import json
+          import sys
           from pathlib import Path
           p = Path("marketing/data/operational_verification_bundle.json")
           d = json.loads(p.read_text())
@@ -98,4 +104,6 @@ jobs:
           for c in d["checks"]:
               if c["status"] in ("fail", "advisory_fail", "skip"):
                   print(f"  {c['status']}: {c['check_id']}")
+          if s["blocking_failures"] > 0:
+              sys.exit(1)
           PY

--- a/.github/workflows/operational-verification-bundle.yml
+++ b/.github/workflows/operational-verification-bundle.yml
@@ -1,0 +1,101 @@
+name: Operational Verification Bundle
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: "Expected semver (blank = latest GitHub release tag)"
+        required: false
+        default: ""
+      public_timeout:
+        description: "Tier-2 public store single-poll timeout (seconds)"
+        required: false
+        default: "10"
+  schedule:
+    - cron: "15 */6 * * *"
+  workflow_run:
+    workflows: ["Native App Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  bundle:
+    name: Operational verification bundle
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install requests==2.32.5
+
+      - name: Write Play service account (if secret present)
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
+            printf '%s' "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
+            echo "GOOGLE_PLAY_JSON_KEY_PATH=/tmp/play-service-account.json" >> "$GITHUB_ENV"
+          fi
+
+      - name: Write ASC API key (if secrets present)
+        env:
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ -n "${APPSTORE_PRIVATE_KEY:-}" ] && [ -n "${APPSTORE_KEY_ID:-}" ]; then
+            printf '%s' "$APPSTORE_PRIVATE_KEY" > /tmp/asc_key.p8
+            echo "APPSTORE_PRIVATE_KEY_PATH=/tmp/asc_key.p8" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run operational verification bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          EXPECTED_VERSION: ${{ github.event.inputs.expected_version || '' }}
+          PUBLIC_TIMEOUT: ${{ github.event.inputs.public_timeout || '10' }}
+        run: |
+          set -euo pipefail
+          CMD=(python3 scripts/operational_verification_bundle.py --public-timeout "$PUBLIC_TIMEOUT")
+          if [ -n "$EXPECTED_VERSION" ]; then
+            CMD+=(--expected-version "$EXPECTED_VERSION")
+          fi
+          "${CMD[@]}" || EC=$?
+          EC=${EC:-0}
+          echo "bundle_exit_code=$EC" >> "$GITHUB_OUTPUT"
+          # Tier-2 and revenue may fail while tier0 passed — upload evidence regardless.
+          exit 0
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: operational-verification-bundle
+          path: marketing/data/operational_verification_bundle.json
+          if-no-files-found: error
+
+      - name: Summary
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          p = Path("marketing/data/operational_verification_bundle.json")
+          d = json.loads(p.read_text())
+          s = d["summary"]
+          print(f"blocking_failures={s['blocking_failures']} pass={s['pass']} fail={s['fail']}")
+          for c in d["checks"]:
+              if c["status"] in ("fail", "advisory_fail", "skip"):
+                  print(f"  {c['status']}: {c['check_id']}")
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ native-android/gradle/gradle-daemon-jvm.properties
 
 # Local-only evidence artifacts (per-checkout screenshots, manual capture)
 evidence/
+marketing/data/operational_verification_bundle.json

--- a/docs/OPERATIONAL_RELIABILITY.md
+++ b/docs/OPERATIONAL_RELIABILITY.md
@@ -79,6 +79,29 @@ When the meaning of a field changes:
 - Never commit tokens, PATs, or private keys. Rotate anything exposed in logs or chat.
 - Verify `.env` key **names** and CI secret **names** exist before claiming “no access.”
 
+## 8. Operational verification bundle (full session proof)
+
+Run one command to produce a single JSON artifact with **every check**, its **tier**, **metric_field_id**, **semantics**, **ground_truth** flag, **command**, and **evidence**:
+
+```bash
+python3 scripts/operational_verification_bundle.py
+# writes marketing/data/operational_verification_bundle.json
+```
+
+CI: workflow `operational-verification-bundle.yml` (on schedule, `workflow_dispatch`, and after successful `Native App Release`). Download artifact `operational-verification-bundle` for redacted session proof.
+
+**How to read results:**
+
+| `status` | Meaning |
+| --- | --- |
+| `pass` | Check succeeded for its tier |
+| `fail` | **Blocking** — do not claim “fixed” / “earning” for that dimension |
+| `advisory_fail` | Expected lag or not yet live (e.g. tier2 storefront, ASC `PREPARE_FOR_SUBMISSION`) |
+| `skip` | Credentials not available in this environment |
+| `unverified` | Could not run (missing file, API error) |
+
+**Revenue / $100 day:** use `revenue_goal` + live `posthog_paywall_purchase_success` check. PostHog is a **proxy**; store ledger is **not wired** in the executive snapshot (`store_ledger_metric_id: not_wired_in_executive_snapshot`). Never equate `pass` on GitHub release with hitting the business goal.
+
 ## 8. CEO veto
 
 The CEO may require explicit approval for any irreversible or high-blast-radius action. Agents must honor that when stated for a task.

--- a/docs/OPERATIONAL_RELIABILITY.md
+++ b/docs/OPERATIONAL_RELIABILITY.md
@@ -95,14 +95,14 @@ CI: workflow `operational-verification-bundle.yml` (on schedule, `workflow_dispa
 | `status` | Meaning |
 | --- | --- |
 | `pass` | Check succeeded for its tier |
-| `fail` | **Blocking** — do not claim “fixed” / “earning” for that dimension |
-| `advisory_fail` | Expected lag or not yet live (e.g. tier2 storefront, ASC `PREPARE_FOR_SUBMISSION`) |
+| `fail` | **Blocking** — do not claim “fixed” for that dimension (e.g. Play IAP catalog broken) |
+| `advisory_fail` | Real gap but not a release gate (tier2 storefront lag, $0 purchases vs $100/day goal, stale snapshot) |
 | `skip` | Credentials not available in this environment |
 | `unverified` | Could not run (missing file, API error) |
 
 **Revenue / $100 day:** use `revenue_goal` + live `posthog_paywall_purchase_success` check. PostHog is a **proxy**; store ledger is **not wired** in the executive snapshot (`store_ledger_metric_id: not_wired_in_executive_snapshot`). Never equate `pass` on GitHub release with hitting the business goal.
 
-## 8. CEO veto
+## 9. CEO veto
 
 The CEO may require explicit approval for any irreversible or high-blast-radius action. Agents must honor that when stated for a task.
 

--- a/marketing/data/README.md
+++ b/marketing/data/README.md
@@ -40,4 +40,14 @@
 
 - **ASN V2 refunds:** `refunds.asn_v2_*` requires `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_KV_NAMESPACE_ID` (wired in CI; see `server/apple-webhook`).
 
+## `operational_verification_bundle.json` (generated)
+
+**What it is:** One JSON file with every release/revenue/store check, each with `metric_field_id`, `semantics`, `ground_truth`, `command`, and `evidence`. **Not committed** (see `.gitignore`); CI uploads artifact `operational-verification-bundle`.
+
+```bash
+python3 scripts/operational_verification_bundle.py
+```
+
+See `docs/OPERATIONAL_RELIABILITY.md` §8 and workflow `operational-verification-bundle.yml`.
+
 See also `docs/OPERATIONAL_RELIABILITY.md` and `docs/OBSERVABILITY.md`.

--- a/scripts/operational_verification_bundle.py
+++ b/scripts/operational_verification_bundle.py
@@ -101,13 +101,24 @@ def _run_command(cmd: list[str], *, cwd: Path | None = None, timeout: int = 120)
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 
 
+def _play_key_path() -> Path | None:
+    path = (os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH") or "").strip()
+    if path:
+        candidate = Path(path)
+        if candidate.is_file():
+            return candidate
+    runner_temp = (os.environ.get("RUNNER_TEMP") or "").strip()
+    if runner_temp:
+        candidate = Path(runner_temp) / "play-service-account.json"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _has_play_credentials() -> bool:
     if (os.environ.get("GOOGLE_PLAY_JSON_KEY") or "").strip():
         return True
-    path = (os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH") or "").strip()
-    if path and Path(path).is_file():
-        return True
-    return Path("/tmp/play-service-account.json").is_file()
+    return _play_key_path() is not None
 
 
 def _has_asc_credentials() -> bool:
@@ -446,7 +457,12 @@ def check_posthog_paywall_revenue(*, window_days: int = 30) -> CheckResult:
         row = result["results"][0]
         events = int(row[0] or 0)
         persons = int(row[1] or 0) if len(row) > 1 else 0
-    status = "pass" if events > 0 else "fail"
+    if errors:
+        status = "fail"
+    elif events > 0:
+        status = "pass"
+    else:
+        status = "advisory_fail"
     return CheckResult(
         "posthog_paywall_purchase_success",
         "analytics",

--- a/scripts/operational_verification_bundle.py
+++ b/scripts/operational_verification_bundle.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Single evidence bundle for release, store, billing, and revenue-proxy verification.
+
+Outputs marketing/data/operational_verification_bundle.json with per-check:
+check_id, tier, status, metric_field_id, ground_truth, semantics, command, evidence.
+
+See docs/OPERATIONAL_RELIABILITY.md and .claude/skills/store-verify-ci.md.
+
+Exit codes:
+  0 — no blocking failures
+  1 — one or more blocking checks failed
+  2 — configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "scripts"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.repo_dotenv import load_repo_dotenv
+from scripts.verify_public_store_versions import (
+    read_android_version,
+    read_github_latest_release_version,
+    read_ios_version,
+    verify_app_store_public_version,
+    verify_play_public_version,
+)
+
+BUNDLE_ID = "operational_verification_bundle_v1"
+OUTPUT_PATH = REPO_ROOT / "marketing" / "data" / "operational_verification_bundle.json"
+RELIABILITY_DOC = "docs/OPERATIONAL_RELIABILITY.md"
+BUSINESS_GOAL_USD_PER_DAY = 100.0
+
+
+@dataclass
+class CheckResult:
+    check_id: str
+    tier: str
+    status: str  # pass | fail | skip | advisory_fail | unverified
+    metric_field_id: str
+    ground_truth: bool
+    semantics: str
+    command: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def snapshot_age_hours(generated_at: str, *, max_age_hours: float) -> tuple[bool, float]:
+    if not generated_at:
+        return True, float("inf")
+    try:
+        ts = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True, float("inf")
+    age = datetime.now(timezone.utc) - ts
+    hours = age.total_seconds() / 3600.0
+    return hours > max_age_hours, hours
+
+
+def summarize_checks(checks: list[CheckResult]) -> dict[str, int]:
+    counts = {"pass": 0, "fail": 0, "skip": 0, "advisory_fail": 0, "unverified": 0}
+    for item in checks:
+        key = item.status if item.status in counts else "unverified"
+        counts[key] = counts.get(key, 0) + 1
+    blocking_fail = sum(1 for c in checks if c.status == "fail")
+    return {
+        **counts,
+        "total": len(checks),
+        "blocking_failures": blocking_fail,
+        "verifiable_pass": counts["pass"],
+    }
+
+
+def _run_command(cmd: list[str], *, cwd: Path | None = None, timeout: int = 120) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _has_play_credentials() -> bool:
+    if (os.environ.get("GOOGLE_PLAY_JSON_KEY") or "").strip():
+        return True
+    path = (os.environ.get("GOOGLE_PLAY_JSON_KEY_PATH") or "").strip()
+    if path and Path(path).is_file():
+        return True
+    return Path("/tmp/play-service-account.json").is_file()
+
+
+def _has_asc_credentials() -> bool:
+    key = (os.environ.get("APPSTORE_PRIVATE_KEY") or "").strip()
+    path = (os.environ.get("APPSTORE_PRIVATE_KEY_PATH") or "").strip()
+    return bool(key or (path and Path(path).is_file())) and bool(
+        (os.environ.get("APPSTORE_KEY_ID") or "").strip()
+        and (os.environ.get("APPSTORE_ISSUER_ID") or "").strip()
+    )
+
+
+def _has_posthog_credentials() -> bool:
+    api_key = (
+        (os.environ.get("POSTHOG_PERSONAL_API_KEY") or "").strip()
+        or (os.environ.get("POSTHOG_API_KEY") or "").strip()
+    )
+    project_id = (os.environ.get("POSTHOG_PROJECT_ID") or "").strip()
+    return bool(api_key and project_id)
+
+
+def check_github_latest_release() -> CheckResult:
+    cmd = ["gh", "release", "view", "--json", "tagName,publishedAt,url"]
+    code, out, err = _run_command(cmd)
+    evidence: dict[str, Any] = {"exit_code": code, "stderr": err[:500] if err else ""}
+    if code != 0:
+        return CheckResult(
+            "github_latest_release",
+            "repo",
+            "fail",
+            "github_release_tag_semver_v1",
+            False,
+            "Latest GitHub Release tag (not store ground truth).",
+            " ".join(cmd),
+            evidence,
+        )
+    try:
+        payload = json.loads(out)
+    except json.JSONDecodeError:
+        return CheckResult(
+            "github_latest_release",
+            "repo",
+            "fail",
+            "github_release_tag_semver_v1",
+            False,
+            "Latest GitHub Release tag (not store ground truth).",
+            " ".join(cmd),
+            {**evidence, "parse_error": True},
+        )
+    tag = str(payload.get("tagName") or "")
+    version = tag.lstrip("v")
+    evidence.update(payload)
+    return CheckResult(
+        "github_latest_release",
+        "repo",
+        "pass",
+        "github_release_tag_semver_v1",
+        False,
+        "Latest GitHub Release tag (not store ground truth).",
+        " ".join(cmd),
+        evidence,
+    )
+
+
+def check_repo_marketing_versions() -> CheckResult:
+    try:
+        ios_v = read_ios_version(REPO_ROOT)
+        android_v = read_android_version(REPO_ROOT)
+        gh_v = read_github_latest_release_version(REPO_ROOT)
+    except RuntimeError as exc:
+        return CheckResult(
+            "repo_marketing_version_sync",
+            "repo",
+            "fail",
+            "repo_native_marketing_version_semver_v1",
+            False,
+            "versionName / MARKETING_VERSION in repo sources (not store).",
+            "read_ios_version + read_android_version + gh release",
+            {"error": str(exc)},
+        )
+    synced = ios_v == android_v == gh_v
+    return CheckResult(
+        "repo_marketing_version_sync",
+        "repo",
+        "pass" if synced else "fail",
+        "repo_native_marketing_version_semver_v1",
+        False,
+        "versionName / MARKETING_VERSION must match latest GitHub release tag.",
+        "read_ios_version + read_android_version + gh release",
+        {"ios": ios_v, "android": android_v, "github_release": gh_v, "synced": synced},
+    )
+
+
+def check_native_release_last_run(expected_version: str) -> CheckResult:
+    cmd = [
+        "gh",
+        "run",
+        "list",
+        "--workflow=native-release.yml",
+        "--limit",
+        "5",
+        "--json",
+        "databaseId,conclusion,status,headBranch,createdAt,url",
+    ]
+    code, out, err = _run_command(cmd)
+    evidence: dict[str, Any] = {"exit_code": code, "stderr": err[:300] if err else ""}
+    if code != 0:
+        return CheckResult(
+            "native_release_last_success",
+            "tier0",
+            "unverified",
+            "github_actions_native_release_last_success_v1",
+            False,
+            "Most recent native-release.yml workflow on release/v* branch.",
+            " ".join(cmd),
+            evidence,
+        )
+    runs = json.loads(out)
+    success_on_release = [
+        r
+        for r in runs
+        if r.get("conclusion") == "success"
+        and str(r.get("headBranch", "")).startswith("release/v")
+    ]
+    evidence["runs"] = runs
+    if not success_on_release:
+        return CheckResult(
+            "native_release_last_success",
+            "tier0",
+            "fail",
+            "github_actions_native_release_last_success_v1",
+            False,
+            "Most recent native-release.yml workflow on release/v* branch.",
+            " ".join(cmd),
+            evidence,
+        )
+    latest = success_on_release[0]
+    branch_version = str(latest.get("headBranch", "")).replace("release/v", "")
+    matches = branch_version == expected_version
+    return CheckResult(
+        "native_release_last_success",
+        "tier0",
+        "pass" if matches else "advisory_fail",
+        "github_actions_native_release_last_success_v1",
+        False,
+        "Green native-release on release/vX.Y.Z (upload/review gate; not public storefront).",
+        " ".join(cmd),
+        {
+            "latest_success": latest,
+            "expected_version": expected_version,
+            "branch_version": branch_version,
+            "matches_expected": matches,
+        },
+    )
+
+
+def check_public_store_tier2(expected_version: str, *, timeout: int) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    ios = verify_app_store_public_version("6758355312", expected_version)
+    play = verify_play_public_version("com.iganapolsky.randomtimer", expected_version)
+    for item in (ios, play):
+        status = "pass" if item.passed else "advisory_fail"
+        metric = (
+            "itunes_lookup_public_version_field_v1"
+            if item.platform == "ios"
+            else "play_store_html_141_string_proxy_v1"
+        )
+        checks.append(
+            CheckResult(
+                f"public_store_{item.platform}",
+                "tier2",
+                status,
+                metric,
+                False,
+                (
+                    "iTunes lookup version field (US) — not ASC ground truth."
+                    if item.platform == "ios"
+                    else "Play listing HTML proxy — not Play Console track truth."
+                ),
+                f"verify_public_store (timeout={timeout}s advisory)",
+                {
+                    "url": item.url,
+                    "expected_version": item.expected_version,
+                    "observed_version": item.observed_version,
+                    "details": item.details,
+                    "propagation_note": "Lag hours–24h+ after tier0 ship; does not invalidate release.",
+                },
+            )
+        )
+    return checks
+
+
+def check_play_iap_catalog() -> CheckResult:
+    if not _has_play_credentials():
+        return CheckResult(
+            "play_iap_catalog",
+            "tier0",
+            "skip",
+            "google_play_monetization_required_subscriptions_v1",
+            False,
+            "Play Monetization API: elite_tactical annual+monthly ACTIVE; pro_base ACTIVE.",
+            "python3 scripts/play_verify_iap_products.py",
+            {"reason": "missing GOOGLE_PLAY_JSON_KEY or GOOGLE_PLAY_JSON_KEY_PATH"},
+        )
+    cmd = [sys.executable, str(SCRIPTS / "play_verify_iap_products.py")]
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env=env,
+    )
+    evidence: dict[str, Any] = {
+        "exit_code": proc.returncode,
+        "stdout_tail": proc.stdout[-2000:] if proc.stdout else "",
+        "stderr_tail": proc.stderr[-500:] if proc.stderr else "",
+    }
+    try:
+        lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+        if lines:
+            evidence["report"] = json.loads(lines[-1])
+    except json.JSONDecodeError:
+        pass
+    return CheckResult(
+        "play_iap_catalog",
+        "tier0",
+        "pass" if proc.returncode == 0 else "fail",
+        "google_play_monetization_required_subscriptions_v1",
+        True,
+        "Play Monetization API subscription/OTP catalog (ground truth for Play billing).",
+        " ".join(cmd),
+        evidence,
+    )
+
+
+def check_asc_version_state(version: str) -> CheckResult:
+    if not _has_asc_credentials():
+        return CheckResult(
+            "asc_app_store_version_state",
+            "tier1",
+            "skip",
+            "asc_app_store_version_app_store_state_v1",
+            True,
+            "App Store Connect appStoreState for target marketing version.",
+            f"PYTHONPATH=. python3 scripts/asc/asc_watch_status.py --version {version}",
+            {"reason": "missing APPSTORE_KEY_ID / ISSUER_ID / PRIVATE_KEY"},
+        )
+    cmd = [
+        sys.executable,
+        str(SCRIPTS / "asc" / "asc_watch_status.py"),
+        "--bundle-id",
+        "com.igorganapolsky.randomtimer",
+        "--version",
+        version,
+        "--max-polls",
+        "1",
+        "--print-json",
+    ]
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env=env,
+    )
+    evidence = {"exit_code": proc.returncode, "stdout": proc.stdout[-1500:], "stderr": proc.stderr[-300:]}
+    state = ""
+    try:
+        for line in proc.stdout.splitlines():
+            if line.strip().startswith("{"):
+                payload = json.loads(line)
+                state = str(payload.get("state") or "")
+                evidence["asc"] = payload
+                break
+    except json.JSONDecodeError:
+        pass
+    live_states = {"READY_FOR_SALE", "PENDING_DEVELOPER_RELEASE", "PROCESSING_FOR_APP_STORE"}
+    in_review = {"WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_APPLE_RELEASE"}
+    prepare = {"PREPARE_FOR_SUBMISSION"}
+    if state in live_states:
+        st = "pass"
+    elif state in in_review:
+        st = "advisory_fail"
+    elif state in prepare:
+        st = "advisory_fail"
+    elif proc.returncode != 0 or not state:
+        st = "fail" if proc.returncode != 0 else "unverified"
+    else:
+        st = "advisory_fail"
+    return CheckResult(
+        "asc_app_store_version_state",
+        "tier1",
+        st,
+        "asc_app_store_version_app_store_state_v1",
+        True,
+        "App Store Connect appStoreState (authoritative for iOS review; not iTunes lookup).",
+        " ".join(cmd),
+        {**evidence, "state": state},
+    )
+
+
+def check_posthog_paywall_revenue(*, window_days: int = 30) -> CheckResult:
+    if not _has_posthog_credentials():
+        return CheckResult(
+            "posthog_paywall_purchase_success",
+            "analytics",
+            "skip",
+            "posthog_hogql_count_events_paywall_purchase_success",
+            False,
+            "In-app telemetry; not App Store / Play ledger proceeds.",
+            "POSTHOG execute-sql or paywall_conversion_report.py",
+            {"reason": "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID"},
+        )
+    from scripts.store_downloads_snapshot import posthog_query
+
+    errors: list[str] = []
+    api_key = (os.environ.get("POSTHOG_PERSONAL_API_KEY") or os.environ.get("POSTHOG_API_KEY") or "").strip()
+    project_id = (os.environ.get("POSTHOG_PROJECT_ID") or "").strip()
+    query = f"""
+        SELECT
+          count() AS events,
+          count(DISTINCT person_id) AS persons
+        FROM events
+        WHERE event = 'paywall_purchase_success'
+          AND timestamp > now() - interval {window_days} day
+    """
+    result = posthog_query(query, api_key, project_id, errors)
+    events = 0
+    persons = 0
+    if result and result.get("results") and result["results"][0]:
+        row = result["results"][0]
+        events = int(row[0] or 0)
+        persons = int(row[1] or 0) if len(row) > 1 else 0
+    status = "pass" if events > 0 else "fail"
+    return CheckResult(
+        "posthog_paywall_purchase_success",
+        "analytics",
+        status,
+        "posthog_hogql_count_events_paywall_purchase_success",
+        False,
+        f"paywall_purchase_success count trailing {window_days}d — revenue proxy only.",
+        "posthog_query (HogQL)",
+        {
+            "events_30d": events,
+            "distinct_persons_30d": persons,
+            "query_errors": errors,
+            "window_days": window_days,
+        },
+    )
+
+
+def check_artifact_staleness() -> list[CheckResult]:
+    artifacts = [
+        ("executive_metrics.json", REPO_ROOT / "marketing/data/executive_metrics.json", 24.0),
+        ("paywall_conversion_report.json", REPO_ROOT / "marketing/data/paywall_conversion_report.json", 24.0),
+        ("north_star.json", REPO_ROOT / "marketing/data/north_star.json", 24.0),
+    ]
+    out: list[CheckResult] = []
+    for name, path, max_h in artifacts:
+        if not path.is_file():
+            out.append(
+                CheckResult(
+                    f"artifact_fresh_{name}",
+                    "repo",
+                    "unverified",
+                    f"committed_snapshot_{name}_generated_at_v1",
+                    False,
+                    "Committed marketing snapshot freshness (not live unless refreshed in-session).",
+                    f"read {path.relative_to(REPO_ROOT)}",
+                    {"missing": True},
+                )
+            )
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            payload = {}
+        generated_at = str(payload.get("generated_at") or "")
+        stale, age_h = snapshot_age_hours(generated_at, max_age_hours=max_h)
+        out.append(
+            CheckResult(
+                f"artifact_fresh_{name}",
+                "repo",
+                "advisory_fail" if stale else "pass",
+                f"committed_snapshot_{name}_generated_at_v1",
+                False,
+                f"Snapshot must be <= {max_h}h old for session-truth claims.",
+                f"read {path.relative_to(REPO_ROOT)}",
+                {"generated_at": generated_at, "age_hours": round(age_h, 2), "stale": stale},
+            )
+        )
+    return out
+
+
+def build_revenue_goal_section() -> dict[str, Any]:
+    exec_path = REPO_ROOT / "marketing/data/executive_metrics.json"
+    goal: dict[str, Any] = {
+        "target_usd_per_day_after_tax": BUSINESS_GOAL_USD_PER_DAY,
+        "metric_bundle_id": "executive_revenue_goal_v1",
+        "status": "unverified",
+        "posthog_paywall_revenue_avg_usd_per_day": None,
+        "posthog_usd_gap_per_day_vs_target": None,
+        "events_paywall_purchase_success_30d": None,
+        "store_ledger_revenue_usd_30d": None,
+        "store_ledger_metric_id": "not_wired_in_executive_snapshot",
+        "note": "Use live posthog check in bundle checks[] for session truth; JSON may be stale.",
+    }
+    if exec_path.is_file():
+        try:
+            data = json.loads(exec_path.read_text(encoding="utf-8"))
+            rg = data.get("revenue_goal") or {}
+            goal.update(
+                {
+                    "status": rg.get("status", "unverified"),
+                    "posthog_paywall_revenue_avg_usd_per_day": rg.get(
+                        "posthog_paywall_revenue_avg_usd_per_day"
+                    ),
+                    "posthog_usd_gap_per_day_vs_target": rg.get("posthog_usd_gap_per_day_vs_target"),
+                    "events_paywall_purchase_success_30d": rg.get(
+                        "events_paywall_purchase_success_30d"
+                    ),
+                    "snapshot_generated_at": data.get("generated_at"),
+                }
+            )
+            stale, age_h = snapshot_age_hours(str(data.get("generated_at") or ""), max_age_hours=24.0)
+            goal["snapshot_stale"] = stale
+            goal["snapshot_age_hours"] = round(age_h, 2)
+        except json.JSONDecodeError:
+            goal["parse_error"] = True
+    return goal
+
+
+def run_all_checks(
+    repo_root: Path,
+    *,
+    expected_version: str,
+    public_timeout: int,
+) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    checks.append(check_github_latest_release())
+    checks.append(check_repo_marketing_versions())
+    checks.append(check_native_release_last_run(expected_version))
+    checks.extend(check_public_store_tier2(expected_version, timeout=public_timeout))
+    checks.append(check_play_iap_catalog())
+    checks.append(check_asc_version_state(expected_version))
+    checks.append(check_posthog_paywall_revenue())
+    checks.extend(check_artifact_staleness())
+    return checks
+
+
+def build_bundle(repo_root: Path, checks: list[CheckResult] | None = None) -> dict[str, Any]:
+    if checks is None:
+        try:
+            expected = read_github_latest_release_version(repo_root)
+        except RuntimeError:
+            expected = ""
+        checks = run_all_checks(repo_root, expected_version=expected, public_timeout=10)
+    summary = summarize_checks(checks)
+    return {
+        "generated_at": utc_now_iso(),
+        "bundle_id": BUNDLE_ID,
+        "reliability_contract_doc": RELIABILITY_DOC,
+        "definitions": {
+            "ground_truth": "Vendor API or ledger field documented in semantics; false = proxy.",
+            "tier0": "Upload/track verify — blocks release when credentials present.",
+            "tier1": "ASC review state — authoritative for iOS pipeline.",
+            "tier2": "Public storefront HTML/lookup — advisory propagation lag.",
+            "blocking_fail": "status=fail counts toward exit code 1.",
+            "revenue_goal": f"Business target ${BUSINESS_GOAL_USD_PER_DAY:.0f}/day after-tax vs PostHog proxy.",
+        },
+        "summary": summary,
+        "revenue_goal": build_revenue_goal_section(),
+        "checks": [c.to_dict() for c in checks],
+    }
+
+
+def print_human_report(payload: dict[str, Any]) -> None:
+    print()
+    print("== Operational Verification Bundle ==")
+    print(f"bundle_id: {payload['bundle_id']}")
+    print(f"generated_at: {payload['generated_at']}")
+    s = payload["summary"]
+    print(
+        f"checks: pass={s['pass']} fail={s['fail']} advisory_fail={s['advisory_fail']} "
+        f"skip={s['skip']} unverified={s['unverified']} blocking_failures={s['blocking_failures']}"
+    )
+    rg = payload.get("revenue_goal") or {}
+    print(
+        f"revenue_goal: target=${rg.get('target_usd_per_day_after_tax')} "
+        f"proxy_avg_day={rg.get('posthog_paywall_revenue_avg_usd_per_day')} "
+        f"gap_day={rg.get('posthog_usd_gap_per_day_vs_target')} "
+        f"(snapshot_stale={rg.get('snapshot_stale')})"
+    )
+    for item in payload["checks"]:
+        marker = item["status"].upper()
+        print(f"  [{marker}] {item['check_id']} (tier={item['tier']}, ground_truth={item['ground_truth']})")
+        if item["status"] in {"fail", "advisory_fail", "skip", "unverified"}:
+            ev = item.get("evidence") or {}
+            brief = {k: ev[k] for k in list(ev)[:6]}
+            print(f"         evidence: {json.dumps(brief, default=str)[:200]}")
+    print("=====================================")
+    print(f"JSON: {OUTPUT_PATH.relative_to(REPO_ROOT)}")
+    print()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--expected-version", default="", help="Override expected semver (default: latest GitHub release)")
+    parser.add_argument(
+        "--public-timeout",
+        type=int,
+        default=10,
+        help="Single-poll public store check (tier2 advisory; default 10s)",
+    )
+    parser.add_argument("--json-out", type=Path, default=OUTPUT_PATH)
+    parser.add_argument("--no-write", action="store_true", help="Print only; do not write JSON file")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    load_repo_dotenv(repo_root)
+
+    try:
+        expected = args.expected_version.strip() or read_github_latest_release_version(repo_root)
+    except RuntimeError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+
+    checks = run_all_checks(
+        repo_root,
+        expected_version=expected,
+        public_timeout=args.public_timeout,
+    )
+    payload = build_bundle(repo_root, checks)
+    print_human_report(payload)
+
+    if not args.no_write:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    blocking = payload["summary"]["blocking_failures"]
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_operational_verification_bundle.py
+++ b/scripts/tests/test_operational_verification_bundle.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from scripts import operational_verification_bundle as bundle
+
+
+class OperationalVerificationBundleTests(unittest.TestCase):
+    def test_check_result_to_dict_includes_semantics(self):
+        check = bundle.CheckResult(
+            check_id="github_latest_release",
+            tier="repo",
+            status="pass",
+            metric_field_id="github_release_tag_semver_v1",
+            ground_truth=False,
+            semantics="Latest GitHub Release tag (not store ledger).",
+            command="gh release view --json tagName",
+            evidence={"tag": "v1.3.41", "version": "1.3.41"},
+        )
+        payload = check.to_dict()
+        self.assertEqual(payload["check_id"], "github_latest_release")
+        self.assertFalse(payload["ground_truth"])
+        self.assertIn("semantics", payload)
+
+    def test_staleness_flags_old_snapshot(self):
+        old = (datetime.now(timezone.utc) - timedelta(hours=50)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stale, age_h = bundle.snapshot_age_hours(old, max_age_hours=24.0)
+        self.assertTrue(stale)
+        self.assertGreater(age_h, 24.0)
+
+    def test_staleness_accepts_fresh_snapshot(self):
+        fresh = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stale, _ = bundle.snapshot_age_hours(fresh, max_age_hours=24.0)
+        self.assertFalse(stale)
+
+    def test_bundle_schema_has_required_top_level_keys(self):
+        required = {
+            "generated_at",
+            "bundle_id",
+            "reliability_contract_doc",
+            "summary",
+            "checks",
+            "revenue_goal",
+            "definitions",
+        }
+        with patch.object(bundle, "run_all_checks", return_value=[]):
+            with patch.object(bundle, "build_revenue_goal_section", return_value={}):
+                payload = bundle.build_bundle(bundle.REPO_ROOT)
+        self.assertTrue(required.issubset(payload.keys()))
+        self.assertEqual(payload["bundle_id"], bundle.BUNDLE_ID)
+
+    def test_summary_counts_statuses(self):
+        checks = [
+            bundle.CheckResult("a", "repo", "pass", "m1", False, "", "", {}),
+            bundle.CheckResult("b", "repo", "fail", "m2", False, "", "", {}),
+            bundle.CheckResult("c", "repo", "skip", "m3", False, "", "", {}),
+            bundle.CheckResult("d", "tier2", "advisory_fail", "m4", False, "", "", {}),
+        ]
+        summary = bundle.summarize_checks(checks)
+        self.assertEqual(summary["pass"], 1)
+        self.assertEqual(summary["fail"], 1)
+        self.assertEqual(summary["skip"], 1)
+        self.assertEqual(summary["advisory_fail"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `scripts/operational_verification_bundle.py` — one command produces evidence-backed checks for GitHub release, repo versions, native-release CI, tier-2 public storefront, Play IAP catalog, ASC state, PostHog purchases, and snapshot staleness.
- Adds `operational-verification-bundle.yml` (schedule, workflow_dispatch, post-release) with artifact upload.
- Documents contract in `docs/OPERATIONAL_RELIABILITY.md` §8 and `marketing/data/README.md`.

## Test plan
- [x] `uv run pytest scripts/tests/test_operational_verification_bundle.py`
- [x] `python3 scripts/operational_verification_bundle.py` locally
- [ ] Merge and run workflow_dispatch on `develop` with CI secrets for full tier0/1/analytics coverage

Made with [Cursor](https://cursor.com)

----
## Summary by Gitar

- **Security enhancements:**
  - Hardened credential handling by using `RUNNER_TEMP` and setting restricted `umask 077` and `chmod 600` permissions.
- **CI/CD pipeline:**
  - Configured CI to exit with error if blocking failures occur in the operational bundle.
  - Added `always()` conditions to ensure artifact uploads and summary reporting trigger even on failures.
- **Operational logic:**
  - Updated credential resolution to support `RUNNER_TEMP` paths dynamically.
  - Adjusted `posthog_paywall_purchase_success` to return `advisory_fail` for non-critical revenue issues.
- **Documentation:**
  - Clarified `fail` vs `advisory_fail` definitions in `OPERATIONAL_RELIABILITY.md` and renumbered sections.

<sub>This will update automatically on new commits.</sub>