### PR TITLE
feat(ios): PostHog error tracking autocapture + observability gaps audit

### DIFF
--- a/marketing/data/observability_gaps_2026-06-10.json
+++ b/marketing/data/observability_gaps_2026-06-10.json
@@ -1,0 +1,76 @@
+{
+  "generated_at": "2026-06-10T19:52:00Z",
+  "audit_id": "observability_gaps_2026-06-10",
+  "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
+  "posthog_project_id": 299775,
+  "summary": {
+    "highest_gap": "ios_posthog_error_tracking_autocapture_missing",
+    "fix_action": "PR feat/ios-posthog-error-tracking — PostHogAnalyticsConfigFactory + SDK bump ≥3.46",
+    "blocking_failures_operational_bundle": 0
+  },
+  "gaps": [
+    {
+      "id": "exception_taxonomy_empty",
+      "severity": "critical",
+      "status": "open",
+      "evidence": "execute-sql 30d: $exception total=0; taxonomy warns event not in project; error_tracking issues=0",
+      "root_cause": "iOS never enabled errorTrackingConfig.autoCapture; Android enabled in #1749 but no field $exception yet (likely no fatals in window)"
+    },
+    {
+      "id": "ios_error_tracking_parity",
+      "severity": "critical",
+      "status": "fix_in_pr",
+      "evidence": "Android PostHogAnalyticsConfigFactory.kt L21 autoCapture; iOS AnalyticsService.swift had no errorTrackingConfig (develop 3.41.1 lacks API)",
+      "fix": "feat/ios-posthog-error-tracking"
+    },
+    {
+      "id": "sdk_version_skew",
+      "severity": "high",
+      "status": "fix_in_pr",
+      "evidence": "repo: Android posthog-android 3.47.4 (libs.versions.toml); iOS Package.resolved 3.41.1; live 7d: android 3.47.4=3354 vs ios 3.41.1=2126 events",
+      "fix": "iOS minimumVersion 3.46.0 → resolved 3.59.3 in PR"
+    },
+    {
+      "id": "error_tracking_symbol_sets",
+      "severity": "high",
+      "status": "open",
+      "evidence": "error-tracking-symbol-sets-list count=0",
+      "fix": "Wire R8/ProGuard + dSYM upload in native-release CI"
+    },
+    {
+      "id": "crashlytics_bq_empty",
+      "severity": "high",
+      "status": "open",
+      "evidence": "executive_metrics.json crashlytics_bigquery.status=skipped reason=BigQuery dataset exists but no tables yet",
+      "fix": "Enable Crashlytics BQ streaming export; set CRASHLYTICS_SERVICE_ACCOUNT_JSON in CI"
+    },
+    {
+      "id": "engagement_dashboard_stale",
+      "severity": "medium",
+      "status": "open",
+      "evidence": "engagement_dashboard.json generated_at=2026-05-12; local run skipped missing POSTHOG credentials",
+      "fix": "Refresh via wqtu-health.yml / engagement_dashboard.py when POSTHOG_* present"
+    },
+    {
+      "id": "store_ledger_not_wired",
+      "severity": "medium",
+      "status": "open",
+      "evidence": "operational_verification_bundle revenue_goal.store_ledger_metric_id=not_wired_in_executive_snapshot; store_ledger_revenue_usd_30d=null",
+      "fix": "Wire ASC+Play ledger into executive_metrics_snapshot.py"
+    },
+    {
+      "id": "executive_metrics_stale",
+      "severity": "advisory",
+      "status": "open",
+      "evidence": "operational_verification_bundle artifact_fresh_executive_metrics.json age_hours=51.55 stale=true",
+      "fix": "Run executive_metrics_snapshot.py in CI/local"
+    }
+  ],
+  "operational_verification_bundle": {
+    "path": "marketing/data/operational_verification_bundle.json",
+    "generated_at": "2026-06-10T19:48:35Z",
+    "blocking_failures": 0,
+    "advisory_fail": ["public_store_ios", "artifact_fresh_executive_metrics.json"],
+    "command": "python3 scripts/operational_verification_bundle.py"
+  }
+}

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		A1B2C3D400000001DEADBEEF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000002DEADBEEF /* Logger.swift */; };
 		A1UPGRADE0011223344556679 /* AppUpgradeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1UPGRADE0011223344556676 /* AppUpgradeTracker.swift */; };
 		A1B2C3D400000003DEADBEEF /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000004DEADBEEF /* AnalyticsService.swift */; };
