### PR TITLE
fix(android): paywall_purchase_result reason + product_id (Ralph PAYWALL-TELEM)

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -237,6 +237,7 @@ class ProManager
                     entryPoint = entryPoint,
                     responseCode = BillingClient.BillingResponseCode.SERVICE_DISCONNECTED,
                     debugMessage = "billing_not_ready",
+                    productId = productID,
                 )
                 clearPendingPaywallLaunch()
                 return false
@@ -256,6 +257,7 @@ class ProManager
                     entryPoint = entryPoint,
                     responseCode = BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
                     debugMessage = "product_details_unavailable",
+                    productId = productID,
                 )
                 clearPendingPaywallLaunch()
                 return false
@@ -295,6 +297,7 @@ class ProManager
                     entryPoint = entryPoint,
                     responseCode = BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
                     debugMessage = "subscription_offer_unavailable",
+                    productId = productID,
                 )
                 clearPendingPaywallLaunch()
                 return false
@@ -346,6 +349,7 @@ class ProManager
                     entryPoint = entryPoint,
                     responseCode = result.responseCode,
                     debugMessage = result.debugMessage,
+                    productId = productID,
                 )
                 clearPendingPaywallLaunch()
                 clearPendingTrialOffer()
@@ -669,12 +673,40 @@ class ProManager
                     mapOf(AnalyticsProperties.PRODUCT_ID to purchasedProductId),
                 )
             }
+            val failureReason =
+                if (hasPurchased) {
+                    null
+                } else {
+                    when (result.responseCode) {
+                        BillingClient.BillingResponseCode.USER_CANCELED -> "user_cancelled"
+                        BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> "service_disconnected"
+                        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> "item_unavailable"
+                        BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> "item_already_owned"
+                        BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> "billing_unavailable"
+                        BillingClient.BillingResponseCode.ERROR -> "billing_error"
+                        BillingClient.BillingResponseCode.NETWORK_ERROR -> "network_error"
+                        else -> "unknown_${result.responseCode}"
+                    }
+                }
+            val failureProductId =
+                if (hasPurchased) {
+                    null
+                } else {
+                    purchases
+                        ?.firstOrNull()
+                        ?.products
+                        ?.firstOrNull()
+                        ?.takeIf { it.isNotBlank() }
+                        ?: pendingLaunchProductId
+                }
             trackPurchaseResult(
                 success = hasPurchased,
                 source = if (pendingPurchaseEntryPoint.isNullOrBlank()) MonetizationSources.BILLING_CALLBACK else MonetizationSources.PAYWALL,
                 entryPoint = pendingPurchaseEntryPoint,
                 responseCode = result.responseCode,
                 debugMessage = result.debugMessage,
+                productId = failureProductId,
+                reason = failureReason,
             )
             clearPendingPaywallLaunch()
             clearPendingTrialOffer()
@@ -735,7 +767,19 @@ class ProManager
             entryPoint: String?,
             responseCode: Int,
             debugMessage: String?,
+            productId: String? = null,
+            reason: String? = null,
         ) {
+            val resolvedProductId =
+                productId?.takeIf { it.isNotBlank() }
+                    ?: pendingLaunchProductId?.takeIf { it.isNotBlank() }
+                    ?: "unknown"
+            val resolvedReason =
+                when {
+                    success -> null
+                    !reason.isNullOrBlank() -> reason
+                    else -> billingFailureReason(responseCode)
+                }
             analyticsService.track(
                 AnalyticsEvents.PAYWALL_PURCHASE_RESULT,
                 MonetizationAnalyticsPayload.resultProperties(
@@ -745,6 +789,8 @@ class ProManager
                     entryPoint = entryPoint,
                     responseCode = responseCode,
                     debugMessage = debugMessage,
+                    productId = resolvedProductId,
+                    reason = resolvedReason,
                 ),
             )
         }
@@ -768,6 +814,18 @@ class ProManager
                 ),
             )
         }
