### PR TITLE
fix(android): monthly IAP catalog queried as SUBS

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -424,12 +424,7 @@ class ProManager
 
         private suspend fun fetchProductDetails(productID: String): com.android.billingclient.api.ProductDetails? {
             val billingProductId = playBillingProductId(productID)
-            val productType =
-                if (billingProductId == ELITE_PRODUCT_ID) {
-                    BillingClient.ProductType.SUBS
-                } else {
-                    BillingClient.ProductType.INAPP
-                }
+            val productType = billingProductTypeForLogicalProductId(productID)
 
             val productList =
                 listOf(
@@ -904,6 +899,14 @@ internal data class SubscriptionOffer(
 
 /** Maps paywall logical SKU to Play Billing product id (identity — monthly uses Play catalog SKU). */
 internal fun playBillingProductId(logicalProductId: String): String = logicalProductId
+
+/** Play Billing product type for [logicalProductId] (monthly SKU is a subscription, not INAPP). */
+internal fun billingProductTypeForLogicalProductId(logicalProductId: String): String {
+    return when (playBillingProductId(logicalProductId)) {
+        ProManager.ELITE_PRODUCT_ID, ProManager.MONTHLY_PRODUCT_ID -> BillingClient.ProductType.SUBS
+        else -> BillingClient.ProductType.INAPP
+    }
+}
 
 internal fun monthlyOfferAvailableFromEliteOffers(offers: List<SubscriptionOffer>): Boolean =
     selectSubscriptionOfferByPeriod(offers, "P1M") != null

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
@@ -1,9 +1,23 @@
 package com.iganapolsky.randomtimer.billing
 
+import com.android.billingclient.api.BillingClient
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class ProManagerPlayBillingProductIdTest {
+    @Test
+    fun `billingProductTypeForLogicalProductId treats monthly subscription as SUBS`() {
+        assertThat(billingProductTypeForLogicalProductId(ProManager.MONTHLY_PRODUCT_ID))
+            .isEqualTo(BillingClient.ProductType.SUBS)
+    }
+
+    @Test
+    fun `billingProductTypeForLogicalProductId treats annual elite as SUBS and base as INAPP`() {
+        assertThat(billingProductTypeForLogicalProductId(ProManager.ELITE_PRODUCT_ID))
+            .isEqualTo(BillingClient.ProductType.SUBS)
+        assertThat(billingProductTypeForLogicalProductId(ProManager.BASE_PRODUCT_ID))
+            .isEqualTo(BillingClient.ProductType.INAPP)
+    }
     @Test
     fun `playBillingProductId uses Play catalog product ids`() {
         assertThat(playBillingProductId(ProManager.MONTHLY_PRODUCT_ID))


### PR DESCRIPTION
## Summary
- Query `elite_tactical_monthly` with `BillingClient.ProductType.SUBS` (was incorrectly `INAPP`)
- Extract `billingProductTypeForLogicalProductId()` with unit tests

## Evidence / root cause
Play catalog (`marketing/data/play_iap_catalog.json`) lists `elite_tactical_monthly` as a **subscription** with base plan `monthly`. Querying as INAPP returns no `ProductDetails`, so `availablePaywallProductIds()` stayed empty → no `offer_select`, no purchases.

## Test plan
- [x] `ProManagerPlayBillingProductIdTest` (new SUBS assertions)
- [ ] CI Android unit tests + Regression Guards


Made with [Cursor](https://cursor.com)