### PR TITLE
fix(ios): release-notes 1.3.48 for metadata preflight

### DIFF
--- a/.github/workflows/android-metadata-sync.yml
+++ b/.github/workflows/android-metadata-sync.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Preflight release checks (Android listing assets)
+        run: bash scripts/shell/preflight-release.sh --platform android --layer 1
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/release-notes/1.3.48.md
+++ b/release-notes/1.3.48.md
@@ -1,0 +1,12 @@
+# Release 1.3.48
+
+## Summary
+Develop integration at **1.3.48** after v1.3.47: Android paywall catalog probe resilience and refreshed Play IAP catalog metadata for store sync.
+
+## Product
+- **Android:** Batched INAPP+SUBS catalog probes with deduped Play product ids; up to 5 query retries with billing-client reconnect on `SERVICE_DISCONNECTED`; `enablePrepaidPlans()` for Billing 7.1.
+- **Ops:** `marketing/data/play_iap_catalog.json` refreshed from Play Console IAP readback.
+
+## Release operations
+- Preflight requires this file before `ios-metadata-sync` and iOS `native-release` jobs.
+- Ship billing fixes to production as **v1.3.49** after CEO real-device QA on a Play production build.


### PR DESCRIPTION
## Summary
- Adds `release-notes/1.3.48.md` required by `preflight-release.sh` layer 1 (fixes failed `ios-metadata-sync` on develop).
- Adds Android `android-metadata-sync` preflight parity so missing versioned notes fail before Play API upload.

## Test plan
- [x] `bash scripts/shell/preflight-release.sh --platform ios --layer 1` passes locally
- [x] `python3 scripts/release_notes.py --repo-root . --version 1.3.48`
- [ ] After merge: dispatch `ios-metadata-sync.yml` on `develop` (metadata_only as needed)


Made with [Cursor](https://cursor.com)