+
+        private fun billingFailureReason(responseCode: Int): String =
+            when (responseCode) {
+                BillingClient.BillingResponseCode.USER_CANCELED -> "user_cancelled"
+                BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> "service_disconnected"
+                BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> "item_unavailable"
+                BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> "item_already_owned"
+                BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> "billing_unavailable"
+                BillingClient.BillingResponseCode.ERROR -> "billing_error"
+                BillingClient.BillingResponseCode.NETWORK_ERROR -> "network_error"
+                else -> "unknown_$responseCode"
+            }
 
         private fun purchaseResultValue(
             success: Boolean,
@@ -922,13 +980,17 @@ internal object MonetizationAnalyticsPayload {
         entryPoint: String?,
         responseCode: Int,
         debugMessage: String?,
+        productId: String? = null,
+        reason: String? = null,
     ): Map<String, Any> =
-        mapOf(
-            AnalyticsProperties.RESULT to result,
-            AnalyticsProperties.SUCCESS to success,
-            AnalyticsProperties.SOURCE to source,
-            AnalyticsProperties.ENTRY_POINT to (entryPoint ?: source),
-            AnalyticsProperties.RESPONSE_CODE to responseCode,
-            AnalyticsProperties.DEBUG_MESSAGE to (debugMessage ?: ""),
-        )
+        buildMap {
+            put(AnalyticsProperties.RESULT, result)
+            put(AnalyticsProperties.SUCCESS, success)
+            put(AnalyticsProperties.SOURCE, source)
+            put(AnalyticsProperties.ENTRY_POINT, entryPoint ?: source)
+            put(AnalyticsProperties.RESPONSE_CODE, responseCode)
+            put(AnalyticsProperties.DEBUG_MESSAGE, debugMessage ?: "")
+            productId?.let { put(AnalyticsProperties.PRODUCT_ID, it) }
+            reason?.let { put(AnalyticsProperties.REASON, it) }
+        }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/MonetizationAnalyticsPayloadTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/MonetizationAnalyticsPayloadTest.kt
@@ -72,4 +72,42 @@ class MonetizationAnalyticsPayloadTest {
         assertThat(properties[AnalyticsProperties.RESULT]).isEqualTo("failed")
         assertThat(properties[AnalyticsProperties.DEBUG_MESSAGE]).isEqualTo("")
     }
+
+    @Test
+    fun `resultProperties includes product id and failure reason when provided`() {
+        val properties =
+            MonetizationAnalyticsPayload.resultProperties(
+                success = false,
+                result = "failed",
+                source = MonetizationSources.PAYWALL,
+                entryPoint = "setup_upgrade_cta",
+                responseCode = 4,
+                debugMessage = "item unavailable",
+                productId = "elite_tactical_monthly",
+                reason = "item_unavailable",
+            )
+
+        assertThat(properties[AnalyticsProperties.PRODUCT_ID]).isEqualTo("elite_tactical_monthly")
+        assertThat(properties[AnalyticsProperties.REASON]).isEqualTo("item_unavailable")
+        assertThat(properties[AnalyticsProperties.RESULT]).isEqualTo("failed")
+        assertThat(properties[AnalyticsProperties.SUCCESS]).isEqualTo(false)
+    }
+
+    @Test
+    fun `resultProperties omits reason on success`() {
+        val properties =
+            MonetizationAnalyticsPayload.resultProperties(
+                success = true,
+                result = "success",
+                source = MonetizationSources.PAYWALL,
+                entryPoint = "setup_upgrade_cta",
+                responseCode = 0,
+                debugMessage = null,
+                productId = "pro_base",
+                reason = null,
+            )
+
+        assertThat(properties[AnalyticsProperties.PRODUCT_ID]).isEqualTo("pro_base")
+        assertThat(properties).doesNotContainKey(AnalyticsProperties.REASON)
+    }
 }

--- a/scripts/paywall_conversion_report.py
+++ b/scripts/paywall_conversion_report.py
@@ -27,6 +27,22 @@ PLAY_STORE_CATALOG_FILTER = (
     "AND coalesce(toString(properties.billing_ready), 'true') = 'true'"
 )
 
+# Include legacy paywall_purchase_result failures (pre-reason instrumentation).
+_PURCHASE_FAILURE_EVENTS = (
+    "('paywall_purchase_fail_reason', 'purchase_failed', 'paywall_purchase_result')"
+)
+_PURCHASE_FAILURE_RESULT_FILTER = """
+          AND (
+            event != 'paywall_purchase_result'
+            OR (
+              lower(coalesce(toString(properties.success), '')) != 'true'
+              AND lower(coalesce(toString(properties.result), '')) NOT IN (
+                'success', 'restored', 'already_unlocked'
+              )
+            )
+          )
+"""
+
 
 def _safe_int(value: Any) -> int:
     try:
@@ -133,9 +149,10 @@ def _failure_reasons(api_key: str, project_id: str, days: int, errors: List[str]
           ) AS reason,
           count() AS failures
         FROM events
-        WHERE event IN ('paywall_purchase_fail_reason', 'purchase_failed')
+        WHERE event IN {_PURCHASE_FAILURE_EVENTS}
           AND timestamp > now() - interval {win}
           AND {LIVE_EVENTS_PREDICATE}
+          {_PURCHASE_FAILURE_RESULT_FILTER}
         GROUP BY reason
         ORDER BY failures DESC
         LIMIT 12
@@ -159,9 +176,10 @@ def _failure_breakdown(api_key: str, project_id: str, days: int, errors: List[st
           count() AS failures,
           count(DISTINCT person_id) AS users
         FROM events
-        WHERE event IN ('paywall_purchase_fail_reason', 'purchase_failed')
+        WHERE event IN {_PURCHASE_FAILURE_EVENTS}
           AND timestamp > now() - interval {win}
           AND {LIVE_EVENTS_PREDICATE}
+          {_PURCHASE_FAILURE_RESULT_FILTER}
         GROUP BY platform, product_id, reason
         ORDER BY failures DESC
         LIMIT 25


### PR DESCRIPTION
## Summary
- **Android:** `paywall_purchase_result` now includes `product_id` and `reason` on all failure paths (pre-flow catalog errors + billing callback), matching iOS `purchaseProperties` semantics.
- **Analytics:** `paywall_conversion_report.py` counts legacy `paywall_purchase_result` failures (not only `paywall_purchase_fail_reason`).

## GSD / Ralph
- Work item: **PAYWALL-TELEM** (REV-PUBLISH follow-on — revenue telemetry, not revenue itself)
- Fresh executive/paywall artifacts: [executive run 26688222388](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26688222388), [analytics paywall job 26688222695](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26688222695) — still **0** purchase successes

## Test plan
- [x] `uv run pytest scripts/tests/test_paywall_conversion_report.py` — 8 passed
- [x] `MonetizationAnalyticsPayloadTest` — new cases for reason/product_id
- [ ] CI Android unit tests + Regression Guards

## Not in scope
- Does not create purchases; needs ship + device proof on **1.3.43+** for `paywall_purchase_success > 0`


Made with [Cursor](https://cursor.com)