### PR TITLE
fix(ci): handle existing release branch in monthly Pro pipeline

### DIFF
--- a/.github/workflows/monthly-pro-content-release.yml
+++ b/.github/workflows/monthly-pro-content-release.yml
@@ -334,8 +334,14 @@ jobs:
             exit 1
           fi
           RELEASE_BRANCH="release/v${NEW_VERSION}"
-          git checkout -b "${RELEASE_BRANCH}"
-          git push origin "${RELEASE_BRANCH}"
+          git fetch origin "${RELEASE_BRANCH}" 2>/dev/null || true
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "Release branch ${RELEASE_BRANCH} already exists; fast-forwarding to origin/develop."
+            git checkout -B "${RELEASE_BRANCH}"
+          else
+            git checkout -b "${RELEASE_BRANCH}"
+          fi
+          git push origin "${RELEASE_BRANCH}" --force-with-lease
           echo "release_branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "release_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/scripts/tests/test_workflow_security_contracts.py
+++ b/scripts/tests/test_workflow_security_contracts.py
@@ -76,6 +76,8 @@ def test_monthly_pro_release_workflow_has_explicit_ci_guards() -> None:
     assert "-f skip_internal_signoff=true" not in contents
     assert "gh pr create" in contents and "|| true" not in contents.split("gh pr create", 1)[1].split("echo \"changes_committed=true\"", 1)[0]
     assert "Public store availability must still be proven by public-store-version-readback.yml" in contents
+    assert "Release branch ${RELEASE_BRANCH} already exists" in contents
+    assert "git push origin \"${RELEASE_BRANCH}\" --force-with-lease" in contents
 
 
 def test_public_store_version_readback_requires_public_evidence() -> None:


### PR DESCRIPTION
## Summary
- Fixes `monthly-pro-content-release` cut step when `release/vX.Y.Z` already exists on remote (run 26891114990 failed on `git push` for `release/v1.3.49`).
- Reuses the branch by checking out `-B` at `origin/develop` and pushing with `--force-with-lease`.
- Adds workflow contract assertions for the new behavior.

## Context
June 2026 Pro audio merged to `develop` via #1695 (`27b60524`). Hosted `latest.json` on `develop` already points at `2026-06_conditioning_lane`; no manifest re-run required.

## Test plan
- [x] `pytest scripts/tests/test_workflow_security_contracts.py::test_monthly_pro_release_workflow_has_explicit_ci_guards`
- [ ] Merge to `develop`, then optional `workflow_dispatch` on `monthly-pro-content-release` only if you want store publish/regression gate (manifest already live on `develop`).


Made with [Cursor](https://cursor.com)