### PR TITLE
chore: bump develop to v1.3.52 after v1.3.51

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1778679353
-        versionName = "1.3.51"
+        versionCode = ciVersionCode ?: 1778679354
+        versionName = "1.3.52"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -796,7 +796,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.51;
+				MARKETING_VERSION = 1.3.52;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -818,7 +818,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.51;
+				MARKETING_VERSION = 1.3.52;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -906,7 +906,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.51;
+				MARKETING_VERSION = 1.3.52;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -928,7 +928,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.51;
+				MARKETING_VERSION = 1.3.52;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Automated post-release version bump after tag `v1.3.51`.

develop rejects direct pushes; merge this PR to align develop with the next patch train.

Workflow: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/26969957289
