### PR TITLE
feat(monetization): P0 paywall ROI + AdMob Android SDK

### DIFF
--- a/docs/ADMOB_SETUP.md
+++ b/docs/ADMOB_SETUP.md
@@ -1,0 +1,43 @@
+# AdMob setup (P1 rewarded ads)
+
+## Account state (verified 2026-05-27)
+
+| Item | Value |
+|------|--------|
+| Publisher ID | `pub-5173650670360699` |
+| Android app | Linked to Play package `com.iganapolsky.randomtimer` (Random Tactical Timer) |
+| app-ads.txt line | `google.com, pub-5173650670360699, DIRECT, f08c47fec0942fa0` |
+| Hosted file | `marketing/site/app-ads.txt` → `https://igorganapolsky.github.io/Random-Timer/app-ads.txt` after site deploy |
+
+## Verification
+
+1. Play Console **Developer website** domain must match where `app-ads.txt` is hosted (path included if listing uses a subpath).
+2. After deploy, run: `python3 scripts/verify_app_ads_txt.py`
+3. In AdMob → **Verify app** → **Check for updates**.
+
+## Payment setup
+
+AdMob home shows **Payment setup incomplete**. Required for payouts and full ad serving; test ads can use Google test unit IDs in debug without payment info.
+
+## Production IDs (CI / local)
+
+Set after creating ad units in AdMob (Apps → app → Ad units → Rewarded):
+
+| Secret / env | Purpose |
+|--------------|---------|
+| `ADMOB_APP_ID_ANDROID` | `ca-app-pub-…~…` from AdMob app settings |
+| `ADMOB_REWARDED_UNIT_ID_ANDROID` | Rewarded ad unit ID |
+| `ADMOB_APP_ID_IOS` | iOS app ID |
+| `ADMOB_REWARDED_UNIT_ID_IOS` | iOS rewarded unit |
+
+Until set, code uses [Google test IDs](https://developers.google.com/admob/android/test-ads) and PostHog flag `rewarded_ads_enabled` stays **off** in production.
+
+## iOS app in AdMob
+
+Add iOS app (App Store link `6758355312`) and a rewarded ad unit — same publisher ID.
+
+## Code
+
+- Feature flag: `rewarded_ads_enabled` (default off)
+- Android: `RewardedAdConfig`, `RewardedAdCoordinator`, `StubRewardedAdPort` (SDK wiring in progress)
+- Events: `rewarded_ad_requested`, `rewarded_ad_completed`, `rewarded_ad_unlock`

--- a/docs/ADMOB_SETUP.md
+++ b/docs/ADMOB_SETUP.md
@@ -6,6 +6,8 @@
 |------|--------|
 | Publisher ID | `pub-5173650670360699` |
 | Android app | Linked to Play package `com.iganapolsky.randomtimer` (Random Tactical Timer) |
+| Android App ID | `ca-app-pub-5173650670360699~4427145410` |
+| Android rewarded unit | `ca-app-pub-5173650670360699/8693693481` (`rtt_pro_sound_trial_rewarded`) |
 | app-ads.txt line | `google.com, pub-5173650670360699, DIRECT, f08c47fec0942fa0` |
 | Hosted file | `marketing/site/app-ads.txt` → `https://igorganapolsky.github.io/Random-Timer/app-ads.txt` after site deploy |
 
@@ -21,16 +23,14 @@ AdMob home shows **Payment setup incomplete**. Required for payouts and full ad 
 
 ## Production IDs (CI / local)
 
-Set after creating ad units in AdMob (Apps → app → Ad units → Rewarded):
+Android IDs are baked into `BuildConfig` (override via env if needed):
 
-| Secret / env | Purpose |
-|--------------|---------|
-| `ADMOB_APP_ID_ANDROID` | `ca-app-pub-…~…` from AdMob app settings |
-| `ADMOB_REWARDED_UNIT_ID_ANDROID` | Rewarded ad unit ID |
-| `ADMOB_APP_ID_IOS` | iOS app ID |
-| `ADMOB_REWARDED_UNIT_ID_IOS` | iOS rewarded unit |
+| Env (optional) | Default (AdMob console) |
+|----------------|-------------------------|
+| `ADMOB_APP_ID_ANDROID` | `ca-app-pub-5173650670360699~4427145410` |
+| `ADMOB_REWARDED_UNIT_ID_ANDROID` | `ca-app-pub-5173650670360699/8693693481` |
 
-Until set, code uses [Google test IDs](https://developers.google.com/admob/android/test-ads) and PostHog flag `rewarded_ads_enabled` stays **off** in production.
+Debug builds use [Google test ad units](https://developers.google.com/admob/android/test-ads). PostHog flag `rewarded_ads_enabled` stays **off** until app-ads.txt verifies and you enable the experiment.
 
 ## iOS app in AdMob
 
@@ -39,5 +39,5 @@ Add iOS app (App Store link `6758355312`) and a rewarded ad unit — same publis
 ## Code
 
 - Feature flag: `rewarded_ads_enabled` (default off)
-- Android: `RewardedAdConfig`, `RewardedAdCoordinator`, `StubRewardedAdPort` (SDK wiring in progress)
+- Android: `AdMobRewardedAdPort`, `RewardedAdCoordinator`, `RewardedAdConfig` (SDK wired; UI hookup + flag still required)
 - Events: `rewarded_ad_requested`, `rewarded_ad_completed`, `rewarded_ad_unlock`

--- a/marketing/site/app-ads.txt
+++ b/marketing/site/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5173650670360699, DIRECT, f08c47fec0942fa0

--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -59,6 +59,15 @@ android {
             "PRO_AUDIO_MANIFEST_URL",
             "\"${project.findProperty("PRO_AUDIO_MANIFEST_URL") ?: "https://raw.githubusercontent.com/IgorGanapolsky/Random-Timer/develop/content/pro_audio/runtime/latest.json"}\"",
         )
+        val admobAppId =
+            System.getenv("ADMOB_APP_ID_ANDROID")
+                ?: "ca-app-pub-5173650670360699~4427145410"
+        val admobRewardedUnitId =
+            System.getenv("ADMOB_REWARDED_UNIT_ID_ANDROID")
+                ?: "ca-app-pub-5173650670360699/8693693481"
+        buildConfigField("String", "ADMOB_APP_ID", "\"$admobAppId\"")
+        buildConfigField("String", "ADMOB_REWARDED_UNIT_ID", "\"$admobRewardedUnitId\"")
+        manifestPlaceholders["admobAppId"] = admobAppId
     }
 
     signingConfigs {
@@ -164,6 +173,9 @@ dependencies {
 
     // In-App Billing
     implementation(libs.play.billing)
+
+    // AdMob (rewarded ads; gated by PostHog flag at runtime)
+    implementation(libs.play.services.ads)
 
     // WorkManager
     implementation(libs.androidx.work.runtime)

--- a/native-android/app/src/main/AndroidManifest.xml
+++ b/native-android/app/src/main/AndroidManifest.xml
@@ -30,9 +30,6 @@
     <!-- In-App Billing for Pro upgrade -->
     <uses-permission android:name="com.android.vending.BILLING" />
 
-    <!-- Remove AD_ID permission added by dependencies (Firebase/PostHog) — app does not use advertising ID -->
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
-
     <application
         android:name=".RandomTimerApp"
         android:allowBackup="true"
@@ -45,6 +42,10 @@
         android:usesCleartextTraffic="false"
         android:theme="@style/Theme.RandomTimer"
         tools:targetApi="35">
+
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="${admobAppId}" />
 
         <activity
             android:name=".MainActivity"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/MainActivity.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/MainActivity.kt
@@ -26,6 +26,7 @@ import com.iganapolsky.randomtimer.service.MediaButtonHandler
 import com.iganapolsky.randomtimer.service.TimerForegroundService
 import com.iganapolsky.randomtimer.ui.navigation.RandomTimerNavHost
 import com.iganapolsky.randomtimer.ui.theme.RandomTimerTheme
+import com.iganapolsky.randomtimer.monetization.ForegroundActivityHolder
 import com.iganapolsky.randomtimer.ui.theme.TimerColors
 import com.iganapolsky.randomtimer.updates.InAppUpdateManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -85,11 +86,13 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        ForegroundActivityHolder.setActivity(this)
         // Tell service app is in foreground - suppress notifications
         sendAppStateToService(isInForeground = true)
     }
 
     override fun onPause() {
+        ForegroundActivityHolder.setActivity(null)
         super.onPause()
         // Tell service app is in background - show notifications
         sendAppStateToService(isInForeground = false)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -106,6 +106,7 @@ class ProManager
 
         private val cachedProductDetails = mutableMapOf<String, com.android.billingclient.api.ProductDetails>()
         private val reportedBillingProductNotFound = ConcurrentHashMap.newKeySet<String>()
+        private var lastCatalogStatusSignature: String? = null
         private var pendingPurchaseEntryPoint: String? = null
 
         /** Last SKU passed to `launchBillingFlow` — Play sometimes omits `products` on failure callbacks. */
@@ -401,6 +402,11 @@ class ProManager
                     missingProductIds.isNotEmpty() -> "missing_required_products"
                     else -> "ok"
                 }
+            val signature = "$status|${availableProductIds.joinToString()}|${missingProductIds.joinToString()}"
+            if (lastCatalogStatusSignature == signature) {
+                return
+            }
+            lastCatalogStatusSignature = signature
             analyticsService.track(
                 AnalyticsEvents.BILLING_PRODUCT_CATALOG_STATUS,
                 mapOf(

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/di/AppModule.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/di/AppModule.kt
@@ -13,6 +13,9 @@ import com.iganapolsky.randomtimer.domain.SoundPreviewManager
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import com.iganapolsky.randomtimer.service.TimerServiceController
 import com.iganapolsky.randomtimer.service.TimerServiceControllerImpl
+import com.iganapolsky.randomtimer.monetization.AdMobRewardedAdPort
+import com.iganapolsky.randomtimer.monetization.RewardedAdPort
+import com.iganapolsky.randomtimer.monetization.RewardedAdUnlockStore
 import com.iganapolsky.randomtimer.stats.TrainingStatsService
 import dagger.Binds
 import dagger.Module
@@ -57,6 +60,16 @@ object AppModule {
     fun provideAppUpdateManager(
         @ApplicationContext context: Context,
     ): AppUpdateManager = AppUpdateManagerFactory.create(context)
+
+    @Provides
+    @Singleton
+    fun provideRewardedAdUnlockStore(
+        @ApplicationContext context: Context,
+    ): RewardedAdUnlockStore = RewardedAdUnlockStore(context)
+
+    @Provides
+    @Singleton
+    fun provideRewardedAdPort(): RewardedAdPort = AdMobRewardedAdPort()
 }
 
 @Module

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/di/AppModule.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/di/AppModule.kt
@@ -13,7 +13,9 @@ import com.iganapolsky.randomtimer.domain.SoundPreviewManager
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import com.iganapolsky.randomtimer.service.TimerServiceController
 import com.iganapolsky.randomtimer.service.TimerServiceControllerImpl
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.monetization.AdMobRewardedAdPort
+import com.iganapolsky.randomtimer.monetization.RewardedAdCoordinator
 import com.iganapolsky.randomtimer.monetization.RewardedAdPort
 import com.iganapolsky.randomtimer.monetization.RewardedAdUnlockStore
 import com.iganapolsky.randomtimer.stats.TrainingStatsService
@@ -70,6 +72,14 @@ object AppModule {
     @Provides
     @Singleton
     fun provideRewardedAdPort(): RewardedAdPort = AdMobRewardedAdPort()
+
+    @Provides
+    @Singleton
+    fun provideRewardedAdCoordinator(
+        analyticsService: AnalyticsService,
+        unlockStore: RewardedAdUnlockStore,
+        port: RewardedAdPort,
+    ): RewardedAdCoordinator = RewardedAdCoordinator(analyticsService, unlockStore, port)
 }
 
 @Module

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/AdMobRewardedAdPort.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/AdMobRewardedAdPort.kt
@@ -1,0 +1,72 @@
+package com.iganapolsky.randomtimer.monetization
+
+import android.app.Activity
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import com.iganapolsky.randomtimer.BuildConfig
+
+/**
+ * Loads and shows AdMob rewarded ads. Requires [ForegroundActivityHolder] and PostHog
+ * `rewarded_ads_enabled` at the call site ([RewardedAdCoordinator]).
+ */
+class AdMobRewardedAdPort : RewardedAdPort {
+    @Volatile
+    private var initialized = false
+
+    override fun showRewardedAd(
+        entryPoint: String,
+        onFinished: (success: Boolean) -> Unit,
+    ) {
+        val activity = ForegroundActivityHolder.getActivity()
+        if (activity == null) {
+            onFinished(false)
+            return
+        }
+        ensureInitialized(activity)
+        val unitId = RewardedAdConfig.resolvedRewardedUnitId(useTestAds = BuildConfig.DEBUG)
+        RewardedAd.load(
+            activity,
+            unitId,
+            AdRequest.Builder().build(),
+            object : RewardedAdLoadCallback() {
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    onFinished(false)
+                }
+
+                override fun onAdLoaded(ad: RewardedAd) {
+                    var rewarded = false
+                    ad.fullScreenContentCallback =
+                        object : com.google.android.gms.ads.FullScreenContentCallback() {
+                            override fun onAdDismissedFullScreenContent() {
+                                if (!rewarded) {
+                                    onFinished(false)
+                                }
+                            }
+
+                            override fun onAdFailedToShowFullScreenContent(
+                                adError: com.google.android.gms.ads.AdError,
+                            ) {
+                                onFinished(false)
+                            }
+                        }
+                    ad.show(activity) {
+                        rewarded = true
+                        onFinished(true)
+                    }
+                }
+            },
+        )
+    }
+
+    private fun ensureInitialized(activity: Activity) {
+        if (initialized) return
+        synchronized(this) {
+            if (initialized) return
+            MobileAds.initialize(activity.applicationContext) {}
+            initialized = true
+        }
+    }
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/ForegroundActivityHolder.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/ForegroundActivityHolder.kt
@@ -1,0 +1,15 @@
+package com.iganapolsky.randomtimer.monetization
+
+import android.app.Activity
+import java.lang.ref.WeakReference
+
+/** Tracks the foreground activity for AdMob rewarded presentation. */
+object ForegroundActivityHolder {
+    private var activityRef: WeakReference<Activity>? = null
+
+    fun setActivity(activity: Activity?) {
+        activityRef = activity?.let { WeakReference(it) }
+    }
+
+    fun getActivity(): Activity? = activityRef?.get()
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/ProSoundAccess.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/ProSoundAccess.kt
@@ -1,0 +1,22 @@
+package com.iganapolsky.randomtimer.monetization
+
+import com.iganapolsky.randomtimer.domain.model.SoundType
+
+/** Free-tier Pro sound access via subscription or rewarded-ad trial unlock. */
+object ProSoundAccess {
+    fun canEquipProSound(
+        isPro: Boolean,
+        hasTrialUnlock: Boolean,
+    ): Boolean = isPro || hasTrialUnlock
+
+    fun shouldConsumeTrialOnEquip(
+        isPro: Boolean,
+        hasTrialUnlock: Boolean,
+        previousSound: SoundType,
+        newSound: SoundType,
+    ): Boolean =
+        !isPro &&
+            hasTrialUnlock &&
+            newSound in SoundType.PRO &&
+            previousSound !in SoundType.PRO
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/RewardedAdConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/RewardedAdConfig.kt
@@ -1,5 +1,6 @@
 package com.iganapolsky.randomtimer.monetization
 
+import com.iganapolsky.randomtimer.BuildConfig
 import com.iganapolsky.randomtimer.analytics.PostHogExperimentKeys
 
 /**
@@ -17,6 +18,19 @@ object RewardedAdConfig {
 
     const val PUBLISHER_ID = "pub-5173650670360699"
 
+    /** Production AdMob app ID (Android). */
+    const val PRODUCTION_APP_ID_ANDROID = "ca-app-pub-5173650670360699~4427145410"
+
+    /** Production rewarded unit (Android). */
+    const val PRODUCTION_REWARDED_UNIT_ID_ANDROID = "ca-app-pub-5173650670360699/8693693481"
+
     const val ADMOB_BLOCKER =
-        "Rewarded ads ship behind PostHog flag (default off) until ADMOB_* unit env IDs are set and app-ads.txt verifies."
+        "Rewarded ads ship behind PostHog flag (default off) until app-ads.txt verifies and flag is enabled."
+
+    fun resolvedRewardedUnitId(useTestAds: Boolean): String =
+        if (useTestAds) {
+            TEST_REWARDED_UNIT_ID_ANDROID
+        } else {
+            BuildConfig.ADMOB_REWARDED_UNIT_ID.ifBlank { PRODUCTION_REWARDED_UNIT_ID_ANDROID }
+        }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/RewardedAdConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/RewardedAdConfig.kt
@@ -15,6 +15,8 @@ object RewardedAdConfig {
     /** Official Google test rewarded unit (iOS). */
     const val TEST_REWARDED_UNIT_ID_IOS = "ca-app-pub-3940256099942544/1712485313"
 
+    const val PUBLISHER_ID = "pub-5173650670360699"
+
     const val ADMOB_BLOCKER =
-        "AdMob publisher account not approved — rewarded ads ship behind PostHog flag (default off)."
+        "Rewarded ads ship behind PostHog flag (default off) until ADMOB_* unit env IDs are set and app-ads.txt verifies."
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/RewardedAdPolicy.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/monetization/RewardedAdPolicy.kt
@@ -3,6 +3,7 @@ package com.iganapolsky.randomtimer.monetization
 /** Free-tier rewarded video: unlock one Pro sound trial per completed ad (when flag + SDK live). */
 object RewardedAdPolicy {
     const val UNLOCK_FEATURE = "pro_sound_trial"
+    const val ENTRY_SOUND_ARSENAL = "sound_arsenal_gate"
 
     fun canOfferRewardedAd(
         rewardedAdsEnabled: Boolean,

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -64,6 +64,8 @@ fun RandomTimerNavHost(
     val timerState by viewModel.timerState.collectAsStateWithLifecycle()
     val isPro by viewModel.proManager.isPro.collectAsStateWithLifecycle()
     val isElite by viewModel.proManager.isElite.collectAsStateWithLifecycle()
+    val proSoundTrialActive by viewModel.proSoundTrialActive.collectAsStateWithLifecycle()
+    val showRewardedAdOffer = viewModel.rewardedAdOfferVisible()
     val currentRoute =
         navController
             .currentBackStackEntryAsState()
@@ -195,6 +197,9 @@ fun RandomTimerNavHost(
                 currentStreak = viewModel.currentStreak,
                 isPro = isPro,
                 isElite = isElite,
+                proSoundTrialActive = proSoundTrialActive,
+                showRewardedAdOffer = showRewardedAdOffer,
+                onWatchRewardedAd = viewModel::requestRewardedProSoundUnlock,
                 onUpgradeTap = { feature ->
                     presentPaywallForFeature(feature)
                 },

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -73,6 +73,16 @@ internal data class PaywallFeatureContext(
     val valueCopy: String,
 )
 
+/** Gates with strong purchase intent — default to annual and emit initial offer_select on open. */
+internal val HIGH_INTENT_ANNUAL_ENTRY_POINTS: Set<String> =
+    setOf(
+        "qualified_training_gate",
+        "voice_gate",
+        "range_gate",
+        "sound_arsenal_gate",
+        "repeat_gate",
+    )
+
 internal fun paywallFeatureContext(entryPoint: String): PaywallFeatureContext =
     when (entryPoint) {
         "setup_upgrade_cta" ->
@@ -154,6 +164,21 @@ fun PaywallSheet(
         }
     }
     val hasPurchasablePlan = hasPurchasablePaywallPlan(availableProductIds, billingCatalogProbed)
+    var initialOfferSelectTracked by remember(entryPoint) { mutableStateOf(false) }
+    LaunchedEffect(entryPoint, billingCatalogProbed, hasPurchasablePlan, selectedPlan) {
+        if (
+            !initialOfferSelectTracked &&
+                entryPoint in HIGH_INTENT_ANNUAL_ENTRY_POINTS &&
+                hasPurchasablePlan
+        ) {
+            initialOfferSelectTracked = true
+            onPlanSelected(
+                planNameForSelection(selectedPlan),
+                productIdForPlan(selectedPlan),
+                "paywall_open",
+            )
+        }
+    }
     val featureContext = paywallFeatureContext(entryPoint)
     val headline =
         if (valueFramingVariant == PaywallValueFraming.OUTCOMES_FIRST) {
@@ -452,6 +477,7 @@ internal fun initialPlanSelection(
         when {
             defaultToAnnualPlan -> SubscriptionPlanSelection.ANNUAL
             entryPoint == "setup_upgrade_cta" -> SubscriptionPlanSelection.LIFETIME
+            entryPoint in HIGH_INTENT_ANNUAL_ENTRY_POINTS -> SubscriptionPlanSelection.ANNUAL
             else -> SubscriptionPlanSelection.MONTHLY
         }
     if (!billingCatalogProbed || availableProductIds.isEmpty()) {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -180,6 +180,9 @@ fun TimerSetupScreen(
     onVoiceGenderSelected: (VoiceGender) -> Unit = {},
     onTrainingPresetApplied: (TrainingPreset) -> Unit = {},
     onSecretUnlock: () -> Unit = {},
+    proSoundTrialActive: Boolean = false,
+    showRewardedAdOffer: Boolean = false,
+    onWatchRewardedAd: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -1042,6 +1045,8 @@ fun TimerSetupScreen(
                             SoundArsenalCard(
                                 config = config,
                                 isPro = isPro,
+                                proSoundTrialActive = proSoundTrialActive,
+                                showRewardedAdOffer = showRewardedAdOffer,
                                 padding = spacing.cardContent,
                                 headerToContent = spacing.headerToContent,
                                 onSelectSound = { sound ->
@@ -1051,6 +1056,7 @@ fun TimerSetupScreen(
                                 },
                                 onPreviewSound = onSoundPreview,
                                 onUpgradeTap = onUpgradeTap,
+                                onWatchRewardedAd = onWatchRewardedAd,
                             )
                         }
                     }
@@ -1066,6 +1072,8 @@ fun TimerSetupScreen(
                     SoundArsenalCard(
                         config = config,
                         isPro = isPro,
+                        proSoundTrialActive = proSoundTrialActive,
+                        showRewardedAdOffer = showRewardedAdOffer,
                         padding = spacing.cardContent,
                         headerToContent = spacing.headerToContent,
                         onSelectSound = { sound ->
@@ -1075,6 +1083,7 @@ fun TimerSetupScreen(
                         },
                         onPreviewSound = onSoundPreview,
                         onUpgradeTap = onUpgradeTap,
+                        onWatchRewardedAd = onWatchRewardedAd,
                     )
                 }
             }
@@ -1094,20 +1103,35 @@ internal fun repeatLoopDetailSummary(
         else -> "$repeatRounds Rounds"
     }
 
+internal fun soundArsenalFreeFooterText(
+    canEquipProSounds: Boolean,
+): String =
+    if (canEquipProSounds) {
+        "Trial active — tap a Pro sound to equip it for your next drill."
+    } else {
+        "Tap a sound to preview. Unlock Pro to equip it."
+    }
+
+internal const val SOUND_ARSENAL_REWARDED_AD_CTA = "Watch ad to try one Pro sound"
+
 @Composable
 private fun SoundArsenalCard(
     config: TimerConfig,
     isPro: Boolean,
+    proSoundTrialActive: Boolean,
+    showRewardedAdOffer: Boolean,
     padding: Dp,
     headerToContent: Dp,
     onSelectSound: (SoundType) -> Unit,
     onPreviewSound: (SoundType) -> Unit,
     onUpgradeTap: (String) -> Unit,
+    onWatchRewardedAd: () -> Unit,
 ) {
+    val canEquipProSounds = isPro || proSoundTrialActive
     GlassCard(
         modifier =
             Modifier.fillMaxWidth().graphicsLayer {
-                alpha = if (isPro) 1f else 0.6f
+                alpha = if (canEquipProSounds) 1f else 0.6f
             },
         padding = padding,
     ) {
@@ -1116,7 +1140,7 @@ private fun SoundArsenalCard(
                 text = "\uD83C\uDFA7 Sound Arsenal",
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
-                color = if (isPro) TimerColors.TextPrimary else TimerColors.TextMuted,
+                color = if (canEquipProSounds) TimerColors.TextPrimary else TimerColors.TextMuted,
             )
             Spacer(modifier = Modifier.height(headerToContent))
 
@@ -1133,10 +1157,10 @@ private fun SoundArsenalCard(
                                     .lowercase()
                                     .replaceFirstChar { it.uppercase() }
                                     .replace("_", " ") +
-                                    if (!isPro) " \uD83D\uDD12" else "",
+                                    if (!canEquipProSounds) " \uD83D\uDD12" else "",
                             selected = config.soundType == sound,
                             onClick = {
-                                if (isPro) {
+                                if (canEquipProSounds) {
                                     onSelectSound(sound)
                                 } else {
                                     onPreviewSound(sound)
@@ -1156,13 +1180,27 @@ private fun SoundArsenalCard(
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
-                        text = "Tap a sound to preview. Unlock Pro to equip it.",
+                        text = soundArsenalFreeFooterText(canEquipProSounds),
                         style = MaterialTheme.typography.labelSmall,
                         color = TimerColors.TextMuted,
                         textAlign = TextAlign.Center,
                     )
+                    if (showRewardedAdOffer && !canEquipProSounds) {
+                        Text(
+                            text = SOUND_ARSENAL_REWARDED_AD_CTA,
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = TimerColors.AccentPrimary,
+                            textAlign = TextAlign.Center,
+                            modifier =
+                                Modifier
+                                    .testTag("rewarded_ad_cta")
+                                    .clickable { onWatchRewardedAd() },
+                        )
+                    }
                 }
             }
         }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -11,7 +11,11 @@ import com.iganapolsky.randomtimer.analytics.AnalyticsService
 import com.iganapolsky.randomtimer.analytics.PaywallExperimentVariants
 import com.iganapolsky.randomtimer.analytics.SubscriptionFunnelSteps
 import com.iganapolsky.randomtimer.billing.ProManager
+import com.iganapolsky.randomtimer.monetization.ProSoundAccess
 import com.iganapolsky.randomtimer.monetization.QualifiedTrainingPaywallAnalytics
+import com.iganapolsky.randomtimer.monetization.RewardedAdCoordinator
+import com.iganapolsky.randomtimer.monetization.RewardedAdPolicy
+import com.iganapolsky.randomtimer.monetization.RewardedAdUnlockStore
 import com.iganapolsky.randomtimer.domain.SoundPreviewManager
 import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
@@ -45,6 +49,8 @@ class TimerViewModel
         val storeReviewManager: StoreReviewManager,
         val trainingStatsService: TrainingStatsService,
         val proManager: ProManager,
+        private val rewardedAdCoordinator: RewardedAdCoordinator,
+        private val rewardedAdUnlockStore: RewardedAdUnlockStore,
     ) : ViewModel() {
         val totalSessions: Int get() = trainingStatsService.totalSessions
         val currentStreak: Int get() = trainingStatsService.currentStreak
@@ -60,6 +66,10 @@ class TimerViewModel
 
         private val _timerState = MutableStateFlow<TimerState?>(null)
         val timerState: StateFlow<TimerState?> = _timerState
+
+        private val _proSoundTrialActive =
+            MutableStateFlow(rewardedAdUnlockStore.hasActiveUnlock())
+        val proSoundTrialActive: StateFlow<Boolean> = _proSoundTrialActive
 
         /** Epoch millis when the alarm was triggered, used to compute alarm_response_time. */
         private var alarmTriggeredAtMs: Long = 0L
@@ -104,8 +114,37 @@ class TimerViewModel
             }
         }
 
+        fun rewardedAdOfferVisible(): Boolean =
+            RewardedAdPolicy.canOfferRewardedAd(
+                rewardedAdsEnabled = analyticsService.rewardedAdsEnabled(),
+                isPro = proManager.isPro.value,
+            )
+
+        fun requestRewardedProSoundUnlock(
+            entryPoint: String = RewardedAdPolicy.ENTRY_SOUND_ARSENAL,
+        ) {
+            rewardedAdCoordinator.requestUnlock(
+                entryPoint = entryPoint,
+                rewardedAdsEnabled = analyticsService.rewardedAdsEnabled(),
+                isPro = proManager.isPro.value,
+                onUnlocked = { _proSoundTrialActive.value = true },
+            )
+        }
+
         fun updateConfig(newConfig: TimerConfig) {
-            trackSettingsChanges(config.value, newConfig)
+            val previous = config.value
+            trackSettingsChanges(previous, newConfig)
+            if (
+                ProSoundAccess.shouldConsumeTrialOnEquip(
+                    isPro = proManager.isPro.value,
+                    hasTrialUnlock = rewardedAdUnlockStore.hasActiveUnlock(),
+                    previousSound = previous.soundType,
+                    newSound = newConfig.soundType,
+                )
+            ) {
+                rewardedAdUnlockStore.consumeUnlock()
+                _proSoundTrialActive.value = false
+            }
             viewModelScope.launch {
                 repository.saveTimerConfig(newConfig)
             }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/monetization/ProSoundAccessTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/monetization/ProSoundAccessTest.kt
@@ -1,0 +1,46 @@
+package com.iganapolsky.randomtimer.monetization
+
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.domain.model.SoundType
+import org.junit.Test
+
+class ProSoundAccessTest {
+    @Test
+    fun `pro users can equip pro sounds`() {
+        assertThat(ProSoundAccess.canEquipProSound(isPro = true, hasTrialUnlock = false)).isTrue()
+    }
+
+    @Test
+    fun `trial unlock allows equip without subscription`() {
+        assertThat(ProSoundAccess.canEquipProSound(isPro = false, hasTrialUnlock = true)).isTrue()
+    }
+
+    @Test
+    fun `free users without trial cannot equip`() {
+        assertThat(ProSoundAccess.canEquipProSound(isPro = false, hasTrialUnlock = false)).isFalse()
+    }
+
+    @Test
+    fun `consumes trial when equipping first pro sound`() {
+        assertThat(
+            ProSoundAccess.shouldConsumeTrialOnEquip(
+                isPro = false,
+                hasTrialUnlock = true,
+                previousSound = SoundType.INTENSE,
+                newSound = SoundType.KLAXON,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `does not consume when switching between pro sounds`() {
+        assertThat(
+            ProSoundAccess.shouldConsumeTrialOnEquip(
+                isPro = false,
+                hasTrialUnlock = true,
+                previousSound = SoundType.KLAXON,
+                newSound = SoundType.WHISTLE,
+            ),
+        ).isFalse()
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/monetization/RewardedAdConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/monetization/RewardedAdConfigTest.kt
@@ -1,0 +1,20 @@
+package com.iganapolsky.randomtimer.monetization
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RewardedAdConfigTest {
+    @Test
+    fun `resolvedRewardedUnitId uses test id in test mode`() {
+        assertThat(RewardedAdConfig.resolvedRewardedUnitId(useTestAds = true))
+            .isEqualTo(RewardedAdConfig.TEST_REWARDED_UNIT_ID_ANDROID)
+    }
+
+    @Test
+    fun `production constants match AdMob console`() {
+        assertThat(RewardedAdConfig.PRODUCTION_APP_ID_ANDROID)
+            .isEqualTo("ca-app-pub-5173650670360699~4427145410")
+        assertThat(RewardedAdConfig.PRODUCTION_REWARDED_UNIT_ID_ANDROID)
+            .isEqualTo("ca-app-pub-5173650670360699/8693693481")
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/monetization/RewardedAdCoordinatorTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/monetization/RewardedAdCoordinatorTest.kt
@@ -1,0 +1,77 @@
+package com.iganapolsky.randomtimer.monetization
+
+import com.google.common.truth.Truth.assertThat
+import com.iganapolsky.randomtimer.analytics.AnalyticsEvents
+import com.iganapolsky.randomtimer.analytics.AnalyticsService
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class RewardedAdCoordinatorTest {
+    private lateinit var analyticsService: AnalyticsService
+    private lateinit var unlockStore: RewardedAdUnlockStore
+    private lateinit var port: RecordingRewardedAdPort
+    private lateinit var coordinator: RewardedAdCoordinator
+
+    @Before
+    fun setup() {
+        analyticsService = mockk(relaxed = true)
+        unlockStore = mockk(relaxed = true)
+        port = RecordingRewardedAdPort()
+        coordinator =
+            RewardedAdCoordinator(
+                analyticsService = analyticsService,
+                unlockStore = unlockStore,
+                port = port,
+            )
+    }
+
+    @Test
+    fun `grants unlock and tracks when ad completes`() {
+        var unlocked = false
+        port.nextSuccess = true
+
+        coordinator.requestUnlock(
+            entryPoint = RewardedAdPolicy.ENTRY_SOUND_ARSENAL,
+            rewardedAdsEnabled = true,
+            isPro = false,
+            onUnlocked = { unlocked = true },
+        )
+
+        assertThat(unlocked).isTrue()
+        verify { unlockStore.grantUnlock() }
+        verify {
+            analyticsService.track(
+                AnalyticsEvents.REWARDED_AD_UNLOCK,
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `does not grant when flag disabled`() {
+        coordinator.requestUnlock(
+            entryPoint = RewardedAdPolicy.ENTRY_SOUND_ARSENAL,
+            rewardedAdsEnabled = false,
+            isPro = false,
+            onUnlocked = {},
+        )
+
+        assertThat(port.showCount).isEqualTo(0)
+        verify(exactly = 0) { unlockStore.grantUnlock() }
+    }
+
+    private class RecordingRewardedAdPort : RewardedAdPort {
+        var nextSuccess = false
+        var showCount = 0
+
+        override fun showRewardedAd(
+            entryPoint: String,
+            onFinished: (success: Boolean) -> Unit,
+        ) {
+            showCount++
+            onFinished(nextSuccess)
+        }
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -129,8 +129,16 @@ class PaywallSheetTest {
             initialPlanSelection(entryPoint = "setup_upgrade_cta", defaultToAnnualPlan = false),
         )
         assertEquals(
-            SubscriptionPlanSelection.MONTHLY,
+            SubscriptionPlanSelection.ANNUAL,
             initialPlanSelection(entryPoint = "range_gate", defaultToAnnualPlan = false),
+        )
+        assertEquals(
+            SubscriptionPlanSelection.ANNUAL,
+            initialPlanSelection(entryPoint = "voice_gate", defaultToAnnualPlan = false),
+        )
+        assertEquals(
+            SubscriptionPlanSelection.ANNUAL,
+            initialPlanSelection(entryPoint = "qualified_training_gate", defaultToAnnualPlan = false),
         )
         assertEquals(
             SubscriptionPlanSelection.ANNUAL,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
@@ -66,4 +66,16 @@ class TimerSetupScreenTextTest {
     fun competitionPrepIsAvailableWithoutPro() {
         assertThat(isCompetitionPrepProGated()).isFalse()
     }
+
+    @Test
+    fun soundArsenalFooterExplainsPreviewWhenTrialInactive() {
+        assertThat(soundArsenalFreeFooterText(canEquipProSounds = false))
+            .contains("preview")
+    }
+
+    @Test
+    fun soundArsenalFooterExplainsTrialEquipWhenActive() {
+        assertThat(soundArsenalFreeFooterText(canEquipProSounds = true))
+            .contains("Trial active")
+    }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModelAnalyticsTest.kt
@@ -16,6 +16,8 @@ import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import com.iganapolsky.randomtimer.domain.usecase.StartTimerUseCase
 import com.iganapolsky.randomtimer.review.StoreReviewManager
 import com.iganapolsky.randomtimer.service.TimerServiceController
+import com.iganapolsky.randomtimer.monetization.RewardedAdCoordinator
+import com.iganapolsky.randomtimer.monetization.RewardedAdUnlockStore
 import com.iganapolsky.randomtimer.stats.TrainingStatsService
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -71,6 +73,10 @@ class TimerViewModelAnalyticsTest {
         every { serviceController.bindService(any()) } just runs
         every { serviceController.unbindService(any()) } just runs
 
+        val rewardedAdCoordinator = mockk<RewardedAdCoordinator>(relaxed = true)
+        val rewardedAdUnlockStore = mockk<RewardedAdUnlockStore>(relaxed = true)
+        every { rewardedAdUnlockStore.hasActiveUnlock() } returns false
+
         viewModel =
             TimerViewModel(
                 repository = repository,
@@ -81,6 +87,8 @@ class TimerViewModelAnalyticsTest {
                 storeReviewManager = storeReviewManager,
                 trainingStatsService = trainingStatsService,
                 proManager = proManager,
+                rewardedAdCoordinator = rewardedAdCoordinator,
+                rewardedAdUnlockStore = rewardedAdUnlockStore,
             )
     }
 

--- a/native-android/gradle/libs.versions.toml
+++ b/native-android/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ media = "1.7.0"
 uiautomator = "2.3.0"
 robolectric = "4.14.1"
 workManager = "2.10.0"
+playServicesAds = "24.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -66,6 +67,7 @@ truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 posthog = { group = "com.posthog", name = "posthog-android", version.ref = "posthog" }
 play-review = { group = "com.google.android.play", name = "review-ktx", version.ref = "playReview" }
 play-billing = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "playBilling" }
+play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "playServicesAds" }
 play-update = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "playUpdate" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }

--- a/native-ios/RandomTimer/Sources/Services/RewardedAdSupport.swift
+++ b/native-ios/RandomTimer/Sources/Services/RewardedAdSupport.swift
@@ -3,8 +3,9 @@ import Foundation
 enum RewardedAdConfig {
     static let featureFlagKey = PostHogExperimentKeys.rewardedAdsEnabled
     static let testRewardedUnitIdIOS = "ca-app-pub-3940256099942544/1712485313"
+    static let publisherId = "pub-5173650670360699"
     static let admobBlocker =
-        "AdMob publisher account not approved — rewarded ads ship behind PostHog flag (default off)."
+        "Rewarded ads ship behind PostHog flag (default off) until production ad unit IDs are configured and app-ads.txt verifies."
 }
 
 enum RewardedAdPolicy {

--- a/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/PaywallSheet.swift
@@ -79,6 +79,14 @@ enum PaywallPlanSelection {
     case lifetime
 }
 
+private let highIntentAnnualEntryPoints: Set<PaywallEntryPoint> = [
+    .qualifiedTrainingGate,
+    .voiceGate,
+    .rangeGate,
+    .soundArsenalGate,
+    .repeatGate,
+]
+
 func initialPaywallPlanSelection(
     entryPoint: PaywallEntryPoint,
     defaultToAnnualExperiment: Bool
@@ -88,6 +96,9 @@ func initialPaywallPlanSelection(
     }
     if entryPoint == .setupUpgradeCTA {
         return .lifetime
+    }
+    if highIntentAnnualEntryPoints.contains(entryPoint) {
+        return .annual
     }
     return .monthly
 }

--- a/native-ios/RandomTimerTests/ProValidationTests.swift
+++ b/native-ios/RandomTimerTests/ProValidationTests.swift
@@ -114,7 +114,15 @@ final class TimerConfigProClampingTests: XCTestCase {
         )
         XCTAssertEqual(
             initialPaywallPlanSelection(entryPoint: .rangeGate, defaultToAnnualExperiment: false),
-            .monthly
+            .annual
+        )
+        XCTAssertEqual(
+            initialPaywallPlanSelection(entryPoint: .voiceGate, defaultToAnnualExperiment: false),
+            .annual
+        )
+        XCTAssertEqual(
+            initialPaywallPlanSelection(entryPoint: .qualifiedTrainingGate, defaultToAnnualExperiment: false),
+            .annual
         )
         XCTAssertEqual(
             initialPaywallPlanSelection(entryPoint: .setupUpgradeCTA, defaultToAnnualExperiment: true),

--- a/scripts/paywall_conversion_report.py
+++ b/scripts/paywall_conversion_report.py
@@ -244,14 +244,10 @@ def _product_catalog_failures(
           count() AS failures,
           count(DISTINCT person_id) AS users
         FROM events
-        WHERE event IN ('billing_product_not_found', 'billing_product_catalog_status')
+        WHERE event = 'billing_product_not_found'
           AND timestamp > now() - interval {win}
           AND {LIVE_EVENTS_PREDICATE}
           {channel_filter}
-          AND (
-            event = 'billing_product_not_found'
-            OR coalesce(toString(properties.status), '') IN ('empty', 'missing_required_products')
-          )
         GROUP BY platform, product_id
         ORDER BY failures DESC
         LIMIT 25

--- a/scripts/tests/test_paywall_conversion_report.py
+++ b/scripts/tests/test_paywall_conversion_report.py
@@ -43,6 +43,22 @@ class PaywallConversionReportTests(unittest.TestCase):
         self.assertIn("play_store", report.PLAY_STORE_CATALOG_FILTER)
         self.assertIn("billing_ready", report.PLAY_STORE_CATALOG_FILTER)
 
+    def test_product_catalog_failures_query_counts_not_found_only(self):
+        from scripts import paywall_conversion_report as report
+
+        captured: list[str] = []
+
+        def fake_table(query: str, *_args, **_kwargs):
+            captured.append(query)
+            return []
+
+        with mock.patch.object(report, "_table", side_effect=fake_table):
+            report._product_catalog_failures("key", "proj", 30, [])
+
+        self.assertEqual(len(captured), 1)
+        self.assertIn("billing_product_not_found", captured[0])
+        self.assertNotIn("billing_product_catalog_status", captured[0])
+
     def test_run_loads_repo_dotenv(self):
         from scripts import paywall_conversion_report as report
 

--- a/scripts/tests/test_verify_app_ads_txt.py
+++ b/scripts/tests/test_verify_app_ads_txt.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from scripts import verify_app_ads_txt as mod
+
+
+class VerifyAppAdsTxtTests(unittest.TestCase):
+    def test_verify_accepts_authorized_line(self):
+        body = "google.com, pub-5173650670360699, DIRECT, f08c47fec0942fa0\n"
+        with patch.object(mod, "fetch", return_value=body):
+            ok, msg = mod.verify_app_ads_txt(url="https://example.com/app-ads.txt")
+        self.assertTrue(ok)
+        self.assertIn("ok", msg)
+
+    def test_verify_rejects_missing_publisher(self):
+        with patch.object(mod, "fetch", return_value="google.com, pub-000, DIRECT, f08c47fec0942fa0\n"):
+            ok, _ = mod.verify_app_ads_txt(url="https://example.com/app-ads.txt")
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_app_ads_txt.py
+++ b/scripts/verify_app_ads_txt.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify hosted app-ads.txt contains the AdMob publisher authorization line."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = "https://igorganapolsky.github.io/Random-Timer/app-ads.txt"
+EXPECTED_PUBLISHER = "pub-5173650670360699"
+EXPECTED_LINE = f"google.com, {EXPECTED_PUBLISHER}, DIRECT, f08c47fec0942fa0"
+
+
+def fetch(url: str, timeout: int) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "Random-Timer-app-ads-verify/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def verify_app_ads_txt(
+    *,
+    url: str,
+    publisher_id: str = EXPECTED_PUBLISHER,
+    timeout: int = 30,
+) -> tuple[bool, str]:
+    try:
+        body = fetch(url, timeout)
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code} for {url}"
+    except urllib.error.URLError as exc:
+        return False, f"fetch failed: {exc.reason}"
+
+    lines = [ln.strip() for ln in body.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+    pattern = re.compile(
+        rf"^google\.com,\s*{re.escape(publisher_id)},\s*DIRECT,\s*f08c47fec0942fa0\s*$",
+        re.IGNORECASE,
+    )
+    if any(pattern.match(ln) for ln in lines):
+        return True, f"ok: found authorized line for {publisher_id} at {url}"
+    return False, f"missing line for {publisher_id} at {url} (got {len(lines)} non-comment lines)"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Verify app-ads.txt is published and authorized.")
+    p.add_argument("--url", default=DEFAULT_URL)
+    p.add_argument("--publisher-id", default=EXPECTED_PUBLISHER)
+    p.add_argument("--timeout", type=int, default=30)
+    args = p.parse_args()
+    ok, msg = verify_app_ads_txt(url=args.url, publisher_id=args.publisher_id, timeout=args.timeout)
+    print(msg)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- P0 paywall: annual default on high-intent gates, auto offer_select, catalog telemetry dedupe.
- AdMob: Android app linked, app-ads.txt, rewarded unit created, SDK wired (flag-gated).
- IDs: app ca-app-pub-5173650670360699~4427145410, unit .../8693693481

## Test plan
- Python + iOS unit tests pass locally
- CI Android tests
- Post-merge: deploy site, verify app-ads.txt, AdMob verify app