### PR TITLE
fix(android): billing catalog empty telemetry on 1.3.45 (#1684)

### DIFF
--- a/marketing/data/posthog_observability.json
+++ b/marketing/data/posthog_observability.json
@@ -1,14 +1,20 @@
 {
   "schema_version": 1,
-  "updated": "2026-06-01T00:00:00Z",
+  "updated": "2026-06-02T20:40:00Z",
   "description": "Canonical HogQL saved queries and alert templates for billing/revenue observability. Apply via scripts/posthog_observability_bootstrap.py.",
   "posthog_host": "https://us.i.posthog.com",
   "saved_queries": [
     {
       "id": "billing_catalog_empty_play",
       "title": "Android Play — empty billing catalog (7d)",
-      "purpose": "Detect production Play builds where SKU queries return no catalog.",
-      "hogql": "SELECT count() AS events, uniq(person_id) AS users FROM events WHERE event = 'billing_product_catalog_status' AND coalesce(toString(properties.status), '') = 'empty' AND coalesce(toString(properties.distribution_channel), 'legacy') IN ('play_store', 'legacy') AND timestamp > now() - interval 7 day"
+      "purpose": "Detect production Play builds where SKU queries succeeded but returned no catalog (billing ready + product details supported).",
+      "hogql": "SELECT count() AS events, uniq(person_id) AS users FROM events WHERE event = 'billing_product_catalog_status' AND coalesce(toString(properties.status), '') = 'empty' AND coalesce(toString(properties.probe_blocked_reason), '') = '' AND coalesce(toString(properties.distribution_channel), 'legacy') IN ('play_store', 'legacy') AND timestamp > now() - interval 7 day"
+    },
+    {
+      "id": "billing_catalog_probe_blocked_play",
+      "title": "Android Play — billing catalog probe blocked (7d)",
+      "purpose": "Billing unavailable, product-details unsupported, or client not ready (not a Play SKU miss).",
+      "hogql": "SELECT coalesce(toString(properties.status), 'unknown') AS status, count() AS events, uniq(person_id) AS users FROM events WHERE event = 'billing_product_catalog_status' AND coalesce(toString(properties.status), '') IN ('billing_not_ready', 'product_details_unsupported', 'catalog_probe_pending') AND coalesce(toString(properties.distribution_channel), 'legacy') IN ('play_store', 'legacy') AND timestamp > now() - interval 7 day GROUP BY status ORDER BY events DESC"
     },
     {
       "id": "billing_product_not_found_feature_unsupported",

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolver.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolver.kt
@@ -1,0 +1,74 @@
+package com.iganapolsky.randomtimer.billing
+
+internal data class BillingCatalogStatusResult(
+    val status: String,
+    val availableProductIds: List<String>,
+    val missingProductIds: List<String>,
+    val probeBlockedReason: String?,
+)
+
+/**
+ * Maps cached Play catalog state to PostHog `billing_product_catalog_status.status`.
+ * `empty` means billing was ready, product-details queries are supported, and Play returned no SKUs —
+ * not "we could not run a catalog probe".
+ */
+internal fun resolveBillingProductCatalogStatus(
+    billingReady: Boolean,
+    productDetailsSupported: Boolean?,
+    requiredProductIds: Set<String>,
+    cachedLogicalProductIds: Set<String>,
+): BillingCatalogStatusResult {
+    if (!billingReady) {
+        return blockedCatalogStatus(
+            status = "billing_not_ready",
+            reason = "billing_not_ready",
+            requiredProductIds = requiredProductIds,
+            cachedLogicalProductIds = cachedLogicalProductIds,
+        )
+    }
+    if (productDetailsSupported != true) {
+        val blockedStatus =
+            if (productDetailsSupported == false) {
+                "product_details_unsupported"
+            } else {
+                "catalog_probe_pending"
+            }
+        return blockedCatalogStatus(
+            status = blockedStatus,
+            reason = blockedStatus,
+            requiredProductIds = requiredProductIds,
+            cachedLogicalProductIds = cachedLogicalProductIds,
+        )
+    }
+
+    val availableProductIds = cachedLogicalProductIds.intersect(requiredProductIds).sorted()
+    val missingProductIds = requiredProductIds.minus(cachedLogicalProductIds).sorted()
+    val status =
+        when {
+            availableProductIds.isEmpty() -> "empty"
+            missingProductIds.isNotEmpty() -> "missing_required_products"
+            else -> "ok"
+        }
+    return BillingCatalogStatusResult(
+        status = status,
+        availableProductIds = availableProductIds,
+        missingProductIds = missingProductIds,
+        probeBlockedReason = null,
+    )
+}
+
+private fun blockedCatalogStatus(
+    status: String,
+    reason: String,
+    requiredProductIds: Set<String>,
+    cachedLogicalProductIds: Set<String>,
+): BillingCatalogStatusResult {
+    val availableProductIds = cachedLogicalProductIds.intersect(requiredProductIds).sorted()
+    val missingProductIds = requiredProductIds.minus(cachedLogicalProductIds).sorted()
+    return BillingCatalogStatusResult(
+        status = status,
+        availableProductIds = availableProductIds,
+        missingProductIds = missingProductIds,
+        probeBlockedReason = reason,
+    )
+}

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -400,6 +400,15 @@ class ProManager
         }
 
         private suspend fun fetchAllProductDetails() {
+            if (!billingClient.isReady) {
+                trackProductCatalogStatus()
+                return
+            }
+            refreshProductDetailsFeatureSupport()
+            if (productDetailsFeatureSupported != true) {
+                trackProductCatalogStatus()
+                return
+            }
             fetchProductDetails(BASE_PRODUCT_ID)
             fetchProductDetails(ELITE_PRODUCT_ID)
             fetchProductDetails(MONTHLY_PRODUCT_ID)
@@ -419,34 +428,64 @@ class ProManager
         }
 
         suspend fun availablePaywallProductIds(): Set<String> {
+            if (!ensureBillingReadyForPurchase()) {
+                trackProductCatalogStatus()
+                return emptySet()
+            }
             fetchAllProductDetails()
-            return cachedProductDetails.keys.toSet()
+            return cachedProductDetails.keys.intersect(
+                setOf(BASE_PRODUCT_ID, ELITE_PRODUCT_ID, MONTHLY_PRODUCT_ID),
+            )
+        }
+
+        private fun refreshProductDetailsFeatureSupport(): Boolean {
+            if (!billingClient.isReady) {
+                return false
+            }
+            val featureResult =
+                billingClient.isFeatureSupported(BillingClient.FeatureType.PRODUCT_DETAILS)
+            productDetailsFeatureSupported =
+                featureResult.responseCode == BillingClient.BillingResponseCode.OK
+            return productDetailsFeatureSupported == true
         }
 
         private fun trackProductCatalogStatus() {
             val requiredProductIds = setOf(BASE_PRODUCT_ID, ELITE_PRODUCT_ID, MONTHLY_PRODUCT_ID)
-            val availableProductIds = cachedProductDetails.keys.sorted()
-            val missingProductIds = requiredProductIds.minus(availableProductIds.toSet()).sorted()
-            val status =
-                when {
-                    availableProductIds.isEmpty() -> "empty"
-                    missingProductIds.isNotEmpty() -> "missing_required_products"
-                    else -> "ok"
-                }
-            val signature = "$status|${availableProductIds.joinToString()}|${missingProductIds.joinToString()}"
+            val cachedLogicalProductIds =
+                cachedProductDetails.keys.intersect(requiredProductIds)
+            val catalogStatus =
+                resolveBillingProductCatalogStatus(
+                    billingReady = billingClient.isReady,
+                    productDetailsSupported = productDetailsFeatureSupported,
+                    requiredProductIds = requiredProductIds,
+                    cachedLogicalProductIds = cachedLogicalProductIds,
+                )
+            val signature =
+                "${catalogStatus.status}|${catalogStatus.probeBlockedReason.orEmpty()}|" +
+                    "${catalogStatus.availableProductIds.joinToString()}|" +
+                    catalogStatus.missingProductIds.joinToString()
             if (lastCatalogStatusSignature == signature) {
                 return
             }
             lastCatalogStatusSignature = signature
             analyticsService.track(
                 AnalyticsEvents.BILLING_PRODUCT_CATALOG_STATUS,
-                mapOf(
-                    AnalyticsProperties.STATUS to status,
-                    AnalyticsProperties.AVAILABLE_PRODUCT_IDS to availableProductIds,
-                    AnalyticsProperties.MISSING_PRODUCT_IDS to missingProductIds,
-                    AnalyticsProperties.PRODUCT_COUNT to availableProductIds.size,
-                    AnalyticsProperties.DISTRIBUTION_CHANNEL to analyticsService.distributionChannel(),
-                ),
+                buildMap {
+                    put(AnalyticsProperties.STATUS, catalogStatus.status)
+                    put(AnalyticsProperties.AVAILABLE_PRODUCT_IDS, catalogStatus.availableProductIds)
+                    put(AnalyticsProperties.MISSING_PRODUCT_IDS, catalogStatus.missingProductIds)
+                    put(AnalyticsProperties.PRODUCT_COUNT, catalogStatus.availableProductIds.size)
+                    put(
+                        AnalyticsProperties.DISTRIBUTION_CHANNEL,
+                        analyticsService.distributionChannel(),
+                    )
+                    catalogStatus.probeBlockedReason?.let { put("probe_blocked_reason", it) }
+                    put("billing_ready", billingClient.isReady)
+                    put(
+                        "product_details_supported",
+                        productDetailsFeatureSupported == true,
+                    )
+                },
             )
         }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolverTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolverTest.kt
@@ -1,0 +1,97 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BillingCatalogStatusResolverTest {
+    private val required =
+        setOf(
+            ProManager.BASE_PRODUCT_ID,
+            ProManager.ELITE_PRODUCT_ID,
+            ProManager.MONTHLY_PRODUCT_ID,
+        )
+
+    @Test
+    fun `empty only when billing ready and product details supported`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+            )
+
+        assertThat(result.status).isEqualTo("empty")
+        assertThat(result.probeBlockedReason).isNull()
+    }
+
+    @Test
+    fun `billing_not_ready when client not ready`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = false,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+            )
+
+        assertThat(result.status).isEqualTo("billing_not_ready")
+        assertThat(result.probeBlockedReason).isEqualTo("billing_not_ready")
+    }
+
+    @Test
+    fun `catalog_probe_pending when product details support not yet known`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = null,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+            )
+
+        assertThat(result.status).isEqualTo("catalog_probe_pending")
+        assertThat(result.probeBlockedReason).isEqualTo("catalog_probe_pending")
+    }
+
+    @Test
+    fun `product_details_unsupported when Play reports feature unsupported`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+            )
+
+        assertThat(result.status).isEqualTo("product_details_unsupported")
+        assertThat(result.probeBlockedReason).isEqualTo("product_details_unsupported")
+    }
+
+    @Test
+    fun `ok when all required logical products cached`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = required,
+            )
+
+        assertThat(result.status).isEqualTo("ok")
+        assertThat(result.missingProductIds).isEmpty()
+    }
+
+    @Test
+    fun `missing_required_products when partial catalog`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = setOf(ProManager.ELITE_PRODUCT_ID),
+            )
+
+        assertThat(result.status).isEqualTo("missing_required_products")
+        assertThat(result.missingProductIds).contains(ProManager.BASE_PRODUCT_ID)
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause (PostHog, 1.3.45, 2026-06-02):** All 8 `billing_product_catalog_status: empty` events are **probe failures**, not missing Play SKUs. Correlated users: **7/8** `billing_client_setup` → `BILLING_UNAVAILABLE`, **5/8** `billing_diagnostic` → `product_details_supported: false` / `FEATURE_NOT_SUPPORTED`, **1/8** `NETWORK_ERROR` query retries. PR #1680 SKU mapping (`elite_tactical_monthly` → `elite_tactical` SUBS) is correct on `develop`; 1.3.45 still reported `empty` because paywall called `availablePaywallProductIds()` before billing was ready / without PRODUCT_DETAILS support and telemetry treated “no cache” as “Play returned zero products”.
- **Fix:** `resolveBillingProductCatalogStatus()` emits `billing_not_ready`, `product_details_unsupported`, or `catalog_probe_pending` instead of misleading `empty`; paywall catalog fetch waits on `ensureBillingReadyForPurchase()` and re-checks PRODUCT_DETAILS; HogQL “empty catalog” alert excludes `probe_blocked_reason`.

## PostHog evidence (3d, Android 1.3.45)

| Event | Signal |
|-------|--------|
| `billing_product_catalog_status` | 8× `empty`, all `play_store`, missing all logical SKUs |
| `billing_client_setup` | 13× `BILLING_UNAVAILABLE`, 7× `OK` |
| `billing_diagnostic` | 6× `product_details_supported: false` (-2) |
| `billing_product_query_retry` | 38× `NETWORK_ERROR` (1 user) |

## Test plan

- [x] `BillingCatalogStatusResolverTest` (new)
- [x] `pytest scripts/tests/test_posthog_observability_bootstrap.py`
- [ ] CI `testDebugUnitTest` + `app-debug` artifact

Closes #1684


Made with [Cursor](https://cursor.com)