### PR TITLE
feat(ios): scaffold rewarded AdMob layer (stub-only, safe)

### DIFF
--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -76,6 +76,11 @@
 		QTWP00112233445566778804 /* QualifiedTrainingPaywallPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = QTWP00112233445566778803 /* QualifiedTrainingPaywallPolicyTests.swift */; };
 		RWAD00112233445566778802 /* RewardedAdSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD00112233445566778801 /* RewardedAdSupport.swift */; };
 		RWAD00112233445566778804 /* RewardedAdSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD00112233445566778803 /* RewardedAdSupportTests.swift */; };
+		RWAD00112233445566778806 /* ProSoundAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD00112233445566778805 /* ProSoundAccess.swift */; };
+		RWAD00112233445566778808 /* ProSoundAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD00112233445566778807 /* ProSoundAccessTests.swift */; };
+		RWAD0011223344556677880A /* RewardedAdCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD00112233445566778809 /* RewardedAdCoordinator.swift */; };
+		RWAD0011223344556677880C /* RewardedAdCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD0011223344556677880B /* RewardedAdCoordinatorTests.swift */; };
+		RWAD0011223344556677880E /* StubRewardedAdPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = RWAD0011223344556677880D /* StubRewardedAdPort.swift */; };
 		DPCK00112233445566778802 /* DisciplinePackCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DPCK00112233445566778801 /* DisciplinePackCatalog.swift */; };
 		DPCK00112233445566778804 /* DisciplinePackCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DPCK00112233445566778803 /* DisciplinePackCatalogTests.swift */; };
 		BC2E89FF69ECC3F835BB9D9D /* RandomTimerWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 05CD46A1911192043939F56F /* RandomTimerWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -201,6 +206,11 @@
 		QTWP00112233445566778803 /* QualifiedTrainingPaywallPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualifiedTrainingPaywallPolicyTests.swift; sourceTree = "<group>"; };
 		RWAD00112233445566778801 /* RewardedAdSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardedAdSupport.swift; sourceTree = "<group>"; };
 		RWAD00112233445566778803 /* RewardedAdSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardedAdSupportTests.swift; sourceTree = "<group>"; };
+		RWAD00112233445566778805 /* ProSoundAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProSoundAccess.swift; sourceTree = "<group>"; };
+		RWAD00112233445566778807 /* ProSoundAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProSoundAccessTests.swift; sourceTree = "<group>"; };
+		RWAD00112233445566778809 /* RewardedAdCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardedAdCoordinator.swift; sourceTree = "<group>"; };
+		RWAD0011223344556677880B /* RewardedAdCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardedAdCoordinatorTests.swift; sourceTree = "<group>"; };
+		RWAD0011223344556677880D /* StubRewardedAdPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubRewardedAdPort.swift; sourceTree = "<group>"; };
 		DPCK00112233445566778801 /* DisciplinePackCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisciplinePackCatalog.swift; sourceTree = "<group>"; };
 		DPCK00112233445566778803 /* DisciplinePackCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisciplinePackCatalogTests.swift; sourceTree = "<group>"; };
 		B346A5600C70703BAB7FB9E6 /* siren.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = siren.mp3; sourceTree = "<group>"; };
@@ -267,6 +277,8 @@
 				PRVT001122334455AABB0001 /* ProValidationTests.swift */,
 				QTWP00112233445566778803 /* QualifiedTrainingPaywallPolicyTests.swift */,
 				RWAD00112233445566778803 /* RewardedAdSupportTests.swift */,
+				RWAD00112233445566778807 /* ProSoundAccessTests.swift */,
+				RWAD0011223344556677880B /* RewardedAdCoordinatorTests.swift */,
 				DPCK00112233445566778803 /* DisciplinePackCatalogTests.swift */,
 				VOLKEY00112233445566778803 /* AlarmVolumeKeyPolicyTests.swift */,
 				C1D2E3F4A5B60718C1D2E3F5 /* SilenceAndStopAlarmTests.swift */,
@@ -324,6 +336,9 @@
 				B1C2D3E4F5A6071800STATS2 /* TrainingStatsService.swift */,
 				QTWP00112233445566778801 /* QualifiedTrainingPaywallPolicy.swift */,
 				RWAD00112233445566778801 /* RewardedAdSupport.swift */,
+				RWAD00112233445566778805 /* ProSoundAccess.swift */,
+				RWAD00112233445566778809 /* RewardedAdCoordinator.swift */,
+				RWAD0011223344556677880D /* StubRewardedAdPort.swift */,
 				DPCK00112233445566778801 /* DisciplinePackCatalog.swift */,
 				A5A3DD46F85A68522E1B0902 /* ProManager.swift */,
 				AIVC00112233445566778800 /* AIVoiceCalloutService.swift */,
