### PR TITLE
fix(android): RangeSlider native-release gate (run 26961450157)

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -1,14 +1,18 @@
 package com.iganapolsky.randomtimer.ui
 
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.MainActivity
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,6 +23,14 @@ class RangeSliderUiTest {
     val composeRule = createAndroidComposeRule<MainActivity>()
 
     private var firstTest = true
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun coldStart() {
+            DeviceTestSupport.prepareColdStart()
+        }
+    }
 
     @Before
     fun prepareTest() {
@@ -38,43 +50,50 @@ class RangeSliderUiTest {
     fun draggingMinBeyondGapPushesMaxForward() {
         DeviceTestSupport.waitForSetupScreen(composeRule)
 
-        composeRule
-            .onNodeWithContentDescription("Maximum time slider", useUnmergedTree = true)
-            .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
-                setProgress(60f)
-            }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithText("Maximum: 1m", useUnmergedTree = true).assertExists()
+        setSliderProgress("Maximum time slider", 60f)
+        waitForLabel(composeRule, "Maximum: 1m")
 
-        composeRule
-            .onNodeWithContentDescription("Minimum time slider", useUnmergedTree = true)
-            .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
-                setProgress(50f)
-            }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithText("Minimum: 50s", useUnmergedTree = true).assertExists()
-        composeRule.onNodeWithText("Maximum: 55s", useUnmergedTree = true).assertExists()
+        setSliderProgress("Minimum time slider", 50f)
+        waitForLabel(composeRule, "Minimum: 50s")
+        waitForLabel(composeRule, "Maximum: 55s")
     }
 
     @Test
     fun draggingMaxBelowGapPullsMinBack() {
         DeviceTestSupport.waitForSetupScreen(composeRule)
 
-        composeRule
-            .onNodeWithContentDescription("Minimum time slider", useUnmergedTree = true)
-            .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
-                setProgress(150f)
-            }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithText("Minimum: 2m 30s", useUnmergedTree = true).assertExists()
+        setSliderProgress("Minimum time slider", 100f)
+        waitForLabel(composeRule, "Minimum: 1m 40s")
 
+        setSliderProgress("Maximum time slider", 200f)
+        waitForLabel(composeRule, "Maximum: 3m 20s")
+
+        setSliderProgress("Maximum time slider", 50f)
+        waitForLabel(composeRule, "Maximum: 50s")
+        waitForLabel(composeRule, "Minimum: 45s")
+    }
+
+    private fun setSliderProgress(
+        contentDescription: String,
+        progress: Float,
+    ) {
         composeRule
-            .onNodeWithContentDescription("Maximum time slider", useUnmergedTree = true)
+            .onNodeWithContentDescription(contentDescription, useUnmergedTree = true)
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
-                setProgress(160f)
+                setProgress(progress)
             }
         composeRule.waitForIdle()
-        composeRule.onNodeWithText("Maximum: 2m 40s", useUnmergedTree = true).assertExists()
-        composeRule.onNodeWithText("Minimum: 2m 35s", useUnmergedTree = true).assertExists()
+    }
+
+    private fun waitForLabel(
+        rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+        text: String,
+    ) {
+        rule.waitUntil(timeoutMillis = DeviceTestSupport.SETUP_READY_TIMEOUT_MS) {
+            rule.onAllNodesWithText(text, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        rule.onNodeWithText(text, useUnmergedTree = true).assertExists()
     }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -1212,9 +1212,7 @@ private fun TimeRangeSliders(
                     modifier =
                         Modifier
                             .weight(1f)
-                            .semantics(mergeDescendants = true) {
-                                contentDescription = "Minimum time slider"
-                            },
+                            .semantics { contentDescription = "Minimum time slider" },
                     colors =
                         SliderDefaults.colors(
                             thumbColor = if (enabled) TimerColors.AccentPrimary else TimerColors.TextMuted,
@@ -1263,9 +1261,7 @@ private fun TimeRangeSliders(
                     modifier =
                         Modifier
                             .weight(1f)
-                            .semantics(mergeDescendants = true) {
-                                contentDescription = "Maximum time slider"
-                            },
+                            .semantics { contentDescription = "Maximum time slider" },
                     colors =
                         SliderDefaults.colors(
                             thumbColor = if (enabled) TimerColors.AccentPrimary else TimerColors.TextMuted,


### PR DESCRIPTION
## Summary
- Remove `mergeDescendants` on min/max sliders so `SemanticsActions.SetProgress` updates thumb values on API 30 CI emulators.
- Fix `draggingMaxBelowGapPullsMinBack` expectations to match `TimeRangeAdjuster` (max 50s with min 100s pulls min to 45s).
- Add `@BeforeClass` cold start, `waitUntil` label helpers, and keep per-method `prepareNextTest` isolation.

## Context
Native App Release run [26961450157](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26961450157) failed `connectedDebugAndroidTest` on `fb991f37` after #1712–#1719.

## Failing tests (before fix)
- `RangeSliderUiTest.draggingMinBeyondGapPushesMaxForward` — missing `Maximum: 1m`
- `RangeSliderUiTest.draggingMaxBelowGapPullsMinBack` — missing `Minimum: 2m 35s` (stale expectation; 10s gap is valid at 150/160)

## Test plan
- [ ] `device-tests` / PR CI green
- [ ] Merge to `release/v1.3.51`
- [ ] Re-run `native-release` with firebase + production signoff

Made with [Cursor](https://cursor.com)