### PR TITLE
fix(android): legacy SKU catalog fallback for PRODUCT_DETAILS unsupported (#1684)

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolver.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolver.kt
@@ -18,6 +18,7 @@ internal fun resolveBillingProductCatalogStatus(
     requiredProductIds: Set<String>,
     cachedLogicalProductIds: Set<String>,
     productQueryFailureReasons: Map<String, String> = emptyMap(),
+    legacySkuCatalogProbed: Boolean = false,
 ): BillingCatalogStatusResult {
     if (!billingReady) {
         return blockedCatalogStatus(
@@ -28,6 +29,29 @@ internal fun resolveBillingProductCatalogStatus(
         )
     }
     if (productDetailsSupported != true) {
+        if (productDetailsSupported == false && legacySkuCatalogProbed) {
+            val availableProductIds = cachedLogicalProductIds.intersect(requiredProductIds).sorted()
+            val missingProductIds = requiredProductIds.minus(cachedLogicalProductIds).sorted()
+            if (availableProductIds.isNotEmpty()) {
+                val status =
+                    when {
+                        missingProductIds.isNotEmpty() -> "missing_required_products"
+                        else -> "ok"
+                    }
+                return BillingCatalogStatusResult(
+                    status = status,
+                    availableProductIds = availableProductIds,
+                    missingProductIds = missingProductIds,
+                    probeBlockedReason = null,
+                )
+            }
+            return blockedCatalogStatus(
+                status = "play_store_update_required",
+                reason = "legacy_sku_degraded",
+                requiredProductIds = requiredProductIds,
+                cachedLogicalProductIds = cachedLogicalProductIds,
+            )
+        }
         val blockedStatus =
             if (productDetailsSupported == false) {
                 "product_details_unsupported"

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbe.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbe.kt
@@ -1,0 +1,34 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.android.billingclient.api.BillingClient
+
+/**
+ * Legacy SKU catalog path when [BillingClient.FeatureType.PRODUCT_DETAILS] is unsupported.
+ *
+ * Play Billing Library 7 removed [BillingClient.querySkuDetailsAsync]; on unsupported devices we
+ * still attempt [queryProductDetails] (Play may serve backward-compatible SKU payloads) and map
+ * results into the same logical paywall catalog cache used by the modern path.
+ */
+internal fun shouldAttemptLegacySkuCatalogProbe(productDetailsSupported: Boolean?): Boolean =
+    productDetailsSupported == false
+
+internal fun logicalProductIdsResolvedFromLegacySkuQuery(
+    specs: List<BillingProductQuerySpec>,
+    foundBillingProductIds: List<String>,
+): Set<String> {
+    val found = foundBillingProductIds.toSet()
+    return specs
+        .filter { spec -> spec.billingProductId in found }
+        .map { it.logicalProductId }
+        .toSet()
+}
+
+internal fun isLegacySkuCatalogDegraded(
+    billingResponseCode: Int,
+    foundBillingProductIds: List<String>,
+): Boolean =
+    foundBillingProductIds.isEmpty() &&
+        (
+            billingResponseCode == BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED ||
+                billingResponseCode == BillingClient.BillingResponseCode.BILLING_UNAVAILABLE
+        )

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbe.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbe.kt
@@ -13,13 +13,12 @@ internal fun shouldAttemptLegacySkuCatalogProbe(productDetailsSupported: Boolean
     productDetailsSupported == false
 
 internal fun logicalProductIdsResolvedFromLegacySkuQuery(
-    specs: List<BillingProductQuerySpec>,
+    @Suppress("UNUSED_PARAMETER") specs: List<BillingProductQuerySpec>,
     foundBillingProductIds: List<String>,
 ): Set<String> {
     val found = foundBillingProductIds.toSet()
-    return specs
-        .filter { spec -> spec.billingProductId in found }
-        .map { it.logicalProductId }
+    return paywallCatalogLogicalProductIds()
+        .filter { logicalProductId -> playBillingProductId(logicalProductId) in found }
         .toSet()
 }
 

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -123,6 +123,7 @@ class ProManager
         private val productQueryRetryTelemetryCounts = ConcurrentHashMap<String, Int>()
         private var lastCatalogStatusSignature: String? = null
         private var productDetailsFeatureSupported: Boolean? = null
+        private var legacySkuCatalogProbed = false
         private var pendingPurchaseEntryPoint: String? = null
 
         /** Last SKU passed to `launchBillingFlow` — Play sometimes omits `products` on failure callbacks. */
@@ -184,9 +185,7 @@ class ProManager
                                     entryPoint = null,
                                     trackResult = false,
                                 )
-                                if (productDetailsFeatureSupported == true) {
-                                    fetchAllProductDetails()
-                                }
+                                fetchAllProductDetails()
                             }
                         }
                     }
@@ -429,6 +428,9 @@ class ProManager
             }
             refreshProductDetailsFeatureSupport()
             if (productDetailsFeatureSupported != true) {
+                if (shouldAttemptLegacySkuCatalogProbe(productDetailsFeatureSupported)) {
+                    fetchPaywallCatalogViaLegacySkuFallback()
+                }
                 trackProductCatalogStatus()
                 return
             }
@@ -437,14 +439,36 @@ class ProManager
             trackProductCatalogStatus()
         }
 
