### PR TITLE
fix(ci): per-class isolation for native-release androidTest gate

### DIFF
--- a/scripts/device-tests/ci-connected-all.sh
+++ b/scripts/device-tests/ci-connected-all.sh
@@ -1,18 +1,32 @@
 #!/usr/bin/env sh
 # ci-connected-all.sh — Run every connectedDebugAndroidTest class on CI emulator.
 # device-tests.yml runs only TimerSetupSmokeTest; native-release must gate on the full suite.
+# One Gradle invocation per class + force-stop between classes avoids cross-class crashes on API 30.
 set -eu
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)"
 
-adb shell am force-stop com.iganapolsky.randomtimer 2>/dev/null || true
-
 cd "${REPO_ROOT}/native-android"
 chmod +x gradlew
 
-echo "== Android connectedDebugAndroidTest (all classes) =="
-./gradlew connectedDebugAndroidTest \
-  --no-daemon \
-  --stacktrace \
-  -PenableFirebasePlugins=false
+# Stable order: isolated Compose screens first, MainActivity UI, service, notification last.
+TEST_CLASSES="
+com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenLandscapeLayoutTest
+com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenTapCircleTest
+com.iganapolsky.randomtimer.ui.RangeSliderUiTest
+com.iganapolsky.randomtimer.ui.TimerSetupSmokeTest
+com.iganapolsky.randomtimer.service.TimerForegroundServiceResetTest
+com.iganapolsky.randomtimer.ui.NotificationE2ETest
+"
+
+echo "== Android connectedDebugAndroidTest (per-class isolation) =="
+for test_class in ${TEST_CLASSES}; do
+  adb shell am force-stop com.iganapolsky.randomtimer 2>/dev/null || true
+  echo "-- class ${test_class} --"
+  ./gradlew connectedDebugAndroidTest \
+    --no-daemon \
+    --stacktrace \
+    -PenableFirebasePlugins=false \
+    -Pandroid.testInstrumentationRunnerArguments.class="${test_class}"
+done

--- a/scripts/tests/test_ci_connected_all_script.py
+++ b/scripts/tests/test_ci_connected_all_script.py
@@ -10,7 +10,9 @@ def test_ci_connected_all_runs_full_connected_debug_android_test_suite():
     source = SCRIPT.read_text(encoding="utf-8")
 
     assert "./gradlew connectedDebugAndroidTest" in source
-    assert "testInstrumentationRunnerArguments.class" not in source
+    assert "testInstrumentationRunnerArguments.class" in source
+    assert "am force-stop com.iganapolsky.randomtimer" in source
+    assert "NotificationE2ETest" in source
     assert "-PenableFirebasePlugins=false" in source
 
 


### PR DESCRIPTION
## Summary
- Run each `connectedDebugAndroidTest` class in its own Gradle invocation with `am force-stop` between classes.
- Keeps full-suite coverage for native-release while avoiding API 30 instrumentation crashes across classes.

## Test plan
- [ ] Merge to `release/v1.3.51`, re-run `native-release.yml` (android production) after firebase signoff on merge SHA

Made with [Cursor](https://cursor.com)