### PR TITLE
fix(store): sanitize public changelogs and add denylist gate

### DIFF
--- a/docs/STORE_CHANGELOG_POLICY.md
+++ b/docs/STORE_CHANGELOG_POLICY.md
@@ -1,0 +1,45 @@
+# Store changelog policy
+
+Public **What's New** / release-notes copy on Google Play and the App Store must describe user-visible product changes only. Never publish implementation details that expose test hooks, bypass paths, or security-sensitive behavior.
+
+## Scope (enforced in CI)
+
+| Path | Audience |
+|------|----------|
+| `native-android/fastlane/metadata/android/en-US/changelogs/*.txt` | Play **What's New** (keyed by `versionCode`) |
+| `native-ios/fastlane/metadata/en-US/release_notes.txt` | App Store **What's New** |
+| `release-notes/*.md` | Internal release ops (still scanned for high-risk terms) |
+
+`scripts/play_publish.py` reads `changelogs/{versionCode}.txt` at upload time. The filename must match the **uploaded** bundle `versionCode` (from `compute_android_release_version_code.py`), not only the `versionCode` in `build.gradle.kts`.
+
+## Denylist (never in store What's New)
+
+- `backdoor`, `secret`, `debug`, `test-only`, `gesture`, `bypass`, `cheat`
+
+Operational terms like `internal distribution` belong in CI/runbooks, not Play/App Store copy. Do not use `internal` or `hidden` to describe unlock bypasses or tester hooks.
+
+Allowed product phrasing: **stealth countdown** / **hidden countdown** in long-form store descriptions only—not unlock bypasses.
+
+## Write user-safe copy
+
+| Do not publish | Publish instead |
+|----------------|-----------------|
+| Fixed Upgrade to Pro backdoor gesture | Improved Pro upgrade reliability |
+| Production Backdoor: Persistent Pro unlock | Improved Pro access for verified beta testers |
+| developer backdoor / hidden hold gesture | developer test mode / internal tester flag |
+| internal distribution pipeline | beta and store release reliability |
+
+## Enforcement
+
+```bash
+python3 scripts/check_store_changelog_policy.py
+python3 -m pytest scripts/tests/test_check_store_changelog_policy.py -q
+```
+
+`preflight-release.sh` (Android layer 1) runs the checker before Play uploads.
+
+## Beta propagation notes
+
+- Beta **What's New** comes from the changelog file for the **version code on the beta track**, not from `default.txt`.
+- If the uploaded `versionCode` has no matching changelog file, Play may keep showing text from an older beta release.
+- Devices must be **beta enrolled** and on a lower `versionCode` than the beta artifact to show **Update** (not **Open**).

--- a/native-android/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,4 +1,4 @@
 - Dual-Mission UI: Standard Ops (5m) and Tactical Expansion (1h) training windows.
 - Tactical Keypad: Direct numeric entry for exact time selection.
 - Semantic Iconography: New 🔥 (Intense) and 💧 (Gentle) material-driven icons.
-- Production Backdoor: Persistent Pro unlock for verified testers.
+- Improved Pro access for verified beta testers.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/11.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/11.txt
@@ -1,4 +1,4 @@
 - Dual-Mission UI: Standard Ops (5m) and Tactical Expansion (1h) training windows.
 - Tactical Keypad: Direct numeric entry for exact time selection.
 - Semantic Iconography: New 🔥 (Intense) and 💧 (Gentle) material-driven icons.
-- Production Backdoor: Persistent Pro unlock for verified testers.
+- Improved Pro access for verified beta testers.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/12.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/12.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773290000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773290000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773320000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773320000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773327000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773327000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773330000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773330000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773335000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773335000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773340000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773340000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773345000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773345000.txt
@@ -1,3 +1,3 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.
 - Implemented Agentic Merchant Protocol (AMP) for AI discovery.
 - Improved stability and performance.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773375000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773375000.txt
@@ -1,1 +1,1 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773380000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773380000.txt
@@ -1,1 +1,1 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773400000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773400000.txt
@@ -1,1 +1,1 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773410000.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773410000.txt
@@ -1,1 +1,1 @@
-- Fixed "Upgrade to Pro" backdoor gesture.
+- Improved Pro upgrade reliability and purchase flow.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1773762924.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1773762924.txt
@@ -1,3 +1,3 @@
 - Fixed iOS Pro range validation and release build path regressions.
