### PR TITLE
chore(ios): ship blockers artifact + v1.3.55 release notes

### DIFF
--- a/marketing/data/ios_ship_blockers_2026-06-10.json
+++ b/marketing/data/ios_ship_blockers_2026-06-10.json
@@ -1,0 +1,15 @@
+{
+  "generated_at": "2026-06-10T19:55:00Z",
+  "revenue_goal_usd_per_day": 100,
+  "repo_version": "1.3.55",
+  "public_ios_9_countries": "1.3.43",
+  "asc_version_1_3_55": "NOT_FOUND",
+  "blockers": [
+    "iOS never shipped: v1.3.55 native-release runs were android-only (ios-testflight skipped; run 27219020294 platform=android)",
+    "ASC has no App Store version 1.3.55 (operational bundle run 27299660672: asc_watch_status exit 1)",
+    "iOS-only release blocked: missing internal-signoff/testflight on release SHA (run 27301825232)",
+    "testflight-signoff env waiting CEO approval (internal-distribution run 27301876671)",
+    "Preflight fail: release-notes/1.3.55.md missing (ios-submit-review dry_run 27302014265)"
+  ],
+  "automated_fix_pr": "feat/ios-ship-blockers-2026-06-10 adds release-notes/1.3.55.md + changelog 1778679357.txt"
+}

--- a/native-android/fastlane/metadata/android/en-US/changelogs/1778679357.txt
+++ b/native-android/fastlane/metadata/android/en-US/changelogs/1778679357.txt
@@ -1,0 +1,1 @@
+Fix Play billing catalog on Samsung and retail devices: probe elite_tactical_monthly separately; paywall billing_not_ready re-probe before purchase CTA.

--- a/release-notes/1.3.55.md
+++ b/release-notes/1.3.55.md
@@ -1,0 +1,13 @@
+# Release 1.3.55
+
+## Summary
+June 2026 monthly Pro catalog refresh plus Android paywall billing fixes (S25/Samsung retail): separate `elite_tactical_monthly` probe, billing-not-ready re-probe before purchase CTA, and first verified paywall purchase telemetry on Play production.
+
+## Product
+- **Android:** Query `elite_tactical_monthly` as its own Play product; voice/repeat gate paywall re-probes billing before CTA when catalog was not ready.
+- **iOS:** Monthly Pro content update — June 2026 (metadata/release notes aligned with Android ship).
+- **Ops:** Refreshed `play_iap_catalog.json`; PostHog billing diagnostics for catalog status and purchase funnel.
+
+## Release operations
+- Android v1.3.55 shipped to Play production (GitHub tag `v1.3.55`, run 27219020294); public listing proxy may lag.
+- iOS requires TestFlight internal proof + `native-release` with `platform=ios` or `both` and `submit_review=true` after CEO approves `testflight-signoff`.


### PR DESCRIPTION
## Summary
- Adds `marketing/data/ios_ship_blockers_2026-06-10.json` — evidence-backed iOS App Store ship blockers for the $100/day revenue path.
- Adds missing `release-notes/1.3.55.md` (preflight gate was failing on develop).
- Adds Android changelog `1778679357.txt` for versionCode parity with develop.

## Test plan
- [x] `bash scripts/shell/preflight-release.sh --platform ios --layer 1` passes in worktree
- [ ] Merge to develop; re-run `ios-submit-review` dry_run to confirm preflight green


Made with [Cursor](https://cursor.com)