### PR TITLE
fix(android): voice/repeat gate paywall billing_not_ready leaks

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -191,6 +191,7 @@ class ProManager
                     }
 
                     override fun onBillingServiceDisconnected() {
+                        invalidatePaywallCatalogCache()
                         externalScope.launch {
                             delay(1000)
                             connectAndRestore()
@@ -279,7 +280,7 @@ class ProManager
             pendingPurchaseEntryPoint = entryPoint
             pendingLaunchProductId = productID
             clearPendingTrialOffer()
-            if (!ensureBillingReadyForPurchase()) {
+            if (!ensureBillingReadyForPurchase(purchaseLaunch = true)) {
                 trackPurchaseResult(
                     success = false,
                     source = MonetizationSources.PAYWALL,
@@ -407,18 +408,27 @@ class ProManager
             return true
         }
 
-        private suspend fun ensureBillingReadyForPurchase(): Boolean {
+        private suspend fun ensureBillingReadyForPurchase(purchaseLaunch: Boolean = false): Boolean {
             if (billingClient.isReady) {
                 return true
             }
             connectAndRestore()
-            repeat(6) {
+            val maxAttempts = if (purchaseLaunch) 16 else 6
+            repeat(maxAttempts) {
                 delay(500)
                 if (billingClient.isReady) {
                     return true
                 }
             }
             return billingClient.isReady
+        }
+
+        fun isBillingClientReady(): Boolean = billingClient.isReady
+
+        internal fun invalidatePaywallCatalogCache() {
+            cachedProductDetails.clear()
+            productQueryFailureReasons.clear()
+            lastCatalogStatusSignature = null
         }
 
         private suspend fun fetchAllProductDetails() {
@@ -484,8 +494,8 @@ class ProManager
             }
         }
 
-        suspend fun availablePaywallProductIds(): Set<String> {
-            if (!ensureBillingReadyForPurchase()) {
+        suspend fun availablePaywallProductIds(forPurchaseLaunch: Boolean = false): Set<String> {
+            if (!ensureBillingReadyForPurchase(purchaseLaunch = forPurchaseLaunch)) {
                 trackProductCatalogStatus()
                 return emptySet()
             }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -29,6 +29,7 @@ import com.iganapolsky.randomtimer.monetization.QualifiedTrainingPaywallPolicy
 import com.iganapolsky.randomtimer.monetization.QualifiedTrainingPaywallStore
 import com.iganapolsky.randomtimer.ui.screens.ActiveTimerScreen
 import com.iganapolsky.randomtimer.ui.screens.PaywallSheet
+import com.iganapolsky.randomtimer.ui.screens.isPaywallPurchaseAllowed
 import com.iganapolsky.randomtimer.ui.screens.TimerSetupScreen
 import com.iganapolsky.randomtimer.ui.viewmodel.TimerViewModel
 import kotlinx.coroutines.launch
@@ -83,6 +84,7 @@ fun RandomTimerNavHost(
     var paywallTrialEligibilityByProductId by remember { mutableStateOf(emptyMap<String, Boolean>()) }
     var paywallAvailableProductIds by remember { mutableStateOf(emptySet<String>()) }
     var paywallBillingCatalogProbed by remember { mutableStateOf(false) }
+    var paywallBillingReady by remember { mutableStateOf(false) }
     var paywallDefaultToAnnual by remember { mutableStateOf(false) }
     var paywallValueFramingVariant by remember { mutableStateOf(PaywallValueFraming.CONTROL) }
     val qualifiedTrainingPaywallStore = remember { QualifiedTrainingPaywallStore(context) }
@@ -95,6 +97,7 @@ fun RandomTimerNavHost(
             lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
             paywallAvailableProductIds = viewModel.proManager.availablePaywallProductIds()
             paywallBillingCatalogProbed = true
+            paywallBillingReady = viewModel.proManager.isBillingClientReady()
             paywallEntryPoint = paywallEntryPointForFeature(feature)
             paywallTrialEligibilityByProductId =
                 mapOf(
@@ -284,6 +287,7 @@ fun RandomTimerNavHost(
             trialEligibilityByProductId = paywallTrialEligibilityByProductId,
             availableProductIds = paywallAvailableProductIds,
             billingCatalogProbed = paywallBillingCatalogProbed,
+            billingReady = paywallBillingReady,
             onPlanSelected = { plan, productId, selectionSource ->
                 viewModel.trackPaywallOfferSelected(
                     entryPoint = paywallEntryPoint,
@@ -294,13 +298,33 @@ fun RandomTimerNavHost(
             },
             onPurchase = { productID ->
                 scope.launch {
+                    paywallAvailableProductIds =
+                        viewModel.proManager.availablePaywallProductIds(forPurchaseLaunch = true)
+                    paywallBillingReady = viewModel.proManager.isBillingClientReady()
+                    if (
+                        !isPaywallPurchaseAllowed(
+                            billingCatalogProbed = paywallBillingCatalogProbed,
+                            billingReady = paywallBillingReady,
+                            availableProductIds = paywallAvailableProductIds,
+                            selectedProductId = productID,
+                        )
+                    ) {
+                        android.widget.Toast
+                            .makeText(
+                                activity ?: return@launch,
+                                "Purchase unavailable. Please try again later.",
+                                android.widget.Toast.LENGTH_LONG,
+                            ).show()
+                        return@launch
+                    }
                     val launched =
                         activity?.let {
                             viewModel.proManager.launchPurchase(it, productID, paywallEntryPoint)
                         } ?: false
                     if (!launched) {
-                        // Purchase failed to launch — keep paywall open
-                        // The billing dialog didn't appear, so user needs feedback
+                        paywallAvailableProductIds =
+                            viewModel.proManager.availablePaywallProductIds(forPurchaseLaunch = true)
+                        paywallBillingReady = viewModel.proManager.isBillingClientReady()
                         android.widget.Toast
                             .makeText(
                                 activity ?: return@launch,
@@ -308,7 +332,6 @@ fun RandomTimerNavHost(
                                 android.widget.Toast.LENGTH_LONG,
                             ).show()
                     }
-                    // Keep the sheet open until entitlement changes so cancellation/errors can retry.
                 }
             },
             onDebugUnlock = {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheet.kt
@@ -141,6 +141,7 @@ fun PaywallSheet(
     trialEligibilityByProductId: Map<String, Boolean> = emptyMap(),
     availableProductIds: Set<String> = emptySet(),
     billingCatalogProbed: Boolean = false,
+    billingReady: Boolean = true,
     onPurchase: (String) -> Unit,
     onPlanSelected: (plan: String, productId: String, selectionSource: String) -> Unit = { _, _, _ -> },
     onRestore: () -> Unit,
@@ -163,7 +164,8 @@ fun PaywallSheet(
             selectedPlan = fallbackPaywallPlan(availableProductIds, billingCatalogProbed)
         }
     }
-    val hasPurchasablePlan = hasPurchasablePaywallPlan(availableProductIds, billingCatalogProbed)
+    val hasPurchasablePlan =
+        hasPurchasablePaywallPlan(availableProductIds, billingCatalogProbed, billingReady)
     var initialOfferSelectTracked by remember(entryPoint) { mutableStateOf(false) }
     LaunchedEffect(entryPoint, billingCatalogProbed, hasPurchasablePlan, selectedPlan) {
         if (
@@ -235,7 +237,14 @@ fun PaywallSheet(
                     PrimaryButton(
                         text = if (hasPurchasablePlan) ctaLabel else "Purchases unavailable",
                         onClick = {
-                            if (!hasPurchasablePlan) {
+                            if (
+                                !isPaywallPurchaseAllowed(
+                                    billingCatalogProbed = billingCatalogProbed,
+                                    billingReady = billingReady,
+                                    availableProductIds = availableProductIds,
+                                    selectedProductId = purchaseProductId,
+                                )
+                            ) {
                                 return@PrimaryButton
                             }
                             onPlanSelected(planNameForSelection(selectedPlan), purchaseProductId, "primary_cta")
@@ -511,11 +520,24 @@ internal fun shouldShowPaywallPlan(
 internal fun hasPurchasablePaywallPlan(
     availableProductIds: Set<String>,
     billingCatalogProbed: Boolean,
+    billingReady: Boolean = true,
 ): Boolean =
     billingCatalogProbed &&
+        billingReady &&
         SubscriptionPlanSelection.entries.any {
             shouldShowPaywallPlan(it, availableProductIds, billingCatalogProbed)
         }
+
+/** Gate purchase taps on a live billing connection, not only the catalog snapshot from paywall open. */
+internal fun isPaywallPurchaseAllowed(
+    billingCatalogProbed: Boolean,
+    billingReady: Boolean,
+    availableProductIds: Set<String>,
+    selectedProductId: String,
+): Boolean =
+    billingCatalogProbed &&
+        billingReady &&
+        availableProductIds.contains(selectedProductId)
 
 internal fun fallbackPaywallPlan(
     availableProductIds: Set<String>,

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallPurchaseReadinessTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallPurchaseReadinessTest.kt
@@ -1,0 +1,56 @@
+package com.iganapolsky.randomtimer.ui.screens
+
+import com.iganapolsky.randomtimer.billing.ProManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaywallPurchaseReadinessTest {
+    @Test
+    fun `purchase blocked when billing disconnected despite cached product ids`() {
+        assertFalse(
+            isPaywallPurchaseAllowed(
+                billingCatalogProbed = true,
+                billingReady = false,
+                availableProductIds = setOf(ProManager.ELITE_PRODUCT_ID),
+                selectedProductId = ProManager.ELITE_PRODUCT_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `purchase allowed when billing ready and selected product is available`() {
+        assertTrue(
+            isPaywallPurchaseAllowed(
+                billingCatalogProbed = true,
+                billingReady = true,
+                availableProductIds = setOf(ProManager.ELITE_PRODUCT_ID),
+                selectedProductId = ProManager.ELITE_PRODUCT_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `purchase blocked when catalog not probed`() {
+        assertFalse(
+            isPaywallPurchaseAllowed(
+                billingCatalogProbed = false,
+                billingReady = true,
+                availableProductIds = setOf(ProManager.ELITE_PRODUCT_ID),
+                selectedProductId = ProManager.ELITE_PRODUCT_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `purchase blocked when selected product missing from refreshed catalog`() {
+        assertFalse(
+            isPaywallPurchaseAllowed(
+                billingCatalogProbed = true,
+                billingReady = true,
+                availableProductIds = setOf(ProManager.BASE_PRODUCT_ID),
+                selectedProductId = ProManager.ELITE_PRODUCT_ID,
+            ),
+        )
+    }
+}

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/ui/screens/PaywallSheetTest.kt
@@ -203,6 +203,14 @@ class PaywallSheetTest {
             shouldShowPaywallPlan(SubscriptionPlanSelection.MONTHLY, emptySet(), billingCatalogProbed = true),
         )
         assertEquals(false, hasPurchasablePaywallPlan(emptySet(), billingCatalogProbed = true))
+        assertEquals(
+            false,
+            hasPurchasablePaywallPlan(
+                setOf(ProManager.ELITE_PRODUCT_ID),
+                billingCatalogProbed = true,
+                billingReady = false,
+            ),
+        )
     }
 
     @Test

--- a/scripts/tests/test_mobile_feature_parity.py
+++ b/scripts/tests/test_mobile_feature_parity.py
@@ -262,14 +262,14 @@ def test_android_purchase_waits_for_billing_reconnect_before_failing():
         1,
     )[0]
 
-    assert "ensureBillingReadyForPurchase()" in launch_purchase
-    assert "private suspend fun ensureBillingReadyForPurchase()" in android_pro_manager
+    assert "ensureBillingReadyForPurchase(purchaseLaunch = true)" in launch_purchase
+    assert "private suspend fun ensureBillingReadyForPurchase(purchaseLaunch: Boolean = false)" in android_pro_manager
     assert "connectAndRestore()" in android_pro_manager
     assert "delay(500)" in android_pro_manager
-    assert launch_purchase.index("ensureBillingReadyForPurchase()") < launch_purchase.index(
+    assert launch_purchase.index("ensureBillingReadyForPurchase(purchaseLaunch = true)") < launch_purchase.index(
         'debugMessage = "billing_not_ready"'
     )
-    assert launch_purchase.index("ensureBillingReadyForPurchase()") < launch_purchase.index(
+    assert launch_purchase.index("ensureBillingReadyForPurchase(purchaseLaunch = true)") < launch_purchase.index(
         "fetchProductDetails(productID)"
     )
 


### PR DESCRIPTION
## Summary
- PostHog 30d: voice_gate 228 views / 20 offer_selects / 0 attempts; repeat_gate 62 / 20 / 0 — 29/29 CTA failures were `billing_not_ready` before `paywall_purchase_attempt`.
- Re-probe catalog with extended billing reconnect on CTA, invalidate SKU cache on billing disconnect, and gate purchase on live `billingReady` (not stale paywall-open snapshot).

## Test plan
- [ ] `PaywallPurchaseReadinessTest` + updated `PaywallSheetTest`
- [ ] CI `testDebugUnitTest` green
- [ ] Post-ship: voice_gate/repeat_gate view→attempt rate > 0 on Android 1.3.54+


Made with [Cursor](https://cursor.com)