### PR TITLE
chore(data): refresh post_publish_gate for v1.3.52 storefront lag

### DIFF
--- a/marketing/data/post_publish_gate.json
+++ b/marketing/data/post_publish_gate.json
@@ -1,28 +1,28 @@
 {
   "source": "post_publish_revenue_gate",
-  "generated_at": "2026-06-05T18:03:10Z",
+  "generated_at": "2026-06-05T22:43:23Z",
   "expected_source": "github_latest_release",
-  "expected_ios": "1.3.51",
-  "expected_android": "1.3.51",
+  "expected_ios": "1.3.52",
+  "expected_android": "1.3.52",
   "store_public_pass": false,
   "stores": [
     {
       "platform": "ios",
       "passed": false,
-      "expected_version": "1.3.51",
+      "expected_version": "1.3.52",
       "observed_version": "1.3.43",
       "status": "VERSION_MISMATCH"
     },
     {
       "platform": "android",
       "passed": false,
-      "expected_version": "1.3.51",
+      "expected_version": "1.3.52",
       "observed_version": "1.3.43",
       "status": "VERSION_MISMATCH"
     }
   ],
   "paywall_proxy": {
-    "generated_at": "2026-06-05T17:31:05+00:00",
+    "generated_at": "2026-06-05T18:51:04+00:00",
     "purchase_successes_30d": 0,
     "purchase_attempts_30d": 4
   },


### PR DESCRIPTION
## Summary
- Refresh `marketing/data/post_publish_gate.json` after v1.3.52 ship: expected versions 1.3.51 → 1.3.52.
- Public Play/App Store HTML still reads **1.3.43** (VERSION_MISMATCH); Play API confirms VC **1780697170** on production (completed).

## Test plan
- [x] `python3 scripts/post_publish_revenue_gate.py --platform both --timeout 0` regenerates matching JSON
- [x] No release dispatch


Made with [Cursor](https://cursor.com)