### PR TITLE
chore(admob): GSD admob_status.json daily snapshot

### DIFF
--- a/.github/workflows/admob-app-ads-verify.yml
+++ b/.github/workflows/admob-app-ads-verify.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: admob-app-ads-verify
@@ -24,3 +24,20 @@ jobs:
 
       - name: Verify hosted app-ads.txt (all Play/AdMob crawl paths)
         run: python3 scripts/admob_status.py --also-check-play-contact-path
+
+      - name: Write admob_status.json (GSD snapshot)
+        run: python3 scripts/admob_metrics_snapshot.py --also-check-play-contact-path
+
+      - name: Commit admob_status.json when changed
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add marketing/data/admob_status.json
+          if git diff --staged --quiet; then
+            echo "No admob_status.json changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(admob): refresh admob_status.json from app-ads verify"
+          git pull --rebase origin develop
+          git push origin HEAD:develop

--- a/docs/ADMOB_SETUP.md
+++ b/docs/ADMOB_SETUP.md
@@ -18,9 +18,11 @@
 2. After deploy, run:
    ```bash
    python3 scripts/admob_status.py --also-check-play-contact-path
+   python3 scripts/admob_metrics_snapshot.py --also-check-play-contact-path
    ```
    (`app-ads.txt` must exist at **repo root** and `support/` for Jekyll Pages on `develop`, plus under `marketing/site/` for the growth artifact deploy.)
-3. In AdMob UI → **Verify app** → **Check for updates** (no API for app-ads crawl; up to ~24h).
+3. **GSD artifact:** `marketing/data/admob_status.json` is refreshed daily by [`admob-app-ads-verify.yml`](../.github/workflows/admob-app-ads-verify.yml) (hosted checks; API section only when CI has creds).
+4. In AdMob UI → **Verify app** → **Check for updates** (no API for app-ads crawl; up to ~24h).
 
 ## IDs in AdMob vs OAuth (do not confuse)
 
