### PR TITLE
chore(data): GSD cycle 1 monetization brief — WQTU + iOS signoff gate

### DIFF
--- a/marketing/data/monetization_decision_brief.json
+++ b/marketing/data/monetization_decision_brief.json
@@ -1,46 +1,85 @@
 {
-  "generated_at": "2026-06-10T18:02:05Z",
-  "source": "posthog_first_purchase_success_s25_2026_06_10",
-  "window_days": 7,
+  "generated_at": "2026-06-10T19:48:13Z",
+  "source": "gsd_cycle_1_posthog_live_mcp_execute_sql",
+  "gsd_cycle": 1,
+  "window_days": 30,
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
+  "research_doc": "marketing/data/june_2026_monetization_research.md",
   "issue_ref": "https://github.com/IgorGanapolsky/Random-Timer/issues/1684",
   "issue_1684": {
     "state": "CLOSED",
     "closed_at": "2026-06-10T17:04:50Z",
     "close_evidence": "billing_product_catalog_status=ok + paywall_purchase_attempt on S25 (SM-S931U1) 1.3.55 @ 2026-06-10T17:03:49Z product_id=elite_tactical"
   },
-  "ship_evidence": {
-    "workflow_run_id": 27209581950,
-    "workflow_conclusion": "success",
-    "git_tag": "v1.3.55",
-    "git_tag_sha": "2a03f3f8",
-    "ship_date_utc": "2026-06-09",
-    "play_api_track": "production",
-    "play_api_version_name": "1.3.55",
-    "play_api_version_code": 1781012436,
-    "play_api_status": "completed",
-    "public_listing_version_name": "1.3.43",
-    "public_listing_note": "Storefront HTML proxy still 1.3.43 at verify-releases 900s timeout; Play Publisher API production completed",
-    "monthly_catalog_fix_pr": 1757
+  "north_star": {
+    "wqtu_7d": 11,
+    "wqtu_target_q2_2026": 25,
+    "wqtu_query": "distinct persons with >=3 timer_completed in trailing 7d (PostHog MCP execute-sql 2026-06-10T19:47:36Z)",
+    "status": "below_target"
   },
-  "posthog_queries": [
-    "paywall_purchase_success 7d count (telemetry proxy, not ledger revenue)",
-    "paywall_purchase_success properties on SM-S931U1 1.3.55",
-    "billing_product_catalog_status 7d breakdown by status"
-  ],
-  "snapshot": "First paywall_purchase_success telemetry on S25 (SM-S931U1) Play-installed 1.3.55 @ 2026-06-10T18:00:04Z — product_id=elite_tactical, revenue_telemetry=29.99. Unintended retail charge GPA.3311-0689-1321-89557 (CEO not on license testers). PostHog 7d: 1 success / 1 user. Issue #1684 CLOSED.",
-  "counts": {
-    "purchase_success_7d": 1,
-    "purchase_success_30d": 1,
-    "purchase_success_distinct_users_7d": 1,
-    "purchase_attempts_today_1_3_55": 1,
-    "purchase_attempts_today_total": 1,
-    "purchase_success_today": 1,
-    "purchase_attempts_30d": 5,
-    "play_api_version_name": "1.3.55",
-    "play_api_version_code": 1781012436,
-    "public_listing_version_name": "1.3.43",
-    "issue_1684_state": "CLOSED"
+  "revenue_goal": {
+    "target_usd_per_day_after_tax": 100.0,
+    "pro_annual_price_usd": 29.99,
+    "net_per_sale_usd_estimate": 17.84,
+    "sales_per_day_needed": 6,
+    "posthog_revenue_proxy_usd_per_day": 0.0,
+    "posthog_revenue_proxy_30d_sum": 29.99,
+    "gap_usd_per_day": 100.0,
+    "gap_math_note": "$29.99 gross → ~$17.84 net after 15% store fee + 30% tax → ~6 annual Pro subs/day for $100/day net (docs/marketing/monetization-roadmap.md)",
+    "metric_id": "paywall_purchase_success properties.revenue is telemetry proxy not ledger"
+  },
+  "paywall_funnel_30d": {
+    "paywall_viewed_users": 169,
+    "paywall_viewed_events": 378,
+    "paywall_offer_select_events": 61,
+    "paywall_purchase_attempt_users": 4,
+    "paywall_purchase_attempt_events": 6,
+    "paywall_purchase_success_users": 1,
+    "paywall_purchase_success_events": 1,
+    "view_to_attempt_pct": 2.4,
+    "attempt_to_success_pct": 25.0,
+    "view_to_success_pct": 0.6,
+    "billing_product_not_found_android_30d": 1104,
+    "posthog_query_evidence": "execute-sql 2026-06-10T19:47:46Z project 299775"
+  },
+  "store_parity": {
+    "android_play_api_version": "1.3.55",
+    "android_play_api_version_code": 1781012436,
+    "ios_public_version": "1.3.43",
+    "ios_repo_marketing_version": "1.3.55",
+    "parity_gap": "iOS public 12 minor versions behind Android production",
+    "top_blocker": "ios_store_parity_blocked_on_testflight_signoff"
+  },
+  "ship_evidence": {
+    "android_workflow_run_id": 27209581950,
+    "android_workflow_conclusion": "success",
+    "android_git_tag": "v1.3.55",
+    "android_git_tag_sha": "2a03f3f8",
+    "android_ship_date_utc": "2026-06-09",
+    "play_api_track": "production",
+    "play_api_status": "completed"
+  },
+  "ceo_gates": {
+    "testflight_signoff": {
+      "status": "waiting",
+      "environment": "testflight-signoff",
+      "internal_distribution_run_id": 27296749967,
+      "internal_distribution_run_url": "https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27296749967",
+      "job": "iOS TestFlight Signoff",
+      "unblocks": "internal-signoff/testflight commit status → native-release.yml iOS production upload",
+      "evidence": "Run waiting 1h+ as of 2026-06-10T19:48Z; Gate Internal Distribution job success; iOS TestFlight Signoff + Android Firebase Signoff waiting CEO Review deployments"
+    },
+    "production_signoff": {
+      "status": "blocked_prerequisite",
+      "last_ios_release_attempt_run_id": 27301825232,
+      "last_ios_release_attempt_url": "https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27301825232",
+      "failure_reason": "missing required status internal-signoff/testflight on release/v1.3.55 SHA"
+    },
+    "firebase_signoff": {
+      "status": "waiting",
+      "internal_distribution_run_id": 27296749967,
+      "job": "Android Firebase Signoff"
+    }
   },
   "first_purchase_success_telemetry": {
     "timestamp": "2026-06-10T18:00:04Z",
@@ -56,12 +95,22 @@
     "ledger_revenue": true,
     "note": "Unintended retail charge — add CEO to Play license testers before further IAP QA."
   },
-  "decision": "first_purchase_success_telemetry_confirmed_retail_charge_refund",
-  "research_doc": "marketing/data/june_2026_monetization_research.md",
+  "decision": "gsd_cycle_1_ios_parity_blocked_testflight_signoff_android_billing_unblocked",
+  "priority_blocker": {
+    "rank": 3,
+    "category": "store_parity_ios",
+    "reason": "Revenue blocker #1684 closed (Android 1.3.55 live). Paywall view→attempt 2.4% largely historical Android billing_product_not_found (1104/30d pre-fix). iOS 1.3.55 cannot ship until CEO approves testflight-signoff on run 27296749967.",
+    "next_code_cycle": "paywall_attempt_rate_after_ios_parity — validate view→attempt on 1.3.55+ cohorts post license-tester QA"
+  },
   "recommended_next_actions": [
-    "refund_play_order: GPA.3311-0689-1321-89557 via Play Console Orders",
-    "license_tester: add iganapolsky@gmail.com to Play Console Settings → License testing",
-    "do_not_claim_revenue: purchase_success is telemetry proxy; ledger revenue not connected",
-    "Hold paid ads until license-tester IAP QA and attempt→success validated without retail charges"
-  ]
+    "CEO: approve testflight-signoff on https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27296749967",
+    "CEO: approve firebase-signoff on same run (Android internal proof for production gate)",
+    "After signoffs: gh workflow run native-release.yml --ref release/v1.3.55 -f platform=ios",
+    "refund_play_order GPA.3311-0689-1321-89557 + add iganapolsky@gmail.com to Play license testers",
+    "Hold paid ads until iOS parity + license-tester IAP QA"
+  ],
+  "gsd_cycle_1_artifact": {
+    "type": "marketing_data_json_pr",
+    "branch": "feat/gsd-monetization-cycle1"
+  }
 }


### PR DESCRIPTION
## Summary
- Live PostHog snapshot (MCP execute-sql): WQTU=11, paywall funnel 169→4→1 users (30d)
- $100/day gap math: ~6 annual Pro subs/day at $29.99 net ~$17.84
- Documents iOS store parity blocker: testflight-signoff waiting on run 27296749967

## Test plan
- [x] PostHog queries reproduced via MCP execute-sql
- [x] JSON validates
- [ ] CI green


Made with [Cursor](https://cursor.com)