### PR TITLE
feat(ops): post-publish revenue gate + Play IAP catalog snapshot

### DIFF
--- a/.github/workflows/play-iap-product-readback.yml
+++ b/.github/workflows/play-iap-product-readback.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   verify-play-iap-products:
@@ -44,6 +44,37 @@ jobs:
           export GOOGLE_PLAY_JSON_KEY_PATH=/tmp/play-service-account.json
           python3 scripts/play_verify_iap_products.py --json-out play-iap-product-readback.json
 
+      - name: Write marketing/data/play_iap_catalog.json (GSD snapshot)
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f play-iap-product-readback.json ]; then
+            python3 -c "
+          import json
+          from datetime import datetime, timezone
+          report = json.load(open('play-iap-product-readback.json'))
+          report['source'] = 'play_iap_product_readback'
+          report['generated_at'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+          json.dump(report, open('marketing/data/play_iap_catalog.json', 'w'), indent=2)
+          print('Wrote marketing/data/play_iap_catalog.json')
+          "
+          fi
+
+      - name: Commit play_iap_catalog.json when changed
+        if: always()
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add marketing/data/play_iap_catalog.json
+          if git diff --staged --quiet; then
+            echo "No play_iap_catalog.json changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(play): refresh play_iap_catalog.json from IAP readback"
+          git pull --rebase origin develop
+          git push origin HEAD:develop
+
       - uses: actions/upload-artifact@v5
         if: always()
         with:
@@ -51,4 +82,5 @@ jobs:
           path: |
             play-iap-product-readback.json
             play-iap-activation.json
+            marketing/data/play_iap_catalog.json
           if-no-files-found: ignore

--- a/scripts/play_activate_iap_products.py
+++ b/scripts/play_activate_iap_products.py
@@ -6,6 +6,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.play_monetization_client import (
     PACKAGE,

--- a/scripts/play_verify_iap_products.py
+++ b/scripts/play_verify_iap_products.py
@@ -6,6 +6,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.play_monetization_client import (
     PACKAGE,

--- a/scripts/post_publish_revenue_gate.py
+++ b/scripts/post_publish_revenue_gate.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""GSD gate: public store versions match latest GitHub release (post-publish smoke)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts import verify_public_store_versions as store_verify
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_report(*, repo_root: Path, platform: str, timeout: int) -> dict:
+    ios_expected, android_expected, expected_source = store_verify.resolve_expected_versions(
+        platform=platform,
+        expected_version="",
+        ios_expected_version="",
+        android_expected_version="",
+        expected_source="github_latest_release",
+        repo_root=repo_root,
+    )
+
+    def verify_once() -> list[store_verify.StoreVersionResult]:
+        checks: list[store_verify.StoreVersionResult] = []
+        if platform in {"ios", "both"}:
+            checks.append(
+                store_verify.verify_app_store_public_version(
+                    store_verify.DEFAULT_IOS_APP_ID,
+                    ios_expected,
+                )
+            )
+        if platform in {"android", "both"}:
+            checks.append(
+                store_verify.verify_play_public_version(
+                    store_verify.DEFAULT_ANDROID_PACKAGE,
+                    android_expected,
+                )
+            )
+        return checks
+
+    results = store_verify.poll_until_public(verify_once, timeout, poll_interval=0)
+    store_pass = all(r.passed for r in results)
+
+    paywall_path = repo_root / "marketing" / "data" / "paywall_conversion_report.json"
+    paywall_summary = None
+    if paywall_path.is_file():
+        paywall = json.loads(paywall_path.read_text(encoding="utf-8"))
+        funnel = paywall.get("funnel") or {}
+        paywall_summary = {
+            "generated_at": paywall.get("generated_at"),
+            "purchase_successes_30d": funnel.get("purchase_successes"),
+            "purchase_attempts_30d": funnel.get("purchase_attempts"),
+        }
+
+    return {
+        "source": "post_publish_revenue_gate",
+        "generated_at": _utc_now(),
+        "expected_source": expected_source,
+        "expected_ios": ios_expected,
+        "expected_android": android_expected,
+        "store_public_pass": store_pass,
+        "stores": [
+            {
+                "platform": r.platform,
+                "passed": r.passed,
+                "expected_version": r.expected_version,
+                "observed_version": r.observed_version,
+                "status": r.status,
+            }
+            for r in results
+        ],
+        "paywall_proxy": paywall_summary,
+        "revenue_note": (
+            "store_public_pass does not imply revenue; check paywall_purchase_success in PostHog."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--platform", choices=("ios", "android", "both"), default="both")
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=_REPO_ROOT / "marketing" / "data" / "post_publish_gate.json",
+    )
+    args = parser.parse_args()
+
+    report = build_report(
+        repo_root=args.repo_root.resolve(),
+        platform=args.platform,
+        timeout=args.timeout,
+    )
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["store_public_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -578,6 +578,8 @@ def test_play_iap_readback_workflow_scheduled_on_develop():
     assert "play_activate_iap_products.py" in source
     assert 'PYTHONPATH: ${{ github.workspace }}' in source
     assert "GOOGLE_PLAY_JSON_KEY" in source
+    assert "marketing/data/play_iap_catalog.json" in source
+    assert "contents: write" in source
 
 
 def test_wiki_sync_builds_wqtu_health_snapshot():

--- a/scripts/tests/test_post_publish_revenue_gate.py
+++ b/scripts/tests/test_post_publish_revenue_gate.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts import post_publish_revenue_gate as gate  # noqa: E402
+from scripts import verify_public_store_versions as store_verify  # noqa: E402
+
+
+class PostPublishRevenueGateTests(unittest.TestCase):
+    def test_build_report_pass_when_stores_match(self):
+        results = [
+            store_verify.StoreVersionResult(
+                platform="ios",
+                passed=True,
+                status="PUBLIC",
+                url="https://example.com/ios",
+                expected_version="1.3.43",
+                observed_version="1.3.43",
+                details="ok",
+            ),
+            store_verify.StoreVersionResult(
+                platform="android",
+                passed=True,
+                status="PUBLIC",
+                url="https://example.com/android",
+                expected_version="1.3.43",
+                observed_version="1.3.43",
+                details="ok",
+            ),
+        ]
+
+        with patch.object(
+            store_verify,
+            "resolve_expected_versions",
+            return_value=("1.3.43", "1.3.43", "github_latest_release"),
+        ), patch.object(store_verify, "poll_until_public", return_value=results):
+            with tempfile.TemporaryDirectory() as tmp:
+                report = gate.build_report(repo_root=Path(tmp), platform="both", timeout=5)
+
+        self.assertTrue(report["store_public_pass"])
+        self.assertEqual(len(report["stores"]), 2)
+
+    def test_main_exits_zero_when_pass(self):
+        with patch.object(
+            gate,
+            "build_report",
+            return_value={"store_public_pass": True, "stores": []},
+        ):
+            with tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp) / "gate.json"
+                with patch(
+                    "sys.argv",
+                    [
+                        "post_publish_revenue_gate.py",
+                        "--json-out",
+                        str(out),
+                        "--repo-root",
+                        tmp,
+                    ],
+                ):
+                    self.assertEqual(gate.main(), 0)
+                self.assertTrue(json.loads(out.read_text(encoding="utf-8"))["store_public_pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **`scripts/post_publish_revenue_gate.py`** — GSD artifact `marketing/data/post_publish_gate.json` (public iOS/Android vs latest GitHub release + paywall proxy summary)
- **Play IAP CLI** — `sys.path` bootstrap so `python3 scripts/play_verify_iap_products.py` works without `PYTHONPATH=.`
- **`play-iap-product-readback.yml`** — commits `marketing/data/play_iap_catalog.json` to `develop` daily

## Evidence (pre-merge)
- Both stores public **1.3.43** PASS (post Play publish)
- Play IAP CI [26687832901](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26687832901): `required_missing: []`, blockers `[]`
- `pytest scripts/tests/test_post_publish_revenue_gate.py` — 2 passed

## Test plan
- [x] Unit tests for gate + play_verify
- [ ] CI green
- [ ] After merge: `python3 scripts/post_publish_revenue_gate.py`

## Not in scope
- Does not fix zero revenue — only measures store/IAP readiness


Made with [Cursor](https://cursor.com)