+		PHCFG00112233445566778802 /* PostHogAnalyticsConfigFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = PHCFG00112233445566778801 /* PostHogAnalyticsConfigFactory.swift */; };
+		PHCFG00112233445566778804 /* PostHogAnalyticsConfigFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PHCFG00112233445566778803 /* PostHogAnalyticsConfigFactoryTests.swift */; };
 		A1B2C3D400000004SHARE01 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000004SHARE02 /* ShareSheet.swift */; };
 		DISTCH00112233445566778802 /* DistributionChannelResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DISTCH00112233445566778801 /* DistributionChannelResolverTests.swift */; };
 		A1UPGRADE0011223344556678 /* AppUpgradeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1UPGRADE0011223344556677 /* AppUpgradeTrackerTests.swift */; };
@@ -189,6 +191,8 @@
 		965D6C9486FA65E74E5A03EC /* ActiveTimerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveTimerScreen.swift; sourceTree = "<group>"; };
 		A1B2C3D400000002DEADBEEF /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		A1B2C3D400000004DEADBEEF /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
+		PHCFG00112233445566778801 /* PostHogAnalyticsConfigFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAnalyticsConfigFactory.swift; sourceTree = "<group>"; };
+		PHCFG00112233445566778803 /* PostHogAnalyticsConfigFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAnalyticsConfigFactoryTests.swift; sourceTree = "<group>"; };
 		A1B2C3D400000004SHARE02 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		A1UPGRADE0011223344556676 /* AppUpgradeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpgradeTracker.swift; sourceTree = "<group>"; };
 		DISTCH00112233445566778801 /* DistributionChannelResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistributionChannelResolverTests.swift; sourceTree = "<group>"; };
@@ -271,6 +275,7 @@
 			children = (
 				ACTD00112233445566778801 /* ActivationDefaultsTests.swift */,
 				DISTCH00112233445566778801 /* DistributionChannelResolverTests.swift */,
+				PHCFG00112233445566778803 /* PostHogAnalyticsConfigFactoryTests.swift */,
 				A1C1001122334455667788CC /* AIVoiceCalloutServiceTests.swift */,
 				A1B2C3D4E5F60718A1B2C3D5 /* CircularTimerViewTests.swift */,
 				DEE000000000000000000003 /* DeepLinkRouterTests.swift */,
