### PR TITLE
chore: bump develop to v1.3.56 after v1.3.55

### DIFF
--- a/native-android/app/build.gradle.kts
+++ b/native-android/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "com.iganapolsky.randomtimer"
         minSdk = 26
         targetSdk = ciTargetSdk ?: 35
-        versionCode = ciVersionCode ?: 1778679357
-        versionName = "1.3.55"
+        versionCode = ciVersionCode ?: 1778679358
+        versionName = "1.3.56"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/native-ios/RandomTimer.xcodeproj/project.pbxproj
+++ b/native-ios/RandomTimer.xcodeproj/project.pbxproj
@@ -804,7 +804,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.55;
+				MARKETING_VERSION = 1.3.56;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -826,7 +826,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.55;
+				MARKETING_VERSION = 1.3.56;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -914,7 +914,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.55;
+				MARKETING_VERSION = 1.3.56;
 				POSTHOG_API_KEY = "$(POSTHOG_API_KEY)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer;
 				SDKROOT = iphoneos;
@@ -936,7 +936,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.55;
+				MARKETING_VERSION = 1.3.56;
 				PRODUCT_BUNDLE_IDENTIFIER = com.igorganapolsky.randomtimer.widget;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Automated post-release version bump after tag `v1.3.55`.

develop rejects direct pushes; merge this PR to align develop with the next patch train.

Workflow: https://github.com/IgorGanapolsky/Random-Timer/actions/runs/27362554124
