### PR TITLE
fix(ci): iOS metadata-sync fail fast without editable ASC version

### DIFF
--- a/.github/workflows/ios-metadata-sync.yml
+++ b/.github/workflows/ios-metadata-sync.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
         default: true
       use_live_version:
-        description: "Force metadata sync against the current live App Store version."
+        description: "Deprecated. Ignored — listing sync always targets an editable App Store version from asc_resolve_version.py (fastlane use_live_version cannot run when ASC has zero editable IOS versions)."
         required: true
         type: boolean
         default: false
@@ -127,37 +127,34 @@ jobs:
           APPSTORE_PRIVATE_KEY: /tmp/appstore_key.p8
           VERSION_RESOLVED: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
           if [[ "$IOS_USE_LIVE_VERSION" == "true" ]]; then
-            echo "selected_version=LIVE" >> "$GITHUB_OUTPUT"
-            echo "Using live App Store version for metadata sync"
-            exit 0
+            echo "⚠️ use_live_version is deprecated; resolving an editable App Store version via ASC API instead of fastlane use_live_version."
           fi
 
           python scripts/asc/asc_resolve_version.py \
             --preferred-version "$VERSION_RESOLVED" \
             --create-if-needed \
             --auto-next-patch \
-            --json-out /tmp/asc_version.json || true
-          if [ -f /tmp/asc_version.json ]; then
-            SELECTED_VERSION=$(python -c 'import json; d=json.load(open("/tmp/asc_version.json")); print(d["selected_version"])')
-            SELECTED_STATE=$(python -c 'import json; d=json.load(open("/tmp/asc_version.json")); print(d.get("selected_state",""))')
-          else
-            SELECTED_VERSION="$VERSION_RESOLVED"
-            SELECTED_STATE="UNKNOWN"
+            --json-out /tmp/asc_version.json
+          SELECTED_VERSION=$(python -c 'import json; d=json.load(open("/tmp/asc_version.json")); print(d["selected_version"])')
+          SELECTED_STATE=$(python -c 'import json; d=json.load(open("/tmp/asc_version.json")); print(d.get("selected_state",""))')
+          SELECTED_REASON=$(python -c 'import json; d=json.load(open("/tmp/asc_version.json")); print(d.get("reason",""))')
+
+          if ! SELECTED_STATE="$SELECTED_STATE" python -c 'from scripts.asc.asc_resolve_version import _is_editable_state; import os, sys; sys.exit(0 if _is_editable_state(os.environ.get("SELECTED_STATE", "")) else 1)'; then
+            echo "❌ Blocked on ASC: App Store version ${SELECTED_VERSION} is not editable (state=${SELECTED_STATE}, reason=${SELECTED_REASON})."
+            echo "Preferred repo version: ${VERSION_RESOLVED}"
+            echo "Deliver/fastlane cannot update IOS listing metadata or screenshots without an editable App Store version."
+            echo "ASC version inventory:"
+            python scripts/asc/asc_list_versions.py || true
+            echo ""
+            echo "Remediation: run native-release for ios (TestFlight build + attach to App Store version) or wait until the in-review version becomes editable."
+            exit 1
           fi
-          # If version is blocked/unknown, fall back to live version metadata update
-          if echo "$SELECTED_STATE" | grep -qiE "UNKNOWN|409|BLOCKED"; then
-            echo "⚠️ Cannot create/find editable version $SELECTED_VERSION — will use live version for metadata"
-            SELECTED_VERSION="LIVE"
-          fi
-          # In metadata-only mode, review-locked versions are not editable. Push to the
-          # current live storefront instead of pretending the pending review version can change.
-          if [[ "$IOS_METADATA_ONLY" == "true" ]] && ! SELECTED_STATE="$SELECTED_STATE" python -c 'from scripts.asc.asc_resolve_version import _is_editable_state; import os, sys; sys.exit(0 if _is_editable_state(os.environ.get("SELECTED_STATE", "")) else 1)'; then
-            echo "⚠️ metadata_only=true and selected version state '$SELECTED_STATE' is not editable — using live version storefront"
-            SELECTED_VERSION="LIVE"
-          fi
+
           echo "selected_version=$SELECTED_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Using editable App Store version: $SELECTED_VERSION"
+          echo "selected_state=$SELECTED_STATE" >> "$GITHUB_OUTPUT"
+          echo "Using editable App Store version: $SELECTED_VERSION (state=$SELECTED_STATE reason=$SELECTED_REASON)"
 
       - name: Strict screenshot replacement + metadata upload
         env:
@@ -177,14 +174,6 @@ jobs:
           if [[ "$IOS_METADATA_ONLY" == "true" ]]; then
             echo "⚠️ metadata_only=true: build attached/VALID check is intentionally skipped."
             BUILD_FLAG="--skip-build-check"
-          fi
-
-          # If using live version, use fastlane deliver directly instead of strict sync
-          if [[ "$SELECTED_VERSION" == "LIVE" ]]; then
-            echo "Using fastlane deliver with use_live_version for metadata-only sync"
-            cd native-ios
-            fastlane metadata use_live_version:true
-            exit $?
           fi
 
           RETRY_FLAG="--retry-on-editable"

