### PR TITLE
chore(rag): June 10 monetization decision lessons

### DIFF
--- a/marketing/data/rag_lessons_2026-06-10.json
+++ b/marketing/data/rag_lessons_2026-06-10.json
@@ -1,0 +1,100 @@
+{
+  "generated_at": "2026-06-10T19:48:12Z",
+  "source": "agentic_rag_monetization_session",
+  "memory_gateway": {
+    "status": "verified",
+    "ingest_id": "monetization_rag_2026_06_10",
+    "cell_id": "cell_store-publishing_8",
+    "recall_scenes": ["store-publishing"]
+  },
+  "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
+  "evidence_refs": [
+    "marketing/data/monetization_decision_brief.json",
+    "marketing/data/post_publish_gate.json",
+    "marketing/data/executive_metrics.json",
+    "agent-transcript:962ce8ef-5438-40bd-8f77-d8df3de3e1c2"
+  ],
+  "contradictions": [
+    {
+      "id": "executive_metrics_stale",
+      "detail": "executive_metrics.json (2026-06-08) reports purchase_success_30d=0; monetization_decision_brief + post_publish_gate (2026-06-10) report 1 success on 1.3.55 S25"
+    },
+    {
+      "id": "api_vs_public_listing",
+      "detail": "Play Publisher API production completed 1.3.55; public HTML proxy still 1.3.43 — store_public_pass=false in post_publish_gate.json"
+    },
+    {
+      "id": "ios_ship_gap",
+      "detail": "git tag v1.3.55 shipped; iOS ASC public still 1.3.43 READY_FOR_SALE per executive_metrics store_apis.ios"
+    }
+  ],
+  "verified_patterns": [
+    {
+      "pattern_id": "managed_publishing",
+      "salience": 0.95,
+      "scene": "store-publishing",
+      "content": "Play Managed Publishing stages production releases; API track can show newer version while public storefront stays old until Publish changes is clicked in Play Console.",
+      "evidence": "Transcript verified 1.3.43 publish (Publish 4 changes → PASS android 1.3.43); Jun 10 1.3.55 API completed but public 1.3.43"
+    },
+    {
+      "pattern_id": "billing_sku_elite_tactical",
+      "salience": 0.90,
+      "scene": "debugging",
+      "content": "Bill monthly via elite_tactical P1M base plan; elite_tactical_monthly has no active base plans → item_unavailable.",
+      "evidence": "PR fix/android-monthly-billing-sku merged; issue #1684 closed with billing_product_catalog_status=ok on 1.3.55"
+    },
+    {
+      "pattern_id": "license_tester_retail_charge",
+      "salience": 0.92,
+      "scene": "store-publishing",
+      "content": "CEO account must be on Play license testers before IAP QA; otherwise paywall_purchase_success triggers real retail charges.",
+      "evidence": "GPA.3311-0689-1321-89557 @ 2026-06-10T18:00:04Z license_tester=false"
+    },
+    {
+      "pattern_id": "public_proxy_not_gate",
+      "salience": 0.85,
+      "scene": "automation",
+      "content": "verify_public_store_versions HTML scrape is lagging proxy; verify_release Play tracks API is tier-0 ship gate — do not block release on HTML timeout alone.",
+      "evidence": "store-verify-ci skill + native-release run 27209581950 success with public mismatch"
+    },
+    {
+      "pattern_id": "telemetry_not_ledger",
+      "salience": 0.80,
+      "scene": "automation",
+      "content": "paywall_purchase_success is PostHog telemetry proxy; do not claim earned revenue until Play/App Store ledger confirms.",
+      "evidence": "OPERATIONAL_RELIABILITY.md + monetization_decision_brief recommended_next_actions"
+    }
+  ],
+  "top_decisions_salience_ranked": [
+    {
+      "rank": 1,
+      "decision": "Publish Play Managed Publishing changes for 1.3.55 before any paywall conversion claim or paid ads",
+      "salience": 0.95,
+      "tags": ["paywall", "android"]
+    },
+    {
+      "rank": 2,
+      "decision": "Add iganapolsky@gmail.com to Play license testers; refund GPA.3311-0689-1321-89557 before further IAP QA",
+      "salience": 0.92,
+      "tags": ["paywall", "qa"]
+    },
+    {
+      "rank": 3,
+      "decision": "Ship iOS 1.3.55 to App Store (public still 1.3.43) before scaling monetization — iOS purchase_success remains 0",
+      "salience": 0.88,
+      "tags": ["ios", "ship"]
+    },
+    {
+      "rank": 4,
+      "decision": "Hold paid ads until license-tester IAP QA validates attempt→success without retail charges",
+      "salience": 0.85,
+      "tags": ["paywall", "budget"]
+    },
+    {
+      "rank": 5,
+      "decision": "Refresh executive_metrics.json — stale Jun 8 snapshot contradicts Jun 10 first purchase telemetry",
+      "salience": 0.75,
+      "tags": ["automation", "evidence"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `marketing/data/rag_lessons_2026-06-10.json` — verified agentic RAG artifact for paywall + iOS ship decisions
- Documents contradictions between stale `executive_metrics.json` (Jun 8) and Jun 10 purchase telemetry
- Salience-ranked top 5 decisions from transcripts + JSON evidence

## Test plan
- [x] Memory gateway ingest verified (`cell_store-publishing_8` recalls on `--scene store-publishing`)
- [x] JSON validates; evidence refs cite monetization_decision_brief + post_publish_gate


Made with [Cursor](https://cursor.com)