### PR TITLE
chore(ci): Actions budget — stagger crons, PR-only Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,27 +5,14 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
-  push:
-    branches: [develop, main, 'release/**', 'hotfix/**']
 
 env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
 jobs:
-  claude-review-push-advisory:
-    name: Claude Review Advisory
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Skip advisory review on push
-        run: |
-          echo "Claude Review only performs PR and @claude review flows."
-          echo "Push events get a green advisory noop to avoid false red checks."
-
-  # Claude deep review for architectural and project-specific checks
   claude-review:
     name: Claude Review
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:
@@ -36,18 +23,11 @@ jobs:
       statuses: write
       id-token: write
     steps:
-      - name: Pass required Claude Review check on push
-        if: github.event_name == 'push'
-        run: |
-          echo "Claude Review runs the real review on pull_request events."
-          echo "Push events get this green noop so required checks do not block PR heads."
-
       - uses: actions/checkout@v6
-        if: github.event_name == 'pull_request'
 
       - name: Claude Code Review
         id: claude_review
-        if: ${{ github.event_name == 'pull_request' && env.ANTHROPIC_API_KEY != '' }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         continue-on-error: true
         uses: anthropics/claude-code-action@ea5a04005c9fd4deed2ed803c15a64d0e6eb65d0 # v1
         with:
@@ -83,17 +63,16 @@ jobs:
           claude_args: '--max-turns 10'
 
       - name: Advisory mode notice when secret is unavailable
-        if: ${{ github.event_name == 'pull_request' && env.ANTHROPIC_API_KEY == '' }}
+        if: ${{ env.ANTHROPIC_API_KEY == '' }}
         run: |
           echo "ANTHROPIC_API_KEY is not available for this run."
           echo "Claude Review remains advisory and non-blocking."
 
       - name: Warn when Claude review crashes
-        if: github.event_name == 'pull_request' && steps.claude_review.outcome != 'success'
+        if: steps.claude_review.outcome != 'success'
         run: |
           echo "Claude review action failed/crashed; leaving non-blocking warning."
 
-  # Auto-approve after Claude review passes (satisfies required 1 approval)
   ai-auto-approve:
     name: AI Auto-Approve
     needs: claude-review
@@ -114,7 +93,6 @@ jobs:
         with:
           review-message: "Auto-approved: Claude AI review passed, all CI checks green."
 
-  # On-demand Claude assist via @claude mention
   claude-assist:
     name: Claude Assist
     if: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Project Automation
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # Run metrics every 6 hours (reduced from 30 min)
+    - cron: '20 */6 * * *' # Staggered :20 UTC (see docs/ACTIONS_BUDGET.md)
   issues:
     types: [opened, labeled, unlabeled, assigned, unassigned]
   issue_comment:

--- a/.github/workflows/store-release-watcher.yml
+++ b/.github/workflows/store-release-watcher.yml
@@ -2,7 +2,7 @@ name: Store Release Watcher
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # Was */30 — shared Actions budget
+    - cron: '10 */6 * * *' # Staggered :10 UTC (see docs/ACTIONS_BUDGET.md)
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -2,7 +2,7 @@ name: Wiki Sync
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # Every 6 hours (was */15 — Actions budget; push to develop still refreshes)
+    - cron: '5 */6 * * *' # Staggered :05 UTC (see docs/ACTIONS_BUDGET.md)
   workflow_dispatch:
   push:
     branches: [develop]

--- a/docs/ACTIONS_BUDGET.md
+++ b/docs/ACTIONS_BUDGET.md
@@ -4,6 +4,19 @@ Org-wide Actions spend is capped. **ThumbGate** and **openclaw-console** are the
 primary burn sources; this repo still must not waste minutes on schedules that do not
 directly earn revenue.
 
+## This repository (public)
+
+`Random-Timer` is a **public** repo: **standard GitHub-hosted runner minutes are free**
+for public repositories ([billing docs](https://docs.github.com/billing/managing-billing-for-github-actions/about-billing-for-github-actions)).
+
+You may still hit:
+
+- **Org-wide** minute caps from **private** repos on the same account
+- **Concurrency** queues (many workflows starting at once)
+- **`ANTHROPIC_API_KEY`** cost from `claude-review.yml` (not GitHub minutes)
+
+**GitHub Pro** adds only **+1,000 minutes/month on private repos** — it does not change public-repo pricing.
+
 ## Tiers
 
 | Tier | Purpose | Trigger |
@@ -20,6 +33,26 @@ directly earn revenue.
 - `stackoverflow-hourly-digest`: hourly → daily
 - `ios-internal-retry`: `*/3` → `*/6`
 - PR iOS device job: `CI_IOS_DEVICE_TIER=smoke` (Maestro smoke only; paywall regressions via dispatch)
+
+### Six-hour stagger (2026-05-31)
+
+Avoid stacking every `*/6` job at **:00** UTC (queue spikes). Current offsets:
+
+| Minute (UTC) | Workflow |
+|--------------|----------|
+| :05 | `wiki-sync` |
+| :10 | `store-release-watcher` |
+| :15 | `operational-verification-bundle` |
+| :17 | `ios-reviews-ops` |
+| :20 | `main` (metrics) |
+| :23 | `ios-release-context` |
+| :25 | `zernio-growth-orchestration` |
+| :35 | `ios-internal-retry` |
+
+## Claude review (Anthropic tokens)
+
+- `claude-review.yml` runs on **`pull_request` only** (no `push` to `develop`/`main`).
+- Required check **Claude Review** still applies on PRs per `.github/ci-config.yml`.
 
 ## Do not
 

--- a/docs/AUTONOMOUS_OPERATIONS.md
+++ b/docs/AUTONOMOUS_OPERATIONS.md
@@ -4,6 +4,8 @@ How Random Timer runs continuously without CEO action on every step, and where h
 
 **Budget:** Hard cap **$20/month** external spend (`CLAUDE.md`). Scheduled jobs use GitHub Actions minutes, PostHog/ASC/Play APIs already in use — no new paid services without CEO approval.
 
+**Actions:** This repo is **public** — standard hosted runner minutes are **free**. Org caps and **Anthropic** (`claude-review`) still matter. See `docs/ACTIONS_BUDGET.md`.
+
 **GSD (Get Shit Done):** Each automation cycle must end with a concrete artifact: merge SHA, workflow run URL, committed JSON snapshot, or wiki update — not a plan.
 
 **Ralph Loop:** Multi-step implement → test → fix cycles for code tasks. See `.claude/skills/ralph-mode.md` and `.claude/scripts/ralph-loop.sh`.
@@ -23,7 +25,7 @@ Ralph state: `.claude/ralph/ATTEMPTS.md` (session-local; not committed).
 
 | Schedule | Workflow | Purpose |
 |----------|----------|---------|
-| Every 15 min | `wiki-sync.yml` | PostHog → `marketing/data/*.json`, commit to `develop`, publish GitHub Wiki |
+| Every 6 h (:05 UTC) | `wiki-sync.yml` | PostHog → `marketing/data/*.json`, commit to `develop`, publish GitHub Wiki |
 | Daily 06:17 UTC | `executive-metrics.yml` | `executive_metrics.json` artifact (WQTU, paywall, stores) |
 | Daily 14:10 UTC | `north-star-guardrail.yml` | WQTU guardrail snapshot |
 | Daily 13:15 UTC | `daily-growth-publishing.yml` | Blog / Pages growth pipeline |

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -630,10 +630,14 @@ def test_ci_crashlytics_job_uses_dedicated_runtime_secret_and_is_not_best_effort
 def test_actions_budget_throttles_high_frequency_schedules():
     wiki = WIKI_SYNC_WORKFLOW.read_text(encoding="utf-8")
     watcher = (ROOT / ".github/workflows/store-release-watcher.yml").read_text(encoding="utf-8")
+    main_metrics = (ROOT / ".github/workflows/main.yml").read_text(encoding="utf-8")
     resolve = (ROOT / ".github/workflows/resolve-bot-comments.yml").read_text(encoding="utf-8")
+    budget_doc = ACTIONS_BUDGET_DOC.read_text(encoding="utf-8")
 
-    assert "cron: '0 */6 * * *'" in wiki
-    assert "cron: '0 */6 * * *'" in watcher
+    assert "cron: '5 */6 * * *'" in wiki
+    assert "cron: '10 */6 * * *'" in watcher
+    assert "cron: '20 */6 * * *'" in main_metrics
     assert "schedule:" not in resolve.split("workflow_dispatch:", 1)[0]
     assert ACTIONS_BUDGET_DOC.exists()
-    assert "CI_IOS_DEVICE_TIER" in ACTIONS_BUDGET_DOC.read_text(encoding="utf-8")
+    assert "CI_IOS_DEVICE_TIER" in budget_doc
+    assert "public" in budget_doc.lower()

--- a/scripts/tests/test_review_stack_contracts.py
+++ b/scripts/tests/test_review_stack_contracts.py
@@ -51,6 +51,12 @@ def test_ci_ai_review_gate_covers_copilot_and_sentry_threads() -> None:
     assert '"copilot-pull-request-reviewer[bot]"' in content
 
 
+def test_claude_review_runs_on_pull_request_only() -> None:
+    content = CLAUDE_REVIEW_WORKFLOW.read_text(encoding="utf-8")
+    assert "pull_request:" in content
+    assert "\n  push:\n" not in content
+
+
 def test_ci_config_documents_tighter_review_requirements() -> None:
     content = CI_CONFIG.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- **`claude-review.yml`**: remove `push` trigger (saves 2 noop jobs per develop push + Anthropic confusion)
- **Stagger `*/6` crons**: `wiki-sync` :05, `store-release-watcher` :10, `main` :20 UTC
- **`docs/ACTIONS_BUDGET.md`**: public repo = free hosted minutes; stagger table; Pro not required for this repo
- **`docs/AUTONOMOUS_OPERATIONS.md`**: fix wiki-sync cadence (6h, not 15m)

## Why
Random-Timer is **public** — paid Actions minutes are not the bottleneck. Org queues and **Anthropic** tokens are.

## Test plan
- [x] `pytest scripts/tests/test_review_stack_contracts.py` — 7 passed
- [ ] CI Regression Guards


Made with [Cursor](https://cursor.com)