@@ -320,6 +325,7 @@
 			children = (
 				A1UPGRADE0011223344556676 /* AppUpgradeTracker.swift */,
 				A1B2C3D400000004DEADBEEF /* AnalyticsService.swift */,
+				PHCFG00112233445566778801 /* PostHogAnalyticsConfigFactory.swift */,
 				CRSVC00112233445566778801 /* CrashReportingService.swift */,
 				A1B2C3D400000002DEADBEEF /* Logger.swift */,
 				VOLKEY00112233445566778801 /* AlarmVolumeKeyPolicy.swift */,
@@ -672,6 +678,7 @@
 			files = (
 				A1UPGRADE0011223344556679 /* AppUpgradeTracker.swift in Sources */,
 				A1B2C3D400000003DEADBEEF /* AnalyticsService.swift in Sources */,
+				PHCFG00112233445566778802 /* PostHogAnalyticsConfigFactory.swift in Sources */,
 				CRSVC00112233445566778802 /* CrashReportingService.swift in Sources */,
 				0D85510DFBFA57EC653BEFAC /* ActiveTimerScreen.swift in Sources */,
 				0B6A472176A53D70127E8133 /* CircularTimerView.swift in Sources */,
@@ -725,6 +732,7 @@
 			files = (
 				ACTD00112233445566778802 /* ActivationDefaultsTests.swift in Sources */,
 				DISTCH00112233445566778802 /* DistributionChannelResolverTests.swift in Sources */,
+				PHCFG00112233445566778804 /* PostHogAnalyticsConfigFactoryTests.swift in Sources */,
 				A1C1001122334455667788AA /* AIVoiceCalloutServiceTests.swift in Sources */,
 				A1B2C3D4E5F60718A1B2C3D4 /* CircularTimerViewTests.swift in Sources */,
 				DEE000000000000000000004 /* DeepLinkRouterTests.swift in Sources */,
@@ -1105,7 +1113,7 @@
 			repositoryURL = "https://github.com/PostHog/posthog-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.41.1;
+				minimumVersion = 3.46.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/native-ios/RandomTimer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/native-ios/RandomTimer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios",
       "state" : {
-        "revision" : "1ba3e8636d4f1ad9f18f5a4273e88d39a162466b",
-        "version" : "3.41.1"
+        "revision" : "179438b8e0c9a357ab0caf453577f766ffddbcb3",
+        "version" : "3.59.3"
       }
     },
     {

--- a/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
+++ b/native-ios/RandomTimer/Sources/Services/AnalyticsService.swift
@@ -77,8 +77,6 @@ final class AnalyticsService { // swiftlint:disable:this type_body_length
         if let s = raw as? String, let n = Int(s) { return n }
         return 0
     }
-    private let host = "https://us.i.posthog.com"
-
 #if DEBUG
     var testEventHandler: ((_ event: String, _ properties: [String: Any]?) -> Void)?
 #endif
@@ -177,22 +175,7 @@ final class AnalyticsService { // swiftlint:disable:this type_body_length
         }
 
 #if canImport(PostHog)
-        let config = PostHogConfig(apiKey: apiKey, host: host)
-        // Emit lifecycle events manually so every event includes our live/dev context tags.
-        config.captureApplicationLifecycleEvents = false
-        config.captureScreenViews = false
-        // Session replay: live device only; enable "Record user sessions" in PostHog.
-        // SwiftUI needs screenshotMode. Masking protects text/images. Tune volume in PostHog project settings
-        // (SDK has no client sampleRate on this pinned version).
-        if !isInternalUser {
-            config.sessionReplay = true
-            config.sessionReplayConfig.maskAllTextInputs = true
-            config.sessionReplayConfig.maskAllImages = true
-            config.sessionReplayConfig.captureLogs = true
-            config.sessionReplayConfig.captureNetworkTelemetry = true
-            config.sessionReplayConfig.screenshotMode = true
-            config.sessionReplayConfig.throttleDelay = 1.0
-        }
+        let config = PostHogAnalyticsConfigFactory.make(apiKey: apiKey, isInternalUser: isInternalUser)
         PostHogSDK.shared.setup(config)
 #endif
         initialized = true

--- a/native-ios/RandomTimer/Sources/Services/PostHogAnalyticsConfigFactory.swift
+++ b/native-ios/RandomTimer/Sources/Services/PostHogAnalyticsConfigFactory.swift
@@ -1,0 +1,28 @@
+import Foundation
+#if canImport(PostHog)
+import PostHog
+#endif
+
+/// Builds PostHog iOS SDK config shared by `AnalyticsService` (parity with Android `PostHogAnalyticsConfigFactory`).
+enum PostHogAnalyticsConfigFactory {
+    private static let posthogHost = "https://us.i.posthog.com"
+
+#if canImport(PostHog)
+    static func make(apiKey: String, isInternalUser: Bool) -> PostHogConfig {
+        let config = PostHogConfig(apiKey: apiKey, host: posthogHost)
+        config.captureApplicationLifecycleEvents = false
+        config.captureScreenViews = false
+        config.errorTrackingConfig.autoCapture = !isInternalUser
+        if !isInternalUser {
+            config.sessionReplay = true
+            config.sessionReplayConfig.maskAllTextInputs = true
+            config.sessionReplayConfig.maskAllImages = true
+            config.sessionReplayConfig.captureLogs = true
+            config.sessionReplayConfig.captureNetworkTelemetry = true
+            config.sessionReplayConfig.screenshotMode = true
+            config.sessionReplayConfig.throttleDelay = 1.0
+        }
+        return config
+    }
+#endif
+}

--- a/native-ios/RandomTimerTests/PostHogAnalyticsConfigFactoryTests.swift
+++ b/native-ios/RandomTimerTests/PostHogAnalyticsConfigFactoryTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import RandomTimer
+
+final class PostHogAnalyticsConfigFactoryTests: XCTestCase {
+    func testErrorTrackingAutocaptureEnabledForProductionUsers() {
+        let config = PostHogAnalyticsConfigFactory.make(apiKey: "phc_test", isInternalUser: false)
+        XCTAssertTrue(config.errorTrackingConfig.autoCapture)
+    }
+
+    func testErrorTrackingAutocaptureDisabledForInternalUsers() {
+        let config = PostHogAnalyticsConfigFactory.make(apiKey: "phc_test", isInternalUser: true)
+        XCTAssertFalse(config.errorTrackingConfig.autoCapture)
+    }
+}

--- a/scripts/tests/test_mobile_analytics_parity.py
+++ b/scripts/tests/test_mobile_analytics_parity.py
@@ -11,6 +11,9 @@ ANDROID_POSTHOG_CONFIG = (
 )
 ANDROID_NAV = ROOT / "native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt"
 IOS_ANALYTICS = ROOT / "native-ios/RandomTimer/Sources/Services/AnalyticsService.swift"
+IOS_POSTHOG_CONFIG = (
+    ROOT / "native-ios/RandomTimer/Sources/Services/PostHogAnalyticsConfigFactory.swift"
+)
 IOS_TIMER_MANAGER = ROOT / "native-ios/RandomTimer/Sources/Services/TimerManager.swift"
 IOS_SETUP_SCREEN = ROOT / "native-ios/RandomTimer/Sources/UI/Screens/TimerSetupScreen.swift"
 IOS_ACTIVE_SCREEN = ROOT / "native-ios/RandomTimer/Sources/UI/Screens/ActiveTimerScreen.swift"
@@ -121,11 +124,21 @@ class MobileAnalyticsParityTests(unittest.TestCase):
         android_source = ANDROID_ANALYTICS.read_text(encoding="utf-8")
         android_config = ANDROID_POSTHOG_CONFIG.read_text(encoding="utf-8")
         ios_source = IOS_ANALYTICS.read_text(encoding="utf-8")
+        ios_config = IOS_POSTHOG_CONFIG.read_text(encoding="utf-8")
         self.assertIn(
             "captureApplicationLifecycleEvents = false",
             android_source + android_config,
         )
-        self.assertIn("config.captureApplicationLifecycleEvents = false", ios_source)
+        self.assertIn(
+            "captureApplicationLifecycleEvents = false",
+            ios_source + ios_config,
+        )
+
+    def test_error_tracking_autocapture_gated_for_internal_users(self):
+        android_config = ANDROID_POSTHOG_CONFIG.read_text(encoding="utf-8")
+        ios_config = IOS_POSTHOG_CONFIG.read_text(encoding="utf-8")
+        self.assertIn("errorTrackingConfig.autoCapture = !isInternalUser", android_config)
+        self.assertIn("errorTrackingConfig.autoCapture = !isInternalUser", ios_config)
 
     def test_manual_lifecycle_events_tracked_on_initialize(self):
         android_source = ANDROID_ANALYTICS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Enable iOS `errorTrackingConfig.autoCapture` gated for internal users (parity with Android #1749).
- Extract `PostHogAnalyticsConfigFactory`; bump posthog-ios minimum to 3.46.0 (resolves 3.59.3).
- Add parity test + unit tests; document full observability gap audit in `marketing/data/observability_gaps_2026-06-10.json`.

## Evidence
- PostHog execute-sql 30d: `$exception` total=0, error tracking issues=0.
- Live SDK skew: Android 3.47.4 vs iOS 3.41.1 in production events.
- `operational_verification_bundle.py`: blocking_failures=0.

## Test plan
- [x] `python3 -m unittest scripts.tests.test_mobile_analytics_parity -v`
- [ ] iOS unit tests (PostHogAnalyticsConfigFactoryTests) via CI

Made with [Cursor](https://cursor.com)