### PR TITLE
chore(release): sync release-notes/1.3.55.md from develop (#1785)

### DIFF
--- a/release-notes/1.3.55.md
+++ b/release-notes/1.3.55.md
@@ -1,14 +1,13 @@
 # Release 1.3.55
 
 ## Summary
-Samsung S25 / retail Play billing catalog fix: probe `elite_tactical_monthly` as its own subscription product instead of expecting monthly on `elite_tactical` P1M. Includes paywall `billing_not_ready` re-probe from v1.3.54 train (#1756).
+June 2026 monthly Pro catalog refresh plus Android paywall billing fixes (S25/Samsung retail): separate `elite_tactical_monthly` probe, billing-not-ready re-probe before purchase CTA, and first verified paywall purchase telemetry on Play production.
 
 ## Product
-- **Android:** `playBillingProductId` leaves monthly on `elite_tactical_monthly`; separate SUBS catalog probe for annual + monthly.
-- **Android:** Voice/repeat gate paywall re-probes billing catalog before CTA (#1756).
-- **Ops:** `scripts/device-tests/adb/verify-billing-catalog.sh` for retail catalog smoke + PostHog correlation.
+- **Android:** Query `elite_tactical_monthly` as its own Play product; voice/repeat gate paywall re-probes billing before CTA when catalog was not ready.
+- **iOS:** Monthly Pro content update — June 2026 (metadata/release notes aligned with Android ship).
+- **Ops:** Refreshed `play_iap_catalog.json`; PostHog billing diagnostics for catalog status and purchase funnel.
 
 ## Release operations
-- Requires Play products: `elite_tactical`, `elite_tactical_monthly`, `pro_base`.
-- After Play production deploy, verify PostHog `billing_product_catalog_status` → `ok` on SM-S931U1 with `elite_tactical_monthly` in `available_product_ids`.
-- Closes #1684 when S25 catalog ok + purchase attempt succeeds.
+- Android v1.3.55 shipped to Play production (GitHub tag `v1.3.55`, run 27219020294); public listing proxy may lag.
+- iOS requires TestFlight internal proof + `native-release` with `platform=ios` or `both` and `submit_review=true` after CEO approves `testflight-signoff`.


### PR DESCRIPTION
## Summary
- Syncs `release-notes/1.3.55.md` from develop (#1785) onto `release/v1.3.55` (3acb5ebc).
- Android changelog `1778679357.txt` already matched; no changelog diff.

## Test plan
- [x] File content matches `origin/develop:release-notes/1.3.55.md`
- [ ] Merge to `release/v1.3.55` only — no `native-release` dispatch


Made with [Cursor](https://cursor.com)