-- Improved internal distribution reliability for TestFlight and Google Play.
+- Improved reliability for beta and store releases.
 - Polished premium setup flow labels and Sound Arsenal behavior.

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1781016382.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1781016382.txt
@@ -1,0 +1,1 @@
+Monthly Pro content update — June 2026

--- a/native-android/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,7 +1,7 @@
 v1.1.0 — Random Tactical Timer
 - Lock screen countdown display
 - Loop mode for automatic timer restart
-- Hidden mode to conceal countdown
+- Stealth countdown mode — no clock watching
 - Bluetooth and Android Auto alarm dismiss
 - Firebase Crashlytics integration
 - Improved alarm reliability with foreground service

--- a/release-notes/1.3.32.md
+++ b/release-notes/1.3.32.md
@@ -7,7 +7,7 @@
 - **Android Paywall Persistence:** Fixed a bug where the paywall would prematurely dismiss itself the moment a purchase was launched. The paywall now stays open until a purchase is confirmed or manually dismissed, allowing for retries and better UX.
 - **Improved Telemetry Accuracy:** Resolved an iOS issue where every paywall impression was tracked twice. Standardized all platforms on the `paywall_viewed` event.
 - **Enhanced Conversion Tracking:** Added explicit tracking for `user_cancelled` events on Android to distinguish between technical failures and user hesitation.
-- **Persistent Developer Filtering:** Implemented a persistent "Internal User" flag. Testing the developer backdoor now permanently excludes the device from production revenue metrics, ensuring our GTM data is 100% accurate.
+- **Persistent Developer Filtering:** Implemented a persistent tester flag. Using the developer test mode now permanently excludes the device from production revenue metrics, ensuring our GTM data is 100% accurate.
 
 ## Release operations
 - Unified release for Android and iOS.

