### PR TITLE
fix(android): catalog_query_failed on network probe failures (#1684 P1)

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolver.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolver.kt
@@ -17,6 +17,7 @@ internal fun resolveBillingProductCatalogStatus(
     productDetailsSupported: Boolean?,
     requiredProductIds: Set<String>,
     cachedLogicalProductIds: Set<String>,
+    productQueryFailureReasons: Map<String, String> = emptyMap(),
 ): BillingCatalogStatusResult {
     if (!billingReady) {
         return blockedCatalogStatus(
@@ -43,8 +44,15 @@ internal fun resolveBillingProductCatalogStatus(
 
     val availableProductIds = cachedLogicalProductIds.intersect(requiredProductIds).sorted()
     val missingProductIds = requiredProductIds.minus(cachedLogicalProductIds).sorted()
+    val catalogQueryBlockedReason =
+        resolveCatalogQueryBlockedReason(
+            requiredProductIds = requiredProductIds,
+            cachedLogicalProductIds = cachedLogicalProductIds,
+            productQueryFailureReasons = productQueryFailureReasons,
+        )
     val status =
         when {
+            catalogQueryBlockedReason != null -> "catalog_query_failed"
             availableProductIds.isEmpty() -> "empty"
             missingProductIds.isNotEmpty() -> "missing_required_products"
             else -> "ok"
@@ -53,8 +61,31 @@ internal fun resolveBillingProductCatalogStatus(
         status = status,
         availableProductIds = availableProductIds,
         missingProductIds = missingProductIds,
-        probeBlockedReason = null,
+        probeBlockedReason = catalogQueryBlockedReason,
     )
+}
+
+/**
+ * When every required SKU failed to load due to network error after retries, distinguish that
+ * from Play returning an empty catalog (`empty`).
+ */
+internal fun resolveCatalogQueryBlockedReason(
+    requiredProductIds: Set<String>,
+    cachedLogicalProductIds: Set<String>,
+    productQueryFailureReasons: Map<String, String>,
+): String? {
+    if (cachedLogicalProductIds.intersect(requiredProductIds).isNotEmpty()) {
+        return null
+    }
+    val missingRequired = requiredProductIds.minus(cachedLogicalProductIds)
+    if (missingRequired.isEmpty()) {
+        return null
+    }
+    return if (missingRequired.all { productQueryFailureReasons[it] == "network_error" }) {
+        "network_error"
+    } else {
+        null
+    }
 }
 
 private fun blockedCatalogStatus(

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingResponseLabels.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingResponseLabels.kt
@@ -35,4 +35,10 @@ internal object BillingResponseLabels {
         attempt: Int,
         maxAttempts: Int = 3,
     ): Boolean = attempt < maxAttempts && responseCode in retryableProductQueryResponseCodes
+
+    /** Caps `billing_product_query_retry` telemetry per logical SKU per session. */
+    internal fun shouldEmitProductQueryRetryTelemetry(
+        emittedCount: Int,
+        maxPerSessionPerSku: Int = 3,
+    ): Boolean = emittedCount < maxPerSessionPerSku
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -106,6 +106,8 @@ class ProManager
 
         private val cachedProductDetails = mutableMapOf<String, com.android.billingclient.api.ProductDetails>()
         private val reportedBillingProductNotFound = ConcurrentHashMap.newKeySet<String>()
+        private val productQueryFailureReasons = ConcurrentHashMap<String, String>()
+        private val productQueryRetryTelemetryCounts = ConcurrentHashMap<String, Int>()
         private var lastCatalogStatusSignature: String? = null
         private var productDetailsFeatureSupported: Boolean? = null
         private var pendingPurchaseEntryPoint: String? = null
@@ -459,6 +461,7 @@ class ProManager
                     productDetailsSupported = productDetailsFeatureSupported,
                     requiredProductIds = requiredProductIds,
                     cachedLogicalProductIds = cachedLogicalProductIds,
+                    productQueryFailureReasons = productQueryFailureReasons,
                 )
             val signature =
                 "${catalogStatus.status}|${catalogStatus.probeBlockedReason.orEmpty()}|" +
@@ -520,6 +523,7 @@ class ProManager
                 val result = billingClient.queryProductDetails(params)
                 val details = result.productDetailsList?.firstOrNull()
                 if (details != null) {
+                    productQueryFailureReasons.remove(productID)
                     cachedProductDetails[productID] = details
                     if (billingProductId != productID) {
                         cachedProductDetails[billingProductId] = details
@@ -532,22 +536,38 @@ class ProManager
 
                 val responseCode = result.billingResult.responseCode
                 if (BillingResponseLabels.shouldRetryProductDetailsQuery(responseCode, attempt)) {
-                    analyticsService.track(
-                        AnalyticsEvents.BILLING_PRODUCT_QUERY_RETRY,
-                        mapOf(
-                            "logical_product_id" to productID,
-                            "billing_product_id" to billingProductId,
-                            "attempt" to attempt,
-                            "billing_response_code" to responseCode,
-                            "billing_response_label" to BillingResponseLabels.labelFor(responseCode),
-                        ),
-                    )
+                    val emittedCount = productQueryRetryTelemetryCounts[productID] ?: 0
+                    if (BillingResponseLabels.shouldEmitProductQueryRetryTelemetry(emittedCount)) {
+                        productQueryRetryTelemetryCounts[productID] = emittedCount + 1
+                        analyticsService.track(
+                            AnalyticsEvents.BILLING_PRODUCT_QUERY_RETRY,
+                            mapOf(
+                                "logical_product_id" to productID,
+                                "billing_product_id" to billingProductId,
+                                "attempt" to attempt,
+                                "billing_response_code" to responseCode,
+                                "billing_response_label" to BillingResponseLabels.labelFor(responseCode),
+                            ),
+                        )
+                    }
                     delay(400L * attempt)
                     continue
                 }
 
+                recordProductQueryFailure(productID, responseCode)
                 maybeReportBillingProductNotFound(billingProductId, result.billingResult)
                 return null
+            }
+        }
+
+        private fun recordProductQueryFailure(
+            productID: String,
+            responseCode: Int,
+        ) {
+            when (responseCode) {
+                BillingClient.BillingResponseCode.NETWORK_ERROR ->
+                    productQueryFailureReasons[productID] = "network_error"
+                else -> productQueryFailureReasons.remove(productID)
             }
         }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolverTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolverTest.kt
@@ -94,4 +94,60 @@ class BillingCatalogStatusResolverTest {
         assertThat(result.status).isEqualTo("missing_required_products")
         assertThat(result.missingProductIds).contains(ProManager.BASE_PRODUCT_ID)
     }
+
+    @Test
+    fun `catalog_query_failed when all required SKUs failed with network error after retries`() {
+        val networkFailures =
+            mapOf(
+                ProManager.BASE_PRODUCT_ID to "network_error",
+                ProManager.ELITE_PRODUCT_ID to "network_error",
+                ProManager.MONTHLY_PRODUCT_ID to "network_error",
+            )
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+                productQueryFailureReasons = networkFailures,
+            )
+
+        assertThat(result.status).isEqualTo("catalog_query_failed")
+        assertThat(result.probeBlockedReason).isEqualTo("network_error")
+    }
+
+    @Test
+    fun `empty when cache empty and Play returned no SKUs without network failure`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+                productQueryFailureReasons = emptyMap(),
+            )
+
+        assertThat(result.status).isEqualTo("empty")
+        assertThat(result.probeBlockedReason).isNull()
+    }
+
+    @Test
+    fun `missing_required_products when partial cache despite network failures on others`() {
+        val networkFailures =
+            mapOf(
+                ProManager.BASE_PRODUCT_ID to "network_error",
+                ProManager.MONTHLY_PRODUCT_ID to "network_error",
+            )
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = true,
+                requiredProductIds = required,
+                cachedLogicalProductIds = setOf(ProManager.ELITE_PRODUCT_ID),
+                productQueryFailureReasons = networkFailures,
+            )
+
+        assertThat(result.status).isEqualTo("missing_required_products")
+        assertThat(result.probeBlockedReason).isNull()
+    }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingResponseLabelsTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingResponseLabelsTest.kt
@@ -44,4 +44,11 @@ class BillingResponseLabelsTest {
             ),
         )
     }
