### PR TITLE
fix(paywall): pre-warm billing on open + monetization GSD refresh (MONETIZATION-100)

### DIFF
--- a/marketing/data/monetization_decision_brief.json
+++ b/marketing/data/monetization_decision_brief.json
@@ -1,13 +1,60 @@
 {
-  "generated_at": "2026-06-10T18:02:05Z",
-  "source": "posthog_first_purchase_success_s25_2026_06_10",
-  "window_days": 7,
+  "generated_at": "2026-06-10T19:47:18Z",
+  "source": "posthog_execute_sql_ralph_monetization_100_2026_06_10",
+  "window_days": 30,
   "reliability_contract_doc": "docs/OPERATIONAL_RELIABILITY.md",
   "issue_ref": "https://github.com/IgorGanapolsky/Random-Timer/issues/1684",
   "issue_1684": {
     "state": "CLOSED",
     "closed_at": "2026-06-10T17:04:50Z",
     "close_evidence": "billing_product_catalog_status=ok + paywall_purchase_attempt on S25 (SM-S931U1) 1.3.55 @ 2026-06-10T17:03:49Z product_id=elite_tactical"
+  },
+  "posthog_queries": [
+    "WQTU: count persons with >=3 timer_completed in trailing 7d",
+    "paywall_view / paywall_dismissed / paywall_purchase_attempt / paywall_purchase_success 30d",
+    "billing_product_catalog_status 30d breakdown by status",
+    "paywall_purchase_result reason 30d"
+  ],
+  "north_star": {
+    "wqtu_7d": 11,
+    "wqtu_target_q2_2026": 25,
+    "wqtu_checkpoint_2026_03_31": 8,
+    "status": "above_march_checkpoint_below_june_target"
+  },
+  "paywall_funnel_30d": {
+    "metric_note": "Telemetry proxies — not store ledger revenue",
+    "paywall_views": 415,
+    "paywall_view_users": 216,
+    "paywall_dismissed": 303,
+    "paywall_purchase_attempts": 6,
+    "paywall_purchase_success": 1,
+    "view_to_attempt_rate": 0.0145,
+    "attempt_to_success_rate": 0.1667,
+    "top_catalog_status": {
+      "empty": 302,
+      "missing_required_products": 60,
+      "ok": 58,
+      "product_details_unsupported": 27,
+      "play_store_update_required": 14,
+      "billing_not_ready": 9
+    }
+  },
+  "revenue_goal": {
+    "target_usd_per_day_after_tax": 100.0,
+    "window_days": 30,
+    "posthog_paywall_revenue_sum_30d": 29.99,
+    "posthog_paywall_revenue_avg_usd_per_day": 1.0,
+    "posthog_usd_gap_per_day_vs_target": 99.0,
+    "events_paywall_purchase_success_30d": 1,
+    "subs_needed_proxy": {
+      "elite_tactical_one_time_usd": 29.99,
+      "purchases_per_day_at_one_time_price": 3.33,
+      "effective_monthly_arpu_usd": 8.0,
+      "paying_subs_per_day_at_arpu": 12.5,
+      "note": "Illustrative gap math using telemetry price; store fees/tax not modeled"
+    },
+    "store_ledger_revenue_usd_30d": null,
+    "note": "paywall_purchase_success is telemetry proxy only — not ASC/Play ledger proceeds"
   },
   "ship_evidence": {
     "workflow_run_id": 27209581950,
@@ -19,28 +66,9 @@
     "play_api_version_name": "1.3.55",
     "play_api_version_code": 1781012436,
     "play_api_status": "completed",
+    "ios_repo_marketing_version": "1.3.55",
     "public_listing_version_name": "1.3.43",
-    "public_listing_note": "Storefront HTML proxy still 1.3.43 at verify-releases 900s timeout; Play Publisher API production completed",
-    "monthly_catalog_fix_pr": 1757
-  },
-  "posthog_queries": [
-    "paywall_purchase_success 7d count (telemetry proxy, not ledger revenue)",
-    "paywall_purchase_success properties on SM-S931U1 1.3.55",
-    "billing_product_catalog_status 7d breakdown by status"
-  ],
-  "snapshot": "First paywall_purchase_success telemetry on S25 (SM-S931U1) Play-installed 1.3.55 @ 2026-06-10T18:00:04Z — product_id=elite_tactical, revenue_telemetry=29.99. Unintended retail charge GPA.3311-0689-1321-89557 (CEO not on license testers). PostHog 7d: 1 success / 1 user. Issue #1684 CLOSED.",
-  "counts": {
-    "purchase_success_7d": 1,
-    "purchase_success_30d": 1,
-    "purchase_success_distinct_users_7d": 1,
-    "purchase_attempts_today_1_3_55": 1,
-    "purchase_attempts_today_total": 1,
-    "purchase_success_today": 1,
-    "purchase_attempts_30d": 5,
-    "play_api_version_name": "1.3.55",
-    "play_api_version_code": 1781012436,
-    "public_listing_version_name": "1.3.43",
-    "issue_1684_state": "CLOSED"
+    "public_listing_note": "Storefront HTML proxy still 1.3.43; Play Publisher API production completed on 1.3.55"
   },
   "first_purchase_success_telemetry": {
     "timestamp": "2026-06-10T18:00:04Z",
@@ -54,14 +82,14 @@
     "license_tester": false,
     "play_order_id": "GPA.3311-0689-1321-89557",
     "ledger_revenue": true,
-    "note": "Unintended retail charge — add CEO to Play license testers before further IAP QA."
+    "note": "Unintended retail charge — add CEO to Play license testers before further IAP QA"
   },
-  "decision": "first_purchase_success_telemetry_confirmed_retail_charge_refund",
-  "research_doc": "marketing/data/june_2026_monetization_research.md",
+  "decision": "catalog_fix_validated_first_telemetry_success_focus_license_tester_and_public_listing_lag",
+  "snapshot": "WQTU 11 (7d). PostHog 30d: 415 paywall views, 6 attempts, 1 success ($29.99 telemetry). Catalog still 64% empty (legacy cohort). Revenue proxy $1.00/day vs $100/day target (gap $99/day). Issue #1684 CLOSED; public listing 1.3.43 vs shipped 1.3.55.",
   "recommended_next_actions": [
-    "refund_play_order: GPA.3311-0689-1321-89557 via Play Console Orders",
     "license_tester: add iganapolsky@gmail.com to Play Console Settings → License testing",
-    "do_not_claim_revenue: purchase_success is telemetry proxy; ledger revenue not connected",
-    "Hold paid ads until license-tester IAP QA and attempt→success validated without retail charges"
+    "refund_play_order: GPA.3311-0689-1321-89557 via Play Console Orders",
+    "ios_ship: CEO testflight-signoff → native-release 1.3.55 (VERSION_MISMATCH on public listing)",
+    "Hold paid ads until license-tester IAP QA validates attempt→success without retail charges"
   ]
 }

