### PR TITLE
feat(observability): PostHog billing diagnostics and saved HogQL pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
 
+# Generated PostHog observability evidence (scripts/posthog_observability_bootstrap.py)
+marketing/data/posthog_observability_status.json
+
 # dependencies
 node_modules/
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -16,6 +16,7 @@ This document is the **source of truth** for what is **implemented in code** ver
 | **Firebase Performance** | **No** (SPM product not linked) | **Yes** (Gradle plugin + `firebase-perf` dependency) | iOS auto-instrumentation was removed to stabilize CI; can be re-added later with the same CI skip pattern if validated. |
 | **Firebase Remote Config** | **No** | **No** | Not referenced in app sources; use PostHog feature flags until/unless RC is added. |
 | **PostHog feature flags (in-app)** | Yes | Yes | SDK `isFeatureEnabled` / `reloadFeatureFlags` (see `AnalyticsService` on each platform). Flags load at init with `preloadFeatureFlags` on Android; iOS reloads before paywall when needed. |
+| **PostHog billing diagnostics (events)** | Partial | Yes | Android emits `billing_*` events with `billing_response_label`; saved HogQL in `marketing/data/posthog_observability.json`. **PostHog Logs OTLP** not wired on native yet — see `docs/POSTHOG_LOGS_PLAYBOOK.md`. |
 | **Firebase Cloud Messaging** | Not wired for product analytics | Not wired for product analytics | Listed only as a future option if you add push. |
 
 **Firebase Analytics (Google Analytics)** in-app collection is **disabled on Android** (`setAnalyticsCollectionEnabled(false)`) so telemetry is not duplicated with PostHog.

--- a/docs/POSTHOG_ANALYTICS.md
+++ b/docs/POSTHOG_ANALYTICS.md
@@ -35,6 +35,7 @@ Events emitted on both platforms:
 - `paywall_purchase_fail_reason`
 - `paywall_restore_result`
 - `subscription_funnel_step` — canonical paywall → plan → purchase → trial funnel; use property **`funnel_step`** (`paywall_viewed` \| `paywall_plan_selected` \| `purchase_flow_launched` \| `purchase_succeeded` \| `trial_started`) with the same `entry_point` / `paywall_experiment_variant` / `paywall_value_framing_variant` context as other paywall events.
+- **Android billing diagnostics:** `billing_client_setup`, `billing_product_catalog_status`, `billing_product_not_found`, `billing_product_query_retry`, `billing_diagnostic` — include **`billing_response_code`** and **`billing_response_label`** where applicable. See `docs/POSTHOG_LOGS_PLAYBOOK.md`.
 
 ### Paywall funnel semantics (single definition of “attempt”)
 