@@ -683,6 +698,9 @@
 				B1C2D3E4F5A6071800STATS1 /* TrainingStatsService.swift in Sources */,
 				QTWP00112233445566778802 /* QualifiedTrainingPaywallPolicy.swift in Sources */,
 				RWAD00112233445566778802 /* RewardedAdSupport.swift in Sources */,
+				RWAD00112233445566778806 /* ProSoundAccess.swift in Sources */,
+				RWAD0011223344556677880A /* RewardedAdCoordinator.swift in Sources */,
+				RWAD0011223344556677880E /* StubRewardedAdPort.swift in Sources */,
 				DPCK00112233445566778802 /* DisciplinePackCatalog.swift in Sources */,
 				A1B2C3D400000001DEADBEEF /* Logger.swift in Sources */,
 				85ABA1B34E3D14E790434638 /* ProManager.swift in Sources */,
@@ -713,6 +731,8 @@
 				PRVT001122334455AABB0002 /* ProValidationTests.swift in Sources */,
 				QTWP00112233445566778804 /* QualifiedTrainingPaywallPolicyTests.swift in Sources */,
 				RWAD00112233445566778804 /* RewardedAdSupportTests.swift in Sources */,
+				RWAD00112233445566778808 /* ProSoundAccessTests.swift in Sources */,
+				RWAD0011223344556677880C /* RewardedAdCoordinatorTests.swift in Sources */,
 				DPCK00112233445566778804 /* DisciplinePackCatalogTests.swift in Sources */,
 				VOLKEY00112233445566778804 /* AlarmVolumeKeyPolicyTests.swift in Sources */,
 				C1D2E3F4A5B60718C1D2E3F4 /* SilenceAndStopAlarmTests.swift in Sources */,

--- a/native-ios/RandomTimer/Sources/Services/ProSoundAccess.swift
+++ b/native-ios/RandomTimer/Sources/Services/ProSoundAccess.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Free-tier Pro sound access via subscription or rewarded-ad trial unlock.
+enum ProSoundAccess {
+    static func canEquipProSound(isPro: Bool, hasTrialUnlock: Bool) -> Bool {
+        isPro || hasTrialUnlock
+    }
+
+    static func shouldConsumeTrialOnEquip(
+        isPro: Bool,
+        hasTrialUnlock: Bool,
+        previousSound: SoundType,
+        newSound: SoundType
+    ) -> Bool {
+        !isPro &&
+            hasTrialUnlock &&
+            newSound.isPro &&
+            !previousSound.isPro
+    }
+}

--- a/native-ios/RandomTimer/Sources/Services/RewardedAdCoordinator.swift
+++ b/native-ios/RandomTimer/Sources/Services/RewardedAdCoordinator.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+@MainActor
+protocol RewardedAdAnalyticsPort: AnyObject {
+    func track(_ event: String, properties: [String: Any]?)
+}
+
+extension AnalyticsService: RewardedAdAnalyticsPort {}
+
+@MainActor
+final class RewardedAdCoordinator {
+    private let analytics: RewardedAdAnalyticsPort
+    private let port: RewardedAdPort
+
+    init(
+        analytics: RewardedAdAnalyticsPort,
+        port: RewardedAdPort = StubRewardedAdPort()
+    ) {
+        self.analytics = analytics
+        self.port = port
+    }
+
+    func requestUnlock(
+        entryPoint: String,
+        rewardedAdsEnabled: Bool,
+        isPro: Bool,
+        onUnlocked: @escaping () -> Void
+    ) {
+        guard RewardedAdPolicy.canOfferRewardedAd(rewardedAdsEnabled: rewardedAdsEnabled, isPro: isPro) else {
+            return
+        }
+
+        analytics.track(
+            AnalyticsEvents.rewardedAdRequested,
+            properties: RewardedAdAnalytics.requestedProperties(entryPoint: entryPoint)
+        )
+        port.showRewardedAd(entryPoint: entryPoint) { [analytics] success in
+            analytics.track(
+                AnalyticsEvents.rewardedAdCompleted,
+                properties: RewardedAdAnalytics.completedProperties(entryPoint: entryPoint, success: success)
+            )
+            guard success else { return }
+
+            RewardedAdUnlockStore.grantUnlock()
+            analytics.track(
+                AnalyticsEvents.rewardedAdUnlock,
+                properties: RewardedAdAnalytics.unlockProperties(entryPoint: entryPoint)
+            )
+            onUnlocked()
+        }
+    }
+}

