### PR TITLE
feat(store): refresh Play and App Store ASO listing copy

### DIFF
--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,55 +1,43 @@
 TRAIN FOR CHAOS. NOT RHYTHM.
 
-Unpredictable random timer for boxing, MMA, BJJ, HIIT, CrossFit, and tactical drills.
+Random Tactical Timer is an unpredictable interval and round timer built for combat sports, reaction training, and HIIT—not another metronome you can anticipate.
 
-Most timers teach anticipation. Random Tactical Timer trains reaction.
+Set a min–max window; the app fires at a random moment inside it. You stay ready, react to the cue, and train real composure under pressure.
 
-Instead of firing on a predictable beat, it triggers at an unpredictable moment inside your chosen time window, forcing real response under pressure. This is pattern-interrupt training built for combat sports, sparring, drills, and reaction work.
+WHY FIGHTERS & COACHES USE IT
+• Stop counting down—train response to the signal
+• Pattern-interrupt rounds for sparring, pads, and conditioning
+• Hidden countdown so athletes cannot watch the clock
+• Loop mode for continuous random rounds (Pro: cap rounds 1–100)
 
-BUILT FOR:
-- Boxing pad rounds, bag intervals, and shadowboxing flurries
-- MMA, Muay Thai, and kickboxing reaction drills
-- BJJ scramble and positional transition drills
-- Military combatives and self-defense scenario training
-- HIIT, CrossFit, and tabata sessions that punish predictability
+BUILT FOR
+• Boxing: pad rounds, bag work, shadowboxing flurries
+• MMA, Muay Thai, kickboxing: reaction and combo drills
+• BJJ & wrestling: scrambles, transitions, competition warmup preset
+• Military combatives, self-defense scenarios, first-responder drills
+• HIIT, Tabata, CrossFit WODs that punish predictability
 
-WHY IT WORKS:
-- Stop anticipation: react to the cue, not the countdown.
-- Stay present: uncertainty keeps your nervous system engaged.
-- Train under pressure: build composure when the trigger is not on your schedule.
+KEY FEATURES
+• True random trigger inside your chosen range
+• Loud alarms, haptics, and volume control for gym floor use
+• Competition Warmup preset (BJJ, judo, wrestling, fight-day prep)
+• Reliable background timing (Android foreground service)
 
-KEY FEATURES:
-- True random trigger within your selected min/max range
-- Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
-- Hidden countdown mode — no timer watching allowed
-- Loop mode for continuous random chaos rounds
-- High-intensity alarm + haptic vibration + volume precision
-- Stable background behavior via Foreground Service
-- Full-screen tactical alerts that command attention
+PRO TACTICAL (OPTIONAL)
+• Coach voice callouts—male or female cues mid-round
+• Command-style previews and elapsed-time callouts for pressure drills
+• Sound Arsenal: bells, horns, sirens, and expanded alarm library
+• Up to 60-minute sessions and structured round loops
 
-PRO FEATURES:
-- AI voice callouts: male or female coach voice with tactical cues so you stay sharp mid-round
-- Command-cue previews and elapsed-time style callouts for pressure drills
-- Sound Arsenal: expanded alarm library for serious training sessions
-- Round selection (1–100) for structured training cycles
-- Extended timer range up to 60 minutes for long sessions
-
-SUBSCRIPTION & UPGRADE:
-- Pro is optional. Monthly and annual subscriptions are available where offered; pricing is shown on the purchase sheet before you confirm.
-- A one-time upgrade may be offered depending on product configuration in your region.
-
-HOW IT WORKS:
+HOW IT WORKS
 1. Set your range (e.g. 15 seconds to 3 minutes)
-2. Press Start
-3. Train normally — move, drill, spar, or hold position
-4. React with explosive intensity when the cue hits
-5. Loop for continuous stress rounds
+2. Tap Start and train—move, drill, spar, or hold position
+3. Explode on the cue; loop for stress rounds
 
