### PR TITLE
fix(android): 15s notification E2E timeouts on CI emulator

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/DeviceTestSupport.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/DeviceTestSupport.kt
@@ -13,6 +13,7 @@ import com.iganapolsky.randomtimer.service.TimerForegroundService
 /** Shared helpers for slow GitHub Actions emulators (API 30, swiftshader). */
 object DeviceTestSupport {
     const val SETUP_READY_TIMEOUT_MS = 30_000L
+    const val NOTIFICATION_UI_TIMEOUT_MS = 15_000L
 
     /**
      * Stops the app process so the next MainActivity lands on setup.

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/NotificationE2ETest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/NotificationE2ETest.kt
@@ -44,34 +44,37 @@ class NotificationE2ETest {
 
     @Test
     fun testNotificationLifecycle() {
+        val uiTimeout = DeviceTestSupport.NOTIFICATION_UI_TIMEOUT_MS
         DeviceTestSupport.waitForSetupScreen(composeRule)
         DeviceTestSupport.clickPrimaryStart(composeRule)
+        composeRule.waitForIdle()
 
         device.pressHome()
         device.openNotification()
 
-        val notificationTitle = device.wait(Until.findObject(By.text("Timer Running")), 5000)
+        val notificationTitle =
+            device.wait(Until.findObject(By.text("Timer Running")), uiTimeout)
         assertNotNull("Notification with title 'Timer Running' should be visible", notificationTitle)
 
-        val pauseButton = device.wait(Until.findObject(By.text("Pause")), 5000)
+        val pauseButton = device.wait(Until.findObject(By.text("Pause")), uiTimeout)
         assertNotNull("Pause button should be visible", pauseButton)
         pauseButton.click()
 
-        val pausedTitle = device.wait(Until.findObject(By.text("Timer Paused")), 5000)
+        val pausedTitle = device.wait(Until.findObject(By.text("Timer Paused")), uiTimeout)
         assertNotNull("Notification title should change to 'Timer Paused'", pausedTitle)
 
-        val resumeButton = device.wait(Until.findObject(By.text("Resume")), 5000)
+        val resumeButton = device.wait(Until.findObject(By.text("Resume")), uiTimeout)
         assertNotNull("Resume button should be visible", resumeButton)
         resumeButton.click()
 
-        val runningTitle = device.wait(Until.findObject(By.text("Timer Running")), 5000)
+        val runningTitle = device.wait(Until.findObject(By.text("Timer Running")), uiTimeout)
         assertNotNull("Notification title should change back to 'Timer Running'", runningTitle)
 
-        val stopButton = device.wait(Until.findObject(By.text("Stop")), 5000)
+        val stopButton = device.wait(Until.findObject(By.text("Stop")), uiTimeout)
         assertNotNull("Stop button should be visible", stopButton)
         stopButton.click()
 
-        val dismissed = device.wait(Until.gone(By.text("Timer Running")), 5000)
+        val dismissed = device.wait(Until.gone(By.text("Timer Running")), uiTimeout)
         assertTrue("Notification should be dismissed after clicking 'Stop'", dismissed)
 
         device.pressHome()
@@ -80,26 +83,28 @@ class NotificationE2ETest {
     /** Runs after [testNotificationLifecycle] (JUnit name order). */
     @Test
     fun testNotification_extendAddsFiveMinutes() {
+        val uiTimeout = DeviceTestSupport.NOTIFICATION_UI_TIMEOUT_MS
         DeviceTestSupport.waitForSetupScreen(composeRule)
         DeviceTestSupport.clickPrimaryStart(composeRule)
+        composeRule.waitForIdle()
 
         device.pressHome()
         device.openNotification()
 
-        device.wait(Until.findObject(By.text("Timer Running")), 5000)
+        device.wait(Until.findObject(By.text("Timer Running")), uiTimeout)
 
-        val extendButton = device.wait(Until.findObject(By.text("+5 Min")), 5000)
+        val extendButton = device.wait(Until.findObject(By.text("+5 Min")), uiTimeout)
         assertNotNull("'+5 Min' button should be visible", extendButton)
         extendButton.click()
 
-        val runningTitle = device.wait(Until.findObject(By.text("Timer Running")), 5000)
+        val runningTitle = device.wait(Until.findObject(By.text("Timer Running")), uiTimeout)
         assertNotNull("Notification should still be visible after extend", runningTitle)
 
-        val stopButton = device.wait(Until.findObject(By.text("Stop")), 5000)
+        val stopButton = device.wait(Until.findObject(By.text("Stop")), uiTimeout)
         assertNotNull("Stop button should be visible", stopButton)
         stopButton.click()
 
-        device.wait(Until.gone(By.text("Timer Running")), 5000)
+        device.wait(Until.gone(By.text("Timer Running")), uiTimeout)
         device.pressHome()
     }
 }


### PR DESCRIPTION
## Summary
- native-release **26956275224** failed `testNotificationLifecycle` at 3/13 (5s waits too tight on API 30 emulator).
- Add `NOTIFICATION_UI_TIMEOUT_MS = 15_000` and `waitForIdle()` after starting the timer.

## Test plan
- [ ] device-tests green
- [ ] native-release android 13/13

Made with [Cursor](https://cursor.com)