### PR TITLE
fix(android): correct MainActivity launch in billing verify script

### DIFF
--- a/.github/workflows/play-mirror-production-to-internal.yml
+++ b/.github/workflows/play-mirror-production-to-internal.yml
@@ -120,6 +120,8 @@ jobs:
       - name: Verify internal track read-back
         env:
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+          VERSION_CODE: ${{ inputs.version_code }}
+          RELEASE_NAME: ${{ inputs.release_name }}
         run: |
           python -m pip install --quiet google-api-python-client==2.149.0 google-auth==2.35.0 requests==2.32.5
           printf '%s' "$GOOGLE_PLAY_JSON_KEY" > /tmp/play-service-account.json
@@ -127,5 +129,5 @@ jobs:
           python scripts/verify_release.py \
             --platform android \
             --track internal \
-            --version-code "${{ inputs.version_code }}" \
-            --version "${{ inputs.release_name }}"
+            --version-code "$VERSION_CODE" \
+            --version "$RELEASE_NAME"

--- a/scripts/device-tests/adb/verify-billing-catalog.sh
+++ b/scripts/device-tests/adb/verify-billing-catalog.sh
@@ -27,7 +27,7 @@ echo "== Launch + paywall affordance tap =="
 adb logcat -c
 adb shell am force-stop "$PACKAGE" 2>/dev/null || true
 sleep 1
-adb shell am start -n "$PACKAGE/$ACTIVITY"
+adb shell am start -n "$ACTIVITY"
 sleep 8
 
 if wait_for_text "PRO: 1H" 15; then


### PR DESCRIPTION
## Summary
- Fix `verify-billing-catalog.sh` `am start` component: use `$ACTIVITY` only (`common.sh` already sets `com.iganapolsky.randomtimer/.MainActivity`).
- Prior `$PACKAGE/$ACTIVITY` doubled the package and failed retail launch.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_verify_billing_catalog_script.py`
- [ ] Re-run `scripts/device-tests/adb/verify-billing-catalog.sh` on S25 when adb available (USB or wireless)


Made with [Cursor](https://cursor.com)

----
## Summary by Gitar

- **CI Configuration:**
  - Moved `VERSION_CODE` and `RELEASE_NAME` to the `env` block in `play-mirror-production-to-internal.yml`.
- **Billing Script:**
  - Corrected `am start` command in `verify-billing-catalog.sh` to use the `$ACTIVITY` component only.

<sub>This will update automatically on new commits.</sub>