### PR TITLE
chore(store): monthly Pro audio ops registry + listing line

### DIFF
--- a/.claude/scheduled_tasks.json
+++ b/.claude/scheduled_tasks.json
@@ -62,6 +62,13 @@
       "cron": "0 0 * * 0",
       "ceo_required": false,
       "artifact": "weekly-paywall-conversion-report"
+    },
+    {
+      "id": "monthly-pro-content-release",
+      "workflow": ".github/workflows/monthly-pro-content-release.yml",
+      "cron": "0 8 1 * *",
+      "ceo_required": false,
+      "artifact": "Pro voice callouts + sound pack (ElevenLabs)"
     }
   ]
 }

--- a/native-android/fastlane/metadata/android/en-US/full_description.txt
+++ b/native-android/fastlane/metadata/android/en-US/full_description.txt
@@ -27,6 +27,7 @@ PRO TACTICAL (OPTIONAL)
 • Command-style previews and elapsed-time callouts for pressure drills
 • Sound Arsenal: bells, horns, sirens, and expanded alarm library
 • Up to 60-minute sessions and structured round loops
+• Fresh Pro voice callouts and sounds added monthly
 
 HOW IT WORKS
 1. Set your range (e.g. 15 seconds to 3 minutes)

--- a/native-ios/fastlane/metadata/en-US/description.txt
+++ b/native-ios/fastlane/metadata/en-US/description.txt
@@ -15,6 +15,7 @@ PRO TACTICAL (OPTIONAL)
 • Command-cue previews and elapsed-time callouts for pressure drills
 • Sound Arsenal: expanded alarm library for serious sessions
 • Round selection (1–100) and sessions up to 60 minutes
+• Fresh Pro voice callouts and sounds added monthly
 
 TRAINING USES
 • Boxing pad rounds, bag work, and shadowboxing flurries


### PR DESCRIPTION
## Summary
- Register `monthly-pro-content-release.yml` in `.claude/scheduled_tasks.json`
- Add one en-US store line (Android + iOS) about monthly Pro audio drops

## Test plan
- [ ] CI green

Made with [Cursor](https://cursor.com)