+
+    @Test
+    fun `shouldEmitProductQueryRetryTelemetry allows up to three events per sku`() {
+        assertTrue(BillingResponseLabels.shouldEmitProductQueryRetryTelemetry(emittedCount = 0))
+        assertTrue(BillingResponseLabels.shouldEmitProductQueryRetryTelemetry(emittedCount = 2))
+        assertFalse(BillingResponseLabels.shouldEmitProductQueryRetryTelemetry(emittedCount = 3))
+    }
 }


### PR DESCRIPTION
## Summary
- When Play `queryProductDetails` exhausts retries with `NETWORK_ERROR`, emit `billing_product_catalog_status` with `status=catalog_query_failed` and `probe_blocked_reason=network_error` instead of misleading `empty`.
- Track per-logical-SKU query failure reasons in `ProManager` and pass them into `resolveBillingProductCatalogStatus`.
- Cap `billing_product_query_retry` telemetry to three events per SKU per session via `shouldEmitProductQueryRetryTelemetry`.

## Test plan
- [x] `BillingCatalogStatusResolverTest`: `catalog_query_failed` when all required SKUs have `network_error` failures
- [x] `BillingCatalogStatusResolverTest`: `empty` preserved when Play returns no SKUs without network failure
- [x] `BillingCatalogStatusResolverTest`: partial catalog still reports `missing_required_products`
- [x] `BillingResponseLabelsTest`: retry telemetry cap at three per SKU
- [ ] CI `testDebugUnitTest` green


Made with [Cursor](https://cursor.com)