--- a/docs/POSTHOG_LOGS_PLAYBOOK.md
+++ b/docs/POSTHOG_LOGS_PLAYBOOK.md
@@ -1,0 +1,55 @@
+# PostHog Logs & billing observability playbook
+
+Last updated: 2026-06-01.
+
+This doc maps PostHog’s **Logs** product updates (alerts, saved views, easier ingestion) to **Random Tactical Timer** — a **native iOS/Android** app, not a PostHog JS site.
+
+## How this helps us
+
+| PostHog capability | Our use | ROI |
+|--------------------|---------|-----|
+| **Saved views / HogQL** | Recurring incidents: empty Play catalog, `FEATURE_NOT_SUPPORTED (-2)`, paywall leak | Faster MTTR on **$0 paywall conversion** |
+| **Alerts (logs)** | CI/automation OTLP (`random-timer-automation`) | Catch billing regressions in scripts without reading Actions logs |
+| **Alerts (events)** | `billing_product_not_found`, `billing_product_catalog_status` | Same checks via HogQL today — no JS “zero setup” on mobile |
+| **Easier ingestion** | JS zero-setup **does not apply** to Kotlin/Swift | We use **structured `billing_*` events** now; OTLP later |
+| **Traces (alpha)** | Future: link paywall → StoreKit/Play Billing spans | Planned; not wired in this repo yet |
+
+**North star link:** paywall failures block **WQTU** and revenue. These queries surface **Play Billing -2** and empty catalogs before store version lag hides the issue.
+
+## What we implemented in the repo
+
+### Native Android (PostHog events)
+
+- `billing_client_setup` — every Play Billing connection result (`billing_response_label`).
+- `billing_product_query_retry` — transient SKU query retries before `billing_product_not_found`.
+- `billing_diagnostic` — structured error companion on catalog failures.
+- `billing_response_label` on `billing_product_not_found` (human-readable, not only `-2`).
+- Product query **retry** (up to 3) for `SERVICE_DISCONNECTED`, `NETWORK_ERROR`, `SERVICE_UNAVAILABLE`, `FEATURE_NOT_SUPPORTED`.
+
+### Repo automation
+
+- **`marketing/data/posthog_observability.json`** — canonical HogQL saved queries + log-alert templates.
+- **`scripts/posthog_observability_bootstrap.py`** — verifies queries live; optional `--apply-log-alerts`.
+- **`marketing/data/posthog_observability_status.json`** — generated evidence (gitignored if sensitive; committed when only counts).
+
+### Manual PostHog UI (5 minutes, one-time)
+
+1. Open **Logs** → run HogQL from `posthog_observability.json` → **bookmark** each query (saved view).
+2. **Activity / Trends** → alert on `billing_product_not_found` count **> 0** in 5 minutes, filter `distribution_channel = play_store`.
+3. When enabling CI OTLP, set template `ci_billing_error_logs` to `enabled: true` and run bootstrap with `--apply-log-alerts`.
+
+## Commands (evidence)
+
+```bash
+# Verify HogQL (requires POSTHOG_API_KEY + POSTHOG_PROJECT_ID in .env)
+python3 scripts/posthog_observability_bootstrap.py
+
+# Optional log alerts (POSTHOG_PERSONAL_API_KEY with logs scope)
+python3 scripts/posthog_observability_bootstrap.py --apply-log-alerts
+```
+
+## Related docs
+
+- `docs/POSTHOG_ANALYTICS.md` — event contract
+- `docs/OBSERVABILITY.md` — stack status
+- `scripts/paywall_conversion_report.py` — weekly funnel + billing breakdown

