### PR TITLE
test(ci): align device-tests contract test

### DIFF
--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -413,9 +413,9 @@ def test_device_tests_workflow_covers_ios_simulator_maestro_and_agent_device():
     ios_script = (ROOT / "scripts/device-tests/ci-maestro-ios.sh").read_text(encoding="utf-8")
     trigger_section = source.split("concurrency:", 1)[0]
 
-    assert "cancel-in-progress: false" in source
+    assert "cancel-in-progress: true" in source
     assert "pull_request:" in trigger_section
-    assert "branches: [develop, main]" in trigger_section
+    assert "branches: [develop, main, 'release/**', 'hotfix/**']" in trigger_section
     assert "paths:" not in trigger_section
     assert "iOS Simulator + Maestro + Agent Device" in source
     assert "scripts/device-tests/ci-maestro-ios.sh" in source


### PR DESCRIPTION
Fixes regression guard after #1651 device-tests concurrency change.