--- a/native-ios/RandomTimer/Sources/Services/RewardedAdSupport.swift
+++ b/native-ios/RandomTimer/Sources/Services/RewardedAdSupport.swift
@@ -4,12 +4,29 @@ enum RewardedAdConfig {
     static let featureFlagKey = PostHogExperimentKeys.rewardedAdsEnabled
     static let testRewardedUnitIdIOS = "ca-app-pub-3940256099942544/1712485313"
     static let publisherId = "pub-5173650670360699"
+    /// Production AdMob app ID (iOS). Empty until App Store app is linked in AdMob console.
+    static let productionAppIdIOS = ""
+    /// Production rewarded unit (iOS). Empty until ad unit is created in AdMob console.
+    static let productionRewardedUnitIdIOS = ""
     static let admobBlocker =
         "Rewarded ads ship behind PostHog flag (default off) until production ad unit IDs are configured and app-ads.txt verifies."
+
+    static func resolvedRewardedUnitId(useTestAds: Bool) -> String {
+        useTestAds ? testRewardedUnitIdIOS : productionRewardedUnitIdIOS
+    }
+
+    static func resolvedRewardedUnitIdForCurrentBuild() -> String {
+        #if DEBUG
+        return testRewardedUnitIdIOS
+        #else
+        return resolvedRewardedUnitId(useTestAds: false)
+        #endif
+    }
 }
 
 enum RewardedAdPolicy {
     static let unlockFeature = "pro_sound_trial"
+    static let entryPointSoundArsenal = "sound_arsenal_gate"
 
     static func canOfferRewardedAd(rewardedAdsEnabled: Bool, isPro: Bool) -> Bool {
         rewardedAdsEnabled && !isPro

--- a/native-ios/RandomTimer/Sources/Services/StubRewardedAdPort.swift
+++ b/native-ios/RandomTimer/Sources/Services/StubRewardedAdPort.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Rewarded ad port. [StubRewardedAdPort] is the default until AdMob SDK + publisher account ship.
+protocol RewardedAdPort {
+    func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void)
+}
+
+/// No-op until AdMob SDK is integrated (flag stays off in production).
+struct StubRewardedAdPort: RewardedAdPort {
+    func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void) {
+        onFinished(false)
+    }
+}

--- a/native-ios/RandomTimer/Sources/Services/StubRewardedAdPort.swift
+++ b/native-ios/RandomTimer/Sources/Services/StubRewardedAdPort.swift
@@ -1,11 +1,13 @@
 import Foundation
 
 /// Rewarded ad port. [StubRewardedAdPort] is the default until AdMob SDK + publisher account ship.
+@MainActor
 protocol RewardedAdPort {
     func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void)
 }
 
 /// No-op until AdMob SDK is integrated (flag stays off in production).
