### PR TITLE
fix(ci): streamline GraphQL + device-test concurrency

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,6 +6,7 @@ on:
   issue_comment:
     types: [created]
   push:
+    branches: [develop, main, 'release/**', 'hotfix/**']
 
 env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -2,14 +2,13 @@ name: Device Tests
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, 'release/**', 'hotfix/**']
   workflow_dispatch:
 
-# Do not cancel in-flight device jobs: iOS Maestro + Agent Device often runs 15–25+ minutes.
-# A new push would previously abort mid-flow (looks like a flake, blocks merge, wastes runner time).
+# Cancel superseded PR runs so stacked pushes do not burn macOS minutes in parallel.
 concurrency:
   group: device-tests-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   changes:

--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -3,7 +3,9 @@ name: PR State Machine
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
-  check_suite:
+  # Reconcile once per CI/Device Tests completion — not on every check_suite (GraphQL/workflow spam).
+  workflow_run:
+    workflows: [CI, Device Tests]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -448,27 +450,18 @@ jobs:
             const prCandidates = [];
             if (context.eventName === "pull_request_target") {
               prCandidates.push(context.payload.pull_request?.number);
-            } else if (context.eventName === "check_suite") {
-              const suite = context.payload.check_suite || {};
-              const suiteStatus = String(suite.status || "");
-              if (suiteStatus !== "completed") {
-                core.info(`Skipping check_suite event with non-terminal status "${suiteStatus || "unknown"}".`);
-              } else {
-                for (const pr of suite.pull_requests || []) {
-                  prCandidates.push(pr.number);
-                }
-
-                if (prCandidates.length === 0 && suite.head_sha) {
-                  const associatedPrs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
-                    owner,
-                    repo,
-                    commit_sha: suite.head_sha,
-                    per_page: 100
-                  });
-                  for (const pr of associatedPrs) {
-                    if (pr.state === "open") {
-                      prCandidates.push(pr.number);
-                    }
+            } else if (context.eventName === "workflow_run") {
+              const run = context.payload.workflow_run || {};
+              if (run.event === "pull_request" && run.head_sha) {
+                const associatedPrs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                  owner,
+                  repo,
+                  commit_sha: run.head_sha,
+                  per_page: 100
+                });
+                for (const pr of associatedPrs) {
+                  if (pr.state === "open") {
+                    prCandidates.push(pr.number);
                   }
                 }
               }

--- a/docs/CI_API_AND_MINUTES.md
+++ b/docs/CI_API_AND_MINUTES.md
@@ -1,0 +1,22 @@
+# CI: API rate limits vs Actions minutes
+
+## Two different budgets
+
+| Budget | Symptom | Typical cause here |
+|--------|---------|-------------------|
+| **GraphQL API** (`gh pr view`, `gh pr checks`) | `API rate limit exceeded` on GraphQL | Tight `gh` polling; `check_suite` fan-out (fixed 2026-05-28) |
+| **Actions minutes** | Slow PRs, high bill | Duplicate Android build (CI + device-tests), macOS Maestro, 33 cron workflows |
+
+Verify GraphQL: `gh api rate_limit --jq .resources.graphql`
+
+## Agent / automation rules
+
+1. Prefer **REST**: `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` — not `gh pr checks` in loops.
+2. Poll interval **≥ 3 minutes**; stop when `pending == 0`.
+3. Never poll GraphQL in parallel across multiple agents.
+
+## Repo guardrails (2026-05-28)
+
+- `pr-state-machine.yml`: reconciles on `workflow_run` (CI + Device Tests completed), not per `check_suite`.
+- `claude-review.yml`: `push` limited to `develop`, `main`, `release/**`, `hotfix/**`.
+- `device-tests.yml`: `cancel-in-progress: true`; PR branches include `release/**`, `hotfix/**`.

--- a/scripts/tests/test_pr_state_machine_workflow.py
+++ b/scripts/tests/test_pr_state_machine_workflow.py
@@ -8,10 +8,11 @@ PR_STATE_MACHINE_WORKFLOW = ROOT / ".github/workflows/pr-state-machine.yml"
 def test_pr_state_machine_reconciles_when_ci_workflow_completes():
     source = PR_STATE_MACHINE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "check_suite:" in source
-    assert "types: [completed]" in source
+    assert "workflow_run:" in source
+    assert 'workflows: [CI, Device Tests]' in source
     assert "listPullRequestsAssociatedWithCommit" in source
     assert "workflow_dispatch:" in source or "workflow_dispatch" in source
+    assert "check_suite:" not in source
 
 
 def test_pr_state_machine_reads_manual_dispatch_input_from_event_payload():


### PR DESCRIPTION
## Summary
- **pr-state-machine:** reconcile on `workflow_run` (CI + Device Tests completed) instead of every `check_suite` — stops API/workflow feedback loop.
- **claude-review:** limit `push` to `develop`, `main`, `release/**`, `hotfix/**`.
- **device-tests:** `cancel-in-progress: true`; run on release/hotfix PRs too.
- **Docs:** `docs/CI_API_AND_MINUTES.md` for agents (REST polling, not `gh pr checks` loops).

## Test plan
- [x] `pytest scripts/tests/test_pr_state_machine_workflow.py`
- [ ] CI green on this PR