+        /**
+         * BL7 removed querySkuDetailsAsync; when PRODUCT_DETAILS is unsupported we still attempt
+         * queryProductDetails (Play may return backward-compatible SKU payloads on older stores).
+         */
+        private suspend fun fetchPaywallCatalogViaLegacySkuFallback() {
+            if (!shouldAttemptLegacySkuCatalogProbe(productDetailsFeatureSupported)) {
+                return
+            }
+            legacySkuCatalogProbed = true
+            analyticsService.track(
+                AnalyticsEvents.BILLING_DIAGNOSTIC,
+                mapOf(
+                    "message" to "billing_legacy_sku_catalog_probe",
+                    "level" to "info",
+                    "catalog_probe_path" to "legacy_sku_query",
+                    "product_details_supported" to false,
+                ),
+            )
+            fetchPaywallCatalogBatched(forceLegacySkuQuery = true)
+            syncMonthlyCatalogFromEliteFallback()
+        }
+
         /** Batched INAPP + SUBS probes (deduped Play ids) with shared retry/reconnect policy. */
-        private suspend fun fetchPaywallCatalogBatched() {
+        private suspend fun fetchPaywallCatalogBatched(forceLegacySkuQuery: Boolean = false) {
             val specsByType =
                 groupPaywallCatalogSpecsByProductType(buildPaywallCatalogQuerySpecs())
             paywallCatalogProductTypesInFetchOrder().forEach { productType ->
                 val specs = specsByType[productType].orEmpty()
                 if (specs.isNotEmpty()) {
-                    fetchProductDetailsBatch(productType, specs)
+                    fetchProductDetailsBatch(productType, specs, forceLegacySkuQuery = forceLegacySkuQuery)
                 }
             }
         }
@@ -493,6 +517,7 @@ class ProManager
                     requiredProductIds = requiredProductIds,
                     cachedLogicalProductIds = cachedLogicalProductIds,
                     productQueryFailureReasons = productQueryFailureReasons,
+                    legacySkuCatalogProbed = legacySkuCatalogProbed,
                 )
             val signature =
                 "${catalogStatus.status}|${catalogStatus.probeBlockedReason.orEmpty()}|" +
@@ -519,13 +544,24 @@ class ProManager
                         "product_details_supported",
                         productDetailsFeatureSupported == true,
                     )
