### PR TITLE
chore(analytics): refresh executive_metrics WQTU to live 8

### DIFF
--- a/marketing/data/executive_metrics.json
+++ b/marketing/data/executive_metrics.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-05T18:03:48+00:00",
+  "generated_at": "2026-06-08T16:15:37+00:00",
   "source": "executive_metrics_snapshot",
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "definitions": {
@@ -35,44 +35,187 @@
     "posthog_usd_gap_per_day_vs_target": 100.0,
     "events_paywall_purchase_success_30d": 0,
     "distinct_persons_paywall_purchase_success_30d": 0,
-    "billing_product_not_found_play_store_android_30d": 0,
+    "billing_product_not_found_play_store_android_30d": 450,
     "store_ledger_revenue_usd_30d": null,
     "store_ledger_metric_id": "not_wired_in_executive_snapshot"
   },
   "posthog": {
     "status": "ok",
+    "host": "https://us.posthog.com",
+    "project_id": "299775",
+    "audience": "pragmatic_live",
+    "audience_sql": "(\n  lower(coalesce(properties.build_type, 'release')) != 'debug'\n  AND lower(coalesce(properties.runtime_target, 'device')) NOT IN ('simulator', 'emulator')\n  AND coalesce(toString(properties.is_internal), 'false') != 'true'\n  AND coalesce(toString(properties.distribution_channel), 'legacy') NOT IN ('testflight', 'non_play_install', 'dev', 'emulator', 'simulator', 'ui_test')\n) AND person_id NOT IN (<redacted: POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS>)",
+    "audience_note": "Excludes debug/sim/emulator, is_internal, non\u2013App Store/TestFlight/Firebase-style distribution_channel values, and optional POSTHOG_EXECUTIVE_EXCLUDE_PERSON_IDS. Legacy events without distribution_channel use coalesce 'legacy' (still included). Not a guarantee of human/non-team users\u2014set person exclusions for known IDs.",
+    "exclude_person_ids_configured": true,
     "window_days": 30,
-    "wqtu_7d_distinct_persons": 4,
-    "distinct_persons_application_installed": 100,
-    "distinct_persons_timer_completed": 40,
+    "errors": [
+      "http_400"
+    ],
+    "distinct_persons_application_installed": 677,
+    "distinct_persons_first_open": 677,
+    "distinct_persons_application_installed_ios": 58,
+    "distinct_persons_application_installed_android": 618,
+    "distinct_persons_application_opened_ios": 66,
+    "distinct_persons_application_opened_android": 623,
+    "timer_started_events": 1886,
+    "timer_completed_events": 587,
+    "distinct_persons_timer_started": 342,
+    "distinct_persons_timer_completed": 79,
+    "distinct_persons_timer_started_and_completed": 79,
+    "wqtu_distinct_persons": 25,
+    "wqtu_7d_distinct_persons": 8,
+    "timer_abandon_rate_event_level_pct": 68.88,
     "distinct_persons_paywall_purchase_success": 0,
     "events_paywall_purchase_success": 0,
-    "paywall_purchase_attempts_30d": 4,
-    "sync_source": "north_star.json+paywall_conversion_report.json+wqtu_health.json",
-    "sync_evidence": {
-      "north_star_generated_at": "2026-06-05T17:30:50+00:00",
-      "paywall_generated_at": "2026-06-05T17:31:05+00:00",
-      "wqtu_health_generated_at": "2026-06-05T17:31:18+00:00"
-    }
+    "distinct_persons_paywall_purchase_success_ios": 0,
+    "distinct_persons_paywall_purchase_success_android": 0,
+    "events_paywall_purchase_success_ios": 0,
+    "events_paywall_purchase_success_android": 0,
+    "paywall_revenue_sum_30d": 0.0,
+    "billing_product_not_found_play_store_android_30d": 450,
+    "in_app_review_prompt_events": 484,
+    "in_app_review_prompt_distinct_persons": 267,
+    "top_screens_by_distinct_persons": [
+      [
+        "Timer Setup",
+        377,
+        2817
+      ],
+      [
+        "Active Timer",
+        322,
+        2320
+      ],
+      [
+        "SmartCart",
+        82,
+        87
+      ],
+      [
+        "LipidSync",
+        75,
+        78
+      ],
+      [
+        "NutriPlan",
+        67,
+        71
+      ],
+      [
+        "Dashboard",
+        21,
+        31
+      ]
+    ],
+    "posthog_exception_events": 0,
+    "metric_bundle_id": "posthog_executive_pragmatic_live_hogql_v1",
+    "metric_field_ids": {
+      "distinct_persons_application_installed": "posthog_hogql_distinct_persons_event_application_installed",
+      "distinct_persons_first_open": "posthog_hogql_distinct_persons_event_first_open",
+      "distinct_persons_application_installed_ios": "posthog_hogql_distinct_persons_event_application_installed_ios",
+      "distinct_persons_application_installed_android": "posthog_hogql_distinct_persons_event_application_installed_android",
+      "distinct_persons_application_opened_ios": "posthog_hogql_distinct_persons_event_application_opened_ios",
+      "distinct_persons_application_opened_android": "posthog_hogql_distinct_persons_event_application_opened_android",
+      "timer_started_events": "posthog_hogql_count_events_timer_started",
+      "timer_completed_events": "posthog_hogql_count_events_timer_completed",
+      "distinct_persons_timer_started": "posthog_hogql_distinct_persons_event_timer_started",
+      "distinct_persons_timer_completed": "posthog_hogql_distinct_persons_event_timer_completed",
+      "distinct_persons_timer_started_and_completed": "posthog_hogql_distinct_persons_completed_also_started_same_window",
+      "wqtu_distinct_persons": "posthog_hogql_wqtu_timer_completed_ge3_trailing_window_days",
+      "wqtu_7d_distinct_persons": "posthog_hogql_wqtu_timer_completed_ge3_trailing_7d_fixed",
+      "timer_abandon_rate_event_level_pct": "posthog_derived_event_level_started_minus_completed_over_started_pct",
+      "distinct_persons_paywall_purchase_success": "posthog_hogql_distinct_persons_event_paywall_purchase_success",
+      "events_paywall_purchase_success": "posthog_hogql_count_events_paywall_purchase_success",
+      "distinct_persons_paywall_purchase_success_ios": "posthog_hogql_distinct_persons_event_paywall_purchase_success_ios",
+      "distinct_persons_paywall_purchase_success_android": "posthog_hogql_distinct_persons_event_paywall_purchase_success_android",
+      "events_paywall_purchase_success_ios": "posthog_hogql_count_events_paywall_purchase_success_ios",
+      "events_paywall_purchase_success_android": "posthog_hogql_count_events_paywall_purchase_success_android",
+      "in_app_review_prompt_events": "posthog_hogql_count_events_review_prompt_requested",
+      "in_app_review_prompt_distinct_persons": "posthog_hogql_distinct_persons_event_review_prompt_requested",
+      "top_screens_by_distinct_persons": "posthog_hogql_top_screens_by_distinct_persons_limit_12_order_desc",
+      "posthog_exception_events": "posthog_hogql_count_events_dollar_exception",
+      "paywall_revenue_sum_30d": "posthog_hogql_sum_paywall_purchase_success_revenue_properties",
+      "billing_product_not_found_play_store_android_30d": "posthog_hogql_count_billing_product_not_found_android_play_store"
+    },
+    "query_errors": [
+      "http_400"
+    ]
   },
   "store_apis": {
     "android": {
-      "status": "skipped"
+      "status": "ok",
+      "review_count": 0,
+      "review_count_metric_id": "google_play_androidpublisher_reviews_list_7d_commented_paginated",
+      "production_release": {
+        "version_codes": [
+          "1780697170"
+        ],
+        "status": "completed",
+        "name": "v1780697170"
+      },
+      "refund_requests_30d": 0,
+      "voided_purchase_reason_counts": {},
+      "refund_count_metric_id": "google_play_androidpublisher_voidedpurchases_list_window_paginated",
+      "refund_window_days": 29,
+      "note": "Play reviews.list: comment-bearing reviews created or modified in the last 7 days only; star-only ratings are excluded. Not equal to public Play review totals. No per-app download count in this API."
     },
     "ios": {
-      "status": "skipped"
+      "status": "ok",
+      "app_id": "6758355312",
+      "app_name": "Random Tactical Timer",
+      "bundle_id": "com.igorganapolsky.randomtimer",
+      "sku": "randomtimer2026",
+      "versions": [
+        {
+          "version": "1.3.43",
+          "state": "READY_FOR_SALE",
+          "created": "2026-05-29T10:03:55-07:00"
+        },
+        {
+          "version": "1.3.42",
+          "state": "READY_FOR_SALE",
+          "created": "2026-05-27T11:12:22-07:00"
+        },
+        {
+          "version": "1.3.40",
+          "state": "READY_FOR_SALE",
+          "created": "2026-05-25T16:04:05-07:00"
+        },
+        {
+          "version": "1.3.39",
+          "state": "READY_FOR_SALE",
+          "created": "2026-05-23T07:21:31-07:00"
+        },
+        {
+          "version": "1.3.36",
+          "state": "READY_FOR_SALE",
+          "created": "2026-05-22T08:47:22-07:00"
+        }
+      ],
+      "review_count": 0,
+      "review_count_metric_id": "app_store_connect_customer_reviews_sort_created_desc_limit_50",
+      "review_count_request_limit": 50,
+      "reviews": [],
+      "ios_refund_units_30d": 0,
+      "ios_gross_units_30d": 354,
+      "ios_net_units_30d": 354,
+      "refund_count_metric_id": "app_store_connect_sales_reports_daily_summary_negative_units_sum",
+      "sales_report_vendor_number_present": true,
+      "sales_report_days_scanned": 30,
+      "sales_report_days_with_data": 29,
+      "note": "App Store Connect Sales reports require async report generation. customerReviews count is the first page only (limit 50, newest first), not total lifetime App Store reviews. Version state is live from the API. iOS refund units are derived from negative Units rows in ASC daily SALES/SUMMARY reports when APPSTORE_VENDOR_NUMBER is configured."
     }
   },
   "refunds": {
-    "android_refund_requests_30d": null,
-    "android_refund_count_metric_id": null,
-    "android_reason_counts": null,
-    "android_status": "skipped",
-    "ios_refund_units_30d": null,
-    "ios_refund_count_metric_id": null,
-    "ios_sales_report_vendor_number_present": null,
-    "ios_sales_report_days_with_data": null,
-    "ios_status": "skipped",
+    "android_refund_requests_30d": 0,
+    "android_refund_count_metric_id": "google_play_androidpublisher_voidedpurchases_list_window_paginated",
+    "android_reason_counts": {},
+    "android_status": "ok",
+    "ios_refund_units_30d": 0,
+    "ios_refund_count_metric_id": "app_store_connect_sales_reports_daily_summary_negative_units_sum",
+    "ios_sales_report_vendor_number_present": true,
+    "ios_sales_report_days_with_data": 29,
+    "ios_status": "ok",
     "asn_v2_status": "skipped",
     "asn_v2_ios_refund_count_production": null,
     "asn_v2_ios_refund_count_total": null,
@@ -81,7 +224,7 @@
     "asn_v2_subscription_lifecycle_count": null,
     "asn_v2_subscription_lifecycle_by_type": null,
     "asn_v2_metric_id": null,
-    "asn_v2_skip_reason": null,
+    "asn_v2_skip_reason": "Missing env vars: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_KV_NAMESPACE_ID",
     "note": "Android uses Google Play voided purchases API. iOS uses two signals: (1) negative Units in App Store Connect SALES/SUMMARY daily reports (requires APPSTORE_VENDOR_NUMBER), and (2) real-time Apple Server Notifications V2 via Cloudflare KV webhook (server/apple-webhook \u2014 requires CLOUDFLARE_API_TOKEN + CLOUDFLARE_KV_NAMESPACE_ID)."
   },
   "uninstalls": {
@@ -92,16 +235,39 @@
     "note": "Proxy only (not store truth): distinct Application Installed minus distinct Application Opened by platform over the same window."
   },
   "crashlytics_bigquery": {
-    "status": "skipped"
+    "status": "skipped",
+    "source": "crashlytics_bigquery",
+    "metric_bundle_id": "crashlytics_bq_streaming_fatal_window_v1",
+    "metric_field_ids": {
+      "fatal_events": "crashlytics_bq_sum_crash_count_in_top_20_issue_groups_only_not_total_window",
+      "fatal_events_in_window": "crashlytics_bq_count_star_all_fatal_rows_in_lookback_window",
+      "top_fatal_issues": "crashlytics_bq_fatal_groups_limited_20_order_by_crash_count_desc",
+      "crash_free_pct": "crashlytics_bq_session_crash_free_rate_by_installation_uuid",
+      "total_users": "crashlytics_bq_distinct_installation_uuids_in_window",
+      "crash_free_users": "crashlytics_bq_installation_uuids_without_fatal_in_window",
+      "affected_users": "crashlytics_bq_total_users_minus_crash_free_users"
+    },
+    "project_id": "random-timer-dist-new",
+    "dataset": "firebase_crashlytics",
+    "package": "com.iganapolsky.randomtimer",
+    "hours": 168,
+    "table_id": null,
+    "fatal_events": 0,
+    "fatal_events_in_window": 0,
+    "affected_users": 0,
+    "total_users": 0,
+    "crash_free_users": 0,
+    "crash_free_pct": null,
+    "top_fatal_issues": [],
+    "reason": "BigQuery dataset exists but no tables yet"
   },
   "canonical_users": {
     "metric_bundle_id": "executive_canonical_users_v1",
     "window_days": 30,
-    "wqtu_7d": 4,
-    "installs_30d": 100,
-    "timer_completed_persons_30d": 40,
+    "wqtu_7d": 8,
+    "installs_30d": 677,
+    "timer_completed_persons_30d": 79,
     "paywall_purchase_success_persons_30d": 0,
-    "paywall_purchase_success_events_30d": 0,
-    "paywall_purchase_attempts_30d": 4
+    "paywall_purchase_success_events_30d": 0
   }
 }


### PR DESCRIPTION
## Summary
- Refresh `marketing/data/executive_metrics.json` from CI `executive-metrics.yml` snapshot (2026-06-08T16:15:37Z).
- Fixes stale `wqtu_7d_distinct_persons`: **4 → 8** (live PostHog North Star).
- `north_star.json` already refreshed on develop via wiki-sync (`b468c90f`).

## Evidence
- PostHog HogQL WQTU canonical query: **8** (trailing 7d, 2026-06-08).
- CI artifact: executive-metrics run `27151137365`.

## Test plan
- [x] JSON parses; `posthog.wqtu_7d_distinct_persons == 8`
- [x] No native-release dispatch

Made with [Cursor](https://cursor.com)

----
## Summary by Gitar

- **Enhanced analytics snapshot:**
  - Expanded `executive_metrics.json` with detailed PostHog query context, platform-specific breakdown, and top screen metrics.
  - Added `store_apis` metadata for Android and iOS performance monitoring and integrated `crashlytics_bigquery` schema structures.
  - Updated `canonical_users` metrics to reflect current `wqtu_7d`, `installs_30d`, and `timer_completed_persons_30d` activity.


<sub>This will update automatically on new commits.</sub>