-WORKS FOR:
-- Random countdown timer for combat sports training
-- Reaction time training for MMA fighters and boxers
-- Pattern-interrupt conditioning for military and first responders
-- HIIT and CrossFit WOD timer that punishes predictability
-- Unpredictable round timer for sparring and pad work
+SEARCH TERMS THIS APP SERVES
+Random interval timer • Round timer • Boxing timer • MMA timer • BJJ timer • Reaction training • Tabata timer • HIIT timer • Sparring timer • Wrestling drills
 
-No ads in the training experience. Optional anonymous product analytics (for example via PostHog) may be used to improve stability and features—see the Privacy Policy linked on the store listing. Optional Pro subscription unlocks advanced training features above.
+SUBSCRIPTION
+Pro is optional. Monthly and annual plans and regional pricing appear on the purchase sheet before you confirm. A one-time upgrade may be offered depending on Play configuration in your region.
+
+Privacy Policy and terms are linked on this store listing. Optional anonymous product analytics may be used to improve stability and features.

--- a/native-android/fastlane/metadata/android/en-US/short_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices.
+Interval timer for MMA, boxing, BJJ & HIIT. Random cues + coach voices.

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -1,33 +1,33 @@
 TRAIN FOR CHAOS. NOT RHYTHM.
 
-Unpredictable random timer for boxing, MMA, BJJ, HIIT, CrossFit, and tactical drills.
+Random Tactical Timer is an unpredictable interval and round timer for boxing, MMA, BJJ, wrestling, Muay Thai, kickboxing, HIIT, and tactical drills.
 
-Most timers teach anticipation. Random Tactical Timer trains reaction.
-
-Instead of firing on a predictable beat, it triggers at an unpredictable moment inside your chosen time window, forcing real response under pressure.
-
-Built for combat sports, HIIT, CrossFit, and reaction training.
+Most timers teach anticipation. This one trains reaction: the cue hits at a random moment inside your range so you stay present under pressure.
 
 FEATURES
-- Random trigger timing inside your selected range
-- Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
-- Hidden countdown mode to stop timer watching
-- Male or female AI coach voice callouts (Pro)
-- Loop mode with optional round limits (Pro)
-- Extended session range up to 60 minutes (Pro)
-- Sound Arsenal and richer alarm options for serious sessions (Pro)
+• Random trigger timing inside your selected min/max range
+• Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
+• Hidden countdown mode—no clock watching
+• High-intensity alarms and haptics for gym use
+• Loop mode for continuous random rounds
+
+PRO TACTICAL (OPTIONAL)
+• Coach voice callouts—male or female tactical cues mid-round
+• Command-cue previews and elapsed-time callouts for pressure drills
+• Sound Arsenal: expanded alarm library for serious sessions
+• Round selection (1–100) and sessions up to 60 minutes
 
 TRAINING USES
-- Boxing pad rounds, bag work, and shadowboxing flurries
-- MMA, Muay Thai, kickboxing, and sparring reaction drills
-- BJJ scrambles and positional transition drills
-- Military combatives and self-defense scenario training
-- HIIT, tabata, and conditioning sessions that punish predictability
+• Boxing pad rounds, bag work, and shadowboxing flurries
+• MMA, Muay Thai, and kickboxing reaction drills
+• BJJ scrambles and positional transitions
+• Wrestling and grappling prep
+• HIIT, Tabata, and CrossFit conditioning that punishes predictability
 
 Stop timing your drills. Start training your response.
 
 SUBSCRIPTION INFO