--- a/scripts/check_store_changelog_policy.py
+++ b/scripts/check_store_changelog_policy.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fail if public store changelog copy contains internal/security denylist terms."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ANDROID_CHANGELOG_DIR = (
+    REPO_ROOT / "native-android" / "fastlane" / "metadata" / "android" / "en-US" / "changelogs"
+)
+IOS_RELEASE_NOTES = REPO_ROOT / "native-ios" / "fastlane" / "metadata" / "en-US" / "release_notes.txt"
+RELEASE_NOTES_DIR = REPO_ROOT / "release-notes"
+
+# High-risk terms that must never appear in Play/App Store "What's New" copy.
+STORE_DENYLIST = (
+    "backdoor",
+    "secret",
+    "debug",
+    "test-only",
+    "gesture",
+    "bypass",
+    "cheat",
+)
+
+# Substrings that are allowed even when a denylist term matches (product/marketing copy).
+ALLOWLIST_SUBSTRINGS = (
+    "hidden countdown",
+    "stealth countdown",
+)
+
+_DENYLIST_PATTERNS = {
+    term: re.compile(rf"\b{re.escape(term)}\b", re.IGNORECASE)
+    for term in STORE_DENYLIST
+}
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    term: str
+    line_number: int
+    line_text: str
+
+
+def _is_allowlisted(line: str, term: str) -> bool:
+    lowered = line.lower()
+    if term.lower() == "hidden":
+        return any(fragment in lowered for fragment in ALLOWLIST_SUBSTRINGS)
+    return False
+
+
+def _scan_file(path: Path, denylist: tuple[str, ...]) -> list[Violation]:
+    violations: list[Violation] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return violations
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for term in denylist:
+            if not _DENYLIST_PATTERNS[term].search(line):
+                continue
+            if _is_allowlisted(line, term):
+                continue
+            violations.append(
+                Violation(
+                    path=path,
+                    term=term,
+                    line_number=line_number,
+                    line_text=line.strip(),
+                )
+            )
+    return violations
+
+
+def collect_store_changelog_paths() -> list[Path]:
+    paths: list[Path] = []
+    if ANDROID_CHANGELOG_DIR.is_dir():
+        paths.extend(sorted(ANDROID_CHANGELOG_DIR.glob("*.txt")))
+    if IOS_RELEASE_NOTES.is_file():
+        paths.append(IOS_RELEASE_NOTES)
+    return paths
+
+
+def collect_release_note_paths() -> list[Path]:
+    if not RELEASE_NOTES_DIR.is_dir():
+        return []
+    return sorted(RELEASE_NOTES_DIR.glob("*.md"))
+
+
+def find_violations() -> list[Violation]:
+    violations: list[Violation] = []
+    for path in collect_store_changelog_paths():
+        violations.extend(_scan_file(path, STORE_DENYLIST))
+    for path in collect_release_note_paths():
+        violations.extend(_scan_file(path, STORE_DENYLIST))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check store changelog policy.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print violations as JSON lines (path, term, line).",
+    )
+    args = parser.parse_args(argv)
+
+    violations = find_violations()
+    if not violations:
+        print("✅ Store changelog policy check passed.")
+        return 0
+
+    for violation in violations:
+        try:
+            rel = violation.path.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = violation.path
+        if args.json:
+            print(
+                f'{{"path":"{rel}","term":"{violation.term}","line":{violation.line_number}}}'
+            )
+        else:
+            print(
+                f"❌ {rel}:{violation.line_number} contains denylisted term "
+                f"'{violation.term}': {violation.line_text}"
+            )
+
+    print(f"Found {len(violations)} store changelog policy violation(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shell/preflight-release.sh
+++ b/scripts/shell/preflight-release.sh
@@ -205,6 +205,11 @@ if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
     warn "Could not detect Android versionCode — skipping changelog check"
   fi
 
+  info "Store changelog policy (denylist scan)"
+  if ! python3 "$PROJECT_ROOT/scripts/check_store_changelog_policy.py"; then
+    err "Store changelog policy check failed — see docs/STORE_CHANGELOG_POLICY.md"
+  fi
+
   # Screenshots
   SCREENSHOTS_DIR="$ANDROID_META/images/phoneScreenshots"
   if [[ -d "$SCREENSHOTS_DIR" ]]; then

--- a/scripts/tests/test_check_store_changelog_policy.py
+++ b/scripts/tests/test_check_store_changelog_policy.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_store_changelog_policy import (
+    ANDROID_CHANGELOG_DIR,
+    IOS_RELEASE_NOTES,
+    find_violations,
+    main,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_store_changelogs_have_no_denylisted_terms() -> None:
+    violations = find_violations()
+    offending = [
+        f"{v.path.relative_to(REPO_ROOT)}:{v.line_number} ({v.term})"
+        for v in violations
+    ]
+    assert not offending, "Store changelog denylist violations:\n" + "\n".join(offending)
+
+
+def test_main_returns_zero_when_policy_clean() -> None:
+    assert main([]) == 0
+
+
+def test_scan_detects_backdoor_in_temp_changelog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    changelog_dir = tmp_path / "changelogs"
+    changelog_dir.mkdir()
+    (changelog_dir / "99.txt").write_text("- Fixed backdoor gesture.\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "scripts.check_store_changelog_policy.ANDROID_CHANGELOG_DIR",
+        changelog_dir,
+    )
+    monkeypatch.setattr(
+        "scripts.check_store_changelog_policy.IOS_RELEASE_NOTES",
+        tmp_path / "missing_release_notes.txt",
+    )
+    monkeypatch.setattr(
+        "scripts.check_store_changelog_policy.RELEASE_NOTES_DIR",
+        tmp_path / "release-notes",
+    )
+
+    violations = find_violations()
+    terms = {v.term for v in violations}
+    assert "backdoor" in terms
+    assert "gesture" in terms
+    assert main([]) == 1


### PR DESCRIPTION
## Summary
- Sanitize 17 Android en-US changelog files that leaked backdoor/gesture/tester-hook language in Play What's New copy.
- Add `docs/STORE_CHANGELOG_POLICY.md` and `scripts/check_store_changelog_policy.py` (denylist: backdoor, secret, debug, test-only, gesture, bypass, cheat).
- Wire policy check into `preflight-release.sh` and pytest (`scripts/tests/test_check_store_changelog_policy.py`).
- Add `1781016382.txt` for the beta VC uploaded in run 27213699414 (was missing at upload → stale May 29 notes persisted).

## Test plan
- [x] `python3 scripts/check_store_changelog_policy.py`
- [x] `python3 -m pytest scripts/tests/test_check_store_changelog_policy.py -q`
- [ ] CI python job green on PR


Made with [Cursor](https://cursor.com)