--- a/marketing/data/post_publish_gate.json
+++ b/marketing/data/post_publish_gate.json
@@ -1,6 +1,6 @@
 {
   "source": "post_publish_revenue_gate",
-  "generated_at": "2026-06-10T18:02:05Z",
+  "generated_at": "2026-06-10T19:47:18Z",
   "expected_source": "github_latest_release",
   "expected_ios": "1.3.55",
   "expected_android": "1.3.55",
@@ -27,20 +27,35 @@
     "closed_at": "2026-06-10T17:04:50Z",
     "evidence": "billing_product_catalog_status=ok + paywall_purchase_attempt SM-S931U1 1.3.55 @ 2026-06-10T17:03:49Z"
   },
+  "ios_ship_readiness": {
+    "repo_marketing_version": "1.3.55",
+    "release_notes_updated": true,
+    "ceo_gates": [
+      "testflight-signoff (internal-distribution.yml)",
+      "production-signoff (native-release.yml submit_review)"
+    ],
+    "blocker": "Public App Store still 1.3.43 — requires CEO signoff + ASC review cycle"
+  },
   "paywall_proxy": {
-    "generated_at": "2026-06-10T18:02:05Z",
+    "generated_at": "2026-06-10T19:47:18Z",
     "metric_id": "posthog_hogql_count_events_paywall_purchase_success",
+    "wqtu_7d": 11,
     "purchase_successes_7d": 1,
     "purchase_successes_30d": 1,
-    "purchase_attempts_30d": 5,
+    "purchase_attempts_30d": 6,
     "purchase_attempts_today": 1,
-    "purchase_attempts_today_1_3_55": 1,
     "purchase_success_today": 1,
-    "last_attempt": {
-      "timestamp": "2026-06-10T17:03:49Z",
-      "app_version": "1.3.55",
-      "device_model": "SM-S931U1",
-      "product_id": "elite_tactical"
+    "view_to_attempt_rate_30d": 0.0145,
+    "attempt_to_success_rate_30d": 0.1667,
+    "catalog_status_30d": {
+      "empty": 302,
+      "ok": 58,
+      "billing_not_ready": 9
+    },
+    "revenue_goal": {
+      "target_usd_per_day_after_tax": 100.0,
+      "posthog_paywall_revenue_avg_usd_per_day": 1.0,
+      "posthog_usd_gap_per_day_vs_target": 99.0
     },
     "first_purchase_success_telemetry": {
       "timestamp": "2026-06-10T18:00:04Z",
@@ -49,12 +64,9 @@
       "platform": "android",
       "product_id": "elite_tactical",
       "revenue_telemetry": 29.99,
-      "source": "paywall",
-      "entry_point": "range_gate",
       "license_tester": false,
       "play_order_id": "GPA.3311-0689-1321-89557",
-      "ledger_revenue": true,
-      "note": "Unintended retail charge — CEO account not on Play license testers; refund initiated via Play Console Orders."
+      "note": "Unintended retail charge — CEO account not on Play license testers"
     }
   },
   "revenue_note": "store_public_pass does not imply revenue; paywall_purchase_success is telemetry proxy only (not ledger revenue).",
@@ -68,6 +80,6 @@
     "play_api_version_code": 1781012436,
     "play_api_status": "completed",
     "public_listing_version_name": "1.3.43",
-    "public_listing_note": "Play Publisher API completed on production; public HTML proxy still 1.3.43 after 900s poll (run 27209581950 verify-releases, non-blocking)"
+    "public_listing_note": "Play Publisher API completed on production; public HTML proxy still 1.3.43 (lagging proxy)"
   }
 }

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/billing/ProManager.kt
@@ -59,6 +59,16 @@ class ProManager
              *  subscription product with billing period P1M under the same base plan as ELITE. */
             const val MONTHLY_PRODUCT_ID = "elite_tactical_monthly"
 
