### PR TITLE
fix: remove Competition Warmup preset + Play short description

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/domain/model/TimerConfig.kt
@@ -213,47 +213,6 @@ fun activationLegacyRangePresetIfEligible(current: TimerConfig): TimerConfig? {
     )
 }
 
-data class TrainingPreset(
-    val id: String,
-    val title: String,
-    val subtitle: String,
-    val minSeconds: Int,
-    val maxSeconds: Int,
-    val alarmDuration: Int,
-    val repeatEnabled: Boolean,
-    val soundType: SoundType,
-    val vibrationEnabled: Boolean,
-) {
-    fun applyTo(config: TimerConfig): TimerConfig =
-        config.copy(
-            minSeconds = minSeconds,
-            maxSeconds = maxSeconds,
-            alarmDuration = alarmDuration,
-            hiddenMode = false,
-            repeatEnabled = repeatEnabled,
-            soundType = soundType,
-            vibrationEnabled = vibrationEnabled,
-            useExtendedRange = false,
-        )
-
-    companion object {
-        val CompetitionWarmup =
-            TrainingPreset(
-                id = "competition_warmup",
-                title = "Competition Warmup",
-                subtitle = "Reactive mat-ready cues for the 30 minutes before first call.",
-                minSeconds = 20,
-                maxSeconds = 90,
-                alarmDuration = 5,
-                repeatEnabled = true,
-                soundType = SoundType.INTENSE,
-                vibrationEnabled = true,
-            )
-
-        val ALL = listOf(CompetitionWarmup)
-    }
-}
-
 /**
  * Represents the current state of an active timer.
  */

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -206,9 +206,6 @@ fun RandomTimerNavHost(
                 onVoiceGenderSelected = { gender ->
                     viewModel.trackVoiceGenderSelected(gender)
                 },
-                onTrainingPresetApplied = { preset ->
-                    viewModel.applyPresetAndStart(preset)
-                },
                 onSecretUnlock = {
                     viewModel.proManager.forcePro()
                 },

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -91,7 +91,6 @@ import com.iganapolsky.randomtimer.domain.model.RangeToggleProfiles
 import com.iganapolsky.randomtimer.domain.model.SoundType
 import com.iganapolsky.randomtimer.domain.model.TimeRangeAdjuster
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
-import com.iganapolsky.randomtimer.domain.model.TrainingPreset
 import com.iganapolsky.randomtimer.domain.model.VoiceGender
 import com.iganapolsky.randomtimer.domain.model.activationLegacyRangePresetIfEligible
 import com.iganapolsky.randomtimer.domain.model.sanitizedStoredRange
@@ -154,10 +153,6 @@ internal fun primaryStartButtonCaption(hasFirstCompleted: Boolean): String? =
         "Quick start: the default drill fires in 5-30 seconds."
     }
 
-internal fun competitionPrepSectionTitle(): String = "Competition Prep"
-
-internal fun isCompetitionPrepProGated(): Boolean = false
-
 internal fun readHasFirstCompleted(context: Context): Boolean =
     context
         .getSharedPreferences(AnalyticsService.PREFS_NAME, Context.MODE_PRIVATE)
