### PR TITLE
test(admob): admob_status unit tests and CI workflow contract

### DIFF
--- a/scripts/tests/test_admob_status.py
+++ b/scripts/tests/test_admob_status.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import admob_status as mod  # noqa: E402
+
+
+class AdmobStatusTests(unittest.TestCase):
+    def test_print_app_ads_report_passes_when_urls_ok(self):
+        with patch.object(mod, "verify_app_ads_txt", return_value=(True, "ok")):
+            rc = mod.print_app_ads_report(also_play_path=False)
+        self.assertEqual(rc, 0)
+
+    def test_print_app_ads_report_fails_on_missing_file(self):
+        with patch.object(mod, "verify_app_ads_txt", return_value=(False, "HTTP 404")):
+            rc = mod.print_app_ads_report(also_play_path=False)
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -23,8 +23,17 @@ PLAY_IAP_READBACK_WORKFLOW = ROOT / ".github/workflows/play-iap-product-readback
 WIKI_SYNC_WORKFLOW = ROOT / ".github/workflows/wiki-sync.yml"
 ACTIONS_BUDGET_DOC = ROOT / "docs/ACTIONS_BUDGET.md"
 STORE_RATINGS_SNAPSHOT_WORKFLOW = ROOT / ".github/workflows/store-ratings-snapshot.yml"
+ADMOB_APP_ADS_VERIFY_WORKFLOW = ROOT / ".github/workflows/admob-app-ads-verify.yml"
 AGENTS_DOC = ROOT / "AGENTS.md"
 ANDROID_AGENT_WORKFLOW_DOC = ROOT / "docs/ANDROID_AGENT_WORKFLOW.md"
+
+
+def test_admob_app_ads_verify_workflow_checks_hosted_files():
+    source = ADMOB_APP_ADS_VERIFY_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "admob_status.py" in source
+    assert "--also-check-play-contact-path" in source
+    assert "contents: read" in source
 
 
 def test_store_ratings_snapshot_workflow_invokes_script_with_read_only_secrets():


### PR DESCRIPTION
## Summary
- Add `scripts/tests/test_admob_status.py` for hosted app-ads report helpers.
- Lock `admob-app-ads-verify.yml` contract (daily `admob_status.py --also-check-play-contact-path`).

## Test plan
- [x] `python3 -m unittest scripts.tests.test_admob_status`
- [x] AdMob app-ads CI workflow green on develop (workflow_dispatch)


Made with [Cursor](https://cursor.com)