### PR TITLE
feat(ci): gate android-release on full connectedDebugAndroidTest

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -321,7 +321,7 @@ jobs:
           path: |
             native-android/app/build/reports/androidTests/connected
             native-android/app/build/outputs/androidTest-results/connected
-          retention-days: 7
+          retention-days: 1
 
   android-release:
     needs:

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -267,17 +267,75 @@ jobs:
           path: native-ios/RandomTimer.ipa
           retention-days: 1
 
+  android-device-test-gate:
+    name: Android connectedDebugAndroidTest (all classes)
+    needs: [release-intent-gate]
+    if: >-
+      (inputs.platform == 'android' || inputs.platform == 'both') &&
+      needs.release-intent-gate.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Create dummy google-services.json for CI
+        working-directory: native-android
+        run: |
+          cat > app/google-services.json << 'GSEOF'
+          {
+            "project_info": { "project_number": "000000000000", "project_id": "random-timer-ci", "storage_bucket": "random-timer-ci.appspot.com" },
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.iganapolsky.randomtimer" } }, "api_key": [{ "current_key": "CI_PLACEHOLDER" }] }],
+            "configuration_version": "1"
+          }
+          GSEOF
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run full connectedDebugAndroidTest suite on emulator
+        uses: reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7 # v2
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 1080x2340
+          disable-animations: false
+          emulator-boot-timeout: 300
+          script: sh scripts/device-tests/ci-connected-all.sh
+
+      - name: Upload Android release device test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-release-device-test-reports
+          path: |
+            native-android/app/build/reports/androidTests/connected
+            native-android/app/build/outputs/androidTest-results/connected
+          retention-days: 7
+
   android-release:
     needs:
       - release-intent-gate
       - internal-proof-or-waive
       - require-production-signoff
       - production-signoff-waive
+      - android-device-test-gate
     if: >-
       (inputs.platform == 'android' || inputs.platform == 'both') &&
       always() && !cancelled() &&
       needs.release-intent-gate.result == 'success' &&
       needs.internal-proof-or-waive.result == 'success' &&
+      needs.android-device-test-gate.result == 'success' &&
       (needs.require-production-signoff.result == 'success' || needs.production-signoff-waive.result == 'success')
     runs-on: ubuntu-latest
     environment: production

--- a/scripts/device-tests/ci-connected-all.sh
+++ b/scripts/device-tests/ci-connected-all.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# ci-connected-all.sh — Run every connectedDebugAndroidTest class on CI emulator.
+# device-tests.yml runs only TimerSetupSmokeTest; native-release must gate on the full suite.
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)"
+
+adb shell am force-stop com.iganapolsky.randomtimer 2>/dev/null || true
+
+cd "${REPO_ROOT}/native-android"
+chmod +x gradlew
+
+echo "== Android connectedDebugAndroidTest (all classes) =="
+./gradlew connectedDebugAndroidTest \
+  --no-daemon \
+  --stacktrace \
+  -PenableFirebasePlugins=false

--- a/scripts/tests/test_ci_connected_all_script.py
+++ b/scripts/tests/test_ci_connected_all_script.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/device-tests/ci-connected-all.sh"
+
+
+def test_ci_connected_all_runs_full_connected_debug_android_test_suite():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "./gradlew connectedDebugAndroidTest" in source
+    assert "testInstrumentationRunnerArguments.class" not in source
+    assert "-PenableFirebasePlugins=false" in source
+
+
+def test_ci_connected_all_is_referenced_by_native_release_workflow():
+    workflow = (ROOT / ".github/workflows/native-release.yml").read_text(encoding="utf-8")
+
+    assert "android-device-test-gate:" in workflow
+    assert "scripts/device-tests/ci-connected-all.sh" in workflow
+    assert "needs.android-device-test-gate.result == 'success'" in workflow


### PR DESCRIPTION
## Summary
- Adds `android-device-test-gate` job to `native-release.yml` that runs all six `connectedDebugAndroidTest` classes on an API 30 emulator before `android-release`.
- Introduces `scripts/device-tests/ci-connected-all.sh` (no single-class filter; contrasts with PR-only `ci-maestro.sh` smoke).
- Contract tests assert the script and workflow wiring.

## Context
- `native-release` had no instrumentation gate; `device-tests.yml` on PRs runs only `TimerSetupSmokeTest` (1/6 androidTest classes).
- Android 1.3.50 shipped without full device proof on release SHA.

## Test plan
- [x] `python3 -m pytest -q scripts/tests/test_ci_connected_all_script.py`
- [ ] Merge and verify next `native-release` android path waits on `android-device-test-gate`


Made with [Cursor](https://cursor.com)