@@ -178,7 +173,6 @@ fun TimerSetupScreen(
     isElite: Boolean = false,
     onUpgradeTap: (String) -> Unit = {},
     onVoiceGenderSelected: (VoiceGender) -> Unit = {},
-    onTrainingPresetApplied: (TrainingPreset) -> Unit = {},
     onSecretUnlock: () -> Unit = {},
     proSoundTrialActive: Boolean = false,
     showRewardedAdOffer: Boolean = false,
@@ -368,72 +362,6 @@ fun TimerSetupScreen(
                                 style = MaterialTheme.typography.labelSmall,
                                 color = TimerColors.AccentPrimary,
                             )
-                        }
-                    }
-                }
-
-                if (!isCompetitionPrepProGated()) {
-                    item {
-                        Text(
-                            text = "STANDARD OPS",
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = TimerColors.TextMuted,
-                            modifier = Modifier.padding(start = 4.dp),
-                        )
-                    }
-                    item {
-                        GlassCard(modifier = Modifier.fillMaxWidth(), padding = spacing.cardContent) {
-                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                Text(
-                                    text = competitionPrepSectionTitle(),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = TimerColors.TextPrimary,
-                                )
-
-                                TrainingPreset.ALL.forEach { preset ->
-                                    Surface(
-                                        onClick = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            onTrainingPresetApplied(preset)
-                                        },
-                                        shape = RoundedCornerShape(8.dp),
-                                        color = TimerColors.GlassBackground,
-                                        border = BorderStroke(1.dp, TimerColors.GlassBorder),
-                                        modifier = Modifier.fillMaxWidth(),
-                                    ) {
-                                        Row(
-                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            Column(
-                                                modifier = Modifier.weight(1f),
-                                                verticalArrangement = Arrangement.spacedBy(4.dp),
-                                            ) {
-                                                Text(
-                                                    text = preset.title,
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    fontWeight = FontWeight.SemiBold,
-                                                    color = TimerColors.TextPrimary,
-                                                )
-                                                Text(
-                                                    text = preset.subtitle,
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = TimerColors.TextMuted,
-                                                )
-                                            }
-                                            Text(
-                                                text = "${formatTime(preset.minSeconds)}-${formatTime(preset.maxSeconds)}",
-                                                style = MaterialTheme.typography.labelSmall,
-                                                fontWeight = FontWeight.Bold,
-                                                color = TimerColors.AccentPrimary,
-                                            )
-                                        }
-                                    }
-                                }
-                            }
                         }
                     }
                 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/viewmodel/TimerViewModel.kt
@@ -22,7 +22,6 @@ import com.iganapolsky.randomtimer.domain.model.TimerConfig
 import com.iganapolsky.randomtimer.domain.model.TimerState
 import com.iganapolsky.randomtimer.domain.model.TimerStatus
 import com.iganapolsky.randomtimer.domain.model.VoiceGender
-import com.iganapolsky.randomtimer.domain.model.TrainingPreset
 import com.iganapolsky.randomtimer.domain.repository.TimerRepository
 import com.iganapolsky.randomtimer.domain.usecase.StartTimerUseCase
 import com.iganapolsky.randomtimer.review.StoreReviewManager
@@ -147,19 +146,6 @@ class TimerViewModel
             }
             viewModelScope.launch {
                 repository.saveTimerConfig(newConfig)
-            }
-        }
-
-        fun applyPresetAndStart(preset: TrainingPreset) {
-            val newConfig = preset.applyTo(config.value)
-            trackTrainingPresetApplied(
-                presetId = preset.id,
-                minSeconds = preset.minSeconds,
-                maxSeconds = preset.maxSeconds,
-            )
-            viewModelScope.launch {
-                repository.saveTimerConfig(newConfig)
-                startTimer(newConfig)
             }
         }
 
@@ -397,21 +383,6 @@ class TimerViewModel
             analyticsService.track(
                 AnalyticsEvents.VOICE_GENDER_SELECTED,
                 mapOf(AnalyticsProperties.GENDER to gender.name.lowercase()),
-            )
-        }
-
-        fun trackTrainingPresetApplied(
-            presetId: String,
-            minSeconds: Int,
-            maxSeconds: Int,
-        ) {
-            analyticsService.track(
-                AnalyticsEvents.TRAINING_PRESET_APPLIED,
-                mapOf(
-                    AnalyticsProperties.PRESET_ID to presetId,
-                    "min_duration" to minSeconds,
-                    "max_duration" to maxSeconds,
-                ),
             )
         }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/domain/model/TimerConfigTest.kt
@@ -289,16 +289,4 @@ class TimerConfigTest {
         assertThat(result.profiles.freeMaxSeconds).isEqualTo(180)
     }
 
-    @Test
-    fun `competition warmup preset applies event day settings`() {
-        val config = TrainingPreset.CompetitionWarmup.applyTo(TimerConfig.DEFAULT)
-
-        assertThat(config.minSeconds).isEqualTo(20)
-        assertThat(config.maxSeconds).isEqualTo(90)
-        assertThat(config.alarmDuration).isEqualTo(5)
-        assertThat(config.repeatEnabled).isTrue()
-        assertThat(config.vibrationEnabled).isTrue()
-        assertThat(config.soundType).isEqualTo(SoundType.INTENSE)
-        assertThat(config.useExtendedRange).isFalse()
-    }
 }

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreenTextTest.kt
@@ -58,16 +58,6 @@ class TimerSetupScreenTextTest {
     }
 
     @Test