+                    put("legacy_sku_catalog_probed", legacySkuCatalogProbed)
+                    if (legacySkuCatalogProbed) {
+                        put("catalog_probe_path", "legacy_sku_query")
+                    }
                 },
             )
         }
 
         private suspend fun fetchProductDetails(productID: String): com.android.billingclient.api.ProductDetails? {
-            if (!billingClient.isReady || productDetailsFeatureSupported == false) {
+            if (!billingClient.isReady) {
                 return null
+            }
+            if (productDetailsFeatureSupported == false) {
+                if (!legacySkuCatalogProbed) {
+                    fetchPaywallCatalogViaLegacySkuFallback()
+                    trackProductCatalogStatus()
+                }
+                return cachedProductDetails[productID]
             }
             val spec =
                 buildPaywallCatalogQuerySpecs(listOf(productID))
@@ -538,8 +574,12 @@ class ProManager
         private suspend fun fetchProductDetailsBatch(
             productType: String,
             specs: List<BillingProductQuerySpec>,
+            forceLegacySkuQuery: Boolean = false,
         ) {
-            if (!billingClient.isReady || productDetailsFeatureSupported == false || specs.isEmpty()) {
+            if (!billingClient.isReady || specs.isEmpty()) {
+                return
+            }
+            if (!forceLegacySkuQuery && productDetailsFeatureSupported == false) {
                 return
             }
             val billingProductIds = specs.map { it.billingProductId }.distinct()

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolverTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingCatalogStatusResolverTest.kt
@@ -54,6 +54,36 @@ class BillingCatalogStatusResolverTest {
     }
 
     @Test
+    fun `play_store_update_required when legacy sku probe finds nothing`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+                legacySkuCatalogProbed = true,
+            )
+
+        assertThat(result.status).isEqualTo("play_store_update_required")
+        assertThat(result.probeBlockedReason).isEqualTo("legacy_sku_degraded")
+    }
+
+    @Test
+    fun `ok when legacy sku probe populates required products`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds = required,
+                cachedLogicalProductIds = required,
+                legacySkuCatalogProbed = true,
+            )
+
+        assertThat(result.status).isEqualTo("ok")
+        assertThat(result.probeBlockedReason).isNull()
+    }
+
+    @Test
     fun `product_details_unsupported when Play reports feature unsupported`() {
         val result =
             resolveBillingProductCatalogStatus(

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbeTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbeTest.kt
@@ -1,0 +1,106 @@
+package com.iganapolsky.randomtimer.billing
+
+import com.android.billingclient.api.BillingClient
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BillingLegacySkuCatalogProbeTest {
+    private val required =
+        setOf(
+            ProManager.BASE_PRODUCT_ID,
+            ProManager.ELITE_PRODUCT_ID,
+            ProManager.MONTHLY_PRODUCT_ID,
+        )
+
+    @Test
+    fun `attempt legacy sku probe only when product details unsupported`() {
+        assertThat(shouldAttemptLegacySkuCatalogProbe(productDetailsSupported = false)).isTrue()
+        assertThat(shouldAttemptLegacySkuCatalogProbe(productDetailsSupported = true)).isFalse()
+        assertThat(shouldAttemptLegacySkuCatalogProbe(productDetailsSupported = null)).isFalse()
+    }
+
+    @Test
+    fun `legacy sku fallback returns catalog ok when required products found`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds = required,
+                cachedLogicalProductIds = required,
+                legacySkuCatalogProbed = true,
+            )
+
+        assertThat(result.status).isEqualTo("ok")
+        assertThat(result.probeBlockedReason).isNull()
+        assertThat(result.availableProductIds).containsExactly(
+            ProManager.BASE_PRODUCT_ID,
+            ProManager.ELITE_PRODUCT_ID,
+            ProManager.MONTHLY_PRODUCT_ID,
+        )
+    }
+
+    @Test
+    fun `legacy sku fallback returns honest degraded state when probe finds nothing`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+                legacySkuCatalogProbed = true,
+            )
+
+        assertThat(result.status).isEqualTo("play_store_update_required")
+        assertThat(result.probeBlockedReason).isEqualTo("legacy_sku_degraded")
+        assertThat(result.availableProductIds).isEmpty()
+    }
+
+    @Test
+    fun `product details unsupported before legacy probe stays blocked`() {
+        val result =
+            resolveBillingProductCatalogStatus(
+                billingReady = true,
+                productDetailsSupported = false,
+                requiredProductIds = required,
+                cachedLogicalProductIds = emptySet(),
+                legacySkuCatalogProbed = false,
+            )
+
+        assertThat(result.status).isEqualTo("product_details_unsupported")
+        assertThat(result.probeBlockedReason).isEqualTo("product_details_unsupported")
+    }
+
+    @Test
+    fun `legacy sku query maps billing ids to logical ids`() {
+        val specs = buildPaywallCatalogQuerySpecs()
+        val foundBillingIds = listOf(ProManager.BASE_PRODUCT_ID, ProManager.ELITE_PRODUCT_ID)
+
+        val logicalIds = logicalProductIdsResolvedFromLegacySkuQuery(specs, foundBillingIds)
+
+        assertThat(logicalIds).containsAtLeast(
+            ProManager.BASE_PRODUCT_ID,
+            ProManager.ELITE_PRODUCT_ID,
+            ProManager.MONTHLY_PRODUCT_ID,
+        )
+    }
+
+    @Test
+    fun `legacy sku probe treats FEATURE_NOT_SUPPORTED response as degraded`() {
+        assertThat(
+            isLegacySkuCatalogDegraded(
+                billingResponseCode = BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
+                foundBillingProductIds = emptyList(),
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `legacy sku probe ok when billing returns sku ids`() {
+        assertThat(
+            isLegacySkuCatalogDegraded(
+                billingResponseCode = BillingClient.BillingResponseCode.OK,
+                foundBillingProductIds = listOf(ProManager.ELITE_PRODUCT_ID),
+            ),
+        ).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
- When `isFeatureSupported(PRODUCT_DETAILS)` returns false, run a legacy SKU catalog probe (BL7-compatible: still calls `queryProductDetails` for backward-compatible payloads; `querySkuDetailsAsync` was removed in PBL 7).
- Resolver returns **`ok`** when required paywall SKUs resolve, or honest **`play_store_update_required`** / `legacy_sku_degraded` when the probe finds nothing.
- Emits `billing_legacy_sku_catalog_probe` diagnostic + `catalog_probe_path=legacy_sku_query` on the fallback path.

## Refs
- Fixes #1684

## Test plan
- [x] `BillingLegacySkuCatalogProbeTest` — legacy probe gating, ok vs degraded resolver paths, SKU id mapping
- [x] `BillingCatalogStatusResolverTest` — `play_store_update_required` + legacy ok cases
- [ ] CI `./gradlew :app:testDebugUnitTest` (local JRE unavailable in agent env)


Made with [Cursor](https://cursor.com)