### PR TITLE
docs(play): production-only QA; no default Open testing

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -13,7 +13,7 @@ on:
         required: true
         default: 'both'
       android_track:
-        description: 'Android only: Google Play track to publish to'
+        description: 'Android only: Play track (default production; beta=Open testing — CEO opt-in only, see docs/PLAY_TESTING_TRACKS.md)'
         type: choice
         options:
           - production

--- a/docs/PLAY_TESTING_TRACKS.md
+++ b/docs/PLAY_TESTING_TRACKS.md
@@ -1,0 +1,65 @@
+# Google Play testing tracks (Random Timer)
+
+**Policy (effective 2026-06-09):** Random Timer ships on the **production** track. CEO and internal QA install the **public Play Store listing** — not Open testing (beta). Beta/Open testing uploads require **explicit CEO opt-in** per dispatch.
+
+## Account context
+
+Random Timer uses a **Google Play business (LLC) account**. Business accounts can publish directly to production without Open testing. Open testing is optional and is **not** required for production releases.
+
+## Track definitions
+
+| Track | Play Console name | Who gets the build | Automation default |
+|-------|-------------------|--------------------|--------------------|
+| **Production** | Production | All Play Store users (public listing) | **Yes** — `native-release.yml` `android_track` default |
+| **Closed testing** | Internal / Closed | Invite-only testers (email list) | Only via explicit dispatch; use for pre-prod smoke if needed |
+| **Open testing** | Open testing (beta) | Anyone who opts in via Play Store beta link | **No** — do not dispatch unless CEO requests |
+| **Internal testing** | Internal testing | Fastest, up to 100 testers | Firebase internal + `internal-distribution.yml` before production |
+
+## Disable / stop Open testing (CEO steps)
+
+Use a logged-in Safari, Comet, or normal Chrome tab on Play Console (not incognito).
+
+1. Open **Play Console** → **Random Tactical Timer** → **Testing** → **Open testing**.
+2. If a release is **Active**, open it → **Halt rollout** or **Deactivate** (wording varies by release state).
+3. On the device (e.g. Samsung S25):
+   - Open Play Store → profile → **Manage apps & device** → **Beta programs** (or **Settings** → **Beta programs**).
+   - Find **Random Tactical Timer** → **Leave** the beta program.
+4. Uninstall the beta build if the launcher title shows **(Beta)** or version lags production.
+5. Reinstall from the **public store listing** (no Beta badge): search "Random Tactical Timer" and install without joining any test program.
+
+Optional: remove stale testers under **Open testing** → **Testers** if you want zero beta enrollment surface.
+
+## CEO device QA (production only)
+
+After `native-release` with `android_track=production` and green `verify-releases`:
+
+1. Confirm Play Publisher API: `versionName` + `versionCode` on **production** track, status `completed` (Tier 0 — blocks ship).
+2. On device: install/update from **production** Play Store (not beta).
+3. If USB debugging enabled: `adb shell dumpsys package com.iganapolsky.randomtimer | grep version` — expect `versionName=1.3.55` (or current ship version).
+
+Public storefront HTML may lag the Publisher API by hours; Tier 0 API read-back is ground truth per `docs/OPERATIONAL_RELIABILITY.md`.
+
+## Automation rules
+
+### `native-release.yml`
+
+- Default `android_track`: **`production`** (workflow input default).
+- Always pass explicitly when dispatching:  
+  `gh workflow run native-release.yml --ref release/vX.Y.Z -f platform=android -f android_track=production`
+- **Never** pass `android_track=beta` unless the CEO explicitly requests Open testing.
+- `verify-releases` must show `Android production … ✅ completed` before claiming shipped.
+
+### Internal pre-prod proof
+
+Use `internal-distribution.yml` (Firebase APK) + signoffs, then production `native-release`. Do **not** substitute Open testing for CEO device validation.
+
+### Closed testing (invite-only)
+
+If pre-production device checks are needed without public rollout, use **Closed testing** (invite CEO email only) — still not Open testing. Document the dispatch in the release PR; default remains production.
+
+## Evidence checklist (ship claim)
+
+- [ ] `verify-releases` job: `Android production <versionCode> (<versionName>) ✅ completed`
+- [ ] Git tag `vX.Y.Z` on release SHA
+- [ ] CEO device on production listing (no beta enrollment)
+- [ ] PostHog `properties.$app_version` matches ship version on retail cohort

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -139,16 +139,18 @@ This validates:
 
 ### 5. Merge `release/*` to `main` and Release
 
+**Play testing policy:** Random Timer uses a business Play account. Ship **production** only for store releases and CEO device QA. Do **not** dispatch Open testing (`android_track=beta`) unless the CEO explicitly requests it. See `docs/PLAY_TESTING_TRACKS.md` for leaving Open testing and installing the public listing.
+
 After the PR is approved and CI passes:
 
 1. **Merge** the PR (squash merge)
 2. **Trigger** the release workflow:
 
 ```bash
-# Release both platforms to production (default platform is both — use this for versioned releases)
+# Release both platforms to production (default platform=both, android_track=production)
 gh workflow run native-release.yml --ref release/vX.Y.Z -f platform=both -f android_track=production
 
-# Or release to beta/alpha first
+# Alpha/closed testing — explicit opt-in only; never default for CEO QA
 gh workflow run native-release.yml -f platform=android -f android_track=alpha
 gh workflow run native-release.yml -f platform=ios -f confirm_ios_only_release=true
 

--- a/docs/STORE_CHANGELOG_POLICY.md
+++ b/docs/STORE_CHANGELOG_POLICY.md
@@ -38,8 +38,17 @@ python3 -m pytest scripts/tests/test_check_store_changelog_policy.py -q
 
 `preflight-release.sh` (Android layer 1) runs the checker before Play uploads.
 
-## Beta propagation notes
+## Production-first QA (no Open testing default)
+
+CEO and internal device validation use the **production** Play Store listing, not Open testing. See `docs/PLAY_TESTING_TRACKS.md`.
+
+- Production **What's New** comes from `changelogs/{versionCode}.txt` for the **production-track** upload.
+- Public storefront HTML can lag the Play Publisher API; Tier 0 API `verify-releases` is ground truth.
+- If automation accidentally dispatches `android_track=beta`, that does **not** update production — re-run with `android_track=production`.
+
+## Beta track (explicit opt-in only)
+
+Only when the CEO requests Open testing:
 
 - Beta **What's New** comes from the changelog file for the **version code on the beta track**, not from `default.txt`.
-- If the uploaded `versionCode` has no matching changelog file, Play may keep showing text from an older beta release.
 - Devices must be **beta enrolled** and on a lower `versionCode` than the beta artifact to show **Update** (not **Open**).


### PR DESCRIPTION
## Summary
- Add `docs/PLAY_TESTING_TRACKS.md`: business-account policy, how to leave Open testing, production-only CEO QA, automation rules.
- Update `docs/RELEASE.md` and `docs/STORE_CHANGELOG_POLICY.md` to state production is the default ship/QA path; beta requires explicit CEO opt-in.
- Clarify `native-release.yml` `android_track` input description (default remains `production`).

## Context
Production already ships **1.3.55** (VC `1781012436`) via native-release run [27209581950](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27209581950). Recent runs [27213699414](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27213699414) and [27219020294](https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27219020294) uploaded to **beta** only — docs now forbid repeating that without CEO request.

## Test plan
- [ ] Docs review only — no code/runtime change

Made with [Cursor](https://cursor.com)