### PR TITLE
fix(android): monthly billing matches Play catalog layout

### DIFF
--- a/docs/PLAY_CONSOLE_IAP_RUNBOOK.md
+++ b/docs/PLAY_CONSOLE_IAP_RUNBOOK.md
@@ -7,7 +7,7 @@
 |------------|---------------------|
 | `pro_base` | One-time (INAPP) |
 | `elite_tactical` | Subscription (SUBS) |
-| `elite_tactical_monthly` | Logical paywall id only — **bill via `elite_tactical` P1M base plan** (Play has no active base plan on `elite_tactical_monthly`) |
+| `elite_tactical_monthly` | Subscription (SUBS) — **monthly base plan must be ACTIVE** (app bills this SKU when Play hosts P1M here) |
 
 PostHog `billing_product_not_found` on Android means Play Billing returned none of these at runtime — fix in **Play Console**, not in app code alone.
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -370,19 +370,19 @@ class ProManager
         private suspend fun fetchAllProductDetails() {
             fetchProductDetails(BASE_PRODUCT_ID)
             fetchProductDetails(ELITE_PRODUCT_ID)
-            syncMonthlyCatalogFromElite()
+            fetchProductDetails(MONTHLY_PRODUCT_ID)
+            syncMonthlyCatalogFromEliteFallback()
             trackProductCatalogStatus()
         }
 
