### PR TITLE
fix(android): query elite_tactical_monthly as separate Play product (#1684)

### DIFF
--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingProductQueryPlan.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/BillingProductQueryPlan.kt
@@ -9,7 +9,7 @@ internal data class BillingProductQuerySpec(
     val productType: String,
 )
 
-/** Deduplicated Play catalog probes for paywall SKUs (monthly shares elite_tactical). */
+/** Deduplicated Play catalog probes for paywall SKUs (elite annual + monthly are separate Play products). */
 internal fun buildPaywallCatalogQuerySpecs(
     logicalProductIds: List<String> = paywallCatalogLogicalProductIds(),
 ): List<BillingProductQuerySpec> =

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -1140,20 +1140,15 @@ internal data class SubscriptionOffer(
         get() = pricingPhases.any { it.isFree }
 }
 
-/** Maps paywall logical SKU to Play Billing product id (monthly bills via elite_tactical P1M). */
-internal fun playBillingProductId(logicalProductId: String): String =
-    when (logicalProductId) {
-        ProManager.MONTHLY_PRODUCT_ID -> ProManager.ELITE_PRODUCT_ID
-        else -> logicalProductId
-    }
+/** Maps paywall logical SKU to Play Billing product id (Play hosts monthly on elite_tactical_monthly). */
+internal fun playBillingProductId(logicalProductId: String): String = logicalProductId
 
-/** Play Billing product type for the Play product id returned by [playBillingProductId]. */
-internal fun billingProductTypeForLogicalProductId(logicalProductId: String): String {
-    return when (playBillingProductId(logicalProductId)) {
-        ProManager.ELITE_PRODUCT_ID -> BillingClient.ProductType.SUBS
+/** Play Billing product type for the logical paywall SKU. */
+internal fun billingProductTypeForLogicalProductId(logicalProductId: String): String =
+    when (logicalProductId) {
+        ProManager.ELITE_PRODUCT_ID, ProManager.MONTHLY_PRODUCT_ID -> BillingClient.ProductType.SUBS
         else -> BillingClient.ProductType.INAPP
     }
-}
 
 internal fun monthlyOfferAvailableFromEliteOffers(offers: List<SubscriptionOffer>): Boolean =
     selectSubscriptionOfferByPeriod(offers, "P1M") != null

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbeTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingLegacySkuCatalogProbeTest.kt
@@ -73,14 +73,32 @@ class BillingLegacySkuCatalogProbeTest {
     @Test
     fun `legacy sku query maps billing ids to logical ids`() {
         val specs = buildPaywallCatalogQuerySpecs()
+        val foundBillingIds =
+            listOf(
+                ProManager.BASE_PRODUCT_ID,
+                ProManager.ELITE_PRODUCT_ID,
+                ProManager.MONTHLY_PRODUCT_ID,
+            )
+
+        val logicalIds = logicalProductIdsResolvedFromLegacySkuQuery(specs, foundBillingIds)
+
+        assertThat(logicalIds).containsExactly(
+            ProManager.BASE_PRODUCT_ID,
+            ProManager.ELITE_PRODUCT_ID,
+            ProManager.MONTHLY_PRODUCT_ID,
+        )
+    }
+
+    @Test
+    fun `legacy sku query omits monthly when only annual subs product found`() {
+        val specs = buildPaywallCatalogQuerySpecs()
         val foundBillingIds = listOf(ProManager.BASE_PRODUCT_ID, ProManager.ELITE_PRODUCT_ID)
 
         val logicalIds = logicalProductIdsResolvedFromLegacySkuQuery(specs, foundBillingIds)
 
-        assertThat(logicalIds).containsAtLeast(
+        assertThat(logicalIds).containsExactly(
             ProManager.BASE_PRODUCT_ID,
             ProManager.ELITE_PRODUCT_ID,
-            ProManager.MONTHLY_PRODUCT_ID,
         )
     }
 

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingProductQueryPlanTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/BillingProductQueryPlanTest.kt
@@ -6,15 +6,16 @@ import org.junit.Test
 
 class BillingProductQueryPlanTest {
     @Test
-    fun `paywall catalog dedupes monthly to elite subs probe`() {
+    fun `paywall catalog probes each Play subscription product id`() {
         val specs = buildPaywallCatalogQuerySpecs()
 
-        assertThat(specs).hasSize(2)
+        assertThat(specs).hasSize(3)
         assertThat(specs.map { it.billingProductId }).containsExactly(
             ProManager.BASE_PRODUCT_ID,
             ProManager.ELITE_PRODUCT_ID,
+            ProManager.MONTHLY_PRODUCT_ID,
         )
-        assertThat(specs.count { it.productType == BillingClient.ProductType.SUBS }).isEqualTo(1)
+        assertThat(specs.count { it.productType == BillingClient.ProductType.SUBS }).isEqualTo(2)
     }
 
     @Test
@@ -26,7 +27,7 @@ class BillingProductQueryPlanTest {
             BillingClient.ProductType.SUBS,
         )
         assertThat(grouped[BillingClient.ProductType.INAPP]).hasSize(1)
-        assertThat(grouped[BillingClient.ProductType.SUBS]).hasSize(1)
+        assertThat(grouped[BillingClient.ProductType.SUBS]).hasSize(2)
     }
 
     @Test
@@ -40,7 +41,7 @@ class BillingProductQueryPlanTest {
 
         assertThat(eliteLogicalIds).containsExactly(ProManager.ELITE_PRODUCT_ID)
         assertThat(playBillingProductId(ProManager.MONTHLY_PRODUCT_ID))
-            .isEqualTo(ProManager.ELITE_PRODUCT_ID)
+            .isEqualTo(ProManager.MONTHLY_PRODUCT_ID)
     }
 
     @Test

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerPlayBillingProductIdTest.kt
@@ -6,9 +6,9 @@ import org.junit.Test
 
 class ProManagerPlayBillingProductIdTest {
     @Test
-    fun `playBillingProductId maps monthly logical id to elite_tactical`() {
+    fun `playBillingProductId maps monthly logical id to elite_tactical_monthly`() {
         assertThat(playBillingProductId(ProManager.MONTHLY_PRODUCT_ID))
-            .isEqualTo(ProManager.ELITE_PRODUCT_ID)
+            .isEqualTo(ProManager.MONTHLY_PRODUCT_ID)
     }
 
     @Test

--- a/scripts/device-tests/adb/verify-billing-catalog.sh
+++ b/scripts/device-tests/adb/verify-billing-catalog.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# verify-billing-catalog.sh — Retail-device billing catalog smoke via adb + PostHog correlation hints.
+# Opens paywall path, captures logcat billing lines, prints device/package version for evidence.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+DEVICE_COUNT=$(adb devices | grep -c "device$" || true)
+if [ "$DEVICE_COUNT" -eq 0 ]; then
+  echo "No Android device connected." >&2
+  exit 2
+fi
+
+MODEL=$(adb shell getprop ro.product.model 2>/dev/null | tr -d '\r')
+SERIAL=$(adb devices -l | awk '/device usb/ {print $1; exit}')
+
+echo "== Device =="
+echo "serial=$SERIAL model=$MODEL"
+
+VERSION_LINE=$(adb shell dumpsys package "$PACKAGE" 2>/dev/null | tr -d '\r' | grep -E "versionName=|versionCode=" | head -2 || true)
+echo "package=$PACKAGE"
+echo "$VERSION_LINE"
+
+echo "== Launch + paywall affordance tap =="
+adb logcat -c
+adb shell am force-stop "$PACKAGE" 2>/dev/null || true
+sleep 1
+adb shell am start -n "$PACKAGE/$ACTIVITY"
+sleep 8
+
+if wait_for_text "PRO: 1H" 15; then
+  tap_text "PRO: 1H" || true
+  sleep 5
+elif wait_for_text "Start First Drill" 10; then
+  tap_text "Start First Drill" || true
+  sleep 2
+  wait_for_text "PRO: 1H" 15 && tap_text "PRO: 1H" || true
+  sleep 5
+else
+  echo "WARN: paywall affordance not found; continuing with launch-only catalog probe"
+fi
+
+echo "== Logcat billing signals (last 80) =="
+adb logcat -d 2>/dev/null | grep -iE "billing|catalog|elite_tactical|ProManager|posthog" | tail -80 || true
+
+echo "== PostHog correlation =="
+echo "Filter: event=billing_product_catalog_status AND properties.\$device_model=$MODEL (last 1h)"
+echo "Expect status=ok with available_product_ids including elite_tactical_monthly after fix ships via Play."

--- a/scripts/device-tests/run-all.sh
+++ b/scripts/device-tests/run-all.sh
@@ -133,6 +133,7 @@ if [ "$ADB_ONLY" = false ]; then
       "alarm-notification-stop-android.yaml"
       "activation-banner-dismiss-android.yaml"
       "activation-smoke-android.yaml"
+      "activation-paywall-from-pro-tap-android.yaml"
       "regression-pro-locks-visible-android.yaml"
     )
 

--- a/scripts/tests/test_verify_billing_catalog_script.py
+++ b/scripts/tests/test_verify_billing_catalog_script.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_verify_billing_catalog_script_targets_random_timer_package():
+    source = _read("scripts/device-tests/adb/verify-billing-catalog.sh")
+
+    assert "$PACKAGE" in source
+    assert "$ACTIVITY" in source
+    assert "PRO: 1H" in source
+    assert "billing_product_catalog_status" in source
+    assert "elite_tactical_monthly" in source
+
+
+def test_verify_billing_catalog_script_sources_adb_common():
+    source = _read("scripts/device-tests/adb/verify-billing-catalog.sh")
+
+    assert 'source "$SCRIPT_DIR/lib/common.sh"' in source


### PR DESCRIPTION
## Summary
- **Root cause (SM-S931U1 / S25):** `playBillingProductId` mapped `elite_tactical_monthly` → `elite_tactical`, so Play only returned annual `elite_tactical` + `pro_base`. PostHog showed `missing_required_products` with `missing_product_ids=["elite_tactical_monthly"]` on Play build **1.3.43**.
- **Fix:** Probe `elite_tactical_monthly` as its own Play subscription product (matches `docs/PLAY_CONSOLE_IAP_RUNBOOK.md` and `play_iap_catalog.json`).
- **Device ops:** `scripts/device-tests/adb/verify-billing-catalog.sh` + paywall Maestro flow in `run-all.sh`.

## Evidence (retail Samsung S25, 2026-06-09 UTC)
- Device: `SM-S931U1`, Play-installed `versionName=1.3.43` / `versionCode=1780072756`
- PostHog `billing_product_catalog_status` at `2026-06-09T12:48:40Z`: status=`missing_required_products`, available=`["elite_tactical","pro_base"]`, missing=`["elite_tactical_monthly"]`
- Debug APK install blocked: `INSTALL_FAILED_VERSION_DOWNGRADE` (Play versionCode newer than CI debug)

## Test plan
- [x] `BillingProductQueryPlanTest`, `ProManagerPlayBillingProductIdTest` updated (3 catalog probes)
- [x] `pytest scripts/tests/test_verify_billing_catalog_script.py`
- [ ] After merge + Play ship: re-run verify script on S25; expect `billing_product_catalog_status.status=ok`

## Ship note
v1.3.54 `native-release` run 27207248106 failed `internal-proof-or-waive` (no internal signoff on release SHA). This fix should land in **v1.3.55** (or cherry-pick onto `release/v1.3.54` before production).


Made with [Cursor](https://cursor.com)