### PR TITLE
chore(data): refresh post_publish_gate snapshot

### DIFF
--- a/marketing/data/post_publish_gate.json
+++ b/marketing/data/post_publish_gate.json
@@ -1,6 +1,6 @@
 {
   "source": "post_publish_revenue_gate",
-  "generated_at": "2026-06-05T22:43:23Z",
+  "generated_at": "2026-06-08T17:25:22Z",
   "expected_source": "github_latest_release",
   "expected_ios": "1.3.52",
   "expected_android": "1.3.52",
@@ -22,7 +22,7 @@
     }
   ],
   "paywall_proxy": {
-    "generated_at": "2026-06-05T18:51:04+00:00",
+    "generated_at": "2026-06-08T16:24:49+00:00",
     "purchase_successes_30d": 0,
     "purchase_attempts_30d": 4
   },


### PR DESCRIPTION
## Summary
- Re-ran `scripts/post_publish_revenue_gate.py` (2026-06-08) to refresh `marketing/data/post_publish_gate.json` timestamps and paywall proxy linkage.
- Store gate still **fails** as expected: public listings at **1.3.43** vs GitHub release **1.3.52** (`VERSION_MISMATCH` both platforms). No revenue claim.

## Evidence
```bash
python3 scripts/post_publish_revenue_gate.py  # exit 1 (store_public_pass=false)
```

## Test plan
- [ ] CI data/marketing checks if any


Made with [Cursor](https://cursor.com)