### PR TITLE
fix(android): isolate RangeSlider tests after notification E2E

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -18,15 +18,10 @@ class RangeSliderUiTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
 
-    private var firstTest = true
-
     @Before
     fun prepareTest() {
-        if (firstTest) {
-            firstTest = false
-        } else {
-            DeviceTestSupport.prepareNextTest(composeRule)
-        }
+        // Notification E2E leaves MainActivity off setup; recreate every method.
+        DeviceTestSupport.prepareNextTest(composeRule)
     }
 
     @After


### PR DESCRIPTION
## Summary\n- native-release **26957808519** passed service + notification tests; RangeSlider failed because the first test skipped recreate after Notification E2E.\n- Always  in .\n\n## Test plan\n- [ ] native-release android 13/13

Made with [Cursor](https://cursor.com)