### PR TITLE
fix(ci): artifact prune rate-limit backoff (3ada7591)

### DIFF
--- a/scripts/prune_actions_artifacts.py
+++ b/scripts/prune_actions_artifacts.py
@@ -10,9 +10,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
+
+MAX_RETRIES = 6
+INITIAL_BACKOFF_SEC = 30
+MAX_BACKOFF_SEC = 300
 
 
 def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -24,39 +30,85 @@ def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def gh_api_json(path: str, *, paginate: bool = False) -> list[dict]:
-    if paginate:
-        return _paginate_artifacts(path)
+def _is_rate_limited(result: subprocess.CompletedProcess[str]) -> bool:
+    text = f"{result.stderr}\n{result.stdout}".lower()
+    return result.returncode != 0 and (
+        "403" in text or "rate limit" in text or "secondary rate limit" in text
+    )
 
-    result = _run_gh(["api", path])
+
+def _retry_after_seconds(result: subprocess.CompletedProcess[str], attempt: int) -> float:
+    text = f"{result.stderr}\n{result.stdout}"
+    match = re.search(r"retry.after[:\s]+(\d+)", text, re.IGNORECASE)
+    if match:
+        return float(match.group(1))
+    return min(INITIAL_BACKOFF_SEC * (2**attempt), MAX_BACKOFF_SEC)
+
+
+def _run_gh_with_retry(args: list[str], *, label: str) -> subprocess.CompletedProcess[str]:
+    last: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(MAX_RETRIES):
+        last = _run_gh(args)
+        if last.returncode == 0:
+            return last
+        if _is_rate_limited(last) and attempt < MAX_RETRIES - 1:
+            wait = _retry_after_seconds(last, attempt)
+            print(
+                f"Rate limited on {label}; sleeping {wait:.0f}s (attempt {attempt + 1}/{MAX_RETRIES})",
+                file=sys.stderr,
+            )
+            time.sleep(wait)
+            continue
+        return last
+    assert last is not None
+    return last
+
+
+def gh_api_json(path: str, *, paginate: bool = False, start_page: int = 1) -> tuple[list[dict], int | None, bool]:
+    """Return (artifacts, total_count, pagination_complete)."""
+    if paginate:
+        return _paginate_artifacts(path, start_page=start_page)
+
+    result = _run_gh_with_retry(["api", path], label=path)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"gh api failed: {path}")
 
     payload = json.loads(result.stdout or "{}")
+    total_count = payload.get("total_count") if isinstance(payload, dict) else None
     if isinstance(payload, dict) and "artifacts" in payload:
-        return payload["artifacts"]
+        return payload["artifacts"], total_count, True
     if isinstance(payload, list):
-        return payload
-    return [payload]
+        return payload, total_count, True
+    return [payload], total_count, True
 
 
-def _paginate_artifacts(path: str) -> list[dict]:
-    """Page through Actions artifacts; ``gh api --paginate`` concatenates JSON blobs."""
+def _paginate_artifacts(path: str, *, start_page: int = 1) -> tuple[list[dict], int | None, bool]:
+    """Page through Actions artifacts; resume from ``start_page`` after rate limits."""
     items: list[dict] = []
-    page = 1
+    total_count: int | None = None
+    page = start_page
     while True:
         sep = "&" if "?" in path else "?"
         page_path = f"{path}{sep}per_page=100&page={page}"
-        result = _run_gh(["api", page_path])
+        result = _run_gh_with_retry(["api", page_path], label=f"page {page}")
         if result.returncode != 0:
+            if _is_rate_limited(result):
+                print(
+                    f"Pagination stopped at page {page} after retries; "
+                    f"resume with --start-page {page}",
+                    file=sys.stderr,
+                )
+                return items, total_count, False
             raise RuntimeError(result.stderr.strip() or f"gh api failed: {page_path}")
         payload = json.loads(result.stdout or "{}")
+        if total_count is None and isinstance(payload, dict):
+            total_count = payload.get("total_count")
         batch = payload.get("artifacts", [])
         items.extend(batch)
         if len(batch) < 100:
-            break
+            return items, total_count, True
         page += 1
-    return items
+    return items, total_count, True
 
 
 def parse_github_ts(value: str) -> datetime:
@@ -67,8 +119,11 @@ def parse_github_ts(value: str) -> datetime:
 
 
 def delete_artifact(repo: str, artifact_id: int) -> None:
-    result = _run_gh(["api", "-X", "DELETE", f"repos/{repo}/actions/artifacts/{artifact_id}"])
+    path = f"repos/{repo}/actions/artifacts/{artifact_id}"
+    result = _run_gh_with_retry(["api", "-X", "DELETE", path], label=f"delete {artifact_id}")
     if result.returncode != 0:
+        if _is_rate_limited(result):
+            raise RuntimeError(f"rate limited deleting artifact {artifact_id}")
         raise RuntimeError(
             f"delete artifact {artifact_id} failed: {result.stderr.strip() or result.stdout.strip()}"
         )
@@ -98,6 +153,12 @@ def main() -> int:
         default=0,
         help="Max deletions per run (0 = no limit)",
     )
+    parser.add_argument(
+        "--start-page",
+        type=int,
+        default=1,
+        help="Resume artifact list pagination from this page (default: 1)",
+    )
     args = parser.parse_args()
 
     repo = args.repo
@@ -118,7 +179,11 @@ def main() -> int:
     print(f"{mode}: repo={repo} cutoff={cutoff.isoformat()} (>{args.days}d old)")
 
     try:
-        artifacts = gh_api_json(f"repos/{repo}/actions/artifacts", paginate=True)
+        artifacts, total_count, pagination_complete = gh_api_json(
+            f"repos/{repo}/actions/artifacts",
+            paginate=True,
+            start_page=args.start_page,
+        )
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -133,9 +198,16 @@ def main() -> int:
             stale.append(artifact)
 
     total_bytes = sum(int(a.get("size_in_bytes") or 0) for a in stale)
-    print(f"Listed {len(artifacts)} artifacts; {len(stale)} older than {args.days}d (~{total_bytes / (1024**3):.2f} GiB)")
+    total_label = total_count if total_count is not None else "?"
+    print(
+        f"Listed {len(artifacts)} artifacts (total_count={total_label}); "
+        f"{len(stale)} older than {args.days}d (~{total_bytes / (1024**3):.2f} GiB)"
+    )
+    if not pagination_complete:
+        print("Pagination incomplete — stale count may be understated.", file=sys.stderr)
 
     deleted = 0
+    rate_limited = False
     for artifact in stale:
         if args.limit and deleted >= args.limit:
             print(f"Stopped at --limit {args.limit}")
@@ -150,7 +222,11 @@ def main() -> int:
             try:
                 delete_artifact(repo, aid)
             except RuntimeError as exc:
-                print(f"  FAIL id={aid} name={name}: {exc}", file=sys.stderr)
+                msg = str(exc)
+                print(f"  FAIL id={aid} name={name}: {msg}", file=sys.stderr)
+                if "rate limited" in msg.lower():
+                    rate_limited = True
+                    break
                 continue
             deleted += 1
             if deleted % 100 == 0:
@@ -164,6 +240,11 @@ def main() -> int:
 
     action = "Deleted" if args.execute else "Would delete"
     print(f"{action} {deleted} artifact(s)")
+    if rate_limited:
+        print("Stopped: delete rate limit hit.", file=sys.stderr)
+        return 2
+    if not pagination_complete:
+        return 2
     return 0
 
 

