### PR TITLE
chore(admob): APPROVED GSD snapshot + rewarded rollout gates

### DIFF
--- a/docs/ADMOB_SETUP.md
+++ b/docs/ADMOB_SETUP.md
@@ -117,7 +117,16 @@ Android IDs are baked into `BuildConfig` (override via env if needed):
 | `ADMOB_APP_ID_ANDROID` | `ca-app-pub-5173650670360699~4427145410` |
 | `ADMOB_REWARDED_UNIT_ID_ANDROID` | `ca-app-pub-5173650670360699/8693693481` |
 
-Debug builds use [Google test ad units](https://developers.google.com/admob/android/test-ads). PostHog flag `rewarded_ads_enabled` stays **off** until app-ads.txt verifies and you enable the experiment.
+Debug builds use [Google test ad units](https://developers.google.com/admob/android/test-ads).
+
+**Android approval (2026-05-30):** AdMob email + API `appApprovalState: APPROVED` for `ca-app-pub-5173650670360699~4427145410`. Hosted app-ads.txt remains **3/3 PASS**.
+
+PostHog flag `rewarded_ads_enabled` stays **off** by default. After approval, safe sequence:
+
+1. Refresh GSD: `python3 scripts/admob_metrics_snapshot.py --also-check-play-contact-path --api` → `marketing/data/admob_status.json` (`rewarded_rollout.ready_for_internal_flag_test`).
+2. Complete **Payment setup** in AdMob (required for payouts / full serving).
+3. Enable flag for **internal testers only** (5–10%), verify `rewarded_ad_requested` / `rewarded_ad_completed` in PostHog.
+4. Ship `AdMobRewardedAdPort` (replace stub) before broad rollout.
 
 ## iOS app in AdMob
 

--- a/marketing/data/admob_status.json
+++ b/marketing/data/admob_status.json
@@ -23,5 +23,34 @@
     ],
     "all_pass": true
   },
-  "api": null
+  "api": {
+    "skipped": false,
+    "token_source": "application-default-credentials",
+    "quota_project": "random-timer-dist-new",
+    "account": "accounts/pub-5173650670360699",
+    "app_count": 1,
+    "apps": [
+      {
+        "platform": "ANDROID",
+        "appId": "ca-app-pub-5173650670360699~4427145410",
+        "appApprovalState": "APPROVED",
+        "displayName": "Random Tactical Timer"
+      }
+    ]
+  },
+  "rewarded_rollout": {
+    "posthog_flag": "rewarded_ads_enabled",
+    "posthog_flag_default": "off",
+    "android_app_approval_state": "APPROVED",
+    "app_ads_hosting_all_pass": true,
+    "ready_for_internal_flag_test": true,
+    "ready_for_production_rewarded": false,
+    "production_blockers": [
+      "Complete AdMob payment setup (payouts / full serving)",
+      "Enable PostHog flag with staged rollout (start internal / 5%)",
+      "Wire AdMobRewardedAdPort (SDK) — StubRewardedAdPort is default",
+      "IAP catalog must be healthy before mixing ads + paywall (see monetization_decision_brief)"
+    ],
+    "ceo_email_evidence": "AdMob app approved email 2026-05-30 aligns with appApprovalState APPROVED when API creds present"
+  }
 }

--- a/scripts/admob_metrics_snapshot.py
+++ b/scripts/admob_metrics_snapshot.py
@@ -57,6 +57,7 @@ def build_snapshot(
             "all_pass": all(c["ok"] for c in checks),
         },
         "api": None,
+        "rewarded_rollout": None,
     }
 
     if include_api:
