### PR TITLE
fix(android): service test @AfterClass must not force-stop

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/service/TimerForegroundServiceResetTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/service/TimerForegroundServiceResetTest.kt
@@ -31,7 +31,9 @@ class TimerForegroundServiceResetTest {
         @JvmStatic
         @AfterClass
         fun tearDownClass() {
-            DeviceTestSupport.prepareColdStart()
+            // Do not force-stop here: it kills the instrumentation process before Gradle
+            // collects results (native-release android-device-test-gate "Process crashed").
+            DeviceTestSupport.stopTimerService()
         }
     }
 

--- a/scripts/tests/test_ci_connected_all_script.py
+++ b/scripts/tests/test_ci_connected_all_script.py
@@ -14,6 +14,21 @@ def test_ci_connected_all_runs_full_connected_debug_android_test_suite():
     assert "am force-stop com.iganapolsky.randomtimer" in source
     assert "NotificationE2ETest" in source
     assert "-PenableFirebasePlugins=false" in source
+    assert source.count('for test_class in ${TEST_CLASSES}') == 1
+    assert source.count("com.iganapolsky.randomtimer.") == 6
+
+
+def test_ci_connected_all_lists_six_instrumentation_classes():
+    source = SCRIPT.read_text(encoding="utf-8")
+    for class_name in (
+        "RangeSliderUiTest",
+        "ActiveTimerScreenLandscapeLayoutTest",
+        "ActiveTimerScreenTapCircleTest",
+        "TimerSetupSmokeTest",
+        "TimerForegroundServiceResetTest",
+        "NotificationE2ETest",
+    ):
+        assert class_name in source
 
 
 def test_ci_connected_all_is_referenced_by_native_release_workflow():

--- a/scripts/tests/test_service_reset_instrumentation_teardown.py
+++ b/scripts/tests/test_service_reset_instrumentation_teardown.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVICE_TEST = (
+    ROOT
+    / "native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/service/TimerForegroundServiceResetTest.kt"
+)
+
+
+def test_after_class_does_not_force_stop_during_instrumentation():
+    """@AfterClass force-stop kills the instrumentation process after tests pass (API 30 CI)."""
+    source = SERVICE_TEST.read_text(encoding="utf-8")
+
+    after_class_block = source.split("@AfterClass", 1)[1].split("fun ", 1)[0]
+    assert "prepareColdStart" not in after_class_block
+    assert "forceStopApp" not in after_class_block


### PR DESCRIPTION
## Summary
- Stop calling `DeviceTestSupport.prepareColdStart()` from `TimerForegroundServiceResetTest.@AfterClass`; it force-stops the app while instrumentation is still running and Gradle reports **Process crashed** even when all tests passed (native-release run 26967409276).
- Use `stopTimerService()` only in `@AfterClass`; per-class `am force-stop` in `ci-connected-all.sh` remains between classes.
- Add regression tests for the teardown contract and six-class `ci-connected-all.sh` coverage (#1716).

## Test plan
- [x] `python3 -m pytest scripts/tests/test_service_reset_instrumentation_teardown.py scripts/tests/test_ci_connected_all_script.py`
- [ ] Merge to `release/v1.3.51`, re-run `native-release.yml` (android) after firebase signoff on merge SHA


Made with [Cursor](https://cursor.com)