### PR TITLE
fix(android): RangeSlider API 34 full-suite (run 26964588213)

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/DeviceTestSupport.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/DeviceTestSupport.kt
@@ -1,19 +1,28 @@
 package com.iganapolsky.randomtimer.ui
 
 import android.content.Intent
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.iganapolsky.randomtimer.MainActivity
 import com.iganapolsky.randomtimer.service.TimerForegroundService
 
-/** Shared helpers for slow GitHub Actions emulators (API 30, swiftshader). */
+/** Shared helpers for slow GitHub Actions emulators (API 30–34, swiftshader). */
 object DeviceTestSupport {
     const val SETUP_READY_TIMEOUT_MS = 30_000L
+    const val LABEL_READY_TIMEOUT_MS = 45_000L
     const val NOTIFICATION_UI_TIMEOUT_MS = 15_000L
+
+    private const val MIN_TIME_SLIDER = "Minimum time slider"
 
     /**
      * Stops the app process so the next MainActivity lands on setup.
@@ -61,6 +70,32 @@ object DeviceTestSupport {
                 .isNotEmpty()
         }
         rule.waitForIdle()
+        scrollToTimeRangeSliders(rule)
+    }
+
+    /** Time range sliders live in setup [LazyColumn]; scroll before slider/label interaction. */
+    fun scrollToTimeRangeSliders(
+        rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+    ) {
+        rule.onNode(hasScrollAction())
+            .performScrollToNode(hasContentDescription(MIN_TIME_SLIDER))
+        rule.waitForIdle()
+    }
+
+    fun waitForLabel(
+        rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+        text: String,
+        timeoutMillis: Long = LABEL_READY_TIMEOUT_MS,
+    ) {
+        rule.waitUntil(timeoutMillis = timeoutMillis) {
+            scrollToTimeRangeSliders(rule)
+            rule.onAllNodesWithText(text, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        rule.onNodeWithText(text, useUnmergedTree = true)
+            .performScrollTo()
+            .assertExists()
     }
 
     fun clickPrimaryStart(

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -1,15 +1,10 @@
 package com.iganapolsky.randomtimer.ui
 
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.percentOffset
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.MainActivity
 import com.iganapolsky.randomtimer.domain.model.TimerConfig
@@ -45,15 +40,15 @@ class RangeSliderUiTest {
         DeviceTestSupport.waitForSetupScreen(composeRule)
 
         tapSliderToSeconds("Maximum time slider", 60, rangeEnd = TimerConfig.MAX_SECONDS_FREE.toFloat())
-        waitForLabel(composeRule, "Maximum: 1m")
+        DeviceTestSupport.waitForLabel(composeRule, "Maximum: 1m")
 
         tapSliderToSeconds(
             "Minimum time slider",
-            50,
+            56,
             rangeEnd = (TimerConfig.MAX_SECONDS_FREE - 5).toFloat(),
         )
-        waitForLabel(composeRule, "Minimum: 50s")
-        waitForLabel(composeRule, "Maximum: 55s")
+        DeviceTestSupport.waitForLabel(composeRule, "Minimum: 56s")
+        DeviceTestSupport.waitForLabel(composeRule, "Maximum: 1m 1s")
     }
 
     @Test
@@ -65,14 +60,14 @@ class RangeSliderUiTest {
             100,
             rangeEnd = (TimerConfig.MAX_SECONDS_FREE - 5).toFloat(),
         )
-        waitForLabel(composeRule, "Minimum: 1m 40s")
+        DeviceTestSupport.waitForLabel(composeRule, "Minimum: 1m 40s")
 
         tapSliderToSeconds("Maximum time slider", 200, rangeEnd = TimerConfig.MAX_SECONDS_FREE.toFloat())
-        waitForLabel(composeRule, "Maximum: 3m 20s")
+        DeviceTestSupport.waitForLabel(composeRule, "Maximum: 3m 20s")
 
         tapSliderToSeconds("Maximum time slider", 50, rangeEnd = TimerConfig.MAX_SECONDS_FREE.toFloat())
-        waitForLabel(composeRule, "Maximum: 50s")
-        waitForLabel(composeRule, "Minimum: 45s")
+        DeviceTestSupport.waitForLabel(composeRule, "Maximum: 50s")
+        DeviceTestSupport.waitForLabel(composeRule, "Minimum: 45s")
     }
 
     private fun tapSliderToSeconds(
@@ -84,24 +79,12 @@ class RangeSliderUiTest {
         val fraction =
             ((targetSeconds - rangeStart) / (rangeEnd - rangeStart))
                 .coerceIn(0f, 1f)
+        DeviceTestSupport.scrollToTimeRangeSliders(composeRule)
         composeRule
             .onNodeWithContentDescription(contentDescription, useUnmergedTree = true)
-            .performScrollTo()
             .performTouchInput {
                 click(percentOffset(fraction, 0.5f))
             }
         composeRule.waitForIdle()
-    }
-
-    private fun waitForLabel(
-        rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
-        text: String,
-    ) {
-        rule.waitUntil(timeoutMillis = DeviceTestSupport.SETUP_READY_TIMEOUT_MS) {
-            rule.onAllNodesWithText(text, useUnmergedTree = true)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-        rule.onNodeWithText(text, useUnmergedTree = true).assertExists()
     }
 }


### PR DESCRIPTION
## Summary
- Scroll setup `LazyColumn` via `performScrollToNode` before slider `SetProgress` and label waits (fixes API 34 emulator timeouts in full `ci-connected-all.sh` suite).
- Move `waitForLabel` into `DeviceTestSupport` with 45s timeout and scroll-to-label before assert.
- Align gap-push test with `TimeRangeAdjuster`: min=56 when max=60 expects `Maximum: 1m 1s` (not 55s from default max=30).

## Evidence
- Failed run: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26964588213 — `RangeSliderUiTest.draggingMinBeyondGapPushesMaxForward` `ComposeTimeout` at `waitForLabel` line 50.

## Test plan
- [ ] PR CI green (device-tests + connected suite)
- [ ] Merge to `release/v1.3.51`
- [ ] `firebase-signoff` on merge SHA + `native-release` android production

Made with [Cursor](https://cursor.com)