### PR TITLE
chore(data): #1684 closed — catalog ok, attempt logged, success 0

### DIFF
--- a/marketing/data/monetization_decision_brief.json
+++ b/marketing/data/monetization_decision_brief.json
@@ -1,9 +1,14 @@
 {
-  "generated_at": "2026-06-09T14:05:00Z",
-  "source": "native_release_27209581950_play_api_verify_2026_06_09",
+  "generated_at": "2026-06-10T17:05:34Z",
+  "source": "issue_1684_closed_s25_catalog_ok_2026_06_10",
   "window_days": 7,
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "issue_ref": "https://github.com/IgorGanapolsky/Random-Timer/issues/1684",
+  "issue_1684": {
+    "state": "CLOSED",
+    "closed_at": "2026-06-10T17:04:50Z",
+    "close_evidence": "billing_product_catalog_status=ok + paywall_purchase_attempt on S25 (SM-S931U1) 1.3.55 @ 2026-06-10T17:03:49Z product_id=elite_tactical"
+  },
   "ship_evidence": {
     "workflow_run_id": 27209581950,
     "workflow_conclusion": "success",
@@ -19,29 +24,27 @@
     "monthly_catalog_fix_pr": 1757
   },
   "posthog_queries": [
-    "billing_product_catalog_status 1h by app_version=1.3.55 and device_model=SM-S931U1",
-    "billing_product_catalog_status 7d breakdown by status",
-    "paywall funnel 7d",
-    "purchase_success 30d (telemetry proxy, not ledger revenue)"
+    "paywall_purchase_attempt today app_version=1.3.55 device_model=SM-S931U1",
+    "paywall_purchase_success 30d (telemetry proxy, not ledger revenue)",
+    "billing_product_catalog_status 7d breakdown by status"
   ],
-  "snapshot": "Android 1.3.55 shipped Play production via native-release run 27209581950. Play Publisher API readback: versionCode 1781012436 (1.3.55) status=completed on production track. Public listing HTML proxy still 1.3.43 after 900s poll (propagation lag; non-blocking). PR #1757 monthly catalog fix merged. PostHog last 1h: 8 billing_product_catalog_status events / 4 users on 1.3.55 (OnePlus8Pro) — statuses play_store_update_required and product_details_unsupported; zero status=ok; no SM-S931U1 events. S25 (R3CY90QPM7E) not connected via adb. Issue #1684 remains open pending retail Play update + catalog ok with elite_tactical_monthly.",
+  "snapshot": "Issue #1684 CLOSED 2026-06-10T17:04:50Z. S25 (SM-S931U1) on Play-installed 1.3.55: billing catalog ok + paywall_purchase_attempt @ 2026-06-10T17:03:49Z (elite_tactical). paywall_purchase_success still 0 (30d and today). Next gate: convert attempt→success on retail cohort before paid ads.",
   "counts": {
-    "billing_catalog_status_events_1_3_55_1h": 8,
-    "billing_catalog_users_1_3_55_1h": 4,
-    "billing_catalog_ok_1_3_55_1h": 0,
-    "billing_catalog_sm_s931u1_1h": 0,
+    "purchase_attempts_today_1_3_55": 1,
+    "purchase_attempts_today_total": 1,
+    "purchase_success_today": 0,
+    "purchase_attempts_30d": 5,
+    "purchase_success_30d": 0,
     "play_api_version_name": "1.3.55",
     "play_api_version_code": 1781012436,
     "public_listing_version_name": "1.3.43",
-    "purchase_attempts_30d": 4,
-    "purchase_success_30d": 0
+    "issue_1684_state": "CLOSED"
   },
-  "decision": "keep_issue_1684_open_awaiting_play_update_on_s25",
+  "decision": "issue_1684_closed_pursue_attempt_to_success",
   "research_doc": "marketing/data/june_2026_monetization_research.md",
   "recommended_next_actions": [
-    "issue_1684: keep open; require billing_product_catalog_status.status=ok with elite_tactical_monthly on Play-installed S25 after public listing propagates",
-    "ceo_qa: tap Update on S25 Play Store (market://details?id=com.iganapolsky.randomtimer) then run verify-billing-catalog.sh",
+    "attempt_to_success: reproduce S25 purchase flow; capture paywall_purchase_success or paywall_purchase_result failure reason on 1.3.55",
     "do_not_claim_revenue: purchase_success is telemetry proxy; ledger revenue not connected",
-    "Hold paid ads until catalog ok on production retail cohort and paywall attempt→success > 0"
+    "Hold paid ads until paywall attempt→success > 0 on production retail cohort"
   ]
 }

--- a/marketing/data/post_publish_gate.json
+++ b/marketing/data/post_publish_gate.json
@@ -1,6 +1,6 @@
 {
   "source": "post_publish_revenue_gate",
-  "generated_at": "2026-06-09T14:04:34Z",
+  "generated_at": "2026-06-10T17:05:34Z",
   "expected_source": "github_latest_release",
   "expected_ios": "1.3.55",
   "expected_android": "1.3.55",
@@ -21,10 +21,25 @@
       "status": "VERSION_MISMATCH"
     }
   ],
+  "billing_catalog_gate": {
+    "issue_ref": "https://github.com/IgorGanapolsky/Random-Timer/issues/1684",
+    "state": "CLOSED",
+    "closed_at": "2026-06-10T17:04:50Z",
+    "evidence": "billing_product_catalog_status=ok + paywall_purchase_attempt SM-S931U1 1.3.55 @ 2026-06-10T17:03:49Z"
+  },
   "paywall_proxy": {
-    "generated_at": "2026-06-08T16:24:49+00:00",
+    "generated_at": "2026-06-10T17:05:34Z",
     "purchase_successes_30d": 0,
-    "purchase_attempts_30d": 4
+    "purchase_attempts_30d": 5,
+    "purchase_attempts_today": 1,
+    "purchase_attempts_today_1_3_55": 1,
+    "purchase_success_today": 0,
+    "last_attempt": {
+      "timestamp": "2026-06-10T17:03:49Z",
+      "app_version": "1.3.55",
+      "device_model": "SM-S931U1",
+      "product_id": "elite_tactical"
+    }
   },
   "revenue_note": "store_public_pass does not imply revenue; check paywall_purchase_success in PostHog.",
   "ship_evidence": {


### PR DESCRIPTION
## Summary
- Confirm issue #1684 CLOSED (2026-06-10T17:04:50Z) after S25 catalog ok + `paywall_purchase_attempt` on 1.3.55 @ 17:03:49Z
- PostHog: `paywall_purchase_success` still 0 (30d); 1 attempt today on 1.3.55 (SM-S931U1, elite_tactical)
- Update `post_publish_gate.json` + `monetization_decision_brief.json`; next action = attempt→success

## Test plan
- [x] `gh issue view 1684` → CLOSED
- [x] PostHog HogQL: success 30d=0, attempts today 1.3.55=1
- [ ] Merge JSON-only data refresh


Made with [Cursor](https://cursor.com)