-    fun competitionPrepSectionTitleMatchesIOS() {
-        assertThat(competitionPrepSectionTitle()).isEqualTo("Competition Prep")
-    }
-
-    @Test
-    fun competitionPrepIsAvailableWithoutPro() {
-        assertThat(isCompetitionPrepProGated()).isFalse()
-    }
-
-    @Test
     fun soundArsenalFooterExplainsPreviewWhenTrialInactive() {
         assertThat(soundArsenalFreeFooterText(canEquipProSounds = false))
             .contains("preview")

--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -13,14 +13,13 @@ WHY FIGHTERS & COACHES USE IT
 BUILT FOR
 • Boxing: pad rounds, bag work, shadowboxing flurries
 • MMA, Muay Thai, kickboxing: reaction and combo drills
-• BJJ & wrestling: scrambles, transitions, competition warmup preset
+• BJJ & wrestling: scrambles, transitions, positional drills
 • Military combatives, self-defense scenarios, first-responder drills
 • HIIT, Tabata, CrossFit WODs that punish predictability
 
 KEY FEATURES
 • True random trigger inside your chosen range
 • Loud alarms, haptics, and volume control for gym floor use
-• Competition Warmup preset (BJJ, judo, wrestling, fight-day prep)
 • Reliable background timing (Android foreground service)
 
 PRO TACTICAL (OPTIONAL)

--- a/native-android/fastlane/metadata/android/en-US/short_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Interval timer for MMA, boxing, BJJ & HIIT. Random cues + coach voices.
+Interval timer for MMA, boxing, BJJ & HIIT. Random cues + tactical audio.

--- a/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
+++ b/native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift
@@ -32,60 +32,6 @@ struct TimerSetupScreen: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
 
-                // Zone 1: Standard Ops
-                Text("STANDARD OPS")
-                    .font(.caption2)
-                    .fontWeight(.bold)
-                    .foregroundColor(.textMuted)
-                    .padding(.top, 16)
-                    .padding(.leading, 4)
-
-                // Event-weekend preset for combat-sports competitors.
-                GlassCard {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Label("Competition Prep", systemImage: "figure.martial.arts")
-                            .font(.headline)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.textPrimary)
-
-                        ForEach(TrainingPreset.all) { preset in
-                            Button {
-                                applyTrainingPreset(preset)
-                            } label: {
-                                HStack(alignment: .center, spacing: 12) {
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(preset.title)
-                                            .font(.subheadline.weight(.semibold))
-                                            .foregroundColor(.textPrimary)
-
-                                        Text(preset.subtitle)
-                                            .font(.caption2)
-                                            .foregroundColor(.textMuted)
-                                            .fixedSize(horizontal: false, vertical: true)
-                                    }
-
-                                    Spacer()
-
-                                    let minLabel = TimeInterval(preset.minSeconds).formattedDuration
-                                    let maxLabel = TimeInterval(preset.maxSeconds).formattedDuration
-                                    Text("\(minLabel)-\(maxLabel)")
-                                        .font(.caption.weight(.bold))
-                                        .foregroundColor(.accentPrimary)
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 10)
-                                .background(Color.glassBackground)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(Color.glassBorder, lineWidth: 1)
-                                )
-                                .cornerRadius(8)
-                            }
-                            .accessibilityLabel("Apply \(preset.title) preset")
-                        }
-                    }
-                }
-
                 // 1. Timer Range Card
                 GlassCard {
                     VStack(alignment: .leading) {
@@ -654,24 +600,6 @@ struct TimerSetupScreen: View {
             paywallDefaultToAnnual = AnalyticsService.shared.paywallDefaultAnnualExperimentEnabled()
             paywallValueFramingVariant = AnalyticsService.shared.paywallValueFramingVariant()
         }
-    }
-
-    private func applyTrainingPreset(_ preset: TrainingPreset) {
-        let presetConfig = preset.applying(to: config)
-        persistActiveRangeProfile(
-            minSeconds: presetConfig.minSeconds,
-            maxSeconds: presetConfig.maxSeconds,
-            useExtendedRange: presetConfig.useExtendedRange
-        )
-        timerManager.updateConfig(presetConfig.clamped(isPro: proManager.isPro))
-        AnalyticsService.shared.track(
-            AnalyticsEvents.trainingPresetApplied,
-            properties: [
-                AnalyticsProperties.presetId: preset.id,
-                "min_duration": preset.minSeconds,
-                "max_duration": preset.maxSeconds,
-            ]
-        )
     }
 
     private var currentRangeProfiles: RangeToggleProfiles {

--- a/native-ios/RandomTimerTests/TimerModelsTests.swift
+++ b/native-ios/RandomTimerTests/TimerModelsTests.swift
@@ -64,19 +64,6 @@ final class TimerConfigTests: XCTestCase {
         XCTAssertTrue(config.vibrationEnabled)
     }
 
-    func testCompetitionWarmupPresetAppliesEventDaySettings() {
-        let base = TimerConfig.default
-        let config = TrainingPreset.competitionWarmup.applying(to: base)
-
-        XCTAssertEqual(config.minSeconds, 20)
-        XCTAssertEqual(config.maxSeconds, 90)
-        XCTAssertEqual(config.alarmDuration, 5)
-        XCTAssertTrue(config.repeatEnabled)
-        XCTAssertTrue(config.vibrationEnabled)
-        XCTAssertEqual(config.soundType, .intense)
-        XCTAssertFalse(config.useExtendedRange)
-    }
-
     func testConfigDecodingFromLooseJSON() throws {
         // Test that our custom decoder handles various formats (strings, numbers, etc)
         let payload = Data("""

--- a/native-ios/SharedModels/TimerModels.swift
+++ b/native-ios/SharedModels/TimerModels.swift
@@ -381,53 +381,6 @@ public struct TimerConfig: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - Training Presets
-
-public struct TrainingPreset: Identifiable, Sendable, Equatable {
-    public let id: String
-    public let title: String
-    public let subtitle: String
-    public let minSeconds: Int
-    public let maxSeconds: Int
-    public let alarmDuration: Int
-    public let repeatEnabled: Bool
-    public let soundType: SoundType
-    public let vibrationEnabled: Bool
-
-    public func applying(to config: TimerConfig) -> TimerConfig {
-        TimerConfig(
-            minSeconds: minSeconds,
-            maxSeconds: maxSeconds,
-            alarmDuration: alarmDuration,
-            hiddenMode: false,
-            repeatEnabled: repeatEnabled,
-            soundType: soundType,
-            volume: config.volume,
-            vibrationEnabled: vibrationEnabled,
-            useExtendedRange: false,
-            voiceEnabled: config.voiceEnabled,
-            voiceGender: config.voiceGender,
-            repeatRounds: config.repeatRounds
-        )
-    }
-
-    public static let competitionWarmup = TrainingPreset(
-        id: "competition_warmup",
-        title: "Competition Warmup",
-        subtitle: "Reactive mat-ready cues for the 30 minutes before first call.",
-        minSeconds: 20,
-        maxSeconds: 90,
-        alarmDuration: 5,
-        repeatEnabled: true,
-        soundType: .intense,
-        vibrationEnabled: true
-    )
-
-    public static let all: [TrainingPreset] = [
-        .competitionWarmup,
-    ]
-}
-
 // MARK: - Range Adjustment
 
 /// Shared business rules for the "Goes Off In This Range" sliders.

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -6,7 +6,6 @@ Most timers teach anticipation. This one trains reaction: the cue hits at a rand
 
 FEATURES
 • Random trigger timing inside your selected min/max range
-• Competition Warmup preset for BJJ, judo, wrestling, and fight-day prep
 • Hidden countdown mode—no clock watching
 • High-intensity alarms and haptics for gym use
 • Loop mode for continuous random rounds

--- a/scripts/tests/test_store_metadata_copy.py
+++ b/scripts/tests/test_store_metadata_copy.py
@@ -20,7 +20,8 @@ def test_android_store_copy_uses_reaction_positioning() -> None:
     assert len(short_description) <= 80
     assert "interval timer" in short_description.lower()
     assert "mma" in short_description.lower()
-    assert "coach" in short_description.lower()
+    assert "tactical" in short_description.lower()
+    assert "coach voices" not in short_description.lower()
     assert "ai coach" not in short_description.lower()
 
 


### PR DESCRIPTION
## Summary
- Removes Competition Warmup preset UI and `TrainingPreset` model on Android and iOS (CEO request).
- Updates Play `short_description` from stale "coach voices" to "tactical audio" ahead of metadata sync.

## Test plan
- [x] Android unit tests (TimerConfigTest, TimerSetupScreenTextTest) — run in CI
- [ ] iOS TimerModelsTests — CI
- [ ] Maestro smoke on develop after merge


Made with [Cursor](https://cursor.com)