--- a/scripts/tests/test_prune_actions_artifacts.py
+++ b/scripts/tests/test_prune_actions_artifacts.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from scripts import prune_actions_artifacts as paa
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_parse_github_ts_accepts_z_suffix():
+    parsed = paa.parse_github_ts("2026-06-01T12:34:56Z")
+    assert parsed == datetime(2026, 6, 1, 12, 34, 56, tzinfo=timezone.utc)
+
+
+def test_is_rate_limited_detects_403_and_phrases():
+    assert paa._is_rate_limited(_completed(1, stderr="HTTP 403: rate limit exceeded"))
+    assert paa._is_rate_limited(_completed(1, stderr="secondary rate limit"))
+    assert not paa._is_rate_limited(_completed(0))
+
+
+def test_retry_after_seconds_parses_header_then_exponential_backoff():
+    with_retry = _completed(1, stderr="retry after: 42")
+    assert paa._retry_after_seconds(with_retry, attempt=0) == 42.0
+    assert paa._retry_after_seconds(_completed(1), attempt=2) == min(30 * (2**2), 300)
+
+
+def test_run_gh_with_retry_sleeps_then_succeeds(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_run(args):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _completed(1, stderr="403 rate limit")
+        return _completed(0, stdout="{}")
+
+    monkeypatch.setattr(paa, "_run_gh", fake_run)
+    monkeypatch.setattr(paa.time, "sleep", lambda _s: None)
+
+    result = paa._run_gh_with_retry(["api", "repos/x"], label="test")
+    assert result.returncode == 0
+    assert calls["n"] == 2
+
+
+def test_gh_api_json_non_paginate_returns_artifacts_and_total_count():
+    payload = {"artifacts": [{"id": 1}], "total_count": 5}
+    with mock.patch.object(paa, "_run_gh_with_retry", return_value=_completed(0, stdout=json.dumps(payload))):
+        artifacts, total_count, complete = paa.gh_api_json("repos/o/r/actions/artifacts")
+
+    assert artifacts == [{"id": 1}]
+    assert total_count == 5
+    assert complete is True
+
+
+def test_paginate_artifacts_stops_on_rate_limit_with_resume_hint():
+    page1 = {"artifacts": [{"id": i} for i in range(100)], "total_count": 250}
+    rate_limited = _completed(1, stderr="403 rate limit")
+
+    with mock.patch.object(
+        paa,
+        "_run_gh_with_retry",
+        side_effect=[_completed(0, stdout=json.dumps(page1)), rate_limited],
+    ):
+        artifacts, total_count, complete = paa._paginate_artifacts("repos/o/r/actions/artifacts", start_page=1)
+
+    assert len(artifacts) == 100
+    assert total_count == 250
+    assert complete is False
+
+
+def test_delete_artifact_raises_rate_limited_message():
+    with mock.patch.object(
+        paa,
+        "_run_gh_with_retry",
+        return_value=_completed(1, stderr="403 rate limit"),
+    ):
+        with pytest.raises(RuntimeError, match="rate limited deleting artifact 99"):
+            paa.delete_artifact("owner/repo", 99)
+
+
+def test_paginate_artifacts_completes_multi_page_list():
+    page1 = {"artifacts": [{"id": i} for i in range(100)], "total_count": 120}
+    page2 = {"artifacts": [{"id": 100}, {"id": 101}]}
+
+    with mock.patch.object(
+        paa,
+        "_run_gh_with_retry",
+        side_effect=[
+            _completed(0, stdout=json.dumps(page1)),
+            _completed(0, stdout=json.dumps(page2)),
+        ],
+    ):
+        artifacts, total_count, complete = paa._paginate_artifacts("repos/o/r/actions/artifacts", start_page=2)
+
+    assert len(artifacts) == 102
+    assert total_count == 120
+    assert complete is True
+
+
+def test_gh_api_json_raises_on_nonzero_exit():
+    with mock.patch.object(paa, "_run_gh_with_retry", return_value=_completed(1, stderr="boom")):
+        with pytest.raises(RuntimeError, match="boom"):
+            paa.gh_api_json("repos/o/r/actions/artifacts")
+
+
+def test_delete_artifact_raises_generic_failure():
+    with mock.patch.object(
+        paa,
+        "_run_gh_with_retry",
+        return_value=_completed(1, stderr="permission denied"),
+    ):
+        with pytest.raises(RuntimeError, match="delete artifact 7 failed"):
+            paa.delete_artifact("owner/repo", 7)


### PR DESCRIPTION
## Summary

- Task **3ada7591**: prior `prune_actions_artifacts.py --execute` deleted 190 artifacts then hit GitHub API 403 rate limits with 2960 stale remaining (`total_count=4228`).
- Adds exponential backoff/retry on 403 for list + delete calls.
- Adds `--start-page` to resume pagination after rate-limit interruption.
- Prints `total_count` from API; exits `2` when rate-limited or pagination incomplete.

## Bulk prune evidence (this session)

| Stage | total_count | stale (>7d) |
|-------|-------------|-------------|
| Start (after prior 190 deletes) | 4228 | 2960 |
| After 6 batches × 500 deletes + 60s pauses | **1265** | **0** |

No rate limits hit with backoff in place.

## Test plan

- [x] Dry-run reports `total_count` and stale count
- [x] `--execute --limit 500` batch loop completed without 403
- [x] Final dry-run: stale=0, total_count=1265


Made with [Cursor](https://cursor.com)