--- a/marketing/data/posthog_observability.json
+++ b/marketing/data/posthog_observability.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "updated": "2026-06-01T00:00:00Z",
+  "description": "Canonical HogQL saved queries and alert templates for billing/revenue observability. Apply via scripts/posthog_observability_bootstrap.py.",
+  "posthog_host": "https://us.i.posthog.com",
+  "saved_queries": [
+    {
+      "id": "billing_catalog_empty_play",
+      "title": "Android Play — empty billing catalog (7d)",
+      "purpose": "Detect production Play builds where SKU queries return no catalog.",
+      "hogql": "SELECT count() AS events, uniq(person_id) AS users FROM events WHERE event = 'billing_product_catalog_status' AND coalesce(toString(properties.status), '') = 'empty' AND coalesce(toString(properties.distribution_channel), 'legacy') IN ('play_store', 'legacy') AND timestamp > now() - interval 7 day"
+    },
+    {
+      "id": "billing_product_not_found_feature_unsupported",
+      "title": "Play — FEATURE_NOT_SUPPORTED on SKU query (7d)",
+      "purpose": "Revenue blocker: billing_response_code -2 on product details.",
+      "hogql": "SELECT coalesce(toString(properties.product_id), 'unknown') AS product_id, count() AS events, uniq(person_id) AS users FROM events WHERE event = 'billing_product_not_found' AND toInt(coalesce(properties.billing_response_code, 0)) = -2 AND coalesce(toString(properties.distribution_channel), 'legacy') IN ('play_store', 'legacy') AND timestamp > now() - interval 7 day GROUP BY product_id ORDER BY events DESC"
+    },
+    {
+      "id": "paywall_views_no_offer_select",
+      "title": "Paywall views without offer select (7d)",
+      "purpose": "Funnel leak: users see paywall but never select a plan.",
+      "hogql": "SELECT count(DISTINCT e.person_id) AS paywall_users FROM events e WHERE e.event IN ('paywall_view', 'paywall_viewed') AND e.timestamp > now() - interval 7 day AND e.person_id NOT IN ( SELECT person_id FROM events WHERE event = 'paywall_offer_select' AND timestamp > now() - interval 7 day )"
+    },
+    {
+      "id": "billing_client_setup_non_ok",
+      "title": "Billing client setup failures (7d)",
+      "purpose": "Play Billing connection did not reach OK on setup.",
+      "hogql": "SELECT coalesce(toString(properties.billing_response_label), 'unknown') AS label, count() AS events FROM events WHERE event = 'billing_client_setup' AND coalesce(toInt64(properties.billing_response_code), 0) != 0 AND timestamp > now() - interval 7 day GROUP BY label ORDER BY events DESC"
+    },
+    {
+      "id": "billing_query_retries",
+      "title": "Billing product query retries (24h)",
+      "purpose": "Transient SKU query failures before final not_found.",
+      "hogql": "SELECT coalesce(toString(properties.billing_response_label), 'unknown') AS label, count() AS events FROM events WHERE event = 'billing_product_query_retry' AND timestamp > now() - interval 1 day GROUP BY label ORDER BY events DESC"
+    }
+  ],
+  "log_alert_templates": [
+    {
+      "id": "ci_billing_error_logs",
+      "name": "RTT CI — billing error logs",
+      "enabled": false,
+      "note": "Enable after OTLP log export from CI/scripts uses service name random-timer-automation.",
+      "window_minutes": 5,
+      "threshold_count": 1,
+      "threshold_operator": "above",
+      "filters": {
+        "severityLevels": ["error"],
+        "filterGroup": {
+          "type": "AND",
+          "values": [
+            {
+              "type": "AND",
+              "values": [
+                {
+                  "key": "body",
+                  "type": "log",
+                  "operator": "icontains",
+                  "value": "billing"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -52,7 +52,7 @@ class TimerSetupSmokeTest {
             .assertExists()
             .performClick()
 
-        composeRule.waitUntil(timeoutMillis = 5_000) {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
             composeRule
                 .onAllNodesWithText("Unlock Full Fight-Ready Training")
                 .fetchSemanticsNodes()

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/analytics/AnalyticsService.kt
@@ -125,6 +125,22 @@ class AnalyticsService
             PostHog.capture(event, properties = mergeProperties(properties))
         }
 
+        /** Structured billing signal for HogQL dashboards (complements PostHog Logs when OTLP is added). */
+        fun trackBillingDiagnostic(
+            message: String,
+            level: String = "info",
+            properties: Map<String, Any>? = null,
+        ) {
+            val payload =
+                mutableMapOf<String, Any>(
+                    "message" to message,
+                    "level" to level,
+                    "subsystem" to "billing",
+                )
+            properties?.let { payload.putAll(it) }
+            track(AnalyticsEvents.BILLING_DIAGNOSTIC, payload)
+        }
+
         fun screen(
             screenName: String,
             properties: Map<String, Any>? = null,
@@ -433,6 +449,9 @@ object AnalyticsEvents {
     const val PAYWALL_PURCHASE_RESULT = "paywall_purchase_result"
     const val PAYWALL_RESTORE_RESULT = "paywall_restore_result"
     const val BILLING_PRODUCT_CATALOG_STATUS = "billing_product_catalog_status"
+    const val BILLING_CLIENT_SETUP = "billing_client_setup"
+    const val BILLING_PRODUCT_QUERY_RETRY = "billing_product_query_retry"
+    const val BILLING_DIAGNOSTIC = "billing_diagnostic"
 
     // Loop
     const val LOOP_ROUND_COMPLETED = "loop_round_completed"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingResponseLabels.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingResponseLabels.kt
@@ -1,0 +1,38 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.android.billingclient.api.BillingClient
+
+/** Human-readable Play Billing response codes for PostHog diagnostics. */
+internal object BillingResponseLabels {
+    fun labelFor(responseCode: Int): String =
+        when (responseCode) {
+            BillingClient.BillingResponseCode.OK -> "OK"
+            BillingClient.BillingResponseCode.USER_CANCELED -> "USER_CANCELED"
+            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE -> "SERVICE_UNAVAILABLE"
+            BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> "BILLING_UNAVAILABLE"
+            BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> "ITEM_UNAVAILABLE"
+            BillingClient.BillingResponseCode.DEVELOPER_ERROR -> "DEVELOPER_ERROR"
+            BillingClient.BillingResponseCode.ERROR -> "ERROR"
+            BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> "ITEM_ALREADY_OWNED"
+            BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> "ITEM_NOT_OWNED"
+            BillingClient.BillingResponseCode.NETWORK_ERROR -> "NETWORK_ERROR"
+            BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> "SERVICE_DISCONNECTED"
+            BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED -> "FEATURE_NOT_SUPPORTED"
+            else -> "UNKNOWN_$responseCode"
+        }
+
+    /** Transient query failures worth retrying before emitting `billing_product_not_found`. */
+    internal val retryableProductQueryResponseCodes: Set<Int> =
+        setOf(
+            BillingClient.BillingResponseCode.SERVICE_DISCONNECTED,
+            BillingClient.BillingResponseCode.NETWORK_ERROR,
+            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE,
+            BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
+        )
+
+    internal fun shouldRetryProductDetailsQuery(
+        responseCode: Int,
+        attempt: Int,
+        maxAttempts: Int = 3,
+    ): Boolean = attempt < maxAttempts && responseCode in retryableProductQueryResponseCodes
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -129,7 +129,17 @@ class ProManager
             billingClient.startConnection(
                 object : BillingClientStateListener {
                     override fun onBillingSetupFinished(result: BillingResult) {
-                        if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                        val responseCode = result.responseCode
+                        analyticsService.track(
+                            AnalyticsEvents.BILLING_CLIENT_SETUP,
+                            mapOf(
+                                "billing_response_code" to responseCode,
+                                "billing_response_label" to BillingResponseLabels.labelFor(responseCode),
+                                "billing_debug_message" to result.debugMessage,
+                                AnalyticsProperties.DISTRIBUTION_CHANNEL to analyticsService.distributionChannel(),
+                            ),
+                        )
+                        if (responseCode == BillingClient.BillingResponseCode.OK) {
                             externalScope.launch {
                                 restorePurchases(
                                     source = MonetizationSources.AUTO_RESTORE,
@@ -418,6 +428,7 @@ class ProManager
                     AnalyticsProperties.AVAILABLE_PRODUCT_IDS to availableProductIds,
                     AnalyticsProperties.MISSING_PRODUCT_IDS to missingProductIds,
                     AnalyticsProperties.PRODUCT_COUNT to availableProductIds.size,
+                    AnalyticsProperties.DISTRIBUTION_CHANNEL to analyticsService.distributionChannel(),
                 ),
             )
         }
@@ -441,20 +452,41 @@ class ProManager
                     .setProductList(productList)
                     .build()
 
-            val result = billingClient.queryProductDetails(params)
-            val details = result.productDetailsList?.firstOrNull()
-            if (details != null) {
-                cachedProductDetails[productID] = details
-                if (billingProductId != productID) {
-                    cachedProductDetails[billingProductId] = details
+            var attempt = 0
+            while (true) {
+                attempt++
+                val result = billingClient.queryProductDetails(params)
+                val details = result.productDetailsList?.firstOrNull()
+                if (details != null) {
+                    cachedProductDetails[productID] = details
+                    if (billingProductId != productID) {
+                        cachedProductDetails[billingProductId] = details
+                    }
+                    if (billingProductId == ELITE_PRODUCT_ID) {
+                        syncMonthlyCatalogFromEliteFallback()
+                    }
+                    return details
                 }
-                if (billingProductId == ELITE_PRODUCT_ID) {
-                    syncMonthlyCatalogFromEliteFallback()
+
+                val responseCode = result.billingResult.responseCode
+                if (BillingResponseLabels.shouldRetryProductDetailsQuery(responseCode, attempt)) {
+                    analyticsService.track(
+                        AnalyticsEvents.BILLING_PRODUCT_QUERY_RETRY,
+                        mapOf(
+                            "logical_product_id" to productID,
+                            "billing_product_id" to billingProductId,
+                            "attempt" to attempt,
+                            "billing_response_code" to responseCode,
+                            "billing_response_label" to BillingResponseLabels.labelFor(responseCode),
+                        ),
+                    )
+                    delay(400L * attempt)
+                    continue
                 }
-            } else {
+
                 maybeReportBillingProductNotFound(billingProductId, result.billingResult)
+                return null
             }
-            return details
         }
 
         private fun maybeReportBillingProductNotFound(
@@ -462,18 +494,39 @@ class ProManager
             billingResult: BillingResult,
         ) {
             val channel = analyticsService.distributionChannel()
-            if (!billingClient.isReady) return
-            if (channel == AndroidInstallChannel.NON_PLAY_INSTALL) return
-            if (!reportedBillingProductNotFound.add(productID)) return
+            if (
+                !shouldReportBillingProductNotFound(
+                    billingReady = billingClient.isReady,
+                    distributionChannel = channel,
+                    alreadyReported = reportedBillingProductNotFound,
+                    productId = productID,
+                )
+            ) {
+                return
+            }
+            reportedBillingProductNotFound.add(productID)
+            val responseCode = billingResult.responseCode
+            val responseLabel = BillingResponseLabels.labelFor(responseCode)
             analyticsService.track(
                 "billing_product_not_found",
                 mapOf(
                     "product_id" to productID,
                     AnalyticsProperties.DISTRIBUTION_CHANNEL to channel,
                     "billing_ready" to billingClient.isReady,
-                    "billing_response_code" to billingResult.responseCode,
+                    "billing_response_code" to responseCode,
+                    "billing_response_label" to responseLabel,
                     "billing_debug_message" to billingResult.debugMessage,
                 ),
+            )
+            analyticsService.trackBillingDiagnostic(
+                message = "billing_product_not_found",
+                level = "error",
+                properties =
+                    mapOf(
+                        "product_id" to productID,
+                        "billing_response_code" to responseCode,
+                        "billing_response_label" to responseLabel,
+                    ),
             )
         }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingResponseLabelsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingResponseLabelsTest.kt
@@ -1,0 +1,47 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.android.billingclient.api.BillingClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BillingResponseLabelsTest {
+    @Test
+    fun `labelFor maps FEATURE_NOT_SUPPORTED`() {
+        assertEquals(
+            "FEATURE_NOT_SUPPORTED",
+            BillingResponseLabels.labelFor(BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED),
+        )
+    }
+
+    @Test
+    fun `shouldRetryProductDetailsQuery allows transient codes under max attempts`() {
+        assertTrue(
+            BillingResponseLabels.shouldRetryProductDetailsQuery(
+                BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
+                attempt = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `shouldRetryProductDetailsQuery stops at max attempts`() {
+        assertFalse(
+            BillingResponseLabels.shouldRetryProductDetailsQuery(
+                BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
+                attempt = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `shouldRetryProductDetailsQuery ignores OK`() {
+        assertFalse(
+            BillingResponseLabels.shouldRetryProductDetailsQuery(
+                BillingClient.BillingResponseCode.OK,
+                attempt = 1,
+            ),
+        )
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerBillingQueryRetryTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerBillingQueryRetryTest.kt
@@ -1,0 +1,16 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.android.billingclient.api.BillingClient
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProManagerBillingQueryRetryTest {
+    @Test
+    fun `catalog retry set includes service disconnected`() {
+        assertTrue(
+            BillingResponseLabels.retryableProductQueryResponseCodes.contains(
+                BillingClient.BillingResponseCode.SERVICE_DISCONNECTED,
+            ),
+        )
+    }
+}

--- a/scripts/posthog_observability_bootstrap.py
+++ b/scripts/posthog_observability_bootstrap.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Verify and optionally apply PostHog observability assets (saved HogQL + log alerts).
+
+Reads marketing/data/posthog_observability.json, runs each saved HogQL query against the
+live project (when POSTHOG_API_KEY + POSTHOG_PROJECT_ID are set), and writes
+marketing/data/posthog_observability_status.json with evidence.
+
+Log alerts (--apply-log-alerts) require POSTHOG_PERSONAL_API_KEY with logs scope.
+Native apps emit billing_* events today; PostHog Logs OTLP is optional for CI/scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parent
+REPO_ROOT = _SCRIPTS.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from repo_dotenv import load_repo_dotenv
+from store_downloads_snapshot import posthog_query
+
+CONFIG_PATH = REPO_ROOT / "marketing" / "data" / "posthog_observability.json"
+STATUS_PATH = REPO_ROOT / "marketing" / "data" / "posthog_observability_status.json"
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_config() -> dict[str, Any]:
+    raw = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("posthog_observability.json must be a JSON object")
+    return raw
+
+
+def _posthog_credentials() -> tuple[str, str] | tuple[None, None]:
+    api_key = os.environ.get("POSTHOG_API_KEY", "").strip()
+    project_id = os.environ.get("POSTHOG_PROJECT_ID", "").strip()
+    if api_key and project_id:
+        return api_key, project_id
+    return None, None
+
+
+def verify_saved_queries(config: dict[str, Any]) -> list[dict[str, Any]]:
+    queries = config.get("saved_queries") or []
+    if not isinstance(queries, list):
+        raise ValueError("saved_queries must be a list")
+
+    api_key, project_id = _posthog_credentials()
+    errors: list[str] = []
+    results: list[dict[str, Any]] = []
+
+    for item in queries:
+        if not isinstance(item, dict):
+            continue
+        query_id = str(item.get("id") or "")
+        hogql = str(item.get("hogql") or "").strip()
+        entry: dict[str, Any] = {
+            "id": query_id,
+            "title": item.get("title"),
+            "verified": False,
+        }
+        if not query_id or not hogql:
+            entry["error"] = "missing id or hogql"
+            results.append(entry)
+            continue
+        if not api_key or not project_id:
+            entry["skipped"] = "POSTHOG_API_KEY or POSTHOG_PROJECT_ID unset"
+            results.append(entry)
+            continue
+
+        payload = posthog_query(hogql, api_key, project_id, errors)
+        if payload is None:
+            entry["error"] = errors[-1] if errors else "query_failed"
+        else:
+            entry["verified"] = True
+            entry["row_count"] = len((payload.get("results") or []))
+            entry["results_preview"] = (payload.get("results") or [])[:5]
+        results.append(entry)
+
+    return results
+
+
+def _requests_module():
+    try:
+        import requests
+
+        return requests
+    except ImportError:
+        return None
+
+
+def apply_log_alerts(config: dict[str, Any], *, dry_run: bool) -> list[dict[str, Any]]:
+    templates = config.get("log_alert_templates") or []
+    personal_key = os.environ.get("POSTHOG_PERSONAL_API_KEY", "").strip()
+    project_id = os.environ.get("POSTHOG_PROJECT_ID", "").strip()
+    host = str(config.get("posthog_host") or "https://us.i.posthog.com").rstrip("/")
+    api_host = host.replace("i.posthog.com", "posthog.com")
+
+    outcomes: list[dict[str, Any]] = []
+    requests = _requests_module()
+
+    for template in templates:
+        if not isinstance(template, dict):
+            continue
+        alert_id = str(template.get("id") or "")
+        enabled = bool(template.get("enabled", True))
+        outcome: dict[str, Any] = {"id": alert_id, "applied": False}
+        if not enabled:
+            outcome["skipped"] = "template disabled in JSON"
+            outcomes.append(outcome)
+            continue
+        if dry_run:
+            outcome["skipped"] = "dry_run"
+            outcomes.append(outcome)
+            continue
+        if not personal_key or not project_id:
+            outcome["skipped"] = "POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID unset"
+            outcomes.append(outcome)
+            continue
+        if requests is None:
+            outcome["error"] = "requests not installed"
+            outcomes.append(outcome)
+            continue
+
+        body = {
+            "name": template.get("name") or alert_id,
+            "enabled": True,
+            "filters": template.get("filters") or {},
+            "window_minutes": int(template.get("window_minutes") or 5),
+            "threshold_count": int(template.get("threshold_count") or 1),
+            "threshold_operator": template.get("threshold_operator") or "above",
+        }
+        url = f"{api_host}/api/projects/{project_id}/logs/alerts/"
+        response = requests.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {personal_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=60,
+        )
+        if response.status_code >= 300:
+            outcome["error"] = f"http_{response.status_code}"
+        else:
+            try:
+                outcome["applied"] = True
+                outcome["remote_id"] = response.json().get("id")
+            except Exception:
+                outcome["applied"] = True
+        outcomes.append(outcome)
+
+    return outcomes
+
+
+def write_status(
+    config: dict[str, Any],
+    query_results: list[dict[str, Any]],
+    alert_results: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    status = {
+        "generated_at": _utc_now(),
+        "config_schema_version": config.get("schema_version"),
+        "saved_queries": query_results,
+        "log_alerts": alert_results or [],
+        "all_queries_verified": all(r.get("verified") for r in query_results if "skipped" not in r),
+    }
+    STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATUS_PATH.write_text(json.dumps(status, indent=2) + "\n", encoding="utf-8")
+    return status
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply-log-alerts",
+        action="store_true",
+        help="Create log alerts from log_alert_templates (requires personal API key).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --apply-log-alerts, print intent without POSTing.",
+    )
+    args = parser.parse_args()
+
+    load_repo_dotenv(REPO_ROOT)
+    config = load_config()
+    query_results = verify_saved_queries(config)
+    alert_results = (
+        apply_log_alerts(config, dry_run=args.dry_run or not args.apply_log_alerts)
+        if args.apply_log_alerts or args.dry_run
+        else None
+    )
+    status = write_status(config, query_results, alert_results)
+
+    verified = sum(1 for r in query_results if r.get("verified"))
+    skipped = sum(1 for r in query_results if "skipped" in r)
+    print(
+        json.dumps(
+            {
+                "status_path": str(STATUS_PATH.relative_to(REPO_ROOT)),
+                "queries_verified": verified,
+                "queries_skipped": skipped,
+                "all_queries_verified": status["all_queries_verified"],
+            }
+        )
+    )
+
+    if any(r.get("error") for r in query_results if "skipped" not in r):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_mobile_analytics_parity.py
+++ b/scripts/tests/test_mobile_analytics_parity.py
@@ -64,7 +64,13 @@ class MobileAnalyticsParityTests(unittest.TestCase):
         # exposes a "+5 min" extend-running-timer action (see
         # TimerForegroundService.kt around line 430). iOS doesn't ship that
         # affordance, so the event has no legitimate iOS emission point.
-        android_only_events = {"timer_extended"}
+        # Billing query diagnostics are Android Play Billing only (StoreKit uses different signals).
+        android_only_events = {
+            "timer_extended",
+            "billing_client_setup",
+            "billing_product_query_retry",
+            "billing_diagnostic",
+        }
         self.assertEqual(
             android_events - android_only_events,
             ios_events - ios_only_events,

--- a/scripts/tests/test_posthog_observability_bootstrap.py
+++ b/scripts/tests/test_posthog_observability_bootstrap.py
@@ -1,0 +1,38 @@
+"""Tests for posthog_observability_bootstrap (no live PostHog required)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "marketing" / "data" / "posthog_observability.json"
+
+
+def test_observability_config_has_unique_query_ids() -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    ids = [q["id"] for q in config["saved_queries"]]
+    assert len(ids) == len(set(ids))
+
+
+def test_observability_config_queries_are_non_empty() -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    for item in config["saved_queries"]:
+        assert item["hogql"].strip()
+        assert "FROM events" in item["hogql"]
+
+
+def test_bootstrap_module_loads_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    import posthog_observability_bootstrap as bootstrap
+
+    monkeypatch.setattr(bootstrap, "CONFIG_PATH", CONFIG_PATH)
+    monkeypatch.setattr(bootstrap, "STATUS_PATH", tmp_path / "status.json")
+    config = bootstrap.load_config()
+    results = bootstrap.verify_saved_queries(config)
+    assert len(results) == len(config["saved_queries"])
+    assert all("skipped" in r for r in results)


### PR DESCRIPTION
## Summary
- Android: `billing_response_label`, `billing_client_setup`, query retries, and `billing_diagnostic` events to debug Play Billing `FEATURE_NOT_SUPPORTED (-2)` and empty catalogs faster.
- Repo: canonical HogQL saved queries (`marketing/data/posthog_observability.json`), `posthog_observability_bootstrap.py`, and `docs/POSTHOG_LOGS_PLAYBOOK.md` mapping PostHog Logs newsletter features to our native stack.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_posthog_observability_bootstrap.py`
- [ ] CI `android` unit tests (billing package)
- [ ] After merge + release: PostHog shows `billing_product_catalog_status: ok` on new Play builds


Made with [Cursor](https://cursor.com)