-        /** Play Console bills monthly via `elite_tactical` P1M base plan, not orphan `elite_tactical_monthly`. */
-        private fun syncMonthlyCatalogFromElite() {
-            val eliteDetails = cachedProductDetails[ELITE_PRODUCT_ID]
-            if (eliteDetails != null &&
-                monthlyOfferAvailableFromEliteOffers(eliteDetails.toSubscriptionOffers())
-            ) {
+        /** Fallback when Play hosts P1M on `elite_tactical` instead of `elite_tactical_monthly`. */
+        private fun syncMonthlyCatalogFromEliteFallback() {
+            if (cachedProductDetails[MONTHLY_PRODUCT_ID] != null) {
+                return
+            }
+            val eliteDetails = cachedProductDetails[ELITE_PRODUCT_ID] ?: return
+            if (monthlyOfferAvailableFromEliteOffers(eliteDetails.toSubscriptionOffers())) {
                 cachedProductDetails[MONTHLY_PRODUCT_ID] = eliteDetails
-            } else {
-                cachedProductDetails.remove(MONTHLY_PRODUCT_ID)
             }
         }
 
@@ -444,7 +444,7 @@ class ProManager
                     cachedProductDetails[billingProductId] = details
                 }
                 if (billingProductId == ELITE_PRODUCT_ID) {
-                    syncMonthlyCatalogFromElite()
+                    syncMonthlyCatalogFromEliteFallback()
                 }
             } else {
                 maybeReportBillingProductNotFound(billingProductId, result.billingResult)
@@ -838,12 +838,8 @@ internal data class SubscriptionOffer(
         get() = pricingPhases.any { it.isFree }
 }
 
-/** Maps paywall logical SKU to Play Billing product id (monthly → elite_tactical). */
-internal fun playBillingProductId(logicalProductId: String): String =
-    when (logicalProductId) {
-        ProManager.MONTHLY_PRODUCT_ID -> ProManager.ELITE_PRODUCT_ID
-        else -> logicalProductId
-    }
+/** Maps paywall logical SKU to Play Billing product id (identity — monthly uses Play catalog SKU). */
+internal fun playBillingProductId(logicalProductId: String): String = logicalProductId
 
 internal fun monthlyOfferAvailableFromEliteOffers(offers: List<SubscriptionOffer>): Boolean =
     selectSubscriptionOfferByPeriod(offers, "P1M") != null

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
@@ -5,13 +5,13 @@ import org.junit.Test
 
 class ProManagerPlayBillingProductIdTest {
     @Test
-    fun `playBillingProductId maps monthly logical id to elite_tactical`() {
+    fun `playBillingProductId uses Play catalog product ids`() {
         assertThat(playBillingProductId(ProManager.MONTHLY_PRODUCT_ID))
-            .isEqualTo(ProManager.ELITE_PRODUCT_ID)
+            .isEqualTo(ProManager.MONTHLY_PRODUCT_ID)
     }
 
     @Test
-    fun `playBillingProductId leaves other ids unchanged`() {
+    fun `playBillingProductId leaves elite and base ids unchanged`() {
         assertThat(playBillingProductId(ProManager.ELITE_PRODUCT_ID))
             .isEqualTo(ProManager.ELITE_PRODUCT_ID)
         assertThat(playBillingProductId(ProManager.BASE_PRODUCT_ID))

--- a/scripts/play_monetization_client.py
+++ b/scripts/play_monetization_client.py
@@ -8,9 +8,10 @@ from typing import Any
 
 PACKAGE = "com.iganapolsky.randomtimer"
 REQUIRED_ONE_TIME = ("pro_base",)
-# Monthly paywall bills via elite_tactical P1M base plan (see ProManager.playBillingProductId).
-REQUIRED_SUBSCRIPTIONS = ("elite_tactical",)
-REQUIRED_ELITE_BASE_PLAN_IDS = ("annual", "monthly")
+# App bills monthly via elite_tactical_monthly when Play hosts P1M there (see ProManager).
+REQUIRED_SUBSCRIPTIONS = ("elite_tactical", "elite_tactical_monthly")
+REQUIRED_ELITE_ANNUAL_BASE_PLAN_ID = "annual"
+REQUIRED_MONTHLY_BASE_PLAN_ID = "monthly"
 TARGET_ONE_TIME = "pro_base"
 # P2 scaffold — document SKUs; not required for verify until Play Console products exist.
 SCAFFOLD_DISCIPLINE_PACKS = (
@@ -155,15 +156,28 @@ def subscription_purchase_blockers(subscriptions: list[dict[str, Any]]) -> list[
     if elite is None:
         return blockers
 
-    active_plans = _active_base_plan_ids(elite)
-    for required_plan in REQUIRED_ELITE_BASE_PLAN_IDS:
-        if required_plan not in active_plans:
-            blockers.append(
-                {
-                    "product_id": "elite_tactical",
-                    "reason": f"missing_active_base_plan:{required_plan}",
-                }
-            )
+    elite_active = _active_base_plan_ids(elite)
+    if REQUIRED_ELITE_ANNUAL_BASE_PLAN_ID not in elite_active:
+        blockers.append(
+            {
+                "product_id": "elite_tactical",
+                "reason": f"missing_active_base_plan:{REQUIRED_ELITE_ANNUAL_BASE_PLAN_ID}",
+            }
+        )
+
+    monthly_on_elite = REQUIRED_MONTHLY_BASE_PLAN_ID in elite_active
+    monthly_sub = by_id.get("elite_tactical_monthly")
+    monthly_on_dedicated = (
+        monthly_sub is not None
+        and REQUIRED_MONTHLY_BASE_PLAN_ID in _active_base_plan_ids(monthly_sub)
+    )
+    if not monthly_on_elite and not monthly_on_dedicated:
+        blockers.append(
+            {
+                "product_id": "elite_tactical",
+                "reason": "missing_active_monthly_base_plan",
+            }
+        )
 
     return blockers
 

--- a/scripts/play_verify_iap_products.py
+++ b/scripts/play_verify_iap_products.py
@@ -9,7 +9,8 @@ import sys
 
 from scripts.play_monetization_client import (
     PACKAGE,
-    REQUIRED_ELITE_BASE_PLAN_IDS,
+    REQUIRED_ELITE_ANNUAL_BASE_PLAN_ID,
+    REQUIRED_MONTHLY_BASE_PLAN_ID,
     REQUIRED_ONE_TIME,
     REQUIRED_SUBSCRIPTIONS,
     build_android_publisher_service,
@@ -51,7 +52,8 @@ def main() -> int:
         "required_missing": missing,
         "subscription_purchase_blockers": blockers,
         "subscription_purchase_warnings": warnings,
-        "required_elite_base_plan_ids": list(REQUIRED_ELITE_BASE_PLAN_IDS),
+        "required_elite_annual_base_plan_id": REQUIRED_ELITE_ANNUAL_BASE_PLAN_ID,
+        "required_monthly_base_plan_id": REQUIRED_MONTHLY_BASE_PLAN_ID,
         "status": (
             "ok"
             if not missing and not blockers

--- a/scripts/tests/test_play_monetization_client.py
+++ b/scripts/tests/test_play_monetization_client.py
@@ -8,7 +8,8 @@ from scripts.play_monetization_client import REQUIRED_ONE_TIME, REQUIRED_SUBSCRI
 class PlayMonetizationClientTests(unittest.TestCase):
     def test_required_product_ids_match_android_billing_layer(self):
         self.assertEqual(REQUIRED_ONE_TIME, ("pro_base",))
-        self.assertEqual(REQUIRED_SUBSCRIPTIONS, ("elite_tactical",))
+        self.assertIn("elite_tactical", REQUIRED_SUBSCRIPTIONS)
+        self.assertIn("elite_tactical_monthly", REQUIRED_SUBSCRIPTIONS)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_play_verify_iap_products.py
+++ b/scripts/tests/test_play_verify_iap_products.py
@@ -41,7 +41,7 @@ class PlayVerifyIapProductsTests(unittest.TestCase):
         products = client.list_one_time_products(service)
         self.assertEqual(products[0]["product_id"], "pro_base")
 
-    def test_subscription_purchase_blockers_requires_active_elite_base_plans(self):
+    def test_subscription_purchase_blockers_requires_monthly_somewhere(self):
         subscriptions = [
             {
                 "product_id": "elite_tactical",
@@ -50,6 +50,20 @@ class PlayVerifyIapProductsTests(unittest.TestCase):
         ]
         blockers = client.subscription_purchase_blockers(subscriptions)
         self.assertTrue(any("monthly" in item["reason"] for item in blockers))
+
+    def test_subscription_purchase_blockers_ok_when_monthly_on_elite_tactical_monthly(self):
+        subscriptions = [
+            {
+                "product_id": "elite_tactical",
+                "base_plans": [{"base_plan_id": "annual", "state": "ACTIVE"}],
+            },
+            {
+                "product_id": "elite_tactical_monthly",
+                "base_plans": [{"base_plan_id": "monthly", "state": "ACTIVE"}],
+            },
+        ]
+        blockers = client.subscription_purchase_blockers(subscriptions)
+        self.assertEqual(blockers, [])
 
     def test_subscription_purchase_blockers_ok_when_elite_annual_and_monthly_active(self):
         subscriptions = [


### PR DESCRIPTION
## Summary
Reverts incorrect monthly→`elite_tactical` Play Billing mapping from #1637. Live Play API readback shows **monthly ACTIVE on `elite_tactical_monthly`**, annual on `elite_tactical` — app must query/purchase the SKU Play actually serves.

## Evidence
- CI bundle run 26533383441: `missing_active_base_plan:monthly` on `elite_tactical` while `elite_tactical_monthly` has monthly ACTIVE
- `play-iap-product-readback.json` on develop (2026-05-27)

## Test plan
- [x] `uv run pytest scripts/tests/test_play_verify_iap_products.py scripts/tests/test_play_monetization_client.py`
- [ ] CI Android unit tests
- [ ] Post-merge: `play-iap-product-readback` + `operational-verification-bundle` on develop

Made with [Cursor](https://cursor.com)