@@ -86,7 +87,36 @@ def build_snapshot(
             except Exception as exc:  # noqa: BLE001 — snapshot must always write
                 payload["api"] = {"skipped": False, "error": str(exc)[:500]}
 
+    payload["rewarded_rollout"] = _rewarded_rollout_readiness(payload)
     return payload
+
+
+def _rewarded_rollout_readiness(payload: dict) -> dict:
+    """Data-driven gate for PostHog `rewarded_ads_enabled` (default off)."""
+    app_ads_ok = bool((payload.get("app_ads") or {}).get("all_pass"))
+    android_state: str | None = None
+    api_block = payload.get("api")
+    if isinstance(api_block, dict) and not api_block.get("skipped") and not api_block.get("error"):
+        for app in api_block.get("apps") or []:
+            if app.get("platform") == "ANDROID":
+                android_state = app.get("appApprovalState")
+                break
+    approved = android_state == "APPROVED"
+    return {
+        "posthog_flag": "rewarded_ads_enabled",
+        "posthog_flag_default": "off",
+        "android_app_approval_state": android_state,
+        "app_ads_hosting_all_pass": app_ads_ok,
+        "ready_for_internal_flag_test": app_ads_ok and approved,
+        "ready_for_production_rewarded": False,
+        "production_blockers": [
+            "Complete AdMob payment setup (payouts / full serving)",
+            "Enable PostHog flag with staged rollout (start internal / 5%)",
+            "Wire AdMobRewardedAdPort (SDK) — StubRewardedAdPort is default",
+            "IAP catalog must be healthy before mixing ads + paywall (see monetization_decision_brief)",
+        ],
+        "ceo_email_evidence": "AdMob app approved email 2026-05-30 aligns with appApprovalState APPROVED when API creds present",
+    }
 
 
 def write_snapshot(repo_root: Path, payload: dict) -> Path:
@@ -101,12 +131,18 @@ def main() -> int:
     p.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
     p.add_argument("--also-check-play-contact-path", action="store_true")
     p.add_argument("--api", action="store_true", help="Include AdMob API apps when creds exist.")
+    p.add_argument(
+        "--no-api",
+        action="store_true",
+        help="Skip AdMob API even if ADC / ADMOB_ACCESS_TOKEN is available.",
+    )
     p.add_argument("--access-token", default=None)
     args = p.parse_args()
 
+    auto_api = not args.no_api and auth_mod.resolve_admob_auth(args.access_token) is not None
     payload = build_snapshot(
         also_play_path=args.also_check_play_contact_path,
-        include_api=args.api,
+        include_api=(args.api or auto_api) and not args.no_api,
         access_token=args.access_token,
     )
     out_path = write_snapshot(args.repo_root.resolve(), payload)

--- a/scripts/tests/test_admob_metrics_snapshot.py
+++ b/scripts/tests/test_admob_metrics_snapshot.py
@@ -18,6 +18,8 @@ class AdmobMetricsSnapshotTests(unittest.TestCase):
         self.assertTrue(payload["app_ads"]["all_pass"])
         self.assertEqual(len(payload["app_ads"]["checks"]), 1)
         self.assertIsNone(payload["api"])
+        self.assertIsNotNone(payload["rewarded_rollout"])
+        self.assertFalse(payload["rewarded_rollout"]["ready_for_internal_flag_test"])
 
     def test_write_snapshot_creates_json(self):
         with patch.object(mod, "verify_app_ads_txt", return_value=(True, "ok")):
@@ -33,6 +35,17 @@ class AdmobMetricsSnapshotTests(unittest.TestCase):
         with patch.object(mod, "verify_app_ads_txt", return_value=(False, "HTTP 404")):
             payload = mod.build_snapshot(also_play_path=False, include_api=False, access_token=None)
         self.assertFalse(payload["app_ads"]["all_pass"])
+
+    def test_rewarded_rollout_ready_when_approved_and_hosting_pass(self):
+        with patch.object(mod, "verify_app_ads_txt", return_value=(True, "ok")):
+            payload = mod.build_snapshot(also_play_path=False, include_api=False, access_token=None)
+        payload["api"] = {
+            "skipped": False,
+            "apps": [{"platform": "ANDROID", "appApprovalState": "APPROVED"}],
+        }
+        rollout = mod._rewarded_rollout_readiness(payload)
+        self.assertTrue(rollout["ready_for_internal_flag_test"])
+        self.assertFalse(rollout["ready_for_production_rewarded"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **`marketing/data/admob_status.json`** — Android `appApprovalState: APPROVED` (API readback 2026-05-31), app-ads 3/3 PASS, `rewarded_rollout` block for staged `rewarded_ads_enabled`
- **`admob_metrics_snapshot.py`** — auto `--api` when ADC/token available; `rewarded_rollout` readiness object
- **`docs/ADMOB_SETUP.md`** — post-approval flag rollout sequence (internal testers first)

## Evidence
```bash
python3 scripts/admob_metrics_snapshot.py --also-check-play-contact-path --api
# appApprovalState: APPROVED
```

CEO AdMob email (2026-05-30) reconciled with API.

## Not in scope
- Does **not** enable `rewarded_ads_enabled` in PostHog or production
- Does **not** wire AdMob SDK (still `StubRewardedAdPort`)
- IAP catalog / paywall revenue (#1659 merged; catalog empty still blocks purchases)

## Test plan
- [x] `pytest scripts/tests/test_admob_metrics_snapshot.py` — 4 passed


Made with [Cursor](https://cursor.com)