@@ -119,7 +121,11 @@ Debug builds use [Google test ad units](https://developers.google.com/admob/andr
 
 ## iOS app in AdMob
 
-Add iOS app (App Store link `6758355312`) and a rewarded ad unit — same publisher ID.
+Add iOS app (App Store `6758355312` / `https://apps.apple.com/app/id6758355312`) and a rewarded ad unit — same publisher ID.
+
+**UI (CEO one click if automation blocked):** AdMob → **Add app** → iOS → listed on store → search App Store URL → **Add** on row **Random Tactical Timer Free | iOS** → create rewarded unit.
+
+**API:** `accounts.apps.create` needs `admob.monetization` scope (not readonly ADC); often 403 until account manager enables write access.
 
 ## Code
 

--- a/marketing/data/admob_status.json
+++ b/marketing/data/admob_status.json
@@ -1,0 +1,41 @@
+{
+  "source": "admob_metrics_snapshot",
+  "generated_at": "2026-05-29T20:38:24Z",
+  "publisher_id": "pub-5173650670360699",
+  "app_ads": {
+    "expected_line": "google.com, pub-5173650670360699, DIRECT, f08c47fec0942fa0",
+    "checks": [
+      {
+        "url": "https://igorganapolsky.github.io/Random-Timer/app-ads.txt",
+        "ok": true,
+        "message": "ok: found authorized line for pub-5173650670360699 at https://igorganapolsky.github.io/Random-Timer/app-ads.txt"
+      },
+      {
+        "url": "https://igorganapolsky.github.io/app-ads.txt",
+        "ok": true,
+        "message": "ok: found authorized line for pub-5173650670360699 at https://igorganapolsky.github.io/app-ads.txt"
+      },
+      {
+        "url": "https://igorganapolsky.github.io/Random-Timer/support/app-ads.txt",
+        "ok": true,
+        "message": "ok: found authorized line for pub-5173650670360699 at https://igorganapolsky.github.io/Random-Timer/support/app-ads.txt"
+      }
+    ],
+    "all_pass": true
+  },
+  "api": {
+    "skipped": false,
+    "token_source": "application-default-credentials",
+    "quota_project": "random-timer-dist-new",
+    "account": "accounts/pub-5173650670360699",
+    "app_count": 1,
+    "apps": [
+      {
+        "platform": "ANDROID",
+        "appId": "ca-app-pub-5173650670360699~4427145410",
+        "appApprovalState": "IN_REVIEW",
+        "displayName": "Random Tactical Timer"
+      }
+    ]
+  }
+}

--- a/scripts/admob_metrics_snapshot.py
+++ b/scripts/admob_metrics_snapshot.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Write marketing/data/admob_status.json — GSD telemetry for AdMob P1 hosting + API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import admob_api_auth as auth_mod
+import admob_status as status_mod
+import verify_app_ads_txt as ads_mod
+
+verify_app_ads_txt = ads_mod.verify_app_ads_txt
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _app_ads_urls(*, also_play_path: bool) -> list[str]:
+    urls = [ads_mod.DEFAULT_URL]
+    if also_play_path:
+        urls.extend(
+            [
+                ads_mod.ADMOB_CRAWLER_ROOT_APP_ADS_URL,
+                ads_mod.PLAY_CONTACT_WEBSITE_APP_ADS_URL,
+            ]
+        )
+    return urls
+
+
+def build_snapshot(
+    *,
+    also_play_path: bool,
+    include_api: bool,
+    access_token: str | None,
+) -> dict:
+    checks: list[dict] = []
+    for url in _app_ads_urls(also_play_path=also_play_path):
+        ok, msg = verify_app_ads_txt(url=url)
+        checks.append({"url": url, "ok": ok, "message": msg})
+
+    payload: dict = {
+        "source": "admob_metrics_snapshot",
+        "generated_at": _utc_now(),
+        "publisher_id": ads_mod.EXPECTED_PUBLISHER,
+        "app_ads": {
+            "expected_line": ads_mod.EXPECTED_LINE,
+            "checks": checks,
+            "all_pass": all(c["ok"] for c in checks),
+        },
+        "api": None,
+    }
+
+    if include_api:
+        auth = auth_mod.resolve_admob_auth(access_token)
+        if not auth:
+            payload["api"] = {"skipped": True, "reason": "no_credentials"}
+        else:
+            try:
+                apps = status_mod.list_apps(auth, status_mod.DEFAULT_ACCOUNT)
+                payload["api"] = {
+                    "skipped": False,
+                    "token_source": auth.source,
+                    "quota_project": auth.quota_project,
+                    "account": status_mod.DEFAULT_ACCOUNT,
+                    "app_count": len(apps),
+                    "apps": [
+                        {
+                            "platform": app.get("platform"),
+                            "appId": app.get("appId"),
+                            "appApprovalState": app.get("appApprovalState"),
+                            "displayName": (app.get("linkedAppInfo") or {}).get("displayName")
+                            or (app.get("manualAppInfo") or {}).get("displayName"),
+                        }
+                        for app in apps
+                    ],
+                }
+            except Exception as exc:  # noqa: BLE001 — snapshot must always write
+                payload["api"] = {"skipped": False, "error": str(exc)[:500]}
+
+    return payload
+
+
+def write_snapshot(repo_root: Path, payload: dict) -> Path:
+    out_path = repo_root / "marketing" / "data" / "admob_status.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return out_path
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Write marketing/data/admob_status.json")
+    p.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    p.add_argument("--also-check-play-contact-path", action="store_true")
+    p.add_argument("--api", action="store_true", help="Include AdMob API apps when creds exist.")
+    p.add_argument("--access-token", default=None)
+    args = p.parse_args()
+
+    payload = build_snapshot(
+        also_play_path=args.also_check_play_contact_path,
+        include_api=args.api,
+        access_token=args.access_token,
+    )
+    out_path = write_snapshot(args.repo_root.resolve(), payload)
+    print(f"Wrote {out_path}")
+    return 0 if payload["app_ads"]["all_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_admob_metrics_snapshot.py
+++ b/scripts/tests/test_admob_metrics_snapshot.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import admob_metrics_snapshot as mod  # noqa: E402
+
+
+class AdmobMetricsSnapshotTests(unittest.TestCase):
+    def test_build_snapshot_all_pass(self):
+        with patch.object(mod, "verify_app_ads_txt", return_value=(True, "ok")):
+            payload = mod.build_snapshot(also_play_path=False, include_api=False, access_token=None)
+        self.assertTrue(payload["app_ads"]["all_pass"])
+        self.assertEqual(len(payload["app_ads"]["checks"]), 1)
+        self.assertIsNone(payload["api"])
+
+    def test_write_snapshot_creates_json(self):
+        with patch.object(mod, "verify_app_ads_txt", return_value=(True, "ok")):
+            payload = mod.build_snapshot(also_play_path=False, include_api=False, access_token=None)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out = mod.write_snapshot(root, payload)
+            data = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(data["source"], "admob_metrics_snapshot")
+        self.assertTrue(data["app_ads"]["all_pass"])
+
+    def test_exit_code_one_when_hosting_fails(self):
+        with patch.object(mod, "verify_app_ads_txt", return_value=(False, "HTTP 404")):
+            payload = mod.build_snapshot(also_play_path=False, include_api=False, access_token=None)
+        self.assertFalse(payload["app_ads"]["all_pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -32,8 +32,10 @@ def test_admob_app_ads_verify_workflow_checks_hosted_files():
     source = ADMOB_APP_ADS_VERIFY_WORKFLOW.read_text(encoding="utf-8")
 
     assert "admob_status.py" in source
+    assert "admob_metrics_snapshot.py" in source
     assert "--also-check-play-contact-path" in source
-    assert "contents: read" in source
+    assert "contents: write" in source
+    assert "marketing/data/admob_status.json" in source
 
 
 def test_store_ratings_snapshot_workflow_invokes_script_with_read_only_secrets():


### PR DESCRIPTION
## Summary
- Adds `scripts/admob_metrics_snapshot.py` → `marketing/data/admob_status.json` (GSD artifact per `.claude/GSD.md`)
- Extends `admob-app-ads-verify.yml` to commit snapshot to `develop` after green hosted checks
- Documents iOS AdMob UI path + API scope limits in `docs/ADMOB_SETUP.md`

## Test plan
- [x] `pytest scripts/tests/test_admob_metrics_snapshot.py`
- [x] `pytest scripts/tests/test_growth_workflow_contracts.py -k admob`
- [ ] CI green on PR

## GSD evidence (pre-merge)
- Workflow dispatch: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26660889163 (app-ads verify **success**)
- Local snapshot: 3/3 app-ads URLs PASS in `marketing/data/admob_status.json`


Made with [Cursor](https://cursor.com)