+            internal const val BILLING_READY_DEFAULT_ATTEMPTS = 6
+            internal const val BILLING_READY_PURCHASE_LAUNCH_ATTEMPTS = 16
+
+            internal fun billingReadyMaxAttempts(forPurchaseLaunch: Boolean): Int =
+                if (forPurchaseLaunch) {
+                    BILLING_READY_PURCHASE_LAUNCH_ATTEMPTS
+                } else {
+                    BILLING_READY_DEFAULT_ATTEMPTS
+                }
+
             internal fun canUseDebugUnlock(
                 @Suppress("UNUSED_PARAMETER") isDebugBuild: Boolean = true,
             ): Boolean = true
@@ -413,7 +423,7 @@ class ProManager
                 return true
             }
             connectAndRestore()
-            val maxAttempts = if (purchaseLaunch) 16 else 6
+            val maxAttempts = billingReadyMaxAttempts(purchaseLaunch)
             repeat(maxAttempts) {
                 delay(500)
                 if (billingClient.isReady) {

--- a/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
+++ b/native-android/app/src/main/java/com/iganapolsky/randomtimer/ui/navigation/Navigation.kt
@@ -95,7 +95,8 @@ fun RandomTimerNavHost(
             proPrice = viewModel.proManager.getFormattedPrice(ProManager.PRO_PRODUCT_ID)
             monthlyPrice = viewModel.proManager.getFormattedMonthlyPrice()
             lifetimePrice = viewModel.proManager.getFormattedPrice(ProManager.BASE_PRODUCT_ID)
-            paywallAvailableProductIds = viewModel.proManager.availablePaywallProductIds()
+            paywallAvailableProductIds =
+                viewModel.proManager.availablePaywallProductIds(forPurchaseLaunch = true)
             paywallBillingCatalogProbed = true
             paywallBillingReady = viewModel.proManager.isBillingClientReady()
             paywallEntryPoint = paywallEntryPointForFeature(feature)

--- a/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerBillingQueryRetryTest.kt
+++ b/native-android/app/src/test/java/com/iganapolsky/randomtimer/billing/ProManagerBillingQueryRetryTest.kt
@@ -13,4 +13,12 @@ class ProManagerBillingQueryRetryTest {
             ),
         )
     }
+
+    @Test
+    fun paywallOpenCatalogProbeUsesExtendedBillingReadyRetry() {
+        assertTrue(
+            ProManager.billingReadyMaxAttempts(forPurchaseLaunch = true) >
+                ProManager.billingReadyMaxAttempts(forPurchaseLaunch = false),
+        )
+    }
 }

--- a/native-ios/fastlane/metadata/en-US/release_notes.txt
+++ b/native-ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,1 @@
-Monthly Pro content update — June 2026
+Version 1.3.55 — billing catalog parity with Android, paywall telemetry improvements, and training stability fixes. Unlock Pro with annual, monthly, or lifetime plans; combat voice callouts and 60-minute random windows for fight-ready drills.


### PR DESCRIPTION
## Summary
- Pre-warm Play Billing on paywall open (`forPurchaseLaunch=true`) with extended retry constants to reduce `billing_not_ready` drop-off.
- Refresh `monetization_decision_brief.json` and `post_publish_gate.json` with live PostHog data: WQTU **11**, revenue proxy **$1.00/day** vs **$100/day** target (gap **$99/day**).
- Update iOS 1.3.55 release notes; document CEO signoff gates for ship parity.

## Test plan
- [x] `uv run pytest scripts/tests/` (ralph check — Python green)
- [ ] CI `ci.yml` Android unit tests (local JVM unavailable)
- [ ] Verify paywall opens with catalog probe on device after merge

## Evidence
PostHog 2026-06-10: WQTU 11, paywall views 415/30d, attempts 6, success 1 ($29.99 telemetry). Catalog empty 302 vs ok 58 (legacy cohort).

MONETIZATION-100

Made with [Cursor](https://cursor.com)