-Pro Tactical is offered as auto-renewable subscriptions (including monthly and annual options where available) and a one-time upgrade may be offered depending on App Store configuration in your region. Example list pricing when configured in App Store Connect: $3.99/month and $29.99/year; actual price is shown on Apple’s purchase confirmation sheet before you buy. Payment is charged to your Apple ID account at confirmation of purchase. Subscription automatically renews unless canceled at least 24 hours before the end of the current period. Manage subscriptions in Settings > Apple ID > Subscriptions.
+Pro Tactical is offered as auto-renewable subscriptions (monthly and annual options where available). A one-time upgrade may be offered depending on App Store configuration in your region. Example list pricing when configured in App Store Connect: $3.99/month and $29.99/year; actual price is shown on Apple’s purchase confirmation sheet before you buy. Payment is charged to your Apple ID account at confirmation of purchase. Subscription automatically renews unless canceled at least 24 hours before the end of the current period. Manage subscriptions in Settings > Apple ID > Subscriptions.
 
 Optional product analytics may be collected to improve stability and features—see the Privacy Policy below.
 

--- a/native-ios/fastlane/metadata/en-US/keywords.txt
+++ b/native-ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-mma,crossfit,boxing,bjj,sparring,muay,thai,kickboxing,tabata,wod,interval,jiujitsu,fighter,reaction
+bjj,hiit,sparring,wrestling,muaythai,tabata,crossfit,reaction,jiujitsu,wod,kickboxing

--- a/native-ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/native-ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Unpredictable intervals for combat sports & HIIT. AI coach voices, 60‑min sessions, full sound library—optional Pro.
+Unpredictable interval & round timer for MMA, boxing, BJJ & HIIT. Random cues train reaction—not rhythm. Coach voice callouts & Sound Arsenal with Pro.

--- a/native-ios/fastlane/metadata/en-US/subtitle.txt
+++ b/native-ios/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Random HIIT & combat training
+MMA & Boxing Round Timer

--- a/scripts/tests/test_store_metadata_copy.py
+++ b/scripts/tests/test_store_metadata_copy.py
@@ -10,21 +10,18 @@ def test_android_store_copy_uses_reaction_positioning() -> None:
     ).read_text(encoding="utf-8")
     short_description = (
         REPO_ROOT / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "short_description.txt"
-    ).read_text(encoding="utf-8")
+    ).read_text(encoding="utf-8").strip()
 
     assert "TRAIN FOR CHAOS. NOT RHYTHM." in full_description
-    assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in full_description
-    assert "pattern-interrupt training built for combat sports, sparring, drills, and reaction work." in full_description
+    assert "unpredictable interval" in full_description.lower()
+    assert "reaction" in full_description.lower()
+    assert "wrestling" in full_description.lower()
     assert "serious fighters and operators" not in full_description
-    # Short description pin (snapshot regression guard). Updated 2026-05-18:
-    # added "muay thai" as a new indexed term (high-volume combat-sport search),
-    # reordered to MMA → BJJ → boxing → muay thai → HIIT for natural reading,
-    # dropped redundant "Random cues" (Random already opens the string).
-    # 75/80 chars within Play Store's limit.
-    assert (
-        short_description.strip()
-        == "Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices."
-    )
+    assert len(short_description) <= 80
+    assert "interval timer" in short_description.lower()
+    assert "mma" in short_description.lower()
+    assert "coach" in short_description.lower()
+    assert "ai coach" not in short_description.lower()
 
 
 def test_ios_store_copy_matches_reaction_positioning() -> None:
@@ -33,7 +30,7 @@ def test_ios_store_copy_matches_reaction_positioning() -> None:
     ).read_text(encoding="utf-8")
     promotional_text = (
         REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "promotional_text.txt"
-    ).read_text(encoding="utf-8")
+    ).read_text(encoding="utf-8").strip()
     subtitle = (
         REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "subtitle.txt"
     ).read_text(encoding="utf-8").strip()
@@ -42,17 +39,16 @@ def test_ios_store_copy_matches_reaction_positioning() -> None:
     ).read_text(encoding="utf-8").strip()
 
     assert "TRAIN FOR CHAOS. NOT RHYTHM." in description
