### PR TITLE
fix(android): RangeSlider instrumentation crash on native-release

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -6,13 +6,13 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.MainActivity
 import org.junit.After
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,14 +23,6 @@ class RangeSliderUiTest {
     val composeRule = createAndroidComposeRule<MainActivity>()
 
     private var firstTest = true
-
-    companion object {
-        @BeforeClass
-        @JvmStatic
-        fun coldStart() {
-            DeviceTestSupport.prepareColdStart()
-        }
-    }
 
     @Before
     fun prepareTest() {
@@ -79,6 +71,7 @@ class RangeSliderUiTest {
     ) {
         composeRule
             .onNodeWithContentDescription(contentDescription, useUnmergedTree = true)
+            .performScrollTo()
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
                 setProgress(progress)
             }

--- a/scripts/device-tests/ci-connected-all.sh
+++ b/scripts/device-tests/ci-connected-all.sh
@@ -10,11 +10,11 @@ REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}/native-android"
 chmod +x gradlew
 
-# Stable order: isolated Compose screens first, MainActivity UI, service, notification last.
+# Stable order: RangeSlider first (fresh emulator), then isolated screens, service, notification last.
 TEST_CLASSES="
+com.iganapolsky.randomtimer.ui.RangeSliderUiTest
 com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenLandscapeLayoutTest
 com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreenTapCircleTest
-com.iganapolsky.randomtimer.ui.RangeSliderUiTest
 com.iganapolsky.randomtimer.ui.TimerSetupSmokeTest
 com.iganapolsky.randomtimer.service.TimerForegroundServiceResetTest
 com.iganapolsky.randomtimer.ui.NotificationE2ETest


### PR DESCRIPTION
## Summary
- Remove `@BeforeClass prepareColdStart()` — `force-stop` during class init crashed instrumentation on run 26962744753.
- `performScrollTo()` before `SetProgress` so sliders are visible on compact API 30 layouts.
- Run `RangeSliderUiTest` first in `ci-connected-all.sh` (fresh emulator).

## Test plan
- [ ] PR CI green
- [ ] Merge and re-run `native-release` after `firebase-signoff` on SHA

Made with [Cursor](https://cursor.com)