### PR TITLE
chore(release): add release-notes/1.3.43.md

### DIFF
--- a/release-notes/1.3.43.md
+++ b/release-notes/1.3.43.md
@@ -1,0 +1,12 @@
+# Release 1.3.43
+
+## Summary
+**1.3.43** restores Android paywall purchase flow by querying `elite_tactical_monthly` as a Play **subscription** (SUBS), so StoreKit-style catalog probes return product details and `offer_select` / purchase can proceed.
+
+## Product
+- **Android billing:** `billingProductTypeForLogicalProductId()` treats `elite_tactical` and `elite_tactical_monthly` as SUBS (was INAPP for monthly).
+- **Paywall:** Unblocks `availablePaywallProductIds()` when Play hosts the monthly SKU as a subscription product.
+
+## Release operations
+- Preflight requires this file (`release-notes/1.3.43.md`) before `internal-distribution` / `native-release` Android jobs run.
+- After Firebase internal signoff on the release SHA, dispatch `native-release` with `platform=android` and `production-signoff` approval.


### PR DESCRIPTION
## Summary
- Adds `release-notes/1.3.43.md` required by `preflight-release.sh`

## Why
Internal distribution run [26720061445](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26720061445) failed Play internal with:
`Versioned release notes missing: release-notes/1.3.43.md`

## Test plan
- [ ] CI Regression Guards
- [ ] Merge → internal-distribution re-runs on develop push


Made with [Cursor](https://cursor.com)