### PR TITLE
fix(android): catalog telemetry when PRODUCT_DETAILS unsupported (#1684)

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -77,6 +77,18 @@ class ProManager
                 if (productId in alreadyReported) return false
                 return true
             }
+
+            /**
+             * Play can connect billing while [BillingClient.FeatureType.PRODUCT_DETAILS] returns
+             * FEATURE_NOT_SUPPORTED. Emit [AnalyticsEvents.BILLING_PRODUCT_CATALOG_STATUS] on setup
+             * so catalog probes are not silent until paywall (fetchAllProductDetails skips query).
+             */
+            internal fun shouldTrackCatalogStatusOnBillingSetupFinished(
+                billingSetupResponseCode: Int,
+                productDetailsFeatureSupported: Boolean?,
+            ): Boolean =
+                billingSetupResponseCode == BillingClient.BillingResponseCode.OK &&
+                    productDetailsFeatureSupported == false
         }
 
         private val _entitlementLevel = MutableStateFlow(EntitlementLevel.NONE)
@@ -158,6 +170,14 @@ class ProManager
                                     "billing_response_label" to BillingResponseLabels.labelFor(featureResult.responseCode),
                                 ),
                             )
+                            if (
+                                shouldTrackCatalogStatusOnBillingSetupFinished(
+                                    billingSetupResponseCode = responseCode,
+                                    productDetailsFeatureSupported = productDetailsFeatureSupported,
+                                )
+                            ) {
+                                trackProductCatalogStatus()
+                            }
                             externalScope.launch {
                                 restorePurchases(
                                     source = MonetizationSources.AUTO_RESTORE,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerBillingSetupCatalogTelemetryTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerBillingSetupCatalogTelemetryTest.kt
@@ -1,0 +1,56 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.android.billingclient.api.BillingClient
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ProManagerBillingSetupCatalogTelemetryTest {
+    @Test
+    fun `emit catalog status when setup OK but product details unsupported`() {
+        assertThat(
+            ProManager.shouldTrackCatalogStatusOnBillingSetupFinished(
+                billingSetupResponseCode = BillingClient.BillingResponseCode.OK,
+                productDetailsFeatureSupported = false,
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `do not emit catalog status on setup when product details supported`() {
+        assertThat(
+            ProManager.shouldTrackCatalogStatusOnBillingSetupFinished(
+                billingSetupResponseCode = BillingClient.BillingResponseCode.OK,
+                productDetailsFeatureSupported = true,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `do not emit catalog status when billing setup failed`() {
+        assertThat(
+            ProManager.shouldTrackCatalogStatusOnBillingSetupFinished(
+                billingSetupResponseCode = BillingClient.BillingResponseCode.BILLING_UNAVAILABLE,
+                productDetailsFeatureSupported = false,
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `catalog status for unsupported uses product_details_unsupported`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds =
+                    setOf(
+                        ProManager.BASE_PRODUCT_ID,
+                        ProManager.ELITE_PRODUCT_ID,
+                        ProManager.MONTHLY_PRODUCT_ID,
+                    ),
+                cachedLogicalProductIds = emptySet(),
+            )
+
+        assertThat(result.status).isEqualTo("product_details_unsupported")
+        assertThat(result.probeBlockedReason).isEqualTo("product_details_unsupported")
+    }
+}


### PR DESCRIPTION
## Summary

- On `onBillingSetupFinished` (billing OK + `isFeatureSupported(PRODUCT_DETAILS)` not OK), emit `billing_product_catalog_status` with `status=product_details_unsupported` via existing `BillingCatalogStatusResolver` / `trackProductCatalogStatus()`.
- Adds `shouldTrackCatalogStatusOnBillingSetupFinished` guard + unit tests (TDD).

Fixes silent catalog telemetry on 1.3.50 Play installs that only reported `billing_diagnostic` (`product_details_supported=false`, FEATURE_NOT_SUPPORTED) with zero `billing_product_catalog_status` events.

**Not a revenue or IAP fix** — observability and catalog-status honesty only.

## Test plan

- [ ] CI `android` job / `testDebugUnitTest` green
- [ ] `ProManagerBillingSetupCatalogTelemetryTest` + `BillingCatalogStatusResolverTest`
- [ ] After ship: PostHog should show `billing_product_catalog_status` with `product_details_unsupported` on affected builds (proxy; not ledger revenue)

Closes #1684

Made with [Cursor](https://cursor.com)