### PR TITLE
fix(android): stabilize v1.3.52 device-test gate (7/13 flake)

### DIFF
--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/DeviceTestSupport.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/DeviceTestSupport.kt
@@ -1,0 +1,39 @@
+package com.iganapolsky.randomtimer.ui
+
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.iganapolsky.randomtimer.MainActivity
+
+/** Shared helpers for slow GitHub Actions emulators (API 30, swiftshader). */
+object DeviceTestSupport {
+    const val SETUP_READY_TIMEOUT_MS = 30_000L
+
+    fun clearAppData() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.uiAutomation.executeShellCommand(
+            "pm clear com.iganapolsky.randomtimer",
+        )
+    }
+
+    fun waitForSetupScreen(
+        rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+        timeoutMillis: Long = SETUP_READY_TIMEOUT_MS,
+    ) {
+        rule.waitUntil(timeoutMillis = timeoutMillis) {
+            rule.onAllNodesWithTag("start_timer", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        rule.waitForIdle()
+    }
+
+    fun clickPrimaryStart(
+        rule: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+    ) {
+        rule.onNodeWithTag("start_timer", useUnmergedTree = true).performClick()
+    }
+}

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/NotificationE2ETest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/NotificationE2ETest.kt
@@ -1,9 +1,6 @@
 package com.iganapolsky.randomtimer.ui
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -32,80 +29,54 @@ class NotificationE2ETest {
 
     @Test
     fun testNotificationLifecycle() {
-        // 1. Start a timer from the UI
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule
-                .onAllNodesWithText("Start First Drill")
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-        
-        composeRule.onNodeWithText("Start First Drill").performClick()
+        DeviceTestSupport.waitForSetupScreen(composeRule)
+        DeviceTestSupport.clickPrimaryStart(composeRule)
 
-        // 2. Background the app to show notification
         device.pressHome()
-
-        // 3. Open notification shade
         device.openNotification()
-        
-        // 4. Verify notification is visible
+
         val notificationTitle = device.wait(Until.findObject(By.text("Timer Running")), 5000)
         assertNotNull("Notification with title 'Timer Running' should be visible", notificationTitle)
 
-        // 5. Click 'Pause'
         val pauseButton = device.findObject(By.text("Pause"))
         assertNotNull("Pause button should be visible", pauseButton)
         pauseButton.click()
 
-        // 6. Verify title changes to 'Timer Paused'
         val pausedTitle = device.wait(Until.findObject(By.text("Timer Paused")), 5000)
         assertNotNull("Notification title should change to 'Timer Paused'", pausedTitle)
 
-        // 7. Click 'Resume'
         val resumeButton = device.findObject(By.text("Resume"))
         assertNotNull("Resume button should be visible", resumeButton)
         resumeButton.click()
-        
-        // 8. Verify title changes back to 'Timer Running'
+
         val runningTitle = device.wait(Until.findObject(By.text("Timer Running")), 5000)
         assertNotNull("Notification title should change back to 'Timer Running'", runningTitle)
 
-        // 9. Click 'Stop'
         val stopButton = device.findObject(By.text("Stop"))
         assertNotNull("Stop button should be visible", stopButton)
         stopButton.click()
 
-        // 10. Verify notification is dismissed
         val dismissed = device.wait(Until.gone(By.text("Timer Running")), 5000)
         assertTrue("Notification should be dismissed after clicking 'Stop'", dismissed)
-        
+
         device.pressHome()
     }
 
     @Test
     fun testExtendTimerAction() {
-        // 1. Start a timer
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithText("Start First Drill").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onNodeWithText("Start First Drill").performClick()
+        DeviceTestSupport.waitForSetupScreen(composeRule)
+        DeviceTestSupport.clickPrimaryStart(composeRule)
 
-        // 2. Open notification
         device.pressHome()
         device.openNotification()
 
-        // 3. Verify '+5 Min' button exists
         val extendButton = device.findObject(By.text("+5 Min"))
         assertNotNull("'+5 Min' button should be visible", extendButton)
-
-        // 4. Click '+5 Min'
         extendButton.click()
-        
-        // 5. Verify notification still shows 'Timer Running' (it shouldn't disappear)
+
         val runningTitle = device.wait(Until.findObject(By.text("Timer Running")), 2000)
         assertNotNull("Notification should still be visible after extend", runningTitle)
 
-        // 6. Stop and cleanup
         device.findObject(By.text("Stop")).click()
         device.pressHome()
     }

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/RangeSliderUiTest.kt
@@ -18,7 +18,8 @@ class RangeSliderUiTest {
 
     @Test
     fun draggingMinBeyondGapPushesMaxForward() {
-        // Reduce max to 60s.
+        DeviceTestSupport.waitForSetupScreen(composeRule)
+
         composeRule
             .onNodeWithContentDescription("Maximum time slider")
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
@@ -27,7 +28,6 @@ class RangeSliderUiTest {
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Maximum: 1m").assertExists()
 
-        // Move min close to max; max should be pushed to keep a 5s gap.
         composeRule
             .onNodeWithContentDescription("Minimum time slider")
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
@@ -40,7 +40,8 @@ class RangeSliderUiTest {
 
     @Test
     fun draggingMaxBelowGapPullsMinBack() {
-        // Set min to 150s (2m 30s). Max is still 5m so this should not push max.
+        DeviceTestSupport.waitForSetupScreen(composeRule)
+
         composeRule
             .onNodeWithContentDescription("Minimum time slider")
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->
@@ -49,7 +50,6 @@ class RangeSliderUiTest {
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Minimum: 2m 30s").assertExists()
 
-        // Move max below min + 5s; min should be pulled back.
         composeRule
             .onNodeWithContentDescription("Maximum time slider")
             .performSemanticsAction(SemanticsActions.SetProgress) { setProgress ->

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/TimerSetupSmokeTest.kt
@@ -1,13 +1,12 @@
 package com.iganapolsky.randomtimer.ui
 
-import androidx.compose.ui.test.hasContentDescription
-import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.iganapolsky.randomtimer.MainActivity
 import org.junit.Rule
@@ -21,38 +20,31 @@ class TimerSetupSmokeTest {
 
     @Test
     fun setupScreenRendersCoreControls() {
-        composeRule.waitUntil(timeoutMillis = 5_000) {
+        DeviceTestSupport.waitForSetupScreen(composeRule)
+
+        composeRule.onNodeWithTag("start_timer", useUnmergedTree = true).assertExists()
+        composeRule.onNodeWithContentDescription("Minimum time slider").assertExists()
+        composeRule.onNodeWithContentDescription("Maximum time slider").assertExists()
+    }
+
+    @Test
+    fun soundArsenalLockOpensPaywallForUpgrade() {
+        DeviceTestSupport.waitForSetupScreen(composeRule)
+
+        composeRule.waitUntil(timeoutMillis = DeviceTestSupport.SETUP_READY_TIMEOUT_MS) {
             composeRule
-                .onAllNodesWithText("Start First Drill")
+                .onAllNodesWithContentDescription("Unlock Sound Arsenal", useUnmergedTree = true)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
 
         composeRule
-            .onNodeWithText("Start First Drill")
-            .assertExists()
-
-        composeRule
-            .onNodeWithContentDescription("Minimum time slider")
-            .assertExists()
-
-        composeRule
-            .onNodeWithContentDescription("Maximum time slider")
-            .assertExists()
-    }
-
-    @Test
-    fun soundArsenalLockOpensPaywallForUpgrade() {
-        composeRule
-            .onNode(hasScrollAction())
-            .performScrollToNode(hasContentDescription("Unlock Sound Arsenal"))
-
-        composeRule
             .onNodeWithContentDescription("Unlock Sound Arsenal", useUnmergedTree = true)
-            .assertExists()
+            .performScrollTo()
             .performClick()
 
-        composeRule.waitUntil(timeoutMillis = 5_000) {
+        composeRule.waitForIdle()
+        composeRule.waitUntil(timeoutMillis = DeviceTestSupport.SETUP_READY_TIMEOUT_MS) {
             composeRule
                 .onAllNodesWithText("Unlock Full Fight-Ready Training")
                 .fetchSemanticsNodes()

--- a/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
+++ b/native-android/app/src/androidTest/java/com/iganapolsky/randomtimer/ui/screens/ActiveTimerScreenTapCircleTest.kt
@@ -1,6 +1,7 @@
 package com.iganapolsky.randomtimer.ui.screens
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -95,11 +96,11 @@ class ActiveTimerScreenTapCircleTest {
             }
         }
 
-        // RUNNING state shows "Timer running" accessibility label, not "Timer complete"
-        // The circle should NOT be clickable during RUNNING state
+        // RUNNING: CircularTimer exposes "Timer running, range …" and is not clickable.
         composeRule
-            .onNodeWithContentDescription("Timer running")
-            .performTouchInput { click() }
+            .onNodeWithContentDescription("Timer running", substring = true)
+            .assertExists()
+            .assertHasNoClickAction()
 
         composeRule.runOnIdle {
             assertTrue(!dismissed)

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/TimerSetupScreen.kt
@@ -1209,7 +1209,12 @@ private fun TimeRangeSliders(
                     },
                     enabled = enabled,
                     valueRange = minFloorSeconds.toFloat()..(maxSliderRangeInt - minGapSeconds).toFloat(),
-                    modifier = Modifier.weight(1f).semantics { contentDescription = "Minimum time slider" },
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .semantics(mergeDescendants = true) {
+                                contentDescription = "Minimum time slider"
+                            },
                     colors =
                         SliderDefaults.colors(
                             thumbColor = if (enabled) TimerColors.AccentPrimary else TimerColors.TextMuted,
@@ -1255,7 +1260,12 @@ private fun TimeRangeSliders(
                     },
                     enabled = enabled,
                     valueRange = minGapSeconds.toFloat()..maxSliderRange,
-                    modifier = Modifier.weight(1f).semantics { contentDescription = "Maximum time slider" },
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .semantics(mergeDescendants = true) {
+                                contentDescription = "Maximum time slider"
+                            },
                     colors =
                         SliderDefaults.colors(
                             thumbColor = if (enabled) TimerColors.AccentPrimary else TimerColors.TextMuted,


### PR DESCRIPTION
## Summary
- Cherry-pick of proven #1709 stabilization for `release/v1.3.52` after native-release run [27033324975](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27033324975) failed **7/13** on `--failed` rerun (same pattern as v1.3.51).
- **`DeviceTestSupport`:** wait up to 30s for `start_timer` test tag; shared setup helpers for Notification/RangeSlider/Smoke tests.
- **`TimerSetupScreen`:** `semantics(mergeDescendants = true)` on min/max sliders so `SetProgress` works on CI emulators.
- **`ActiveTimerScreenTapCircleTest`:** `assertHasNoClickAction` instead of `performTouchInput` on non-clickable running timer node.

## Evidence
- Initial failure: run 27033324975 @ `6f8f765` — 7 failures (`NotificationE2ETest`, `RangeSliderUiTest`, `TimerSetupSmokeTest`, `ActiveTimerScreenTapCircleTest`).
- Rerun #1 (`gh run rerun 27033324975 --failed`): **failure** again, same 7 tests @ 19:29 UTC.

## Test plan
- [ ] Merge to `release/v1.3.52`
- [ ] `gh run rerun 27033324975 --failed` (one post-merge rerun per release monitor playbook)
- [ ] On green: verify Play production `versionCode` **1778679354** + tag `v1.3.52`


Made with [Cursor](https://cursor.com)