-    assert "Most timers teach anticipation. Random Tactical Timer trains reaction." in description
-    assert "Built for combat sports, HIIT, CrossFit, and reaction training." in description
-    assert (
-        promotional_text.strip()
-        == "Unpredictable intervals for combat sports & HIIT. AI coach voices, 60‑min sessions, full sound library—optional Pro."
-    )
-    # Subtitle copy pinned (snapshot regression guard). Updated 2026-05-18 from
-    # "Random HIIT & combat rounds" to "Random HIIT & combat training": ASO swap
-    # gaining "training" as a new indexed term (high search volume, not in title
-    # or keywords field) and dropping combat-sports-only "rounds" — broader
-    # funnel, same reaction positioning. 29/30 chars within Apple's limit.
-    assert subtitle == "Random HIIT & combat training"
-    assert "mma" in keywords
-    assert "crossfit" in keywords
+    assert "trains reaction" in description.lower()
+    assert "wrestling" in description.lower()
+    assert len(subtitle) <= 30
+    assert "round timer" in subtitle.lower() or "interval" in subtitle.lower()
+    assert len(promotional_text) <= 170
+    assert "unpredictable" in promotional_text.lower()
+    assert "ai coach" not in promotional_text.lower()
+    assert len(keywords) <= 100
+    keyword_tokens = {k.strip() for k in keywords.split(",")}
+    assert "mma" not in keyword_tokens
+    assert "boxing" not in keyword_tokens
+    assert "bjj" in keyword_tokens
+    assert "wrestling" in keyword_tokens


### PR DESCRIPTION
## Summary
- **Google Play short description** (80-char cap): leads with *interval timer* + *random cues* instead of generic “random tactical timer”; adds wrestling via full description; removes “AI coach” label (app uses recorded coach callouts).
- **Play full + iOS description**: restructured for ASO (round timer, boxing timer, MMA timer, reaction training, Tabata) while keeping subscription/legal blocks on iOS.
- **iOS subtitle** (30): `MMA & Boxing Round Timer` — indexes high-intent combat timer queries.
- **iOS keywords** (100): `bjj,hiit,sparring,wrestling,muaythai,tabata,crossfit,reaction,jiujitsu,wod,kickboxing` (85 chars; avoids duplicating title/subtitle terms per Apple guidance).
- **iOS promotional text** (170): reaction-first hook + Pro features (151 chars).

## Play “(Beta)” in screenshot
Repo `title.txt` remains **`Random Tactical Timer`** (21/30 chars). **“(Beta)”** on the Play listing comes from the **closed/open testing track**, not fastlane title — drop Beta on the production track when promoting.

## Before → after (en-US)

| Field | Before | After | Limit |
|-------|--------|-------|-------|
| Play short | Random tactical timer: MMA, BJJ, boxing, muay thai & HIIT. AI coach voices. (79) | Interval timer for MMA, boxing, BJJ & HIIT. Random cues + coach voices. (71) | 80 |
| iOS subtitle | Random HIIT & combat training (29) | MMA & Boxing Round Timer (24) | 30 |
| iOS keywords | mma,crossfit,boxing,bjj,... (mixed) | bjj,hiit,sparring,wrestling,muaythai,... (85) | 100 |
| iOS promo | Unpredictable intervals for combat sports & HIIT. AI coach voices... | Unpredictable interval & round timer for MMA, boxing, BJJ & HIIT... | 170 |

## Test plan
- [x] `python3 scripts/check_store_listing_parity.py`
- [x] `python3 -m pytest scripts/tests/test_store_metadata_copy.py`
- [ ] CI Path-Aware CI Gate + Python Script Tests
- [ ] After merge: upload listing via native-release / deliver when next store publish runs

## Note
Listing copy improves discovery; **Android billing -2 / empty catalog** is a separate revenue blocker (not fixed by metadata).


Made with [Cursor](https://cursor.com)