### PR TITLE
chore(data): refresh executive metrics + post-publish gate

### DIFF
--- a/marketing/data/executive_metrics.json
+++ b/marketing/data/executive_metrics.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-22T17:23:06+00:00",
+  "generated_at": "2026-06-05T18:03:48+00:00",
   "source": "executive_metrics_snapshot",
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "definitions": {
@@ -42,11 +42,18 @@
   "posthog": {
     "status": "ok",
     "window_days": 30,
-    "wqtu_7d_distinct_persons": 12,
+    "wqtu_7d_distinct_persons": 4,
     "distinct_persons_application_installed": 100,
     "distinct_persons_timer_completed": 40,
     "distinct_persons_paywall_purchase_success": 0,
-    "events_paywall_purchase_success": 0
+    "events_paywall_purchase_success": 0,
+    "paywall_purchase_attempts_30d": 4,
+    "sync_source": "north_star.json+paywall_conversion_report.json+wqtu_health.json",
+    "sync_evidence": {
+      "north_star_generated_at": "2026-06-05T17:30:50+00:00",
+      "paywall_generated_at": "2026-06-05T17:31:05+00:00",
+      "wqtu_health_generated_at": "2026-06-05T17:31:18+00:00"
+    }
   },
   "store_apis": {
     "android": {
@@ -90,10 +97,11 @@
   "canonical_users": {
     "metric_bundle_id": "executive_canonical_users_v1",
     "window_days": 30,
-    "wqtu_7d": 12,
+    "wqtu_7d": 4,
     "installs_30d": 100,
     "timer_completed_persons_30d": 40,
     "paywall_purchase_success_persons_30d": 0,
-    "paywall_purchase_success_events_30d": 0
+    "paywall_purchase_success_events_30d": 0,
+    "paywall_purchase_attempts_30d": 4
   }
 }

--- a/marketing/data/post_publish_gate.json
+++ b/marketing/data/post_publish_gate.json
@@ -1,0 +1,30 @@
+{
+  "source": "post_publish_revenue_gate",
+  "generated_at": "2026-06-05T18:03:10Z",
+  "expected_source": "github_latest_release",
+  "expected_ios": "1.3.51",
+  "expected_android": "1.3.51",
+  "store_public_pass": false,
+  "stores": [
+    {
+      "platform": "ios",
+      "passed": false,
+      "expected_version": "1.3.51",
+      "observed_version": "1.3.43",
+      "status": "VERSION_MISMATCH"
+    },
+    {
+      "platform": "android",
+      "passed": false,
+      "expected_version": "1.3.51",
+      "observed_version": "1.3.43",
+      "status": "VERSION_MISMATCH"
+    }
+  ],
+  "paywall_proxy": {
+    "generated_at": "2026-06-05T17:31:05+00:00",
+    "purchase_successes_30d": 0,
+    "purchase_attempts_30d": 4
+  },
+  "revenue_note": "store_public_pass does not imply revenue; check paywall_purchase_success in PostHog."
+}


### PR DESCRIPTION
## Summary
- Refresh `marketing/data/executive_metrics.json`: WQTU 7d **4** (was 12), paywall attempts **4**, success **0** — synced from live CI snapshots (`north_star.json`, `paywall_conversion_report.json`, `wqtu_health.json` generated 2026-06-05 UTC).
- Add `marketing/data/post_publish_gate.json` from `post_publish_revenue_gate.py`: public listing **1.3.43** vs GitHub release **1.3.51** (both platforms VERSION_MISMATCH).

## Evidence
- PostHog MCP WQTU HogQL (pragmatic_live filter): **4**
- `paywall_conversion_report.json`: 4 attempts / 0 successes (30d)
- `post_publish_revenue_gate.py` exit 1 (store_public_pass=false) — gate file written

## Note
Full `executive_metrics_snapshot.py` requires `POSTHOG_PERSONAL_API_KEY` locally (missing); PostHog scalars merged from wiki-sync artifacts instead of a degraded skip run.

## Test plan
- [x] JSON validates
- [x] Counts match source snapshots


Made with [Cursor](https://cursor.com)