--- a/docs/APP_STORE_VERSION_AUTOMATION.md
+++ b/docs/APP_STORE_VERSION_AUTOMATION.md
@@ -33,8 +33,10 @@ Behavior:
 ## Workflow integration
 
 - `.github/workflows/ios-metadata-sync.yml`
-  - Resolves editable version before `fastlane metadata`.
-  - Uses `asc_verify_ready.py --skip-build-check` because this workflow is listing-only.
+  - Resolves editable version before `asc_strict_screenshot_sync.py` (which calls `fastlane metadata` for that version).
+  - **Does not** use `fastlane deliver` `use_live_version:true`. When ASC has zero editable IOS versions (e.g. preferred `1.3.48` is `WAITING_FOR_REVIEW` and create-next-patch returns HTTP 409), the job fails fast with `asc_list_versions.py` inventory instead of retrying deliver for ~20 minutes.
+  - `metadata_only=true` only skips the VALID build gate (`--skip-build-check`); it does not bypass the editable-version requirement.
+  - `use_live_version` input is deprecated/ignored.
   - Uploads `asc-version-resolution` artifact.
 
 - `.github/workflows/ios-submit-review.yml`

--- a/scripts/asc/asc_resolve_version.py
+++ b/scripts/asc/asc_resolve_version.py
@@ -62,6 +62,8 @@ def _is_editable_state(state: Optional[str]) -> bool:
     s = (state or "").strip().upper()
     if not s:
         return False
+    if s == "UNKNOWN" or "BLOCKED" in s or "409" in s:
+        return False
     return s not in NON_EDITABLE_STATES
 
 

--- a/scripts/tests/test_asc_resolve_version.py
+++ b/scripts/tests/test_asc_resolve_version.py
@@ -66,6 +66,8 @@ class AscResolveVersionUnitTests(unittest.TestCase):
         self.assertTrue(_is_editable_state("PREPARE_FOR_SUBMISSION"))
         self.assertFalse(_is_editable_state("READY_FOR_SALE"))
         self.assertFalse(_is_editable_state("WAITING_FOR_REVIEW"))
+        self.assertFalse(_is_editable_state("UNKNOWN_409_BLOCKED"))
+        self.assertFalse(_is_editable_state("UNKNOWN"))
 
     def test_reuses_preferred_when_editable(self):
         client = _FakeClient([_version("1.1.2", "PREPARE_FOR_SUBMISSION")])

--- a/scripts/tests/test_growth_workflow_contracts.py
+++ b/scripts/tests/test_growth_workflow_contracts.py
@@ -241,16 +241,22 @@ def test_ios_submit_review_workflow_guards_ios_version_lineage():
     assert "fastlane submit_review" not in source
 
 
-def test_ios_metadata_sync_falls_back_to_live_storefront_when_metadata_only_version_is_review_locked():
+def test_ios_metadata_sync_fails_fast_when_no_editable_app_store_version():
     source = IOS_METADATA_SYNC_WORKFLOW.read_text(encoding="utf-8")
 
     resolve_section = source.split("- name: Resolve editable App Store version", 1)[1].split(
         "- name: Strict screenshot replacement + metadata upload", 1
     )[0]
-    assert 'if [[ "$IOS_METADATA_ONLY" == "true" ]]' in resolve_section
+    upload_section = source.split("- name: Strict screenshot replacement + metadata upload", 1)[1].split(
+        "- name: Upload readiness report", 1
+    )[0]
+    assert "asc_resolve_version.py" in resolve_section
     assert "from scripts.asc.asc_resolve_version import _is_editable_state" in resolve_section
-    assert "selected version state '$SELECTED_STATE' is not editable" in resolve_section
-    assert 'SELECTED_VERSION="LIVE"' in resolve_section
+    assert "Blocked on ASC" in resolve_section
+    assert "asc_list_versions.py" in resolve_section
+    assert 'SELECTED_VERSION="LIVE"' not in resolve_section
+    assert "use_live_version:true" not in upload_section
+    assert "asc_strict_screenshot_sync.py" in upload_section
 
 
 def test_native_release_workflow_disables_hidden_play_fallback_and_verifies_requested_platforms_only():


### PR DESCRIPTION
## Summary

- Run `26890766981` failed after ~20m because `metadata_only=true` + `use_live_version=true` forced `fastlane deliver use_live_version:true`, but ASC had **no editable IOS App Store version** (deliver error: "could not find an editable version for IOS").
- Removes the `LIVE` / `use_live_version` fastlane shortcut and LIVE fallbacks on 409/review-locked states.
- `ios-metadata-sync` always runs `asc_resolve_version.py`, fails fast with `asc_list_versions.py` inventory when the selected state is not editable, then uses `asc_strict_screenshot_sync.py` only on a real editable version.

## Blocker (current ASC state — not verified locally)

Re-run with default inputs (no `use_live_version`) after **native-release** creates/attaches a VALID build to an editable version (likely next patch above `1.3.48` if `1.3.48` is review-locked).

## Test plan

- [x] `pytest scripts/tests/test_growth_workflow_contracts.py::test_ios_metadata_sync_fails_fast_when_no_editable_app_store_version`
- [ ] Merge and re-dispatch `ios-metadata-sync` without `use_live_version=true` once ASC has an editable slot


Made with [Cursor](https://cursor.com)