### PR TITLE
fix(android): RangeSlider CI crash (drop @BeforeClass force-stop)

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -12,7 +12,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.MainActivity
 import org.junit.After
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,14 +22,6 @@ class RangeSliderUiTest {
     val composeRule = createAndroidComposeRule<MainActivity>()
 
     private var firstTest = true
-
-    companion object {
-        @BeforeClass
-        @JvmStatic
-        fun coldStart() {
-            DeviceTestSupport.prepareColdStart()
-        }
-    }
 
     @Before
     fun prepareTest() {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -1212,7 +1212,9 @@ private fun TimeRangeSliders(
                     modifier =
                         Modifier
                             .weight(1f)
-                            .semantics { contentDescription = "Minimum time slider" },
+                            .semantics(mergeDescendants = true) {
+                                contentDescription = "Minimum time slider"
+                            },
                     colors =
                         SliderDefaults.colors(
                             thumbColor = if (enabled) TimerColors.AccentPrimary else TimerColors.TextMuted,
@@ -1261,7 +1263,9 @@ private fun TimeRangeSliders(
                     modifier =
                         Modifier
                             .weight(1f)
-                            .semantics { contentDescription = "Maximum time slider" },
+                            .semantics(mergeDescendants = true) {
+                                contentDescription = "Maximum time slider"
+                            },
                     colors =
                         SliderDefaults.colors(
                             thumbColor = if (enabled) TimerColors.AccentPrimary else TimerColors.TextMuted,


### PR DESCRIPTION
## Summary
- Removes `RangeSliderUiTest` `@BeforeClass prepareColdStart()` — `am force-stop` during instrumentation startup caused **Process crashed** on native-release run [26962744753](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26962744753) at `89f52984`.
- Restores `mergeDescendants = true` on min/max slider semantics so `SetProgress` targets a single merged node (reverts #1720 regression).

## Evidence
- Failed job: `draggingMinBeyondGapPushesMaxForward` — instrumentation crash, no logcat; per-class isolation already `force-stop`s before `RangeSliderUiTest`.
- #1720 diff added `@BeforeClass` `DeviceTestSupport.prepareColdStart()` → `forceStopApp()`.

## Test plan
- [ ] `device-tests.yml` / native-release `android-device-test-gate` green on merge SHA
- [ ] `internal-signoff/firebase` on release SHA after internal-distribution

Made with [Cursor](https://cursor.com)