+@MainActor
 struct StubRewardedAdPort: RewardedAdPort {
     func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void) {
         onFinished(false)

--- a/native-ios/RandomTimerTests/ProSoundAccessTests.swift
+++ b/native-ios/RandomTimerTests/ProSoundAccessTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import RandomTimer
+
+final class ProSoundAccessTests: XCTestCase {
+    func testProUsersCanEquipProSounds() {
+        XCTAssertTrue(ProSoundAccess.canEquipProSound(isPro: true, hasTrialUnlock: false))
+    }
+
+    func testTrialUnlockAllowsEquipWithoutSubscription() {
+        XCTAssertTrue(ProSoundAccess.canEquipProSound(isPro: false, hasTrialUnlock: true))
+    }
+
+    func testFreeUsersWithoutTrialCannotEquip() {
+        XCTAssertFalse(ProSoundAccess.canEquipProSound(isPro: false, hasTrialUnlock: false))
+    }
+
+    func testConsumesTrialWhenEquippingFirstProSound() {
+        XCTAssertTrue(
+            ProSoundAccess.shouldConsumeTrialOnEquip(
+                isPro: false,
+                hasTrialUnlock: true,
+                previousSound: .intense,
+                newSound: .klaxon
+            )
+        )
+    }
+
+    func testDoesNotConsumeWhenSwitchingBetweenProSounds() {
+        XCTAssertFalse(
+            ProSoundAccess.shouldConsumeTrialOnEquip(
+                isPro: false,
+                hasTrialUnlock: true,
+                previousSound: .klaxon,
+                newSound: .whistle
+            )
+        )
+    }
+}

--- a/native-ios/RandomTimerTests/RewardedAdCoordinatorTests.swift
+++ b/native-ios/RandomTimerTests/RewardedAdCoordinatorTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import RandomTimer
+
+@MainActor
+final class RewardedAdCoordinatorTests: XCTestCase {
+    private var analytics: RecordingRewardedAdAnalytics!
+    private var port: RecordingRewardedAdPort!
+    private var coordinator: RewardedAdCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        analytics = RecordingRewardedAdAnalytics()
+        port = RecordingRewardedAdPort()
+        coordinator = RewardedAdCoordinator(analytics: analytics, port: port)
+        RewardedAdUnlockStore.consumeUnlock()
+    }
+
+    func testGrantsUnlockAndTracksWhenAdCompletes() {
+        var unlocked = false
+        port.nextSuccess = true
+
+        coordinator.requestUnlock(
+            entryPoint: RewardedAdPolicy.entryPointSoundArsenal,
+            rewardedAdsEnabled: true,
+            isPro: false,
+            onUnlocked: { unlocked = true }
+        )
+
+        XCTAssertTrue(unlocked)
+        XCTAssertTrue(RewardedAdUnlockStore.hasActiveUnlock())
+        XCTAssertTrue(
+            analytics.trackedEvents.contains(where: { $0.event == AnalyticsEvents.rewardedAdUnlock })
+        )
+    }
+
+    func testDoesNotGrantWhenFlagDisabled() {
+        coordinator.requestUnlock(
+            entryPoint: RewardedAdPolicy.entryPointSoundArsenal,
+            rewardedAdsEnabled: false,
+            isPro: false,
+            onUnlocked: {}
+        )
+
+        XCTAssertEqual(port.showCount, 0)
+        XCTAssertFalse(RewardedAdUnlockStore.hasActiveUnlock())
+    }
+
+    private final class RecordingRewardedAdAnalytics: RewardedAdAnalyticsPort {
+        struct TrackedEvent {
+            let event: String
+            let properties: [String: Any]?
+        }
+
+        private(set) var trackedEvents: [TrackedEvent] = []
+
+        func track(_ event: String, properties: [String: Any]?) {
+            trackedEvents.append(TrackedEvent(event: event, properties: properties))
+        }
+    }
+
+    private final class RecordingRewardedAdPort: RewardedAdPort {
+        var nextSuccess = false
+        private(set) var showCount = 0
+
+        func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void) {
+            showCount += 1
+            onFinished(nextSuccess)
+        }
+    }
+}

--- a/native-ios/RandomTimerTests/RewardedAdCoordinatorTests.swift
+++ b/native-ios/RandomTimerTests/RewardedAdCoordinatorTests.swift
@@ -2,22 +2,39 @@ import XCTest
 @testable import RandomTimer
 
 @MainActor
