### PR TITLE
chore(data): monetization decision brief (#1684)

### DIFF
--- a/marketing/data/monetization_decision_brief.json
+++ b/marketing/data/monetization_decision_brief.json
@@ -1,0 +1,25 @@
+{
+  "generated_at": "2026-06-03T16:51:27Z",
+  "source": "audit_98232663_followup",
+  "window_days": 30,
+  "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
+  "issue_ref": "https://github.com/IgorGanapolsky/Random-Timer/issues/1684",
+  "snapshot": "Android 1.3.50 (VC 1780500214) is on the Play API while the public listing still shows 1.3.43; iOS 1.3.50 was not shipped (native-release run 26894611247: android-release success, ios-testflight skipped). PostHog 30d: 0 purchase_success, 4 purchase attempts; WQTU 4. Billing catalog telemetry reported empty on 1.3.49 only with no 1.3.50 events yet — hold paid ads and do not claim revenue until listing parity, catalog health on 1.3.50, and purchase funnel are verified.",
+  "counts": {
+    "wqtu_7d": 4,
+    "purchase_attempts_30d": 4,
+    "purchase_success_30d": 0,
+    "play_api_version_name": "1.3.50",
+    "play_api_version_code": 1780500214,
+    "public_listing_version_name": "1.3.43",
+    "ios_shipped_1_3_50": false,
+    "billing_catalog_empty_play_7d_app_versions": ["1.3.49"],
+    "billing_catalog_events_1_3_50": 0
+  },
+  "decision": "issue_1684_stays_open",
+  "next_actions": [
+    "Verify Play public listing reaches 1.3.50 and billing_product_catalog_status on 1.3.50",
+    "iOS: internal-distribution TestFlight signoff then native-release platform=ios on release/v1.3.50",
+    "Do not scale paid ads until paywall attempt→success improves with catalog proof"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `marketing/data/monetization_decision_brief.json` (audit follow-up for #1684).

## Test plan
- [ ] JSON validates; links issue #1684.

Made with [Cursor](https://cursor.com)