-final class RewardedAdCoordinatorTests: XCTestCase {
-    private var analytics: RecordingRewardedAdAnalytics!
-    private var port: RecordingRewardedAdPort!
-    private var coordinator: RewardedAdCoordinator!
-
-    override func setUp() {
-        super.setUp()
-        analytics = RecordingRewardedAdAnalytics()
-        port = RecordingRewardedAdPort()
-        coordinator = RewardedAdCoordinator(analytics: analytics, port: port)
-        RewardedAdUnlockStore.consumeUnlock()
+private final class RecordingRewardedAdAnalytics: RewardedAdAnalyticsPort {
+    struct TrackedEvent {
+        let event: String
+        let properties: [String: Any]?
     }
 
+    private(set) var trackedEvents: [TrackedEvent] = []
+
+    func track(_ event: String, properties: [String: Any]?) {
+        trackedEvents.append(TrackedEvent(event: event, properties: properties))
+    }
+}
+
+@MainActor
+private final class RecordingRewardedAdPort: RewardedAdPort {
+    var nextSuccess = false
+    private(set) var showCount = 0
+
+    func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void) {
+        showCount += 1
+        onFinished(nextSuccess)
+    }
+}
+
+@MainActor
+final class RewardedAdCoordinatorTests: XCTestCase {
     func testGrantsUnlockAndTracksWhenAdCompletes() {
-        var unlocked = false
+        RewardedAdUnlockStore.consumeUnlock()
+        let analytics = RecordingRewardedAdAnalytics()
+        let port = RecordingRewardedAdPort()
         port.nextSuccess = true
+        let coordinator = RewardedAdCoordinator(analytics: analytics, port: port)
+        var unlocked = false
 
         coordinator.requestUnlock(
             entryPoint: RewardedAdPolicy.entryPointSoundArsenal,
@@ -34,6 +51,11 @@ final class RewardedAdCoordinatorTests: XCTestCase {
     }
 
     func testDoesNotGrantWhenFlagDisabled() {
+        RewardedAdUnlockStore.consumeUnlock()
+        let analytics = RecordingRewardedAdAnalytics()
+        let port = RecordingRewardedAdPort()
+        let coordinator = RewardedAdCoordinator(analytics: analytics, port: port)
+
         coordinator.requestUnlock(
             entryPoint: RewardedAdPolicy.entryPointSoundArsenal,
             rewardedAdsEnabled: false,
@@ -43,28 +65,5 @@ final class RewardedAdCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(port.showCount, 0)
         XCTAssertFalse(RewardedAdUnlockStore.hasActiveUnlock())
-    }
-
-    private final class RecordingRewardedAdAnalytics: RewardedAdAnalyticsPort {
-        struct TrackedEvent {
-            let event: String
-            let properties: [String: Any]?
-        }
-
-        private(set) var trackedEvents: [TrackedEvent] = []
-
-        func track(_ event: String, properties: [String: Any]?) {
-            trackedEvents.append(TrackedEvent(event: event, properties: properties))
-        }
-    }
-
-    private final class RecordingRewardedAdPort: RewardedAdPort {
-        var nextSuccess = false
-        private(set) var showCount = 0
-
-        func showRewardedAd(entryPoint: String, onFinished: @escaping (Bool) -> Void) {
-            showCount += 1
-            onFinished(nextSuccess)
-        }
     }
 }

--- a/native-ios/RandomTimerTests/RewardedAdSupportTests.swift
+++ b/native-ios/RandomTimerTests/RewardedAdSupportTests.swift
@@ -19,4 +19,29 @@ final class RewardedAdSupportTests: XCTestCase {
         XCTAssertEqual(RewardedAdAnalytics.completedEvent, "rewarded_ad_completed")
         XCTAssertEqual(RewardedAdAnalytics.unlockEvent, "rewarded_ad_unlock")
     }
+
+    func testResolvedRewardedUnitIdUsesTestIdInTestMode() {
+        XCTAssertEqual(
+            RewardedAdConfig.resolvedRewardedUnitId(useTestAds: true),
+            RewardedAdConfig.testRewardedUnitIdIOS
+        )
+    }
+
+    func testProductionIOSAdMobIdsRemainEmptyUntilConfigured() {
+        XCTAssertEqual(RewardedAdConfig.productionAppIdIOS, "")
+        XCTAssertEqual(RewardedAdConfig.productionRewardedUnitIdIOS, "")
+    }
+
+    func testResolvedRewardedUnitIdForDebugBuildUsesTestUnit() {
+        #if DEBUG
+        XCTAssertEqual(
+            RewardedAdConfig.resolvedRewardedUnitIdForCurrentBuild(),
+            RewardedAdConfig.testRewardedUnitIdIOS
+        )
+        #endif
+    }
+
+    func testEntryPointSoundArsenalMatchesAndroidContract() {
+        XCTAssertEqual(RewardedAdPolicy.entryPointSoundArsenal, "sound_arsenal_gate")
+    }
 }


### PR DESCRIPTION
## Summary
- Adds iOS rewarded-ad scaffold mirroring Android: `RewardedAdCoordinator` (default `StubRewardedAdPort`), `ProSoundAccess`, and extended `RewardedAdConfig`/`RewardedAdPolicy` with `entryPointSoundArsenal`, empty production iOS AdMob ID placeholders, and `resolvedRewardedUnitId` (DEBUG → Google test unit).
- TDD coverage: 15 unit tests across `RewardedAdSupportTests`, `ProSoundAccessTests`, and `RewardedAdCoordinatorTests`.
- **No Google Mobile Ads SPM** and **no PostHog flag enablement** — `rewarded_ads_enabled` remains default off; stub port returns `success=false`.

## GSD
- **Goal:** Safe iOS IAA prep without shipping live ads.
- **Scope:** Stub port + config/policy/access types only; no UI hookup, no SDK, no production IDs.
- **Done when:** Unit tests pass; production iOS AdMob IDs empty; flag untouched.

## Test plan
- [x] `xcodebuild -scheme RandomTimer -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:RandomTimerTests/RewardedAdSupportTests -only-testing:RandomTimerTests/ProSoundAccessTests -only-testing:RandomTimerTests/RewardedAdCoordinatorTests` → **15 tests, 0 failures**
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)